### PR TITLE
ci: drop deprecated always-auth input from publish-npm workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -44,8 +44,11 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
+          # `registry-url` alone configures npm auth via NODE_AUTH_TOKEN
+          # for the npm whoami + publish steps below; `always-auth: true`
+          # was redundant and is no longer a valid input in setup-node@v6
+          # (it now emits "Unexpected input(s) 'always-auth'" warnings).
           registry-url: 'https://registry.npmjs.org/'
-          always-auth: true
 
       - name: Install dependencies
         # --frozen-lockfile aborts if pnpm-lock.yaml is stale, so the


### PR DESCRIPTION
## Summary

`actions/setup-node@v6` (just landed via #121) removed the `always-auth` input. Leaving it in emits a warning on every Setup Node.js step that uses it:

\`\`\`
Warning: Unexpected input(s) 'always-auth', valid inputs are
  ['node-version', 'node-version-file', 'architecture',
   'check-latest', 'registry-url', 'scope', 'token', 'cache',
   'package-manager-cache', 'cache-dependency-path', 'mirror',
   'mirror-token']
\`\`\`

`registry-url: 'https://registry.npmjs.org/'` alone configures the npm auth path that \`npm whoami\` + \`pnpm publish --access public --provenance\` consume via \`NODE_AUTH_TOKEN\`. The \`always-auth: true\` line has been redundant since setup-node's v3 era — removing it is behavior-preserving.

Only touches \`.github/workflows/publish-npm.yml\` (the only workflow that had the input).

## Test plan

- [x] YAML syntactically valid (\`yaml-lint\`)
- [ ] CI on this PR runs \`matrix.yml\` (no \`always-auth\`) — validates nothing else regressed
- [ ] \`publish-npm.yml\` is \`workflow_dispatch\`-only, so next real validation is the next publish. Expect no warning in the Setup Node.js step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)