### PR TITLE
feat!: handleSubmit returns a submit handler instead of running immediately

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,22 @@ _**note**: detailed documentation coming soon_
 
 `register(name: string)` – Binds a field to form state.
 
-`handleSubmit(onSubmit, onError?)` – Handles submission with validation.
+`handleSubmit(onSubmit, onError?)` – Builds a submit handler that runs validation and dispatches to your callback. Bind it to `@submit.prevent` directly:
+
+```vue
+<script setup lang="ts">
+const { handleSubmit } = useForm({ schema, key: 'signup' })
+const onSubmit = handleSubmit(async (values) => {
+  await api.post('/signup', values)
+})
+</script>
+
+<template>
+  <form @submit.prevent="onSubmit">...</form>
+</template>
+```
+
+You can also call the returned handler programmatically: `await onSubmit()`.
 
 `getValue(name: string)` – Retrieves a field value.
 

--- a/src/runtime/lib/core/utils/process-form.ts
+++ b/src/runtime/lib/core/utils/process-form.ts
@@ -91,44 +91,33 @@ export function getHandleSubmitFactory<Form extends GenericForm>(
   form: ComputedRef<Form>,
   validate: () => Readonly<Ref<ValidationResponseWithoutValue<Form>>>
 ) {
-  const handleSubmitLogic: HandleSubmit<Form> = async (onSubmit, onError) => {
-    try {
-      const { errors, success } = validate().value
-      if (!success) {
-        throw new AbstractSchemaValidationError(errors ?? [])
-      }
-
-      const rawForm = toRaw(form.value)
-      await onSubmit(rawForm)
-    } catch (error) {
-      if (!onError) return
-
-      if (error instanceof AbstractSchemaValidationError) {
-        try {
-          await onError(error.validationErrors)
-        } catch (error) {
-          if (error instanceof Error) {
-            console.error(error.message)
-            return
-          }
+  const handleSubmit: HandleSubmit<Form> = (onSubmit, onError) => {
+    return async (_event?: Event) => {
+      try {
+        const { errors, success } = validate().value
+        if (!success) {
+          throw new AbstractSchemaValidationError(errors ?? [])
         }
 
-        return
-      }
+        const rawForm = toRaw(form.value)
+        await onSubmit(rawForm)
+      } catch (error) {
+        if (error instanceof AbstractSchemaValidationError) {
+          if (!onError) return
+          try {
+            await onError(error.validationErrors)
+          } catch (innerError) {
+            if (innerError instanceof Error) {
+              console.error(innerError.message)
+            }
+          }
+          return
+        }
 
-      // TODO: Eventually tap into these in a useful way
-      if (error instanceof Error) {
-        console.error(error.message)
-      }
-    }
-  }
-
-  const handleSubmit: HandleSubmit<Form> = async (onSubmit, onError) => {
-    try {
-      return handleSubmitLogic(onSubmit, onError)
-    } catch (error) {
-      if (error instanceof Error) {
-        console.error(error.message)
+        // TODO: Eventually tap into these in a useful way
+        if (error instanceof Error) {
+          console.error(error.message)
+        }
       }
     }
   }

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -85,10 +85,21 @@ export type FormSummaryStore = Map<FormKey, FormSummaryValueRecord>
 export type OnSubmit<Form extends GenericForm> = (form: Form) => void | Promise<void>
 export type OnError = (error: ValidationError[]) => void | Promise<void>
 
+/**
+ * `handleSubmit(onSubmit, onError?)` returns a submit handler — a function
+ * that runs validation and dispatches to `onSubmit` (success) or `onError`
+ * (failure). Bind it directly to a form's `@submit.prevent` or invoke it
+ * programmatically.
+ *
+ * The returned handler optionally accepts the originating `Event` so it can
+ * sit on `@submit` directly (without `.prevent` if you want to call
+ * `event.preventDefault()` yourself).
+ */
+export type SubmitHandler = (event?: Event) => Promise<void>
 export type HandleSubmit<Form extends GenericForm> = (
   onSubmit: OnSubmit<Form>,
   onError?: OnError
-) => Promise<void>
+) => SubmitHandler
 
 export type MetaTrackerValue = {
   updatedAt: string | null

--- a/test/fixtures/ssr/app.vue
+++ b/test/fixtures/ssr/app.vue
@@ -50,6 +50,16 @@
       details: { username: ['Username taken', 'Reserved word'] },
     },
   })
+
+  // -- handleSubmit return-shape fixture --
+  // Proves handleSubmit(cb) returns a function (not a Promise) so it can be
+  // bound directly to a form's @submit handler without a wrapper.
+  const submitForm = useForm({
+    schema: z.object({ name: z.string().min(1) }),
+    key: 'submit-shape',
+  })
+  const submitHandler = submitForm.handleSubmit(() => {})
+  const submitHandlerType = typeof submitHandler
 </script>
 
 <template>
@@ -135,6 +145,11 @@
         <span id="errors-from-api-first">{{ apiErrors.username?.[0]?.message ?? '' }}</span>
         <span id="errors-from-api-second">{{ apiErrors.username?.[1]?.message ?? '' }}</span>
         <span id="errors-from-api-count">{{ apiErrors.username?.length ?? 0 }}</span>
+      </div>
+
+      <!-- handleSubmit return shape -->
+      <div id="handle-submit-shape">
+        <span id="handle-submit-typeof">{{ submitHandlerType }}</span>
       </div>
     </section>
   </div>

--- a/test/ssr.test.ts
+++ b/test/ssr.test.ts
@@ -230,6 +230,17 @@ describe('SSR behavior of useForm', async () => {
       expect(countEl?.textContent?.trim()).toBe('2')
     })
 
+    it('handleSubmit(cb) returns a function (bindable directly to @submit)', async () => {
+      const html = await $fetch('/')
+      assertHTML(html)
+      const window = new JSDOM(html).window
+      const typeofEl = window.document.getElementById('handle-submit-typeof')
+      // Pre-0.7 returned Promise<void> here; the API was changed so consumers
+      // can write `const onSubmit = handleSubmit(cb)` and bind directly to
+      // a form. Catches accidental regressions to the old shape.
+      expect(typeofEl?.textContent?.trim()).toBe('function')
+    })
+
     it('keeps each form key isolated (errors-direct vs errors-from-api do not bleed)', async () => {
       const html = await $fetch('/')
       assertHTML(html)


### PR DESCRIPTION
## Summary
**BREAKING CHANGE.** \`handleSubmit(onSubmit, onError?)\` now returns a \`SubmitHandler = (event?: Event) => Promise<void>\` instead of a \`Promise<void>\`. The returned handler runs validation and dispatches when called (or awaited).

This aligns cx with every other Vue/React form library (react-hook-form, vee-validate, tanstack-form, formik) and unblocks the canonical template binding pattern:

\`\`\`vue
<script setup>
const { handleSubmit } = useForm({ schema, key: 'signup' })
const onSubmit = handleSubmit(async (values) => { ... })
</script>

<template>
  <form @submit.prevent="onSubmit">    <!-- works directly, no wrapper -->
</template>
\`\`\`

Pre-0.7, that exact snippet was broken: \`handleSubmit(cb)\` returned a \`Promise<void>\`, Vue's event system rejected it as a handler (TypeScript caught it as a type error too), and consumers had to write \`function onSubmit() { return handleSubmit(cb) }\` for every form.

## Migration
| Pattern | Pre-0.7 | 0.7+ |
|---|---|---|
| Method binding (\`@submit="onSubmit"\` where \`onSubmit = handleSubmit(cb)\`) | broken (TS + runtime) | works |
| Inline binding (\`@submit="handleSubmit(cb)"\`) | worked (Promise side-effect) | use \`@submit="handleSubmit(cb)($event)"\` |
| Programmatic (\`await handleSubmit(cb)\`) | worked | \`await handleSubmit(cb)()\` |

## Implementation
- \`HandleSubmit<Form>\` type changed in \`src/runtime/types/types-api.ts\`; new \`SubmitHandler\` type exported
- \`getHandleSubmitFactory\` in \`src/runtime/lib/core/utils/process-form.ts\` rewritten to return a builder; the validation/dispatch loop is now inside the returned handler instead of at the call site. Vestigial outer try/catch dropped.
- \`useAbstractForm\` wrapper at \`src/runtime/composables/use-abstract-form.ts:91\` needed **no changes** — the arrow \`(onSubmit, onError) => rawHandleSubmit(...)\` inherits the new return shape automatically.
- README + playground already used the canonical \`const onSubmit = handleSubmit(cb)\` pattern (which was broken under 0.6 and now works correctly).

## Test plan
- [x] \`make check\` clean
- [x] \`make test\` 27/27 (added a new SSR test asserting \`typeof handleSubmit(cb) === 'function'\`)
- [x] \`make publish-prep\` produces clean dist
- [x] CI matrix passes
- [ ] After merge: dispatch publish workflow with \`minor\` → v0.7.0 (technically \`major\` since this is breaking, but per pre-1.0 semver convention minor bumps can break)
- [ ] cubic-forms upgrade test: drop the function-wrapper from \`cx-spike.vue\`, confirm submit works

Closes #15.