### PR TITLE
ci: enable Dependabot + GitHub Dependency Review on PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,10 +34,13 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
+    # Conventional-commit scope is embedded in the prefix directly
+    # (`chore(deps): …`, `chore(deps-dev): …`). Do NOT also set
+    # `include: 'scope'` — Dependabot concatenates the two, producing
+    # malformed `chore(deps)(deps): …` subjects that fail commitlint.
     commit-message:
       prefix: 'chore(deps)'
       prefix-development: 'chore(deps-dev)'
-      include: 'scope'
     labels:
       - 'dependencies'
 
@@ -47,9 +50,10 @@ updates:
       interval: 'weekly'
       day: 'monday'
     open-pull-requests-limit: 5
+    # Same pattern as the npm block: scope is in the prefix itself;
+    # `include: 'scope'` is intentionally omitted to avoid a double scope.
     commit-message:
       prefix: 'chore(ci)'
-      include: 'scope'
     labels:
       - 'dependencies'
       - 'github-actions'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,55 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# Dependabot version updates.
+# Reference: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Two ecosystems are scanned:
+#   - `npm` for runtime + dev dependencies (pnpm uses npm-compatible manifests).
+#   - `github-actions` for workflow action versions (e.g. actions/checkout@v4).
+#
+# Dev-dep updates land as PRs against `main`; the usual CI gate (matrix.yml)
+# runs `pnpm check`, so any update that breaks lint / typecheck / tests / size
+# fails the PR and blocks auto-merge. Security advisories are filed separately
+# by GitHub's native advisory scanner regardless of this schedule.
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
+      day: 'monday'
+    # Cap open PRs so a dep graph with many out-of-date packages doesn't
+    # carpet-bomb the PR list. Security PRs are NOT counted against this cap.
+    open-pull-requests-limit: 5
+    # Group non-security updates by kind so the review surface stays small.
+    # Security updates are intentionally NOT grouped — each one gets its own
+    # PR so the severity, advisory link, and upgrade blast radius are clear.
+    groups:
+      dev-dependencies:
+        dependency-type: 'development'
+        update-types:
+          - 'minor'
+          - 'patch'
+      production-dependencies:
+        dependency-type: 'production'
+        update-types:
+          - 'minor'
+          - 'patch'
+    commit-message:
+      prefix: 'chore(deps)'
+      prefix-development: 'chore(deps-dev)'
+      include: 'scope'
+    labels:
+      - 'dependencies'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: 'chore(ci)'
+      include: 'scope'
+    labels:
+      - 'dependencies'
+      - 'github-actions'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,13 +12,29 @@ name: Dependency Review
 # Reference:
 # https://docs.github.com/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review
 
+# Forked-PR limitation: GitHub strips `pull-requests: write` from
+# workflows triggered by `pull_request` events from forks (security —
+# a malicious fork would otherwise be able to write to the PR). That
+# means `comment-summary-in-pr` below does NOT post a comment when
+# the PR originates from a fork. The failure itself is still
+# enforced — the workflow still fails the check — but reviewers have
+# to open the Actions log to see *why*. If fork-PR comments ever
+# become a hard requirement, the standard workaround is the two-
+# workflow pattern: keep this `pull_request` workflow for the check,
+# and add a companion `workflow_run` workflow (triggered on this
+# workflow's completion) that has the write scope and posts the
+# comment. See:
+#   https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_run
+#   https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
 on:
   pull_request:
     branches: ['main']
 
 permissions:
   contents: read
-  # Required for the action to post a summary comment on the PR.
+  # Needed for `comment-summary-in-pr: on-failure` below. GitHub
+  # automatically downgrades this to read-only for forked-PR runs,
+  # so the comment post silently no-ops on forks (see note above).
   pull-requests: write
 
 jobs:
@@ -41,7 +57,22 @@ jobs:
           # the diff without clicking into the Actions log.
           comment-summary-in-pr: on-failure
           # License policy — deny copyleft licenses that would legally
