### PR TITLE
feat: reactive field-error store + setFieldErrorsFromApi

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,47 @@ _**note**: detailed documentation coming soon_
 `setValue(name: string, value: any)` – Updates a field programmatically.
 
 `getFieldState(name: string)` – Returns field state (value, touched, errors, etc.).
+
+`fieldErrors` – Reactive `Record<path, ValidationError[]>`. Auto-populated by `handleSubmit` on validation failure and cleared on success.
+
+`setFieldErrors(errors)` / `addFieldErrors(errors)` – Replace or merge errors imperatively.
+
+`clearFieldErrors(path?)` – Clear one path or every path.
+
+`setFieldErrorsFromApi(payload)` – Map a server error envelope (`{ error: { details: { path: [msg] } } }` or a raw `Record<path, string|string[]>`) into `ValidationError[]` and populate the store. Returns the produced errors.
 <br><br>
+
+**Per-field error display**
+
+```vue
+<script setup lang="ts">
+import { z } from 'zod'
+
+const { register, fieldErrors, handleSubmit, setFieldErrorsFromApi } = useForm({
+  schema: z.object({ email: z.string().email() }),
+  key: 'signup',
+})
+
+const onSubmit = handleSubmit(async (values) => {
+  // server-side hydration after client validation passed:
+  try {
+    await $fetch('/api/signup', { method: 'POST', body: values })
+  } catch (err) {
+    if (err.statusCode === 422) setFieldErrorsFromApi(err.data)
+  }
+})
+</script>
+
+<template>
+  <form @submit.prevent="onSubmit">
+    <input v-register="register('email')" />
+    <small v-if="fieldErrors.email?.[0]">{{ fieldErrors.email[0].message }}</small>
+    <button>Submit</button>
+  </form>
+</template>
+```
+
+<br>
 
 ## 🥇 Advanced Features
 

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,19 +1,82 @@
 <script setup lang="ts">
   import { z } from 'zod'
 
+  // -- Original demo: register + getValue across multiple inputs --
   const schema = z.object({ fruit: z.string() })
   const { register, getValue } = useForm({ schema, key: 'example-form' })
   const registerValue = register('fruit')
+
+  // -- New error API demo --
+  const signupSchema = z.object({
+    email: z.string().email('Enter a valid email'),
+    password: z.string().min(8, 'At least 8 characters'),
+  })
+  const {
+    register: registerSignup,
+    fieldErrors: signupErrors,
+    handleSubmit: handleSignupSubmit,
+    setFieldErrorsFromApi,
+    clearFieldErrors,
+    getFieldState,
+  } = useForm({ schema: signupSchema, key: 'signup' })
+
+  const emailReg = registerSignup('email')
+  const passwordReg = registerSignup('password')
+
+  // handleSubmit wraps the user callback: validation failure auto-populates
+  // signupErrors, success clears it. The user's onSubmit can then call
+  // setFieldErrorsFromApi(...) to layer server-side errors on top.
+  const onSubmit = handleSignupSubmit(async (values) => {
+    // simulate server returning a 422
+    setFieldErrorsFromApi({
+      error: { details: { email: ['Already taken'] } },
+    })
+    // eslint-disable-next-line no-console
+    console.log('client-validated values:', values)
+  })
+
+  const emailFieldState = getFieldState('email')
 </script>
 
 <template>
-  <div>
-    current fruit: '{{ getValue('fruit').value }}'
-    <hr />
+  <div style="font-family: system-ui; max-width: 640px; margin: 2rem auto; padding: 0 1rem">
+    <h1>chemical-x-forms playground</h1>
+
+    <h2>Original API</h2>
+    <p>current fruit: '{{ getValue('fruit').value }}'</p>
     <input v-register="registerValue" />
     <hr />
     <input v-register="registerValue" />
     <hr />
     <RootInput :fruit="registerValue" />
