### PR TITLE
Claude/optional form key

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ const { register, handleSubmit, fieldErrors, isSubmitting } = useForm({
     email: z.email(),
     password: z.string().min(8),
   }),
-  key: 'signup',
 })
 
 const onSubmit = handleSubmit(async (values) => {
@@ -121,7 +120,7 @@ const schema = z.object({
 Validate as the user types or tabs away — no submit needed:
 
 ```ts
-useForm({ schema, key, fieldValidation: { on: 'change', debounceMs: 200 } })
+useForm({ schema, fieldValidation: { on: 'change', debounceMs: 200 } })
 ```
 
 Three modes — `'change'` (debounced), `'blur'` (immediate), `'none'` (default). Rapid typing is debounced + auto-cancelled. [Recipe →](./docs/recipes/field-level-validation.md)
@@ -129,7 +128,7 @@ Three modes — `'change'` (debounced), `'blur'` (immediate), `'none'` (default)
 ### Focus / scroll to first error
 
 ```ts
-useForm({ schema, key, onInvalidSubmit: 'focus-first-error' })
+useForm({ schema, onInvalidSubmit: 'focus-first-error' })
 ```
 
 Or call `focusFirstError()` / `scrollToFirstError({ block: 'start' })` imperatively after a failed submit or a `setFieldErrorsFromApi` hydration. [Recipe →](./docs/recipes/focus-on-error.md)
@@ -152,7 +151,7 @@ Adds `undo()` / `redo()` / `canUndo` / `canRedo` with a bounded snapshot stack (
 
 ### Nested form components
 
-Call `useFormContext()` in any descendant to reach the ancestor's form without prop-threading. Pass a form's `key` to reach a form that isn't an ancestor. [Recipe →](./docs/recipes/form-context.md)
+Call `useFormContext()` in any descendant to reach the ancestor's form without prop-threading. Pass a form's `key` to reach a form that isn't an ancestor — or when a single parent owns more than one form and descendants need to disambiguate. [Recipe →](./docs/recipes/form-context.md)
 
 ### Server errors
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -40,7 +40,7 @@ Options:
 | Field             | Type                                                          | Required | Description                                                              |
 | ----------------- | ------------------------------------------------------------- | -------- | ------------------------------------------------------------------------ |
 | `schema`          | `z.ZodType`                                                   | yes      | The Zod schema describing the form shape.                                |
-| `key`             | `string`                                                      | yes      | Unique form key within the app. Prevents cross-form state collision.     |
+| `key`             | `string`                                                      | no       | Form identity. Omit for one-off forms (runtime allocates a synthetic `cx:anon:<id>` via `useId()`). Pass a string when you need cross-component lookup via `useFormContext(key)`, shared state across call-sites, a stable `persist` storage-key default, or a recognisable DevTools label. |
 | `initialState`    | `DeepPartial<Form>`                                           | no       | Constraints applied over schema defaults.                                |
 | `validationMode`  | `'lax'` \| `'strict'`                                         | no       | Defaults to `'lax'`. See [Types](#types).                                |
 | `onInvalidSubmit` | `'none'` \| `'focus-first-error'` \| `'scroll-to-first-error'` \| `'both'` | no | What to do when submit fails validation. See [recipe](./recipes/focus-on-error.md). |

--- a/docs/migration/0.7-to-0.8.md
+++ b/docs/migration/0.7-to-0.8.md
@@ -4,21 +4,39 @@ Three breaking changes + six opt-in additions. Most 0.7 code
 compiles unchanged — only the three in the first block force an
 edit.
 
-## Breaking: `key` is now required on `useForm`
+## Non-breaking: `key` is optional; pass it when you need identity
 
-**0.7:** `key` was recommended.<br>
-**0.8:** `key` is required at the type level.
+**0.7:** `key` was recommended but not type-enforced.<br>
+**0.8:** `key` is still optional. When omitted, the runtime
+allocates a collision-free synthetic id via Vue's `useId()` —
+SSR-safe, positional, and stable across server→client hydration.
+Each anonymous `useForm` call resolves to its own `FormState`, so
+sibling components don't accidentally share store.
 
 ```ts
-// Compile error under 0.8:
+// Valid — anonymous, one-off form:
 useForm({ schema })
 
-// Fix — give it a key unique within the app:
+// Also valid — named form (required for cross-component lookup,
+// shared state across call-sites, stable persistence keys, or a
+// recognisable DevTools label):
 useForm({ schema, key: 'signup' })
 ```
 
-Non-TS callers get a clear runtime error too if they pass
-`undefined`, `null`, or `''`.
+Pass a `key` when:
+
+- a distant (non-descendant) component needs to look the form up via
+  `useFormContext('signup')`;
+- you want multiple `useForm({ key: 'x' })` call-sites to resolve to
+  the same shared store;
+- you're using `persist` and want a deterministic storage-key
+  default;
+- you want a legible label in Vue DevTools or in
+  `ValidationError.formKey`.
+
+Descendant components under a form's provider can always call
+`useFormContext<Form>()` (ambient mode) regardless of whether the
+form has a key.
 
 ## Breaking: `/zod` vs `/zod-v3` subpaths
 

--- a/docs/recipes/form-context.md
+++ b/docs/recipes/form-context.md
@@ -97,6 +97,23 @@ Pass the same `key` you passed to `useForm({ key: 'signup' })`. If no
 form is registered under that key when the component mounts, you
 get a clear error naming the missing key.
 
+## Do I need to pass a `key` to `useForm`?
+
+Only if something else needs to find the form by name:
+
+- **Ambient access is free.** `useFormContext<Form>()` with no
+  argument resolves via Vue's `provide`/`inject` and doesn't care
+  whether the owning `useForm` had a key. A key-less parent + a
+  key-less descendant call works identically to a named pair.
+- **Distant access needs a key.** `useFormContext<Form>('signup')`
+  looks the form up in the registry by name; if `useForm` didn't
+  supply one, the name isn't discoverable.
+
+Skip `key` for single-component one-off forms (login modal,
+settings panel). Supply one when you want cross-component lookup,
+multi-call-site shared state, a stable persistence default, or a
+legible DevTools label.
+
 ## Lifetime
 
 Both resolution modes ref-count on the form's registry entry. In

--- a/docs/recipes/form-context.md
+++ b/docs/recipes/form-context.md
@@ -114,6 +114,38 @@ settings panel). Supply one when you want cross-component lookup,
 multi-call-site shared state, a stable persistence default, or a
 legible DevTools label.
 
+### Gotcha: multiple `useForm` calls in the same component
+
+Vue's `provide`/`inject` is last-write-wins per component. If a
+parent calls `useForm` twice, the second call overwrites the first
+in the ambient context, and descendants using
+`useFormContext<Form>()` (no key) will only see the second form.
+
+```ts
+// Parent component
+const formA = useForm({ schema: schemaA }) // provides ambient → A
+const formB = useForm({ schema: schemaB }) // provides ambient → B (overwrites A)
+// Descendants' useFormContext<Form>() reads B. A is unreachable via ambient.
+```
+
+The runtime emits a dev-mode `console.warn` when it detects a
+second ambient provide on the same component, naming both forms so
+the regression is visible at the site.
+
+**Fixes** — either give each form a key and use explicit lookup
+downstream:
+
+```ts
+useForm({ schema: schemaA, key: 'a' })
+useForm({ schema: schemaB, key: 'b' })
+// Descendants:
+const a = useFormContext<FormA>('a')
+const b = useFormContext<FormB>('b')
+```
+
+…or split the two forms into their own components. Components
+owning a single form don't hit this.
+
 ## Lifetime
 
 Both resolution modes ref-count on the form's registry entry. In

--- a/src/runtime/adapters/zod-v3/types-zod-adapter.ts
+++ b/src/runtime/adapters/zod-v3/types-zod-adapter.ts
@@ -14,9 +14,11 @@ export type UseFormConfigurationWithZod<Schema extends z.ZodType<unknown>, Initi
       ? Schema
       : never
     : never
-  // Required by design — matches the core `UseFormConfiguration`. See
-  // types-api.ts for the rationale.
-  key: FormKey
+  // Optional — matches the core `UseFormConfiguration`. Omit for
+  // one-off forms; pass a string when the form needs identity (shared
+  // state, distant lookup, persistence default, DevTools label). See
+  // types-api.ts for the full rationale.
+  key?: FormKey
   initialState?: InitialState
   validationMode?: ValidationMode
   onInvalidSubmit?: OnInvalidSubmitPolicy

--- a/src/runtime/composables/use-abstract-form.ts
+++ b/src/runtime/composables/use-abstract-form.ts
@@ -1,6 +1,7 @@
 import { getCurrentInstance, getCurrentScope, onScopeDispose, provide, toRaw, useId } from 'vue'
 import { buildFormApi } from '../core/build-form-api'
 import { createFormState, type FormState } from '../core/create-form-state'
+import { __DEV__ } from '../core/dev'
 import type { FieldStateView } from '../core/field-state-api'
 import { getComputedSchema } from '../core/get-computed-schema'
 import { createHistoryModule, type HistoryModule } from '../core/history'
@@ -107,6 +108,15 @@ export function useAbstractForm<
   // `useFormContext()` can resolve it without prop-threading. The key is
   // the already-canonicalised formKey; looking up a specific form by key
   // is possible via `useFormContext(key)` even without the ambient provide.
+  //
+  // Ambient mode is "last-provide wins": if two `useForm` calls run in the
+  // same component, the second overwrites the first and descendants
+  // reading via `useFormContext<F>()` (no key) see only the second form.
+  // The dev-mode check below flags that case so someone converting a
+  // multi-form component to anonymous keys doesn't get a silent
+  // regression. Descendants that want unambiguous access to a specific
+  // form should use `useFormContext<F>(key)` with an explicit key.
+  warnOnDuplicateAmbientProvide(key)
   provide(kFormContext, state as FormState<GenericForm>)
 
   const apiOptions: Parameters<typeof buildFormApi<Form, GetValueFormType>>[1] = {}
@@ -164,6 +174,39 @@ function buildFreshState<F extends GenericForm, G extends GenericForm = F>(
  * works without user bookkeeping.
  */
 let anonCounter = 0
+
+/**
+ * Tracks which Vue component instances have already run
+ * `provide(kFormContext, ...)` via `useAbstractForm`. Dev-only —
+ * `null` in production so the WeakMap allocation tree-shakes out.
+ * A `WeakMap` keyed by the instance object lets Vue GC each
+ * component's entry when it unmounts without us tracking
+ * lifecycle.
+ */
+const ambientProvideHistory: WeakMap<object, FormKey[]> | null = __DEV__
+  ? new WeakMap<object, FormKey[]>()
+  : null
+
+function warnOnDuplicateAmbientProvide(key: FormKey): void {
+  if (!__DEV__ || ambientProvideHistory === null) return
+  const instance = getCurrentInstance()
+  if (instance === null) return
+  const instanceKey = instance as unknown as object
+  const existing = ambientProvideHistory.get(instanceKey)
+  if (existing === undefined) {
+    ambientProvideHistory.set(instanceKey, [key])
+    return
+  }
+  console.warn(
+    '[@chemical-x/forms] Multiple useForm() calls in the same component ' +
+      'provide ambient form context; descendants using useFormContext<F>() ' +
+      '(no key) will only see the last-provided form. Keys already ' +
+      `provided in this component: [${existing.join(', ')}]. Adding: "${key}". ` +
+      'Fix: pass a key to each useForm() and use useFormContext<F>(key) in ' +
+      'descendants, or split the forms across separate components.'
+  )
+  existing.push(key)
+}
 
 /**
  * Normalise `configuration.key` into a concrete FormKey. Explicit keys

--- a/src/runtime/composables/use-abstract-form.ts
+++ b/src/runtime/composables/use-abstract-form.ts
@@ -1,4 +1,4 @@
-import { getCurrentScope, onScopeDispose, provide, toRaw } from 'vue'
+import { getCurrentInstance, getCurrentScope, onScopeDispose, provide, toRaw, useId } from 'vue'
 import { buildFormApi } from '../core/build-form-api'
 import { createFormState, type FormState } from '../core/create-form-state'
 import type { FieldStateView } from '../core/field-state-api'
@@ -51,7 +51,7 @@ export function useAbstractForm<
     DeepPartial<Form>
   >
 ): UseAbstractFormReturnType<Form, GetValueFormType> {
-  const key = requireFormKey(configuration.key)
+  const key = resolveFormKey(configuration.key)
 
   // Resolve the schema (accepts either an AbstractSchema or a factory).
   // Preserve both generics — dropping `GetValueFormType` here would make
@@ -154,14 +154,43 @@ function buildFreshState<F extends GenericForm, G extends GenericForm = F>(
   return state
 }
 
-function requireFormKey(key: FormKey | undefined): FormKey {
-  if (key === undefined || key === null || key === '') {
-    throw new Error(
-      '[@chemical-x/forms] useForm requires an explicit `key` option. ' +
-        'Anonymous forms share state across unrelated components; pass a unique string per form.'
-    )
+/**
+ * Module-local counter for the "no Vue instance in scope" fallback
+ * (tests, raw composable calls outside setup). Collisions with
+ * user-supplied keys are avoided by the `cx:anon:` prefix. Inside
+ * setup — the common path — `useId()` produces a tree-position-stable
+ * id that matches across SSR hydration, so two mounts of the same
+ * component tree resolve to the same anonymous key and hydration
+ * works without user bookkeeping.
+ */
+let anonCounter = 0
+
+/**
+ * Normalise `configuration.key` into a concrete FormKey. Explicit keys
+ * pass through; empty / nullish keys are treated as anonymous and
+ * allocated a unique id. `cx:anon:` prefix makes the origin obvious in
+ * DevTools, ValidationError payloads, and the registry's key space —
+ * and guarantees no collision with the (user-chosen) string keys that
+ * share a flat namespace.
+ *
+ * Anonymous semantics: each `useForm({ schema })` call without a key
+ * resolves to a distinct FormState. Descendant components reach it via
+ * ambient `useFormContext<F>()`; cross-component lookup by key is not
+ * possible (and not meaningful — the key is synthetic). Callers that
+ * need shared state, distant lookup, persistence defaults, or a
+ * recognisable DevTools label should pass an explicit `key`.
+ */
+function resolveFormKey(key: FormKey | undefined): FormKey {
+  if (key !== undefined && key !== null && key !== '') return key
+  // In setup context, `useId()` threads through Vue's SSR id-allocator
+  // so server-rendered and client-hydrated trees agree on the same
+  // synthetic key.
+  if (getCurrentInstance() !== null) {
+    return `cx:anon:${useId()}`
   }
-  return key
+  // Outside setup (tests, ad-hoc composable use) there's no Vue
+  // instance to draw from; fall back to a module-local counter.
+  return `cx:anon:${anonCounter++}`
 }
 
 /**

--- a/src/runtime/composables/use-form.ts
+++ b/src/runtime/composables/use-form.ts
@@ -54,7 +54,11 @@ export function useForm<
   // Spread the full configuration so opt-in options (`onInvalidSubmit`,
   // `fieldValidation`, `persist`, `history`) reach useAbstractForm.
   // The explicit overrides below narrow schema / initialState /
-  // validationMode to the shapes useAbstractForm expects.
+  // validationMode to the shapes useAbstractForm expects. `key` is
+  // intentionally NOT re-listed — the spread carries it through, and
+  // writing `key: configuration.key` would re-introduce an explicit
+  // `undefined` that `exactOptionalPropertyTypes` rejects against the
+  // optional-key contract.
   return useAbstractForm<Form, GetValueFormType>({
     ...(configuration as UseFormConfiguration<
       Form,
@@ -64,7 +68,6 @@ export function useForm<
     >),
     schema: abstractSchema,
     initialState: configuration.initialState as DeepPartial<Form>,
-    key: configuration.key,
     validationMode: configuration.validationMode ?? 'lax',
   })
 }

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -218,10 +218,25 @@ export type UseFormConfiguration<
   InitialState extends DeepPartial<Form>,
 > = {
   schema: Schema | ((key: FormKey) => Schema)
-  // Required by design: forms without an explicit key silently share state
-  // across unrelated components. The runtime `requireFormKey` still throws
-  // for non-TS consumers passing `undefined` / `''`.
-  key: FormKey
+  /**
+   * Optional — omit for one-off forms. When absent, the runtime
+   * allocates a collision-free synthetic id via Vue's `useId()`
+   * (SSR-safe, positional, stable across server→client hydration).
+   * Each anonymous `useForm` call resolves to a distinct `FormState`.
+   *
+   * Pass an explicit string key when the form needs identity:
+   * - cross-component lookup via `useFormContext(key)` (distant,
+   *   non-descendant access);
+   * - intentionally shared state (multiple `useForm({ key: 'x' })`
+   *   calls resolving to the same store);
+   * - a stable persistence storage-key default;
+   * - a recognisable DevTools / `ValidationError.formKey` label.
+   *
+   * Descendant-only access via ambient `useFormContext<F>()` works
+   * for anonymous forms too — it resolves via `provide`/`inject`,
+   * not the registry's key space.
+   */
+  key?: FormKey
   initialState?: InitialState
   validationMode?: ValidationMode
   /**

--- a/test/composables/anonymous-form.test.ts
+++ b/test/composables/anonymous-form.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+import { createApp, createSSRApp, defineComponent, h } from 'vue'
+import { renderToString } from '@vue/server-renderer'
+import { useForm, useFormContext } from '../../src'
+import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { fakeSchema } from '../utils/fake-schema'
+
+/**
+ * Semantic coverage for anonymous (key-less) forms.
+ *
+ * The post-0.8.3 contract treats `key` as optional and allocates a
+ * synthetic `cx:anon:<id>` id via Vue's `useId()` when absent. That
+ * shifts two behaviours relative to the old "key required" contract:
+ *
+ *   1. Two sibling `useForm({ schema })` calls no longer share
+ *      state. Each call resolves to its own `cx:anon:` id and
+ *      therefore its own FormState.
+ *   2. Descendant-only access still works via ambient
+ *      `useFormContext<F>()`, which resolves through `provide`/
+ *      `inject` and doesn't touch the registry's key space.
+ *   3. SSR/hydration remains deterministic because `useId()` is
+ *      positional — the server and client trees allocate matching
+ *      ids at the same tree location.
+ */
+
+type Form = { name: string }
+const defaults: Form = { name: '' }
+
+describe('anonymous useForm — independent state per setup call', () => {
+  it('two sibling components get distinct FormStates', async () => {
+    type Api = ReturnType<typeof useForm<Form>>
+    const captured: { a?: Api; b?: Api } = {}
+
+    const ChildA = defineComponent({
+      setup() {
+        captured.a = useForm<Form>({ schema: fakeSchema<Form>(defaults) })
+        return () => h('div', 'a')
+      },
+    })
+    const ChildB = defineComponent({
+      setup() {
+        captured.b = useForm<Form>({ schema: fakeSchema<Form>(defaults) })
+        return () => h('div', 'b')
+      },
+    })
+    const App = defineComponent({
+      setup() {
+        return () => h('div', [h(ChildA), h(ChildB)])
+      },
+    })
+
+    const app = createApp(App).use(createChemicalXForms())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+
+    expect(captured.a?.key).not.toBe(captured.b?.key)
+    expect(captured.a?.key).toMatch(/^cx:anon:/)
+    expect(captured.b?.key).toMatch(/^cx:anon:/)
+
+    // Writing to one form must not leak into the other.
+    captured.a?.setValue('name', 'Alice')
+    expect(captured.a?.getValue('name').value).toBe('Alice')
+    expect(captured.b?.getValue('name').value).toBe('')
+
+    app.unmount()
+  })
+})
+
+describe('anonymous useForm — ambient useFormContext access', () => {
+  it('descendant composable reads the same FormState via provide/inject', async () => {
+    type Api = ReturnType<typeof useForm<Form>>
+    const captured: { owner?: Api; consumer?: Api } = {}
+
+    const Child = defineComponent({
+      setup() {
+        // Ambient mode — no key passed, resolves via `inject(kFormContext)`.
+        captured.consumer = useFormContext<Form>()
+        return () => h('span', 'child')
+      },
+    })
+    const Parent = defineComponent({
+      setup() {
+        captured.owner = useForm<Form>({ schema: fakeSchema<Form>(defaults) })
+        return () => h('div', [h(Child)])
+      },
+    })
+
+    const app = createApp(Parent).use(createChemicalXForms())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+
+    // Same synthetic key.
+    expect(captured.consumer?.key).toBe(captured.owner?.key)
+
+    // Writes land on the same form.
+    captured.owner?.setValue('name', 'Bob')
+    expect(captured.consumer?.getValue('name').value).toBe('Bob')
+
+    app.unmount()
+  })
+})
+
+describe('anonymous useForm — SSR determinism', () => {
+  it('server and client mounts allocate the same synthetic key', async () => {
+    type Api = ReturnType<typeof useForm<Form>>
+    let serverApi: Api | undefined
+    let clientApi: Api | undefined
+
+    const App = (onCaptured: (api: Api) => void) =>
+      defineComponent({
+        setup() {
+          const api = useForm<Form>({ schema: fakeSchema<Form>(defaults) })
+          onCaptured(api)
+          return () => h('div')
+        },
+      })
+
+    // Server-side render — useId() draws from Vue's SSR id allocator.
+    const serverApp = createSSRApp(App((api) => (serverApi = api)))
+    serverApp.use(createChemicalXForms({ override: true }))
+    await renderToString(serverApp)
+
+    // Client-side mount of the same tree shape — useId() must match
+    // what the server produced so hydration can find the registry
+    // entry. We simulate the client by creating a fresh app (new
+    // registry, fresh id allocator) and confirming the same position
+    // resolves to the same id.
+    const clientApp = createApp(App((api) => (clientApi = api))).use(createChemicalXForms())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    clientApp.mount(root)
+
+    expect(serverApi?.key).toBeDefined()
+    expect(clientApi?.key).toBe(serverApi?.key)
+
+    clientApp.unmount()
+  })
+})

--- a/test/composables/anonymous-form.test.ts
+++ b/test/composables/anonymous-form.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, createSSRApp, defineComponent, h } from 'vue'
 import { renderToString } from '@vue/server-renderer'
 import { useForm, useFormContext } from '../../src'
@@ -98,6 +98,73 @@ describe('anonymous useForm — ambient useFormContext access', () => {
     // Writes land on the same form.
     captured.owner?.setValue('name', 'Bob')
     expect(captured.consumer?.getValue('name').value).toBe('Bob')
+
+    app.unmount()
+  })
+})
+
+describe('anonymous useForm — ambient-overwrite dev warning', () => {
+  // Two useForm calls in the same component overwrite each other's
+  // ambient provide (Vue's provide/inject semantics — last write
+  // wins). The old "key is required" contract forced users to name
+  // both forms and prevented this from becoming a silent regression.
+  // Under the new optional-key contract the path of least resistance
+  // (two anonymous forms in one parent) hits this footgun, so the
+  // runtime emits a dev-mode warning when it sees a second ambient
+  // provide on the same component instance.
+  let warnSpy: ReturnType<typeof vi.spyOn>
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+  })
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  it('warns when a component calls useForm twice', () => {
+    const App = defineComponent({
+      setup() {
+        useForm({ schema: fakeSchema<Form>(defaults) })
+        useForm({ schema: fakeSchema<Form>(defaults) })
+        return () => h('div')
+      },
+    })
+    const app = createApp(App).use(createChemicalXForms())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    const message = String(warnSpy.mock.calls[0]?.[0] ?? '')
+    expect(message).toContain('Multiple useForm() calls in the same component')
+    expect(message).toContain('useFormContext<F>(key)')
+
+    app.unmount()
+  })
+
+  it('stays quiet when sibling components each call useForm once', () => {
+    const ChildA = defineComponent({
+      setup() {
+        useForm({ schema: fakeSchema<Form>(defaults) })
+        return () => h('span')
+      },
+    })
+    const ChildB = defineComponent({
+      setup() {
+        useForm({ schema: fakeSchema<Form>(defaults) })
+        return () => h('span')
+      },
+    })
+    const App = defineComponent({
+      setup() {
+        return () => h('div', [h(ChildA), h(ChildB)])
+      },
+    })
+    const app = createApp(App).use(createChemicalXForms())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+
+    expect(warnSpy).not.toHaveBeenCalled()
 
     app.unmount()
   })

--- a/test/composables/type-inference.test.ts
+++ b/test/composables/type-inference.test.ts
@@ -77,19 +77,22 @@ const form: Form = (() => {
 })()
 
 describe('useForm type inference — factory signature', () => {
-  it('requires `key` at the type level (Phase 7.2)', () => {
-    // Type-only assertion — exercises the parameter shape directly so
-    // the @ts-expect-error fires for the right reason. The previous
-    // pattern (a dead-code call inside `if (false)`) errored because
-    // `useForm` is imported as type-only and has no runtime binding,
-    // not because `key` is missing.
-    // @ts-expect-error - missing required `key`
-    const missingKeyConfig: UseFormOptions = { schema }
-    void missingKeyConfig
+  it('accepts `key` as optional for anonymous forms', () => {
+    // Post-0.8.3: `key` is optional. Omitted keys resolve to a
+    // collision-free synthetic id via Vue's `useId()` at runtime, so
+    // a config without `key` must typecheck cleanly.
+    const anonymousConfig: UseFormOptions = { schema }
+    void anonymousConfig
 
-    // Sanity: providing `key` typechecks cleanly.
-    const validConfig: UseFormOptions = { schema, key: 'test' }
-    void validConfig
+    // Explicit keys still typecheck — the string form is required
+    // when supplied (not `FormKey | undefined`).
+    const namedConfig: UseFormOptions = { schema, key: 'test' }
+    void namedConfig
+
+    // `schema` remains required — omitting it should still fail.
+    // @ts-expect-error - missing required `schema`
+    const missingSchemaConfig: UseFormOptions = { key: 'test' }
+    void missingSchemaConfig
   })
 
   it('returns the inferred Form shape at the top-level getValue()', () => {

--- a/test/composables/use-abstract-form.test.ts
+++ b/test/composables/use-abstract-form.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { createSSRApp, defineComponent, h } from 'vue'
 import { renderToString } from '@vue/server-renderer'
 import { useForm } from '../../src'
@@ -6,61 +6,62 @@ import { createChemicalXForms } from '../../src/runtime/core/plugin'
 import { fakeSchema } from '../utils/fake-schema'
 
 /**
- * Belt-and-braces coverage for `requireFormKey` in use-abstract-form.ts.
+ * Coverage for `resolveFormKey` in use-abstract-form.ts.
  *
- * Phase 7.2 tightened the type-level contract — `UseFormConfiguration.key`
- * is no longer optional — but the runtime guard still catches non-TS
- * callers (e.g. JS consumers, `as` casts, null from dynamic inputs). These
- * tests prove the throw fires for the three shapes the guard intercepts.
+ * The post-0.8.3 contract treats `key` as optional: a missing /
+ * nullish / empty-string key resolves to a synthetic `cx:anon:<id>`
+ * allocated via Vue's `useId()` (inside setup) or a module counter
+ * (outside). These tests prove all four "anonymous" shapes produce a
+ * working form and that an explicit key passes through unchanged.
  */
 
 type Form = { name: string }
+type ApiReturn = ReturnType<typeof useForm<Form>>
 
-function mountWith(keyValue: unknown): Promise<string> {
-  const App = defineComponent({
-    setup() {
-      // Bypass the type-level `key: FormKey` constraint to simulate a
-      // non-TS caller. The runtime guard is the last line of defence.
-      useForm<Form>({
-        schema: fakeSchema<Form>({ name: '' }),
-        key: keyValue as string,
-      })
-      return () => h('div')
-    },
+function mountWith(config: { keyValue?: unknown; provideKey: boolean }): Promise<ApiReturn> {
+  return new Promise((resolve) => {
+    const App = defineComponent({
+      setup() {
+        // Bypass the type-level `key?: FormKey` constraint so non-TS
+        // paths (null from a dynamic input, `as` casts, literal '')
+        // are exercised alongside the typed forms.
+        const api = useForm<Form>({
+          schema: fakeSchema<Form>({ name: '' }),
+          ...(config.provideKey ? { key: config.keyValue as string } : {}),
+        })
+        resolve(api)
+        return () => h('div')
+      },
+    })
+    const app = createSSRApp(App)
+    app.use(createChemicalXForms({ override: true }))
+    void renderToString(app)
   })
-  const app = createSSRApp(App)
-  app.use(createChemicalXForms({ override: true }))
-  return renderToString(app)
 }
 
-describe('useForm — runtime requireFormKey guard', () => {
-  // Vue logs `[Vue warn]: Unhandled error during execution of setup`
-  // via `console.warn` when setup() throws during renderToString. The
-  // three throw-tests below intentionally exercise that throw; silencing
-  // the expected warn keeps test output clean without losing a
-  // real regression signal — Vue's native warn channel is the only
-  // thing we suppress.
-  let warnSpy: ReturnType<typeof vi.spyOn>
-  beforeEach(() => {
-    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
-  })
-  afterEach(() => {
-    warnSpy.mockRestore()
+describe('useForm — runtime key resolution', () => {
+  it('allocates an anonymous key when `key` is omitted entirely', async () => {
+    const api = await mountWith({ provideKey: false })
+    expect(api.key).toMatch(/^cx:anon:/)
   })
 
-  it('throws when key is undefined', async () => {
-    await expect(mountWith(undefined)).rejects.toThrow(/requires an explicit `key`/)
+  it('allocates an anonymous key when `key` is `undefined`', async () => {
+    const api = await mountWith({ keyValue: undefined, provideKey: true })
+    expect(api.key).toMatch(/^cx:anon:/)
   })
 
-  it('throws when key is null', async () => {
-    await expect(mountWith(null)).rejects.toThrow(/requires an explicit `key`/)
+  it('allocates an anonymous key when `key` is `null`', async () => {
+    const api = await mountWith({ keyValue: null, provideKey: true })
+    expect(api.key).toMatch(/^cx:anon:/)
   })
 
-  it('throws when key is an empty string', async () => {
-    await expect(mountWith('')).rejects.toThrow(/requires an explicit `key`/)
+  it('allocates an anonymous key when `key` is the empty string', async () => {
+    const api = await mountWith({ keyValue: '', provideKey: true })
+    expect(api.key).toMatch(/^cx:anon:/)
   })
 
-  it('accepts a non-empty key', async () => {
-    await expect(mountWith('form-1')).resolves.toContain('<div')
+  it('preserves an explicit key verbatim', async () => {
+    const api = await mountWith({ keyValue: 'form-1', provideKey: true })
+    expect(api.key).toBe('form-1')
   })
 })


### PR DESCRIPTION
One-off forms shouldn't need to specify keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Forms now work without an explicit `key`—the library automatically generates a unique identifier for anonymous forms, enabling simpler usage while maintaining isolated state across multiple instances.

* **Documentation**
  * Updated README and API documentation to reflect optional form `key` and new anonymous form behavior.
  * Added migration guidance and recipe documentation clarifying when and why to use explicit form keys for cross-component lookup and shared state.

* **Tests**
  * Added comprehensive test coverage for anonymous form semantics, type inference, and server-side rendering consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->