-          # contaminate a library published under MIT. Extend this list if
-          # the ecosystem grows. (Consumers' own license audits are still
-          # their responsibility; this is a belt-and-braces check.)
-          deny-licenses: 'AGPL-3.0, AGPL-3.0-only, AGPL-3.0-or-later, GPL-3.0, GPL-3.0-only, GPL-3.0-or-later'
+          # contaminate a library published under MIT. Consumers bundle
+          # npm packages statically (via Vite / Webpack / Rollup), so the
+          # "dynamic linking" exception that usually makes LGPL OK for
+          # *applications* does NOT apply here — LGPL contamination in a
+          # bundled JS library is equivalent to GPL. Hence LGPL is on the
+          # deny list too. SPDX 3.0+ deprecated the suffix-less forms
+          # (`GPL-3.0`, `AGPL-3.0`, etc.); only the `-only` / `-or-later`
+          # variants are listed.
+          # Consumers' own license audits remain their responsibility;
+          # this is a belt-and-braces check at dependency-introduction time.
+          deny-licenses: >-
+            AGPL-1.0-only, AGPL-1.0-or-later,
+            AGPL-3.0-only, AGPL-3.0-or-later,
+            GPL-1.0-only, GPL-1.0-or-later,
+            GPL-2.0-only, GPL-2.0-or-later,
+            GPL-3.0-only, GPL-3.0-or-later,
+            LGPL-2.0-only, LGPL-2.0-or-later,
+            LGPL-2.1-only, LGPL-2.1-or-later,
+            LGPL-3.0-only, LGPL-3.0-or-later

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,47 @@
+name: Dependency Review
+
+# Runs GitHub's Dependency Review Action on every PR against main.
+# The action diffs the PR's dependency graph against the base branch and
+# fails the check when the PR introduces a dependency with a known
+# vulnerability at or above the configured severity threshold.
+#
+# This is the PR-time gate. Weekly Dependabot PRs (see .github/dependabot.yml)
+# handle the *maintenance* side — fixing known vulnerabilities in the current
+# graph. Together they cover "don't land new CVEs" + "fix existing CVEs."
+#
+# Reference:
+# https://docs.github.com/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review
+
+on:
+  pull_request:
+    branches: ['main']
+
+permissions:
+  contents: read
+  # Required for the action to post a summary comment on the PR.
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    name: Review dependency changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@v4
+        with:
+          # Fail the PR when any newly introduced dependency has a known
+          # vulnerability at `moderate` or higher. Tighten to `high` if the
+          # noise-to-signal ratio is too low in practice; loosen to `low`
+          # for a stricter review surface.
+          fail-on-severity: moderate
+          # Post a human-readable summary as a PR comment so reviewers see
+          # the diff without clicking into the Actions log.
+          comment-summary-in-pr: on-failure
+          # License policy — deny copyleft licenses that would legally
+          # contaminate a library published under MIT. Extend this list if
+          # the ecosystem grows. (Consumers' own license audits are still
+          # their responsibility; this is a belt-and-braces check.)
+          deny-licenses: 'AGPL-3.0, AGPL-3.0-only, AGPL-3.0-or-later, GPL-3.0, GPL-3.0-only, GPL-3.0-or-later'


### PR DESCRIPTION
## Summary

Two-part supply-chain hardening. Replaces the stub `.github/dependabot.yml` (previously `package-ecosystem: ""` — scanning nothing) and adds a PR-time CVE gate.

- **Dependabot, live configuration.** Scans `npm` and `github-actions` ecosystems weekly (Monday). Non-security updates grouped by dev vs prod to keep the PR surface small; security advisories arrive as individual PRs so each advisory's severity and upgrade blast radius stay visible. Open-PR cap of 5 per ecosystem.
- **Dependency Review Action on every PR.** `actions/dependency-review-action@v4` runs on every PR against `main`, fails when a new dependency introduces a `moderate`-or-higher CVE. License policy denies AGPL / GPL so copyleft can't contaminate the MIT-licensed library.

Commit-message convention aligns with existing `commitlint.config.js`: `chore(deps): ...`, `chore(deps-dev): ...`, `chore(ci): ...` all pass `type-enum` + `scope-case: lower-case`. (commitlint only runs via husky on local commits; Dependabot's API-driven commits bypass it anyway.)

## Test plan

- [x] YAML syntactically valid (verified via `yaml-lint`)
- [x] Commit-message prefixes align with existing commitlint rules
- [x] No runtime code changed → `matrix.yml` CI on this PR will verify the existing `pnpm check` gate still passes with the new workflow file present
- [ ] Once merged: first Dependabot PRs land next Monday — may be chunky if deps have drifted; skim and merge
- [ ] Dependency Review workflow runs on its own PR (checks its own diff — trivially zero new deps → passes)

## Follow-ups

- If `fail-on-severity: moderate` turns out noisy in practice, one-line tighten to `high` (comment in the workflow file flags the knob).
- Snyk optional layer can be added on top if the free tools leave gaps visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automation for dependency updates and security vulnerability reviews in the development pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->