+
+    <h2 style="margin-top: 2rem">Error API (new in 0.6)</h2>
+    <form style="display: flex; flex-direction: column; gap: 1rem" @submit.prevent="onSubmit">
+      <label style="display: flex; flex-direction: column; gap: 0.25rem">
+        <span>Email</span>
+        <input v-register="emailReg" type="email" />
+        <small v-if="signupErrors.email?.[0]" style="color: #dc2626">
+          {{ signupErrors.email[0].message }}
+        </small>
+      </label>
+
+      <label style="display: flex; flex-direction: column; gap: 0.25rem">
+        <span>Password</span>
+        <input v-register="passwordReg" type="password" />
+        <small v-if="signupErrors.password?.[0]" style="color: #dc2626">
+          {{ signupErrors.password[0].message }}
+        </small>
+      </label>
+
+      <div style="display: flex; gap: 0.5rem">
+        <button type="submit">Submit</button>
+        <button type="button" @click="clearFieldErrors()">Clear errors</button>
+      </div>
+    </form>
+
+    <h3 style="margin-top: 1.5rem">Same data via getFieldState (FieldState.errors)</h3>
+    <pre style="background: #f8fafc; padding: 0.75rem; border-radius: 6px">{{
+      JSON.stringify(emailFieldState.errors, null, 2)
+    }}</pre>
   </div>
 </template>

--- a/src/runtime/composables/use-abstract-form.ts
+++ b/src/runtime/composables/use-abstract-form.ts
@@ -1,14 +1,20 @@
 import { useDOMFieldStateStore } from '../lib/core/composables/use-field-state-store'
+import { useFormErrorStore } from '../lib/core/composables/use-form-error-store'
 import { useFormKey } from '../lib/core/composables/use-form-key'
 import { useFormStore } from '../lib/core/composables/use-form-store'
 import { useMetaTrackerStore } from '../lib/core/composables/use-meta-tracker-store'
 import { fieldStateFactory } from '../lib/core/utils/field-state-api'
 import { getComputedSchema } from '../lib/core/utils/get-computed-schema'
+import { hydrateApiErrors } from '../lib/core/utils/hydrate-api-errors'
 import { registerFactory } from '../lib/core/utils/register'
 import type {
   AbstractSchema,
+  ApiErrorDetails,
+  ApiErrorEnvelope,
+  HandleSubmit,
   UseAbstractFormReturnType,
   UseFormConfiguration,
+  ValidationError,
 } from '../types/types-api'
 import type { DeepPartial, GenericForm } from '../types/types-core'
 
@@ -46,7 +52,7 @@ export function useAbstractForm<
   const getValue = getValueFactory<Form, GetValueFormType>(form, metaTracker)
   const setValue = setValueFactory(formStore, key, computedSchema, metaTracker)
   const validate = getValidateFactory(form, key, computedSchema)
-  const handleSubmit = getHandleSubmitFactory(form, validate)
+  const rawHandleSubmit = getHandleSubmitFactory(form, validate)
   const { getElementHelpers, domFieldStateStore } = useDOMFieldStateStore(form)
   const register = registerFactory(
     formStore,
@@ -57,12 +63,50 @@ export function useAbstractForm<
     getElementHelpers
   )
 
+  const {
+    fieldErrors,
+    setErrors: setFieldErrors,
+    addErrors: addFieldErrors,
+    clearErrors: clearFieldErrors,
+  } = useFormErrorStore(key)
+
   const getFieldState = fieldStateFactory<Form>(
     formSummaryValues.value,
     metaTracker,
     domFieldStateStore,
+    fieldErrors,
     key
   )
+
+  /**
+   * Wraps the raw `handleSubmit` to make the error store a reactive mirror
+   * of the most recent validation result:
+   * - success → clear all field errors before calling user's `onSubmit`
+   * - failure → populate the store, then fire user's `onError` (if any)
+   *
+   * Always passes an `onError` into the raw handler so the auto-populate
+   * runs even when the caller doesn't provide one (otherwise process-form's
+   * early-return on `!onError` would skip our side-effect).
+   */
+  const handleSubmit: HandleSubmit<Form> = (onSubmit, onError) =>
+    rawHandleSubmit(
+      async (values) => {
+        clearFieldErrors()
+        await onSubmit(values)
+      },
+      async (errors) => {
+        setFieldErrors(errors)
+        if (onError) await onError(errors)
+      }
+    )
+
+  function setFieldErrorsFromApi(
+    payload: ApiErrorEnvelope | ApiErrorDetails | null | undefined
+  ): ValidationError[] {
+    const errors = hydrateApiErrors(payload, { formKey: key })
+    setFieldErrors(errors)
+    return errors
+  }
 
   return {
     getFieldState,
@@ -72,6 +116,11 @@ export function useAbstractForm<
     validate,
     register,
     key,
+    fieldErrors,
+    setFieldErrors,
+    addFieldErrors,
+    clearFieldErrors,
+    setFieldErrorsFromApi,
   } satisfies UseAbstractFormReturnType<Form, GetValueFormType>
 }
 

