### PR TITLE
ci: bump pnpm/action-setup and actions/cache to v5

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v5
@@ -39,7 +39,7 @@ jobs:
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: Setup pnpm cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -38,7 +38,7 @@ jobs:
         run: echo "::notice title=Version::Publishing version ${{ steps.calculate-next-version.outputs.next_version }}"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v5


### PR DESCRIPTION
## Summary
Follow-up to #104. v4 of both actions still run on Node 20 — the deprecation warning reappeared on the last matrix run. v5 is the current major and runs on Node 24.

- \`pnpm/action-setup\`: v4 → v5 (both workflows)
- \`actions/cache\`: v4 → v5 (matrix.yml)

## Test plan
- [ ] \`matrix.yml\` green on this PR, no more Node 20 deprecation warnings
- [ ] After merge: re-dispatch "Publish to NPM and Version Bump" → minor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow dependencies to newer versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->