### PR TITLE
docs: slim README, add Vue 3 / Nuxt 3 + 4 / TypeScript badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,22 @@
-# Chemical X Forms
+# @chemical-x/forms
 
 [![npm version][npm-version-src]][npm-version-href]
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
 [![License][license-src]][license-href]
-[![Node.js Test Suite](https://github.com/cubicforms/chemical-x-forms/actions/workflows/matrix.yml/badge.svg)](https://github.com/cubicforms/chemical-x-forms/actions/workflows/matrix.yml)
-[![Nuxt][nuxt-src]][nuxt-href]
+[![Tests](https://github.com/cubicforms/chemical-x-forms/actions/workflows/matrix.yml/badge.svg)](https://github.com/cubicforms/chemical-x-forms/actions/workflows/matrix.yml)
+[![Vue 3][vue-src]][vue-href]
+[![Nuxt 3 / 4][nuxt-src]][nuxt-href]
+[![TypeScript][ts-src]][ts-href]
 
-**A fully type-safe, schema-driven form library that gives you superpowers**.<br>Comes with a minimal composition API that prioritizes developer experience and form correctness.<br><br>
+Type-safe, schema-driven forms for Vue 3 and Nuxt 3 / 4. Composition API, branded paths, Zod v3 / v4 adapters included; custom adapters via `AbstractSchema`.
 
-## 🚀 60-second start
+## Install
 
 ```bash
 npm install @chemical-x/forms zod
 ```
 
-**Nuxt 3 / 4** — add the module:
+**Nuxt 3 / 4**
 
 ```ts
 // nuxt.config.ts
@@ -23,7 +25,7 @@ export default defineNuxtConfig({
 })
 ```
 
-**Bare Vue 3** — install the plugin:
+**Bare Vue 3**
 
 ```ts
 // main.ts
@@ -43,26 +45,23 @@ export default defineConfig({
 })
 ```
 
-That's it. [Jump to your first form →](#-your-first-form)
-<br><br>
-
-## 🪄 Your first form
+## Quick start
 
 ```vue
 <script setup lang="ts">
-import { useForm } from '@chemical-x/forms/zod' // zod v4; use /zod-v3 for v3
-import { z } from 'zod'
+  import { useForm } from '@chemical-x/forms/zod' // zod v4; use /zod-v3 for v3
+  import { z } from 'zod'
 
-const { register, handleSubmit, fieldErrors, isSubmitting } = useForm({
-  schema: z.object({
-    email: z.email(),
-    password: z.string().min(8),
-  }),
-})
+  const { register, handleSubmit, fieldErrors, isSubmitting } = useForm({
+    schema: z.object({
+      email: z.email(),
+      password: z.string().min(8),
+    }),
+  })
 
-const onSubmit = handleSubmit(async (values) => {
-  await fetch('/api/signup', { method: 'POST', body: JSON.stringify(values) })
-})
+  const onSubmit = handleSubmit(async (values) => {
+    await fetch('/api/signup', { method: 'POST', body: JSON.stringify(values) })
+  })
 </script>
 
 <template>
@@ -78,34 +77,28 @@ const onSubmit = handleSubmit(async (values) => {
 </template>
 ```
 
-You get: schema-typed values, per-field errors, a submit handler that
-validates first, and a reactive `isSubmitting` flag. Every leaf of
-`fieldErrors` and every branded path is inferred from your Zod schema.
-<br><br>
+Schema-typed values, per-field errors, a submit handler that validates first, and a reactive `isSubmitting` flag. `fieldErrors` keys and every branded path are inferred from the schema.
 
-## 🎯 The core you always have
+## Core API
 
-Everything below is on by default — no opt-in needed:
+On by default — no opt-in.
 
-- **`register(path)` + `v-register`** — bind an input to a field in one directive. SSR-safe, no per-input `v-model` + `@input` boilerplate.
-- **`handleSubmit(onSubmit, onError?)`** — validates, then dispatches. Bind straight to `@submit.prevent`.
-- **`fieldErrors`** — reactive `Record<path, ValidationError[]>`. Auto-populated by `handleSubmit` on failure, cleared on success. Also writable from your own code.
-- **`isDirty` / `isValid`** — computed refs. Gate a "Save" button on `isDirty && isValid` without wiring per-field watchers.
-- **`isSubmitting` / `submitCount` / `submitError`** — full submission lifecycle. Spinner, per-click counter, reactive error banner with zero extra refs.
+- **`register(path)` + `v-register`** — bind an input to a field in one directive. SSR-safe.
+- **`handleSubmit(onSubmit, onError?)`** — validates, then dispatches. Bind to `@submit.prevent`.
+- **`fieldErrors`** — reactive `Record<path, ValidationError[]>`. Auto-populated on submit failure, cleared on success, writable from your code.
+- **`isDirty` / `isValid`** — computed refs. Gate a Save button on `isDirty && isValid` without per-field watchers.
+- **`isSubmitting` / `submitCount` / `submitError`** — full submission lifecycle.
 - **`getValue(path)` / `setValue(path, value)`** — read / write any field programmatically.
-- **`getFieldState(path)`** — everything for one path: value, errors, touched, focused, blurred, isConnected, updatedAt.
-- **`reset(next?)` / `resetField(path)`** — restore the whole form, or a single subtree, back to schema defaults (or a partial override).
+- **`getFieldState(path)`** — value, errors, touched, focused, blurred, isConnected, updatedAt.
+- **`reset(next?)` / `resetField(path)`** — restore the form (or a subtree) to schema defaults, or override.
 - **Field-array helpers** — `append` / `prepend` / `insert` / `remove` / `swap` / `move` / `replace`. Path is narrowed to arrays, value to the element type — `append('title', …)` on a string field is a compile error. [Recipe →](./docs/recipes/dynamic-field-arrays.md)
-- **Structured paths** — field names with literal dots? `register(['user.name'])` keeps them as a single segment. `register('user.name')` splits.
-  <br><br>
+- **Structured paths** — literal dots in field names? `register(['user.name'])` keeps them as one segment; `register('user.name')` splits.
 
-## ⚡ Superpowers (opt-in)
+## Optional features
 
-Flip a config flag, get a whole feature. Each of these is off by default.
+Each is off by default; flip a flag to enable.
 
 ### Async validation
-
-Use `z.refine(async …)` to check uniqueness, allow-lists, server availability. `handleSubmit` awaits it for you.
 
 ```ts
 const schema = z.object({
@@ -113,17 +106,15 @@ const schema = z.object({
 })
 ```
 
-`validate()` / `validateAsync(path?)` / `isValidating` give you reactive + imperative surfaces for live validation UI. [Recipe →](./docs/recipes/async-validation.md)
+`handleSubmit` awaits async refinements; `validate()` / `validateAsync(path?)` / `isValidating` give imperative + reactive surfaces. [Recipe →](./docs/recipes/async-validation.md)
 
 ### Live field validation
-
-Validate as the user types or tabs away — no submit needed:
 
 ```ts
 useForm({ schema, fieldValidation: { on: 'change', debounceMs: 200 } })
 ```
 
-Three modes — `'change'` (debounced), `'blur'` (immediate), `'none'` (default). Rapid typing is debounced + auto-cancelled. [Recipe →](./docs/recipes/field-level-validation.md)
+Modes: `'change'` (debounced), `'blur'`, `'none'`. Rapid typing is debounced and auto-cancelled. [Recipe →](./docs/recipes/field-level-validation.md)
 
 ### Focus / scroll to first error
 
@@ -131,15 +122,15 @@ Three modes — `'change'` (debounced), `'blur'` (immediate), `'none'` (default)
 useForm({ schema, onInvalidSubmit: 'focus-first-error' })
 ```
 
-Or call `focusFirstError()` / `scrollToFirstError({ block: 'start' })` imperatively after a failed submit or a `setFieldErrorsFromApi` hydration. [Recipe →](./docs/recipes/focus-on-error.md)
+Or call `focusFirstError()` / `scrollToFirstError({ block: 'start' })` after a failed submit or `setFieldErrorsFromApi` hydration. [Recipe →](./docs/recipes/focus-on-error.md)
 
-### Persist drafts across reloads
+### Persist drafts
 
 ```ts
 useForm({ schema, key, persist: { storage: 'local' } })
 ```
 
-Backends: `'local'` / `'session'` / `'indexeddb'` (or your own). Writes debounced, clears on successful submit, survives hard refresh. [Recipe →](./docs/recipes/persistence.md)
+Backends: `'local'` / `'session'` / `'indexeddb'` or your own. Writes are debounced; cleared on successful submit. [Recipe →](./docs/recipes/persistence.md)
 
 ### Undo / redo
 
@@ -147,19 +138,19 @@ Backends: `'local'` / `'session'` / `'indexeddb'` (or your own). Writes debounce
 useForm({ schema, key, history: true })
 ```
 
-Adds `undo()` / `redo()` / `canUndo` / `canRedo` with a bounded snapshot stack (default 50). Wire it to <kbd>⌘Z</kbd> / <kbd>⌘⇧Z</kbd> in one line. [Recipe →](./docs/recipes/undo-redo.md)
+Adds `undo()` / `redo()` / `canUndo` / `canRedo` with a bounded snapshot stack (default 50). [Recipe →](./docs/recipes/undo-redo.md)
 
 ### Nested form components
 
-Call `useFormContext()` in any descendant to reach the ancestor's form without prop-threading. Pass a form's `key` to reach a form that isn't an ancestor — or when a single parent owns more than one form and descendants need to disambiguate. [Recipe →](./docs/recipes/form-context.md)
+`useFormContext()` reaches the ancestor form without prop-threading. Pass an explicit `key` to disambiguate when a parent owns multiple forms. [Recipe →](./docs/recipes/form-context.md)
 
 ### Server errors
 
 ```ts
-setFieldErrorsFromApi(err.data) // accepts { error: { details: { path: [msg] } } } or { path: [msg] }
+setFieldErrorsFromApi(err.data) // { error: { details: { path: [msg] } } } or { path: [msg] }
 ```
 
-Drops straight into your `catch` block. Built-in caps on entry count + path depth keep untrusted payloads safe. [Recipe →](./docs/recipes/server-errors.md)
+Drops into a `catch` block. Built-in caps on entry count and path depth keep untrusted payloads safe. [Recipe →](./docs/recipes/server-errors.md)
 
 ### Vue DevTools
 
@@ -167,60 +158,43 @@ Drops straight into your `catch` block. Built-in caps on entry count + path dept
 npm install -D @vue/devtools-api
 ```
 
-Every registered form shows up in the DevTools sidebar with an editable tree, an error view, and a timeline for submit / reset / mutation events. Auto-wired; pass `createChemicalXForms({ devtools: false })` to disable. [Recipe →](./docs/recipes/devtools.md)
+Forms appear in the DevTools sidebar with an editable tree, an error view, and a submit / reset / mutation timeline. Auto-wired; pass `createChemicalXForms({ devtools: false })` to disable. [Recipe →](./docs/recipes/devtools.md)
 
 ### SSR
 
-Nuxt: zero config — the module handles payload round-trip via `nuxtApp.payload`.<br>
-Bare Vue + `@vue/server-renderer`: `renderChemicalXState(app)` on the server, `hydrateChemicalXState(app, payload)` on the client. [Recipe →](./docs/recipes/ssr-hydration.md)
+Nuxt: zero config — the module handles payload round-trip via `nuxtApp.payload`. Bare Vue + `@vue/server-renderer`: `renderChemicalXState(app)` on the server, `hydrateChemicalXState(app, payload)` on the client. [Recipe →](./docs/recipes/ssr-hydration.md)
 
-### Bring your own schema library
+### Custom schema adapter
 
-Zod v4 is the default. Valibot, ArkType, hand-rolled — implement four methods on `AbstractSchema` and `useForm` works against it. [Recipe →](./docs/recipes/custom-adapter.md)
-<br><br>
+Zod v4 is the default; Zod v3 ships at `/zod-v3`. To use Valibot, ArkType, or a hand-rolled validator, implement four methods on `AbstractSchema`. [Recipe →](./docs/recipes/custom-adapter.md)
 
-## 📚 Documentation
+## Subpath exports
 
-- [**`docs/api.md`**](./docs/api.md) — every public export with signatures and return shapes
-- [**`docs/recipes/`**](./docs/recipes) — task-oriented walkthroughs for everything above
-- [**`docs/troubleshooting.md`**](./docs/troubleshooting.md) — common gotchas and fixes
-- [**`docs/migration/`**](./docs/migration) — per-release upgrade notes
-- [**`docs/perf.md`**](./docs/perf.md) — how it scales; when to worry
-- [**`CHANGELOG.md`**](./CHANGELOG.md) — full release history
-  <br><br>
+| Subpath                        | Purpose                                                |
+| ------------------------------ | ------------------------------------------------------ |
+| `@chemical-x/forms`            | Framework-agnostic core (plugin, `useForm`, directive) |
+| `@chemical-x/forms/nuxt`       | Nuxt 3 / 4 module                                      |
+| `@chemical-x/forms/vite`       | Vite plugin (registers node transforms)                |
+| `@chemical-x/forms/transforms` | Raw node transforms for custom bundlers                |
+| `@chemical-x/forms/zod`        | Zod v4 adapter (recommended; requires `zod@^4`)        |
+| `@chemical-x/forms/zod-v3`     | Zod v3 adapter (legacy; requires `zod@^3`)             |
 
-## 🏔️ What's in the box
+## Documentation
 
-- **Framework-agnostic core** — Nuxt 3 / 4, bare Vue 3 (CSR), bare Vue 3 + `@vue/server-renderer` (SSR). One Vue plugin; the Nuxt module wraps it.
-- **Schema-agnostic, Zod-friendly** — Zod v4 at `/zod`, Zod v3 at `/zod-v3`. Bring your own validator if you don't use Zod.
-- **TypeScript-first** — every strictness flag on, branded `PathKey` / `FormKey`, no `any` in the public surface.
-- **Performance** — keystroke path is 6–12× faster than the pre-rewrite baseline; a CI job fails the run if the ratio drops.
-- **Zero framework-specific validator ceremony** — no `v-model` + `@input` wiring, no manual error mapping from your schema library to your UI.
-  <br><br>
+- [`docs/api.md`](./docs/api.md) — every public export with signatures
+- [`docs/recipes/`](./docs/recipes) — task-oriented walkthroughs
+- [`docs/troubleshooting.md`](./docs/troubleshooting.md) — common gotchas
+- [`docs/migration/`](./docs/migration) — per-release upgrade notes
+- [`docs/perf.md`](./docs/perf.md) — benchmarks and scaling notes
+- [`CHANGELOG.md`](./CHANGELOG.md) — full release history
 
-## 📦 Status
+## Status
 
-**Pre-1.0.** The API is stable and under SemVer from `v1.0` onward —
-0.x minor bumps may still include small breaking changes; each one
-lands with a migration note under [`docs/migration/`](./docs/migration). [Recent changes →](./CHANGELOG.md)
-<br><br>
+Pre-1.0. The public API is stable; 0.x minor bumps may still include small breaking changes, each documented under [`docs/migration/`](./docs/migration). 1.0 will lock SemVer. [Recent changes →](./CHANGELOG.md)
 
-### Subpath exports
+## License
 
-| Subpath                          | Purpose                                                   |
-| -------------------------------- | --------------------------------------------------------- |
-| `@chemical-x/forms`              | Framework-agnostic core (plugin, `useForm`, directive)    |
-| `@chemical-x/forms/nuxt`         | Nuxt 3 / 4 module                                         |
-| `@chemical-x/forms/vite`         | Vite plugin (registers node transforms)                   |
-| `@chemical-x/forms/transforms`   | Raw node transforms for custom bundlers                   |
-| `@chemical-x/forms/zod`          | Zod v4 adapter (recommended; requires `zod@^4`)           |
-| `@chemical-x/forms/zod-v3`       | Zod v3 adapter (legacy; requires `zod@^3`)                |
-
-<br>
-
-## 🪪 License
-
-`@chemical-x/forms` is released under the MIT License. See the [LICENSE](https://github.com/cubicforms/chemical-x-forms/blob/main/LICENSE) file for details.
+MIT — see [LICENSE](https://github.com/cubicforms/chemical-x-forms/blob/main/LICENSE).
 
 <!-- Badges -->
 
@@ -230,5 +204,9 @@ lands with a migration note under [`docs/migration/`](./docs/migration). [Recent
 [npm-downloads-href]: https://npm.chart.dev/@chemical-x/forms
 [license-src]: https://img.shields.io/npm/l/@chemical-x/forms.svg?style=flat&colorA=020420&colorB=00DC82
 [license-href]: https://npmjs.com/package/@chemical-x/forms
-[nuxt-src]: https://img.shields.io/badge/Nuxt-020420?logo=nuxt.js
+[vue-src]: https://img.shields.io/badge/Vue-3-020420?logo=vue.js&logoColor=4FC08D
+[vue-href]: https://vuejs.org
+[nuxt-src]: https://img.shields.io/badge/Nuxt-3%20%2F%204-020420?logo=nuxt.js
 [nuxt-href]: https://nuxt.com
+[ts-src]: https://img.shields.io/badge/TypeScript-strict-020420?logo=typescript&logoColor=3178C6
+[ts-href]: https://www.typescriptlang.org


### PR DESCRIPTION
## Summary

- **Badges**: add Vue 3, Nuxt 3 / 4 (replaces the generic Nuxt badge), and TypeScript; rename the CI badge to "Tests".
- **Tone**: drop emoji section headings and marketing phrasing ("gives you superpowers", "magic", "in the box") for a more professional, scannable layout that fits a pre-1.0 library README.
- **Structure**: consolidate the intro into a single accurate sentence; reorder so **Subpath exports** sits before **Documentation** (higher signal for someone landing on the npm page); fold the redundant "What's in the box" section into the intro.
- **Net delta**: 22 lines shorter (235 → 213), no features dropped, every doc / recipe link preserved.

Pre-existing prettier drift on `main`'s README is fixed in the same commit.

## Test plan

- [x] `pnpm prettier --check README.md` clean
- [x] All `./docs/...` links still resolve to real files
- [ ] Visual check on the rendered PR view (GitHub) — badges line up, table renders, code blocks highlight
- [ ] npm page preview after next publish (no relative-link breakage on npmjs.com)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized README with improved navigation and structure
  * Added dedicated "Custom schema adapter" section covering multiple adapter options
  * Enhanced "Install" and "Quick start" sections for clearer onboarding
  * Added "Subpath exports" reference table for easier feature discovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->