--- a/src/runtime/lib/core/composables/use-form-error-store.ts
+++ b/src/runtime/lib/core/composables/use-form-error-store.ts
@@ -1,0 +1,91 @@
+import { useState } from 'nuxt/app'
+import { computed } from 'vue'
+import type {
+  FormErrorRecord,
+  FormErrorStore,
+  FormKey,
+  ValidationError,
+} from '../../../types/types-api'
+
+/**
+ * Reactive per-form error store, mirroring `useMetaTrackerStore`:
+ * - `useState` for SSR-safe serialisation / hydration
+ * - one `Map<FormKey, FormErrorRecord>` shared across every form instance
+ * - a `computed` with defensive initialisation so 2+ forms on the same page
+ *   don't observe an undefined record
+ *
+ * Paths are stored as dotted strings (`address.line1.street`) — matching the
+ * shape `getFieldState(path)` already uses for lookups.
+ */
+export function useFormErrorStore(formKey: FormKey) {
+  const formErrorStore = useState<FormErrorStore>(
+    'chemical-x/form-error-store',
+    () => new Map([[formKey, {}]])
+  )
+
+  const fieldErrors = computed<FormErrorRecord>(() => {
+    // Defensive init: `useState` runs its initialiser once per SSR root; a
+    // second `useForm({ key: 'other' })` on the same page would otherwise
+    // find no record for its key.
+    if (!formErrorStore.value.has(formKey)) {
+      formErrorStore.value.set(formKey, {})
+    }
+    return formErrorStore.value.get(formKey)!
+  })
+
+  function pathToKey(path: string | (string | number)[]): string {
+    return Array.isArray(path) ? path.join('.') : path
+  }
+
+  function groupByPath(errors: ValidationError[]): FormErrorRecord {
+    const record: FormErrorRecord = {}
+    for (const err of errors) {
+      const key = pathToKey(err.path)
+      if (!record[key]) record[key] = []
+      record[key].push(err)
+    }
+    return record
+  }
+
+  /** Replace the current error record for this form with a fresh one. */
+  function setErrors(errors: ValidationError[]) {
+    formErrorStore.value.set(formKey, groupByPath(errors))
+  }
+
+  /** Merge the provided errors onto the existing record (appending per path). */
+  function addErrors(errors: ValidationError[]) {
+    const existing = formErrorStore.value.get(formKey) ?? {}
+    const next: FormErrorRecord = { ...existing }
+    for (const err of errors) {
+      const key = pathToKey(err.path)
+      next[key] = next[key] ? [...next[key], err] : [err]
+    }
+    formErrorStore.value.set(formKey, next)
+  }
+
+  /** Clear a specific path, or every path when called without arguments. */
+  function clearErrors(path?: string | (string | number)[]) {
+    if (path === undefined) {
+      formErrorStore.value.set(formKey, {})
+      return
+    }
+    const key = pathToKey(path)
+    const existing = formErrorStore.value.get(formKey) ?? {}
+    if (!(key in existing)) return
+    const { [key]: _removed, ...rest } = existing
+    formErrorStore.value.set(formKey, rest)
+  }
+
+  /** Readonly lookup helper — always returns an array (possibly empty). */
+  function getErrorsForPath(path: string | (string | number)[]): ValidationError[] {
+    return fieldErrors.value[pathToKey(path)] ?? []
+  }
+
+  return {
+    fieldErrors,
+    setErrors,
+    addErrors,
+    clearErrors,
+    getErrorsForPath,
+  }
+}

