### PR TITLE
fix(tsconfig.json): remove extended .nuxt tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,11 @@
 {
-  "extends": "./.nuxt/tsconfig.json",
   "compilerOptions": {
     "lib": [
       "ES2020",
       "DOM",
       "DOM.Iterable"
     ],
+    "module": "ES2020",
     "moduleResolution": "Node",
     "strict": true,
     "noUncheckedIndexedAccess": true,


### PR DESCRIPTION
At build time, we couldn't reference the tsconfig.json file in the .nuxt folder, which led to build errors. Simply removing the extended reference (which I added in a recent previous PR thinking I was solving something, before I understood the root cause) resolves this build issue.

In addition, module is set to "ES2020" to line up with the lib and build.config.ts build target

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the project’s configuration to adopt a modern ECMAScript module system, enhancing module resolution and overall compatibility. This behind-the-scenes improvement lays the foundation for smoother functionality without any visible changes to the end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->