### PR TITLE
feat(zod): make zod and zod-adapter truly optional via nuxt config

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License][license-src]][license-href]
 [![Nuxt][nuxt-src]][nuxt-href]
 
-**A fully type-safe, schema-driven form library that gives you superpowers**. Comes with a minimal composition API that prioritizes developer experience and form correctness.<br><br>
+**A fully type-safe, schema-driven form library that gives you superpowers**.<br>Comes with a minimal composition API that prioritizes developer experience and form correctness.<br><br>
 🚧 this library is not production ready _yet_.
 <br><br>
 
@@ -60,69 +60,32 @@ export default defineNuxtConfig({
 
 ```vue
 <script setup lang="ts">
-import type { OnError, OnSubmit } from "@chemical-x/forms/types";
 import { z } from "zod";
 
-const planetSchema = z.object({
-  address: z.object({
-    planet: z
-      .string()
-      .refine((x) => x.toLowerCase() !== "moon", {
-        message: "the moon ain't no planet",
-        path: ["address.planet"],
-      })
-      .default("Moon"),
-  }),
-});
+// Define your schema
+const schema = z.object({ planet: z.string() });
 
-type Bio = z.infer<typeof planetSchema>;
+// Create your form
+const { getFieldState, register, key } = useForm({ schema });
 
-const { getFieldState, register, handleSubmit, key, validate } = useForm({
-  schema: planetSchema,
-  key: "planet-form-key",
-});
-
-const planetState = getFieldState("address.planet");
-
-const onSubmit: OnSubmit<Bio> = async (data) => console.log("nice!", data);
-const onError: OnError = async (error) => console.log("oopsies!", error);
-
-const planetValidationResponse = validate("address.planet");
+// Get the state of the 'planet' field
+const planetState = getFieldState("planet");
 </script>
 
 <template>
-  <form @submit.prevent="handleSubmit(onSubmit, onError)">
-    <h1>Fancy Form '{{ key }}'</h1>
+  <div>
+    <h1>Planet Form</h1>
 
     <input
-      v-xmodel="register('address.planet')"
+      v-xmodel="register('planet')"
       placeholder="Enter your favorite planet"
     />
 
+    <p>Planet field State:</p>
+    <pre>{{ JSON.stringify(planetState, null, 2) }}</pre>
     <hr />
-
-    <p>Favorite Planet field state:</p>
-
-    <pre>
-      {{ JSON.stringify(planetState, null, 2) }}
-    </pre>
-    <hr />
-
-    <p>Realtime path validation, if you need it:</p>
-
-    <pre>
-      {{ JSON.stringify(planetValidationResponse, null, 2) }}
-    </pre>
-
-    <button>Submit (check your console)</button>
-  </form>
+  </div>
 </template>
-
-<style>
-body {
-  font-family: Arial, Helvetica, sans-serif;
-}
-</style>
 ```
 
 **Core API Functions**

--- a/package.json
+++ b/package.json
@@ -46,15 +46,14 @@
     },
     "./adapters/*": {
       "types": "./dist/runtime/adapters/*/index.d.ts",
-      "import": "./dist/runtime/adapters/*/index.mjs",
-      "require": "./dist/runtime/adapters/*/index.cjs"
+      "import": "./dist/runtime/adapters/*/index",
+      "require": null
     },
     "./types": {
       "types": "./dist/runtime/types/types-api.d.ts",
       "import": null,
       "require": null,
-      "default": "./dist/runtime/types/types-api.d.ts",
-      "node": "./dist/runtime/types/types-api.d.ts"
+      "default": "./dist/runtime/types/types-api.d.ts"
     }
   },
   "keywords": [

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,64 +1,30 @@
 <script setup lang="ts">
-import type { OnError, OnSubmit } from "@chemical-x/forms/types"
 import { z } from "zod"
 
-const planetSchema = z.object({
-  address: z.object({
-    planet: z
-      .string()
-      .refine(x => x.toLowerCase() !== "moon", {
-        message: "the moon ain't no planet",
-        path: ["address.planet"],
-      })
-      .default("Moon"),
-  }),
-})
+// Define your schema with a dash of magic
+const schema = z.object({ planet: z.string() })
 
-type Bio = z.infer<typeof planetSchema>
-
-const { getFieldState, register, handleSubmit, key, validate } = useForm({
-  schema: planetSchema,
+// Create your form with a unique key
+const { getFieldState, register, key } = useForm({
+  schema,
   key: "planet-form-key",
 })
 
-const planetState = getFieldState("address.planet")
-
-const onSubmit: OnSubmit<Bio> = async data => console.log("nice!", data)
-const onError: OnError = async error => console.log("oopsies!", error)
-
-const planetValidationResponse = validate("address.planet")
+// Get the state of the 'planet' field
+const planetState = getFieldState("planet")
 </script>
 
 <template>
-  <form @submit.prevent="handleSubmit(onSubmit, onError)">
-    <h1>Fancy Form '{{ key }}'</h1>
+  <div>
+    <h1>Fancy Form "{{ key }}"</h1>
 
     <input
-      v-xmodel.lazy.trim="register('address.planet')"
+      v-xmodel="register('planet')"
       placeholder="Enter your favorite planet"
     >
 
-    <hr>
-
     <p>Favorite Planet field state:</p>
-
-    <pre>
-      {{ JSON.stringify(planetState, null, 2) }}
-    </pre>
+    <pre>{{ JSON.stringify(planetState, null, 2) }}</pre>
     <hr>
-
-    <p>Realtime path validation, if you need it:</p>
-
-    <pre>
-      {{ JSON.stringify(planetValidationResponse, null, 2) }}
-    </pre>
-
-    <button>Submit (check your console)</button>
-  </form>
+  </div>
 </template>
-
-<style>
-body {
-  font-family: Arial, Helvetica, sans-serif;
-}
-</style>

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,5 +1,5 @@
 export default defineNuxtConfig({
-  modules: ["../src/module"],
+  modules: [["../src/module", { useZod: true }]],
   devtools: { enabled: true },
   alias: {
     "@chemical-x/forms/types": "../src/runtime/types/types-api.ts"

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,5 +1,5 @@
 import {
-  addImportsDir,
+  addImports,
   addPlugin,
   addTypeTemplate,
   createResolver,
@@ -9,8 +9,9 @@ import { inputTextAreaNodeTransform } from "./runtime/lib/core/transforms/input-
 import { selectNodeTransform } from "./runtime/lib/core/transforms/select-transform"
 
 // Module options TypeScript interface definition
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface CXModuleOptions {}
+export interface CXModuleOptions {
+  useZod?: boolean
+}
 
 export default defineNuxtModule<CXModuleOptions>({
   meta: {
@@ -20,8 +21,10 @@ export default defineNuxtModule<CXModuleOptions>({
       nuxt: "^3.0.0"
     }
   },
-  defaults: {},
-  setup(_options, nuxt) {
+  defaults: {
+    useZod: true
+  },
+  setup(options, nuxt) {
     nuxt.options.vue.compilerOptions.nodeTransforms ||= []
     nuxt.options.vue.compilerOptions.nodeTransforms.push(
       selectNodeTransform,
@@ -29,7 +32,13 @@ export default defineNuxtModule<CXModuleOptions>({
     )
 
     const resolver = createResolver(import.meta.url)
-    addImportsDir(resolver.resolve("./runtime/composables"))
+    const useFormComposable = options.useZod ? "use-form" : "use-abstract-form"
+    addImports([
+      {
+        name: "useForm",
+        from: resolver.resolve(`./runtime/composables/${useFormComposable}`)
+      },
+    ])
 
     addPlugin({
       src: resolver.resolve("./runtime/plugins/xmodel"),

--- a/src/runtime/composables/use-abstract-form.ts
+++ b/src/runtime/composables/use-abstract-form.ts
@@ -79,3 +79,6 @@ export function useAbstractForm<
     key,
   } satisfies UseAbstractFormReturnType<Form, GetValueFormType>
 }
+
+// create an alias for conditional import in the consumer app
+export { useAbstractForm as useForm }

--- a/src/runtime/composables/use-form.ts
+++ b/src/runtime/composables/use-form.ts
@@ -4,7 +4,7 @@ import type { AbstractSchema, UseAbstractFormReturnType, UseFormConfiguration } 
 import type { DeepPartial, GenericForm } from "../types/types-core"
 import type { TypeWithNullableDynamicKeys } from "../types/types-zod"
 import type { UnwrapZodObject, UseFormConfigurationWithZod } from "../types/types-zod-adapter"
-import { useAbstractForm } from "./use-abstract-form"
+import { useForm as useAbstractForm } from "./use-abstract-form"
 
 // Overload the useForm type definition to signal that zod schemas have 1st class support
 export function useForm<

--- a/src/runtime/composables/use-form.ts
+++ b/src/runtime/composables/use-form.ts
@@ -4,7 +4,7 @@ import type { AbstractSchema, UseAbstractFormReturnType, UseFormConfiguration } 
 import type { DeepPartial, GenericForm } from "../types/types-core"
 import type { TypeWithNullableDynamicKeys } from "../types/types-zod"
 import type { UnwrapZodObject, UseFormConfigurationWithZod } from "../types/types-zod-adapter"
-import { useForm as useAbstractForm } from "./use-abstract-form"
+import { useAbstractForm } from "./use-abstract-form"
 
 // Overload the useForm type definition to signal that zod schemas have 1st class support
 export function useForm<


### PR DESCRIPTION
Tested in a local build and all is well.

Nuxt module: `{ useZod?: boolean }`, defaults to `true` and imports update in realtime (if server is running ofc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated usage examples to showcase a streamlined form experience with a simplified, flat schema focused on a single field.
- **New Features**
	- Introduced enhanced module configuration options for customizable behavior.
	- Improved API consistency through refined import aliasing.
- **Chores**
	- Optimized module export definitions to improve compatibility across various environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->