--- a/src/runtime/lib/core/composables/use-form-store.ts
+++ b/src/runtime/lib/core/composables/use-form-store.ts
@@ -22,10 +22,14 @@ export const useFormStore = <Form extends GenericForm>(
   initialFormState: InitialStateResponse<Form>
 ) => {
   const formStore = useState<FormStore<Form>>('useform/store', () => new Map())
-  const formSummaryStore = useState<FormSummaryStore>(
-    'useform/form-summary-store',
-    () => new Map([[formKey, {}]])
-  )
+  const formSummaryStore = useState<FormSummaryStore>('useform/form-summary-store', () => new Map())
+  // `useState`'s initialiser only fires once per SSR root, so a second
+  // `useForm({ key: 'other' })` on the same page would find no entry for
+  // its own key, and `updateFormSummaryValuesRecord` would early-return
+  // (its `if (!summaryValues) return` guard). Initialise defensively.
+  if (!formSummaryStore.value.has(formKey)) {
+    formSummaryStore.value.set(formKey, {})
+  }
   updateFormSummaryValuesRecord(initialFormState.data, undefined, formSummaryStore, formKey)
 
   // internally make sure form is registered

--- a/src/runtime/lib/core/utils/field-state-api.ts
+++ b/src/runtime/lib/core/utils/field-state-api.ts
@@ -1,8 +1,9 @@
-import type { Ref } from 'vue'
+import type { ComputedRef, Ref } from 'vue'
 import { computed } from 'vue'
 import type {
   DOMFieldStateStore,
   FieldState,
+  FormErrorRecord,
   FormKey,
   FormSummaryValueRecord,
   MetaTracker,
@@ -13,6 +14,7 @@ export function fieldStateFactory<Form extends GenericForm>(
   formSummaryRecord: Readonly<FormSummaryValueRecord>,
   metaTracker: Ref<MetaTracker>,
   domFieldStateStore: Ref<DOMFieldStateStore, DOMFieldStateStore>,
+  fieldErrors: Readonly<ComputedRef<FormErrorRecord>>,
   formKey: FormKey
 ) {
   function getFieldState<Path extends CompleteFlatPath<Form>>(path: Path) {
@@ -47,6 +49,7 @@ export function fieldStateFactory<Form extends GenericForm>(
         blurred: metaTrackerValue.isConnected ? clientBlurred : null,
         touched: metaTrackerValue.isConnected ? clientTouched : null,
         meta: metaTrackerValue,
+        errors: fieldErrors.value[path] ?? [],
       } satisfies FieldState
     })
   }

--- a/src/runtime/lib/core/utils/hydrate-api-errors.ts
+++ b/src/runtime/lib/core/utils/hydrate-api-errors.ts
@@ -1,0 +1,73 @@
+import type {
+  ApiErrorDetails,
+  ApiErrorEnvelope,
+  FormKey,
+  ValidationError,
+} from '../../../types/types-api'
+import { PATH_SEPARATOR } from './constants'
+
+/**
+ * Normalise an API validation-error payload into `ValidationError[]`.
+ *
+ * Accepts:
+ * - the wrapped envelope: `{ error: { details: { "email": ["taken"] } } }`
+ * - the unwrapped envelope: `{ details: { "email": ["taken"] } }`
+ * - a raw details record: `{ "email": ["taken"], "message": "too short" }`
+ * - `null` / `undefined` — returns `[]`
+ *
+ * Each detail entry may be either a single string or an array of strings;
+ * both forms are expanded into individual `ValidationError` records, so the
+ * UI can show multiple messages per field.
+ *
+ * Dotted paths (`"address.line1"`) are split on `.` to match the
+ * `ValidationError.path` array shape produced by the zod adapter.
+ */
+export function hydrateApiErrors(
+  payload: ApiErrorEnvelope | ApiErrorDetails | null | undefined,
+  options: { formKey: FormKey }
+): ValidationError[] {
+  const details = extractDetails(payload)
+  if (!details) return []
+
+  return Object.entries(details).flatMap(([path, messages]) => {
+    const messageList = Array.isArray(messages) ? messages : [messages]
+    return messageList
+      .filter((m): m is string => typeof m === 'string' && m.length > 0)
+      .map<ValidationError>((message) => ({
+        message,
+        path: path.split(PATH_SEPARATOR),
+        formKey: options.formKey,
+      }))
+  })
+}
+
+function extractDetails(
+  payload: ApiErrorEnvelope | ApiErrorDetails | null | undefined
+): ApiErrorDetails | null {
+  if (payload === null || payload === undefined) return null
+  if (typeof payload !== 'object') return null
+
+  // Wrapped envelope: { error: { details: {...} } }
+  if ('error' in payload && payload.error && typeof payload.error === 'object') {
+    const inner = (payload.error as { details?: unknown }).details
+    if (isDetailsRecord(inner)) return inner
+  }
+
+  // Unwrapped envelope: { details: {...} }
+  if ('details' in payload) {
+    const inner = (payload as { details?: unknown }).details
+    if (isDetailsRecord(inner)) return inner
+  }
+
+  // Raw details record: every value is string | string[]
+  if (isDetailsRecord(payload)) return payload
+
+  return null
+}
+
+function isDetailsRecord(value: unknown): value is ApiErrorDetails {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false
+  return Object.values(value as Record<string, unknown>).every(
+    (v) => typeof v === 'string' || (Array.isArray(v) && v.every((s) => typeof s === 'string'))
+  )
+}

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -1,4 +1,4 @@
-import type { ObjectDirective, Ref } from 'vue'
+import type { ComputedRef, ObjectDirective, Ref } from 'vue'
 import type { DeepPartial, FlatPath, GenericForm, IsObjectOrArray, NestedType } from './types-core'
 
 export type FormKey = string
@@ -225,8 +225,37 @@ export type DOMFieldState = {
   blurred: boolean | null
   touched: boolean | null
 }
-export type FieldState = DeepFlatten<DOMFieldState & { meta: MetaTrackerValue } & FormSummaryValue>
+export type FieldState = DeepFlatten<
+  DOMFieldState & {
+    meta: MetaTrackerValue
+    /**
+     * Validation errors for this field's path. Populated automatically when
+     * `handleSubmit` validates, and manually via `setFieldErrors` /
+     * `setFieldErrorsFromApi`. Empty array when there are no errors for the
+     * field — safe to read without a null check.
+     */
+    errors: ValidationError[]
+  } & FormSummaryValue
+>
 export type DOMFieldStateStore = Map<string, DOMFieldState | undefined>
+
+/** Reactive per-field error store, keyed by `path.join('.')`. */
+export type FormErrorRecord = Record<string, ValidationError[]>
+export type FormErrorStore = Map<FormKey, FormErrorRecord>
+
+/**
+ * Normalised API error envelope — the shape cubic-forms (and many DRF-style
+ * APIs) return for 4xx validation failures. Both the wrapped
+ * `{ error: { details } }` form and the raw `{ details }` form are accepted.
+ */
+export type ApiErrorDetails = Record<string, string | string[]>
+export type ApiErrorEnvelope = {
+  error?: {
+    details?: ApiErrorDetails
+    [k: string]: unknown
+  }
+  details?: ApiErrorDetails
+}
 
 export type UseAbstractFormReturnType<
   Form extends GenericForm,
@@ -263,4 +292,36 @@ export type UseAbstractFormReturnType<
     _context?: RegisterContext<typeof path, NestedType<Form, typeof path>>
   ) => RegisterValue<NestedType<Form, typeof path> | undefined>
   key: FormKey
