### PR TITLE
docs: surface reactive field-errors API in Features list

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ const planetState = getFieldState("planet");
 
 _**note**: detailed documentation coming soon_
 
-`useForm(options?)` – Initializes form state. Abstract schema required.
+`useForm(options)` – Initializes form state. `schema` is required; `key` is recommended on every form so multiple forms on a page don't share state.
 
 `v-register` – Custom, SSR-safe directive for registering components with Chemical X
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - **Abstract Schema Support** – Integrates with validation libraries like Zod for type-safe schemas and automatic validation.
 - **v-register Directive** – One SSR-safe directive that automatically tracks everything.
 - **Full State Tracking** – Automatically tracks field states (value, touched, dirty status, validation errors, etc).
+- **Reactive Field Errors** – `fieldErrors` auto-populates on validation failure and clears on success; `setFieldErrorsFromApi` maps server 422 envelopes onto fields for inline display.
 - **TypeScript Friendly** – Fully type-safe, with advanced form type inference from your schema.
   <br><br>
 


### PR DESCRIPTION
## Summary
The 0.6 / 0.7 error-handling work (#107, #108) shipped \`fieldErrors\`, \`setFieldErrors\`, \`addFieldErrors\`, \`clearFieldErrors\`, and \`setFieldErrorsFromApi\` — but the README's Features section still doesn't mention any of it. Adds one bullet so the list reflects what's actually in the box.

Also serves as a small, low-risk dispatch target to verify PR #110's GPG-signing change produces a "Verified" version-bump commit on the next publish.

## Test plan
- [ ] CI matrix passes
- [ ] After merge (both this and #110): dispatch publish workflow with \`patch\` → confirm the resulting version-bump commit on \`main\` shows the **Verified** badge