### PR TITLE
Fix: Add abstract useform composable to module runtime

### DIFF
--- a/src/lib/core/utils/register.ts
+++ b/src/lib/core/utils/register.ts
@@ -1,10 +1,9 @@
 import { get } from "lodash-es"
 import { toRef, type Ref } from "vue"
-import type { AbstractSchema, FieldTransformer, FormKey, FormStore, MetaTracker } from "../../../types/types-api"
+import type { AbstractSchema, FieldTransformer, FormKey, FormStore, MetaTracker, XModelValue } from "../../../types/types-api"
 import type { GenericForm } from "../../../types/types-core"
 import type { GetElementHelpers } from "../composables/use-element-store"
 import { updateMetaTracker } from "../composables/use-meta-tracker-store"
-import type { XModelValue } from "../directives/xmodel"
 import { getForm } from "./get-value"
 
 // undefined by default (defer to useForm global setting)

--- a/src/module.ts
+++ b/src/module.ts
@@ -35,6 +35,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     const resolver = createResolver(import.meta.url)
     addImportsDir(resolver.resolve("./runtime/composables"))
+    addImportsDir(resolver.resolve("./runtime/directives"))
     addImportsDir(resolver.resolve("./runtime/adapters/zod"))
 
     addPlugin(resolver.resolve("./runtime/plugins/xmodel"))

--- a/src/runtime/composables/use-abstract-form.ts
+++ b/src/runtime/composables/use-abstract-form.ts
@@ -1,15 +1,15 @@
+import { useElementStore } from "../../lib/core/composables/use-element-store"
+import { useFormKey } from "../../lib/core/composables/use-form-key"
+import { useFormStore } from "../../lib/core/composables/use-form-store"
+import { useMetaTrackerStore } from "../../lib/core/composables/use-meta-tracker-store"
+import { elementStateFactory } from "../../lib/core/utils/element-state-api"
+import { getComputedSchema } from "../../lib/core/utils/get-computed-schema"
+import { registerFactory } from "../../lib/core/utils/register"
 import type {
   AbstractSchema,
   UseFormConfiguration,
-} from "../../../types/types-api"
-import type { DeepPartial, GenericForm } from "../../../types/types-core"
-import { elementStateFactory } from "../utils/element-state-api"
-import { getComputedSchema } from "../utils/get-computed-schema"
-import { registerFactory } from "../utils/register"
-import { useElementStore } from "./use-element-store"
-import { useFormKey } from "./use-form-key"
-import { useFormStore } from "./use-form-store"
-import { useMetaTrackerStore } from "./use-meta-tracker-store"
+} from "../../types/types-api"
+import type { DeepPartial, GenericForm } from "../../types/types-core"
 
 export function useAbstractForm<
   Form extends GenericForm,
@@ -70,3 +70,8 @@ export function useAbstractForm<
     key,
   }
 }
+
+export type UseAbstractFormReturnType<Form extends GenericForm, GetValueFormType extends GenericForm = Form> = ReturnType<typeof useAbstractForm<
+  Form,
+  GetValueFormType
+>>

--- a/src/runtime/composables/use-form.ts
+++ b/src/runtime/composables/use-form.ts
@@ -1,15 +1,10 @@
 import type { z } from "zod"
-import { useAbstractForm } from "../../lib/core/composables/use-abstract-form"
 import type { AbstractSchema, UseFormConfiguration } from "../../types/types-api"
 import type { DeepPartial, GenericForm } from "../../types/types-core"
 import type { TypeWithNullableDynamicKeys } from "../../types/types-zod"
 import type { UnwrapZodObject, UseFormConfigurationWithZod } from "../../types/types-zod-adapter"
 import { zodAdapter } from "../adapters/zod"
-
-type UseFormReturnType<Form extends GenericForm, GetValueFormType extends GenericForm = Form> = ReturnType<typeof useAbstractForm<
-  Form,
-  GetValueFormType
->>
+import { useAbstractForm, type UseAbstractFormReturnType } from "./use-abstract-form"
 
 // Overload the useForm type definition to signal that zod schemas have 1st class support
 export function useForm<
@@ -22,7 +17,7 @@ export function useForm<
     AbstractSchema<Form, GetValueFormType>,
     DeepPartial<Form>
   >,
-): UseFormReturnType<Form, GetValueFormType>
+): UseAbstractFormReturnType<Form, GetValueFormType>
 export function useForm<
   Schema extends z.ZodObject<z.ZodRawShape>,
   GetValueFormType extends GenericForm = TypeWithNullableDynamicKeys<Schema>
@@ -31,7 +26,7 @@ export function useForm<
     Schema,
     DeepPartial<z.infer<UnwrapZodObject<Schema>>>
   >,
-): UseFormReturnType<z.infer<UnwrapZodObject<Schema>>, GetValueFormType>
+): UseAbstractFormReturnType<z.infer<UnwrapZodObject<Schema>>, GetValueFormType>
 export function useForm<
   Schema extends z.ZodSchema<unknown>,
   Form extends GenericForm = z.infer<UnwrapZodObject<Schema>>,
@@ -46,7 +41,7 @@ export function useForm<
     Schema,
     DeepPartial<z.infer<UnwrapZodObject<Schema>>>
   >,
-): UseFormReturnType<Form, GetValueFormType> {
+): UseAbstractFormReturnType<Form, GetValueFormType> {
   function isZodType(value: unknown): value is z.ZodType {
     return typeof value === "object" && value !== null && "_def" in value
   }

--- a/src/runtime/directives/xmodel.ts
+++ b/src/runtime/directives/xmodel.ts
@@ -2,7 +2,6 @@ import type {
   DirectiveBinding,
   DirectiveHook,
   ObjectDirective,
-  Ref,
   VNode
 } from "@vue/runtime-core"
 import {
@@ -19,13 +18,7 @@ import {
   looseIndexOf,
   looseToNumber
 } from "@vue/shared"
-
-export type XModelValue<Value = unknown> = {
-  innerRef: Readonly<Ref<Value>>
-  registerElement: (el: HTMLElement) => void
-  deregisterElement: (el: HTMLElement) => void
-  setValueWithInternalPath: (value: unknown) => boolean
-}
+import type { XModelValue } from "../../types/types-api"
 
 type AssignerFn = (value: unknown) => void
 

--- a/src/runtime/plugins/xmodel.ts
+++ b/src/runtime/plugins/xmodel.ts
@@ -1,5 +1,5 @@
 import { defineNuxtPlugin } from "nuxt/app"
-import { vXModelDynamic } from "../../lib/core/directives/xmodel"
+import { vXModelDynamic } from "../directives/xmodel"
 
 export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.vueApp.directive("xmodel", vXModelDynamic)

--- a/src/types/types-api.ts
+++ b/src/types/types-api.ts
@@ -118,3 +118,10 @@ export type CurrentValueWithContext<Value, FormSubtree = Value> = {
   currentValue: Readonly<Ref<Value>>
   meta: Readonly<Ref<DeepPartial<RemapLeafNodes<FormSubtree, MetaTrackerValue>>>>
 }
+
+export type XModelValue<Value = unknown> = {
+  innerRef: Readonly<Ref<Value>>
+  registerElement: (el: HTMLElement) => void
+  deregisterElement: (el: HTMLElement) => void
+  setValueWithInternalPath: (value: unknown) => boolean
+}


### PR DESCRIPTION
This is intended to resolve: https://github.com/cubicforms/chemical-x-forms/issues/12

Types were broken because the useAbstractForm composable wasn't exported in the module runtime,
so the runtime behavior was good because of the bundling process, yet types broke because they pointed
to files that did not exist in the dist. 