+
+  // --- Reactive field-error API ---
+
+  /**
+   * Reactive map of field errors keyed by the dotted path. Populated
+   * automatically by `handleSubmit` on validation failure and cleared on
+   * validation success. Also writable via `setFieldErrors` /
+   * `setFieldErrorsFromApi` for server-side hydration.
+   */
+  fieldErrors: Readonly<ComputedRef<FormErrorRecord>>
+
+  /** Replace all field errors for this form with the provided list. */
+  setFieldErrors: (errors: ValidationError[]) => void
+
+  /** Append errors to the existing set, preserving current entries. */
+  addFieldErrors: (errors: ValidationError[]) => void
+
+  /**
+   * Clear errors for a specific path (string or path-array), or — when called
+   * with no arguments — clear every field error for this form.
+   */
+  clearFieldErrors: (path?: string | (string | number)[]) => void
+
+  /**
+   * Convenience for server-error hydration: accepts either the wrapped
+   * `{ error: { details } }` envelope or a raw `{ path: [msg] }` record,
+   * maps it to `ValidationError[]`, stamps the current form key, and calls
+   * `setFieldErrors`. Returns the produced errors for downstream use.
+   */
+  setFieldErrorsFromApi: (
+    payload: ApiErrorEnvelope | ApiErrorDetails | null | undefined
+  ) => ValidationError[]
 }

--- a/test/fixtures/ssr/app.vue
+++ b/test/fixtures/ssr/app.vue
@@ -7,6 +7,49 @@
     chessInArray: z.array(z.string()).default(['chess']),
   })
   const { register } = useForm({ schema })
+
+  // -- Error API SSR fixtures --
+  // Destructured at setup level so the refs become top-level template
+  // bindings (Vue auto-unwraps top-level refs but not refs nested in plain
+  // objects, so `directErrorForm.fieldErrors.value` would not unwrap reliably).
+
+  // Direct setFieldErrors on the server, rendered into HTML so the SSR test
+  // can prove the reactive error store survives serialisation/hydration.
+  const directErrorSchema = z.object({
+    email: z.string().email(),
+    password: z.string().min(8),
+  })
+  const {
+    fieldErrors: directErrors,
+    setFieldErrors: setDirectErrors,
+    getFieldState: getDirectFieldState,
+  } = useForm({
+    schema: directErrorSchema,
+    key: 'errors-direct',
+  })
+  setDirectErrors([
+    { message: 'Email already in use', path: ['email'], formKey: 'errors-direct' },
+    {
+      message: 'Password must be at least 8 characters',
+      path: ['password'],
+      formKey: 'errors-direct',
+    },
+  ])
+  const directEmailState = getDirectFieldState('email')
+
+  // Hydration helper applied during setup, simulating a 422 from the server
+  // being mapped onto fields before the page renders.
+  const { fieldErrors: apiErrors, setFieldErrorsFromApi: setApiErrors } = useForm({
+    schema: z.object({ username: z.string() }),
+    key: 'errors-from-api',
+  })
+  setApiErrors({
+    error: {
+      code: 'VALIDATION_ERROR',
+      message: 'Invalid input',
+      details: { username: ['Username taken', 'Reserved word'] },
+    },
+  })
 </script>
 
 <template>
