### PR TITLE
fix(exports): drop null values and fix missing .js extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,14 +56,10 @@
     },
     "./adapters/*": {
       "types": "./dist/runtime/adapters/*/index.d.ts",
-      "import": "./dist/runtime/adapters/*/index",
-      "require": null
+      "import": "./dist/runtime/adapters/*/index.js"
     },
     "./types": {
-      "types": "./dist/runtime/types/types-api.d.ts",
-      "import": null,
-      "require": null,
-      "default": "./dist/runtime/types/types-api.d.ts"
+      "types": "./dist/runtime/types/types-api.d.ts"
     }
   },
   "keywords": [


### PR DESCRIPTION
## Summary
Nuxt 4's module loader (mlly@1.8.2) recurses into exports condition objects and calls \`Object.entries\` on nested values. The \`null\` entries in \`./types\` and \`./adapters/*\` crashed consumers with **"Cannot convert undefined or null to object"** during \`nuxt build\`.

- \`./adapters/*\`: added \`.js\` extension to \`"import"\` (required by Node ESM), dropped \`"require": null\` (absent condition = same behaviour)
- \`./types\`: reduced to a pure types-only condition. The previous \`"default": "./dist/runtime/types/types-api.d.ts"\` pointed at a \`.d.ts\` which is not runnable anyway — this was already a types-only path in practice

Not a behavioural change: the previous \`null\` values explicitly blocked runtime import at these subpaths, so no working consumer is affected.

## Reproduction
\`\`\`bash
# in a Nuxt 4 project
pnpm add @chemical-x/forms@0.5.0 immer lodash-es zod
# add modules: ['@chemical-x/forms'] to nuxt.config.ts
nuxt build
# → ERROR  Cannot convert undefined or null to object
#     at _flattenExports (mlly/dist/index.mjs:2211)
\`\`\`

## Test plan
- [x] \`make check\` clean locally
- [x] \`make test\` 8/8 locally
- [x] \`make publish-prep\` produces clean dist
- [x] CI matrix passes
- [ ] After merge: dispatch publish workflow with \`patch\` → v0.5.1; verify cubic-forms \`nuxt build\` succeeds