### PR TITLE
Bug using trim on v-xmodel causes unhandled runtime exception

### DIFF
--- a/playground/app.vue
+++ b/playground/app.vue
@@ -34,7 +34,7 @@ const planetValidationResponse = validate("address.planet")
     <h1>Fancy Form '{{ key }}'</h1>
 
     <input
-      v-xmodel="register('address.planet')"
+      v-xmodel.lazy.trim="register('address.planet')"
       placeholder="Enter your favorite planet"
     >
 

--- a/src/runtime/lib/core/utils/flatten-object.ts
+++ b/src/runtime/lib/core/utils/flatten-object.ts
@@ -1,5 +1,5 @@
 import { set } from "lodash-es"
-import { toRaw } from "vue"
+import { isProxy, isRef, toRaw } from "vue"
 import { isArrayOrRecord, isRecord } from "./helpers"
 
 const NO_KEY = "___USEFORM_INTERNAL_ERROR__NO_PATH_KEY_FOUND_FOR_FLATTEN___"
@@ -29,7 +29,9 @@ export function flattenObjectWithBaseKey(obj: unknown, basePath?: string) {
     }
   }
 
-  logic(obj, basePath)
+  const unwrappedObj = isRef(obj) ? obj.value : obj
+  const nonProxyObj = isProxy(unwrappedObj) ? toRaw(unwrappedObj) : unwrappedObj
+  logic(nonProxyObj, basePath) // no not pass in refs or proxies
   return recordedPaths
 }
 


### PR DESCRIPTION
The fix was to make sure to explicitly resolve refs and proxies before attempting to flatten them
in the `flattenObjectWithBaseKey` function, as shown in PR changes.

Confirmed working.

Note: modifier chaining is very possible, and allows for nice "composable" behavior in the v-xmodel directive.