@@ -68,6 +111,31 @@
       >
         <option value="chess">Chess</option>
       </select>
+    </section>
+
+    <section>
+      <h2>Error API</h2>
+
+      <!-- Direct setFieldErrors -->
+      <div id="errors-direct">
+        <span id="errors-direct-fielderrors-email">{{
+          directErrors.email?.[0]?.message ?? ''
+        }}</span>
+        <span id="errors-direct-fielderrors-password">{{
+          directErrors.password?.[0]?.message ?? ''
+        }}</span>
+        <span id="errors-direct-fieldstate-email">{{
+          directEmailState.errors[0]?.message ?? ''
+        }}</span>
+        <span id="errors-direct-count">{{ Object.keys(directErrors).length }}</span>
+      </div>
+
+      <!-- setFieldErrorsFromApi -->
+      <div id="errors-from-api">
+        <span id="errors-from-api-first">{{ apiErrors.username?.[0]?.message ?? '' }}</span>
+        <span id="errors-from-api-second">{{ apiErrors.username?.[1]?.message ?? '' }}</span>
+        <span id="errors-from-api-count">{{ apiErrors.username?.length ?? 0 }}</span>
+      </div>
     </section>
   </div>
 </template>

--- a/test/hydrate-api-errors.test.ts
+++ b/test/hydrate-api-errors.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import { hydrateApiErrors } from '../src/runtime/lib/core/utils/hydrate-api-errors'
+
+/*
+  Test Suite: hydrateApiErrors
+  Focus: Pure-function payload-shape coverage. The composable wiring around
+  this helper is exercised end-to-end in ssr.test.ts.
+*/
+
+describe('hydrateApiErrors', () => {
+  const formKey = 'cx-test-form'
+
+  describe('input handling', () => {
+    it('returns [] for null', () => {
+      expect(hydrateApiErrors(null, { formKey })).toEqual([])
+    })
+
+    it('returns [] for undefined', () => {
+      expect(hydrateApiErrors(undefined, { formKey })).toEqual([])
+    })
+
+    it('returns [] for empty details', () => {
+      expect(hydrateApiErrors({}, { formKey })).toEqual([])
+    })
+  })
+
+  describe('envelope shapes', () => {
+    it('unwraps the cubic-forms-style { error: { details } } envelope', () => {
+      const result = hydrateApiErrors(
+        {
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'Invalid input',
+            details: { email: ['Email already in use'] },
+          },
+        },
+        { formKey }
+      )
+      expect(result).toEqual([{ message: 'Email already in use', path: ['email'], formKey }])
+    })
+
+    it('unwraps the bare { details } envelope', () => {
+      const result = hydrateApiErrors({ details: { email: ['Email already in use'] } }, { formKey })
+      expect(result).toEqual([{ message: 'Email already in use', path: ['email'], formKey }])
+    })
+
+    it('accepts a raw details record', () => {
+      const result = hydrateApiErrors({ email: ['Email already in use'] }, { formKey })
+      expect(result).toEqual([{ message: 'Email already in use', path: ['email'], formKey }])
+    })
+  })
+
+  describe('value normalisation', () => {
+    it('wraps a single-string message in a one-element array', () => {
+      const result = hydrateApiErrors({ details: { email: 'taken' } }, { formKey })
+      expect(result).toEqual([{ message: 'taken', path: ['email'], formKey }])
+    })
+
+    it('expands an array into multiple ValidationError records', () => {
+      const result = hydrateApiErrors(
+        { details: { password: ['too short', 'must include a number'] } },
+        { formKey }
+      )
+      expect(result).toEqual([
+        { message: 'too short', path: ['password'], formKey },
+        { message: 'must include a number', path: ['password'], formKey },
+      ])
+    })
+
+    it('drops empty-string messages', () => {
+      const result = hydrateApiErrors({ details: { email: ['', 'taken'] } }, { formKey })
+      expect(result).toEqual([{ message: 'taken', path: ['email'], formKey }])
+    })
+
+    it('splits dotted paths into segments', () => {
+      const result = hydrateApiErrors({ details: { 'address.line1': ['required'] } }, { formKey })
+      expect(result).toEqual([{ message: 'required', path: ['address', 'line1'], formKey }])
+    })
+  })
+
+  describe('robustness', () => {
+    it('returns [] when the wrapped envelope has no details', () => {
+      expect(hydrateApiErrors({ error: { code: 'X', message: 'oops' } }, { formKey })).toEqual([])
+    })
+
+    it('returns [] when details is malformed (object-of-object)', () => {
+      // Defensive guard: details values must be string | string[]
+      expect(
+        hydrateApiErrors(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          { details: { email: { nested: 'bad' } } } as any,
+          { formKey }
+        )
+      ).toEqual([])
+    })
+
+    it('returns [] for primitive payloads', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(hydrateApiErrors('oops' as any, { formKey })).toEqual([])
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(hydrateApiErrors(42 as any, { formKey })).toEqual([])
+    })
+  })
+
+  it('stamps the provided formKey on every error', () => {
+    const result = hydrateApiErrors(
+      { details: { email: ['taken'], password: 'short' } },
+      { formKey: 'custom-key' }
+    )
+    expect(result.every((e) => e.formKey === 'custom-key')).toBe(true)
+  })
+})

