### PR TITLE
ci: bump crazy-max/ghaction-import-gpg + actions/upload-artifact

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -105,7 +105,7 @@ jobs:
         run: pnpm check:coverage
 
       - name: Upload coverage HTML
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: coverage-html
           path: coverage/

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -79,7 +79,7 @@ jobs:
       # whose email is in the key's UID, otherwise GitHub still marks the
       # commit "Unverified".
       - name: Import GPG signing key
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@v7
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}


### PR DESCRIPTION
GitHub is deprecating Node 20 actions (forced to Node 24 on 2026-06-02, Node 20 removed 2026-09-16). The publish workflow's post-run log flagged `crazy-max/ghaction-import-gpg@v6` as the affected cell; `actions/upload-artifact@v4` hits the same deadline for the coverage-HTML upload on the matrix workflow.

- `crazy-max/ghaction-import-gpg@v6` → `@v7` (Node 24 default as of v7.0.0, released 2026-03-02).
- `actions/upload-artifact@v4` → `@v5` (Node 24 default as of v5.0.0).

The rest of the in-use actions (checkout@v5, setup-node@v5, cache@v5, pnpm/action-setup@v5) already run on Node 24.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow action versions to ensure reliability and compatibility of automated testing and deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->