### PR TITLE
ci: sign publish-workflow version-bump commits with GPG

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -64,10 +64,24 @@ jobs:
       - name: Run tests
         run: pnpm test
 
-      - name: Configure Git identity
-        run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
+      # Import a GPG signing key so the version-bump commit + tag created
+      # below by `pnpm version` are signed and show as "Verified" on GitHub.
+      # Configures git user.name + user.email from the key's primary UID
+      # (so the author identity matches the signature) and turns on
+      # commit/tag autosigning. Requires repo secrets:
+      #   - GPG_PRIVATE_KEY: ASCII-armored private key (gpg --armor --export-secret-keys KEYID)
+      #   - GPG_PASSPHRASE:  the key's passphrase (omit if the key has none)
+      # The key's matching public key must be uploaded to the GitHub account
+      # whose email is in the key's UID, otherwise GitHub still marks the
+      # commit "Unverified".
+      - name: Import GPG signing key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
 
       - name: Bump version
         run: |


### PR DESCRIPTION
## Summary
The publish workflow's \`pnpm version <type>\` creates a commit + tag locally and \`git push --follow-tags\` pushes them. Until now those commits were unsigned, so GitHub showed them as **Unverified** (e.g. [\`8067e42\`](https://github.com/cubicforms/chemical-x-forms/commit/8067e4240e0530d8b412b49440e9118b8956bc53)).

Switches the \`Configure Git identity\` step to [\`crazy-max/ghaction-import-gpg@v6\`](https://github.com/crazy-max/ghaction-import-gpg), which:
- imports the GPG private key from secrets,
- sets \`git user.name\` + \`git user.email\` from the key's primary UID (so the signature email matches the author email — GitHub requires this match to verify),
- enables \`commit.gpgsign\` and \`tag.gpgsign\` so the subsequent \`pnpm version\` step auto-signs.

## Required setup before the next dispatch
**Will fail at the import step until the secrets are in place** — intentional, since shipping unsigned commits is the bug.

1. **Generate a GPG key** whose UID email matches the GitHub account that should "own" the verified commit (your account, or a dedicated bot account):
   \`\`\`
   gpg --quick-generate-key "Oswald Chisala <ozzy@cubicforms.com>" ed25519 default 1y
   \`\`\`
   (substitute the email shown on https://github.com/settings/emails — must be verified there)

2. **Upload the public key** to that GitHub account → Settings → SSH and GPG keys → New GPG key:
   \`\`\`
   gpg --armor --export <KEYID>
   \`\`\`

3. **Add repo secrets** at https://github.com/cubicforms/chemical-x-forms/settings/secrets/actions:
   - \`GPG_PRIVATE_KEY\` — paste the output of \`gpg --armor --export-secret-keys <KEYID>\`
   - \`GPG_PASSPHRASE\` — the passphrase (omit if the key has none)

## Test plan
- [ ] Generate key + upload to GitHub + add secrets
- [ ] Merge this PR
- [ ] Dispatch the workflow with \`patch\` against main
- [ ] Confirm the resulting version-bump commit shows as **Verified** with the GPG key