--- a/test/ssr.test.ts
+++ b/test/ssr.test.ts
@@ -184,4 +184,68 @@ describe('SSR behavior of useForm', async () => {
       })
     })
   })
+
+  /*
+    Test Suite: Reactive field-error API in SSR
+    Focus: Errors set on the server (via setFieldErrors / setFieldErrorsFromApi)
+    must serialise into the rendered HTML and survive hydration. Also covers
+    that getFieldState(path).value.errors mirrors the underlying store.
+  */
+  describe('SSR behavior of error API >>', () => {
+    it('renders direct setFieldErrors output for each path', async () => {
+      const html = await $fetch('/')
+      assertHTML(html)
+      const window = new JSDOM(html).window
+      const { document } = window
+
+      const emailEl = document.getElementById('errors-direct-fielderrors-email')
+      const passwordEl = document.getElementById('errors-direct-fielderrors-password')
+      const countEl = document.getElementById('errors-direct-count')
+
+      expect(emailEl?.textContent?.trim()).toBe('Email already in use')
+      expect(passwordEl?.textContent?.trim()).toBe('Password must be at least 8 characters')
+      expect(countEl?.textContent?.trim()).toBe('2')
+    })
+
+    it('exposes the same errors via getFieldState(path).errors', async () => {
+      const html = await $fetch('/')
+      assertHTML(html)
+      const window = new JSDOM(html).window
+      const fieldStateEl = window.document.getElementById('errors-direct-fieldstate-email')
+      expect(fieldStateEl?.textContent?.trim()).toBe('Email already in use')
+    })
+
+    it('hydrates a wrapped { error: { details } } envelope across the SSR boundary', async () => {
+      const html = await $fetch('/')
+      assertHTML(html)
+      const window = new JSDOM(html).window
+      const { document } = window
+
+      const firstEl = document.getElementById('errors-from-api-first')
+      const secondEl = document.getElementById('errors-from-api-second')
+      const countEl = document.getElementById('errors-from-api-count')
+
+      expect(firstEl?.textContent?.trim()).toBe('Username taken')
+      expect(secondEl?.textContent?.trim()).toBe('Reserved word')
+      expect(countEl?.textContent?.trim()).toBe('2')
+    })
+
+    it('keeps each form key isolated (errors-direct vs errors-from-api do not bleed)', async () => {
+      const html = await $fetch('/')
+      assertHTML(html)
+      const window = new JSDOM(html).window
+      const { document } = window
+
+      // The api-form's section must not surface errors from the direct form,
+      // and vice versa. A single shared error store keyed by formKey would
+      // fail this; per-key isolation passes.
+      const directSection = document.getElementById('errors-direct')?.textContent ?? ''
+      const apiSection = document.getElementById('errors-from-api')?.textContent ?? ''
+
+      expect(directSection).not.toContain('Username taken')
+      expect(directSection).not.toContain('Reserved word')
+      expect(apiSection).not.toContain('Email already in use')
+      expect(apiSection).not.toContain('Password must be at least 8 characters')
+    })
+  })
 })


### PR DESCRIPTION
## Summary
Adds an SSR-safe reactive per-field error API on top of the existing \`useForm\` surface, plus a server-error hydration helper. **Additive — no breaking changes.** Bumps to **0.6.0** (workflow handles the version bump).

### New on \`useForm()\` return
| Surface | Type | Purpose |
|---|---|---|
| \`fieldErrors\` | \`Readonly<ComputedRef<Record<path, ValidationError[]>>>\` | Reactive per-path errors. Auto-populated by \`handleSubmit\` on validation failure, cleared on success. |
| \`setFieldErrors(errors)\` | replace | Imperative replace |
| \`addFieldErrors(errors)\` | merge | Imperative merge |
| \`clearFieldErrors(path?)\` | clear one or all | Reset |
| \`setFieldErrorsFromApi(payload)\` | sugar | Maps \`{ error: { details: { path: [msg] } } }\` / \`{ details }\` / raw records into \`ValidationError[]\` and writes to the store |

\`FieldState\` (from \`getFieldState(path)\`) now also carries \`errors: ValidationError[]\` for read-side ergonomics:
\`\`\`vue
<small v-if="getFieldState('email').value.errors.length">
  {{ getFieldState('email').value.errors[0].message }}
</small>
\`\`\`

### Pre-existing bug fixed in passing
\`useFormStore\` initialised \`formSummaryStore\` via \`useState(..., () => new Map([[formKey, {}]]))\` — but \`useState\`'s initialiser only fires **once per SSR root**, so any second \`useForm({ key: 'other' })\` on the same page would find no entry for its own key, \`updateFormSummaryValuesRecord\` would early-return on its \`if (!summaryValues) return\` guard, and \`getFieldState\` would later throw \`Cannot read properties of undefined (reading '<path>')\`. Fixed by initialising defensively after \`useState\` — same pattern \`use-meta-tracker-store\` uses internally.

This bug never surfaced before because the existing test fixture only declares one form per page.

### Implementation
- New \`src/runtime/lib/core/composables/use-form-error-store.ts\` — \`useState\` + \`computed\` + defensive init, mirrors \`useMetaTrackerStore\`
- New \`src/runtime/lib/core/utils/hydrate-api-errors.ts\` — pure envelope→\`ValidationError[]\` mapper (cubic-forms / DRF-style payloads)
- \`src/runtime/composables/use-abstract-form.ts\` — wires the store, wraps \`handleSubmit\` (process-form.ts untouched)
- \`src/runtime/lib/core/utils/field-state-api.ts\` — takes the new \`fieldErrors\` arg, includes \`errors\` in returned \`FieldState\`
- \`src/runtime/types/types-api.ts\` — extends \`FieldState\`, \`UseAbstractFormReturnType\`; exports \`FormErrorRecord\`, \`FormErrorStore\`, \`ApiErrorEnvelope\`, \`ApiErrorDetails\`

### Tests
- \`test/hydrate-api-errors.test.ts\` — 14 tests covering wrapped/bare/raw envelope shapes, single-vs-array values, dotted paths, malformed input, formKey stamping
- \`test/ssr.test.ts\` — 4 new SSR tests: direct \`setFieldErrors\`, \`setFieldErrorsFromApi\` envelope hydration, FieldState mirror, per-key isolation
- All 26 tests pass; \`make check\` clean

### Motivation
Surfaced while integrating \`@chemical-x/forms@0.5.1\` into a Nuxt 4 app — the missing per-field error reactivity made the canonical \`<small>{{ getFieldState('email').value.errors[0].message }}</small>\` pattern impossible without consumers hand-rolling a parallel error store. Closes that gap and gives a clean integration point for server-side validation errors (e.g. 422 responses).

## Test plan
- [x] \`make check\` clean
- [x] \`make test\` 26/26 pass
- [x] \`make publish-prep\` produces clean dist
- [x] CI matrix passes on Node 18/20/22/lts
- [ ] After merge: dispatch publish workflow with \`minor\` → v0.6.0
- [ ] Verify cubic-forms' \`/cx-spike\` page renders per-field errors with the new API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added field-level error management system with reactive `fieldErrors` store
  * New error manipulation APIs: `setFieldErrors`, `addFieldErrors`, `clearFieldErrors`
  * Server error integration with `setFieldErrorsFromApi` to handle API validation responses

* **Documentation**
  * Extended README with field error API reference and per-field error display example

* **Tests**
  * Added test coverage for API error hydration and SSR error state isolation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Closes

Closes #89, #65, #88, #69, #84
