### PR TITLE
feat(api)!: expose fieldErrors as a Proxy view, drop ComputedRef wrapper

### DIFF
--- a/src/runtime/core/build-form-api.ts
+++ b/src/runtime/core/build-form-api.ts
@@ -13,6 +13,7 @@ import type {
   ValidationResponseWithoutValue,
 } from '../types/types-api'
 import type { DeepPartial, GenericForm } from '../types/types-core'
+import { __DEV__ } from './dev'
 import type { FormState } from './create-form-state'
 import { buildFieldArrayApi } from './field-arrays'
 import { buildFieldStateAccessor } from './field-state-api'
@@ -121,7 +122,12 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
   // errors merge under the shared dotted key. Consumers who need
   // collision-free access read from `state.errors` via the validate()
   // / getFieldState() paths instead of the legacy dotted record.
-  const fieldErrors = computed<FormErrorRecord>(() => {
+  //
+  // The internal computed stays — laziness + dependency tracking are
+  // useful. The public surface wraps it in a Proxy (see fieldErrorsView
+  // below) so templates can dot-access directly without `.value`, and
+  // the readonly contract is enforced at runtime via set/delete traps.
+  const fieldErrorsComputed = computed<FormErrorRecord>(() => {
     const record: FormErrorRecord = {}
     for (const [, entries] of state.errors) {
       for (const err of entries) {
@@ -133,6 +139,8 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
     }
     return record
   })
+
+  const fieldErrors = createReadonlyErrorView(fieldErrorsComputed)
 
   function setFieldErrors(errors: ValidationError[]): void {
     state.setAllErrors(errors)
@@ -226,7 +234,7 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
     >['validateAsync'],
     register: register as UseAbstractFormReturnType<Form, GetValueFormType>['register'],
     key: state.formKey,
-    fieldErrors: fieldErrors as unknown as Readonly<ComputedRef<FormFieldErrors<Form>>>,
+    fieldErrors: fieldErrors as unknown as Readonly<FormFieldErrors<Form>>,
     setFieldErrors,
     addFieldErrors,
     clearFieldErrors,
@@ -269,4 +277,71 @@ function contextualiseValue<F extends GenericForm>(
     } as unknown as CurrentValueWithContext<unknown>
   }
   return currentValue as Readonly<Ref<unknown>>
+}
+
+/**
+ * Wrap a `ComputedRef<FormErrorRecord>` in a Proxy that exposes the
+ * underlying record's keys directly on the public object.
+ *
+ * Why a Proxy and not the bare ComputedRef:
+ *   - Vue templates auto-unwrap refs only when they are top-level keys
+ *     of the setup return. `useForm()` returns an API object, so any
+ *     ref nested inside (`fieldErrors`, etc.) does NOT auto-unwrap.
+ *     Authors hit this as `anon.fieldErrors.value.email` in templates,
+ *     which is a footgun. The Proxy lets them write
+ *     `anon.fieldErrors.email` directly.
+ *   - Readonly is preserved: `set` / `deleteProperty` / `defineProperty`
+ *     traps reject writes. Consumers must go through `setFieldErrors`,
+ *     `addFieldErrors`, or `clearFieldErrors`. (Type-level `Readonly<>`
+ *     enforces this at compile time too.)
+ *   - Reactivity is preserved: every trap that delegates to
+ *     `source.value` reads the ComputedRef inside the consumer's render
+ *     scope, so Vue tracks the dependency exactly as it would for a
+ *     direct `.value` read. Templates re-render on error changes.
+ *   - Laziness is preserved: the underlying ComputedRef only recomputes
+ *     when its inputs (state.errors) change AND a trap that reads
+ *     `source.value` fires.
+ */
+function createReadonlyErrorView<T extends FormErrorRecord>(source: ComputedRef<T>): T {
+  const target: T = Object.create(null) as T
+  return new Proxy(target, {
+    get(_, key) {
+      return (source.value as Record<string | symbol, unknown>)[key as string]
+    },
+    has(_, key) {
+      return key in source.value
+    },
+    ownKeys() {
+      return Reflect.ownKeys(source.value as object)
+    },
+    getOwnPropertyDescriptor(_, key) {
+      const desc = Reflect.getOwnPropertyDescriptor(source.value as object, key)
+      // Proxy invariant: when the underlying target ({}) lacks the key,
+      // the descriptor we report MUST have configurable: true. The
+      // delegated descriptor inherits configurable: true from the plain
+      // object record, but we set it explicitly to be defensive.
+      if (desc !== undefined) desc.configurable = true
+      return desc
+    },
+    set() {
+      if (__DEV__) {
+        console.warn(
+          '[@chemical-x/forms] fieldErrors is read-only — write via setFieldErrors / addFieldErrors / clearFieldErrors.'
+        )
+      }
+      return false
+    },
+    deleteProperty() {
+      if (__DEV__) {
+        console.warn('[@chemical-x/forms] fieldErrors is read-only — clear via clearFieldErrors.')
+      }
+      return false
+    },
+    defineProperty() {
+      return false
+    },
+    setPrototypeOf() {
+      return false
+    },
+  })
 }

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -616,16 +616,33 @@ export type UseAbstractFormReturnType<
   /**
    * Reactive map of field errors keyed by the dotted path. Populated
    * automatically by `handleSubmit` on validation failure and cleared on
-   * validation success. Also writable via `setFieldErrors` /
-   * `setFieldErrorsFromApi` for server-side hydration.
+   * validation success. Also writable (via the imperative methods below,
+   * not via direct mutation) — `setFieldErrors`, `addFieldErrors`,
+   * `clearFieldErrors`, `setFieldErrorsFromApi`.
    *
-   * Typed as `FormFieldErrors<Form>` — a mapped type over the form's
-   * own `FlatPath<Form>`. Dot access works for known top-level paths
-   * (`fieldErrors.email`); bracket access is required for dotted
-   * nested keys (`fieldErrors['user.profile.email']`) because JS dot
-   * notation splits on literal dots.
+   * Typed as `Readonly<FormFieldErrors<Form>>` — a frozen view over the
+   * form's own `FlatPath<Form>` mapped type. Dot access works for known
+   * top-level paths (`fieldErrors.email`); bracket access is required
+   * for dotted nested keys (`fieldErrors['user.profile.email']`)
+   * because JS dot notation splits on literal dots.
+   *
+   * Internally backed by a `ComputedRef` wrapped in a Proxy:
+   *   - **Templates** dot-access directly with no `.value` (the API
+   *     object isn't a top-level setup binding, so Vue's auto-unwrap
+   *     would not reach a nested ComputedRef otherwise).
+   *   - **Readonly** at compile time (the type) and at runtime (Proxy
+   *     `set` / `deleteProperty` traps reject writes; assignments fail
+   *     silently and emit a dev-mode console warning pointing at the
+   *     correct mutator).
+   *   - **Reactive**: reads inside a render or `watchEffect` track the
+   *     underlying ComputedRef as a dependency, exactly as a direct
+   *     `.value` read would. Re-renders fire on error-state changes.
+   *   - **Watchable from script** via the getter form:
+   *     `watch(() => api.fieldErrors.email, …)`. Direct
+   *     `watch(api.fieldErrors, …)` no longer works — `fieldErrors` is
+   *     a plain reactive view, not a `Ref`.
    */
-  fieldErrors: Readonly<ComputedRef<FormFieldErrors<Form>>>
+  fieldErrors: Readonly<FormFieldErrors<Form>>
 
   /** Replace all field errors for this form with the provided list. */
   setFieldErrors: (errors: ValidationError[]) => void

--- a/test/composables/async-validation.test.ts
+++ b/test/composables/async-validation.test.ts
@@ -85,7 +85,7 @@ describe('async validation — handleSubmit awaits async refinements', () => {
     )
     await handler()
     expect(onErrorFired).toBe(true)
-    const emailErrors = api.fieldErrors.value.email
+    const emailErrors = api.fieldErrors.email
     expect(emailErrors?.[0]?.message).toBe('Email already registered')
   })
 

--- a/test/composables/field-errors-view.test.ts
+++ b/test/composables/field-errors-view.test.ts
@@ -1,0 +1,232 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, type App } from 'vue'
+import { useForm } from '../../src/zod'
+import { z } from 'zod'
+import { createChemicalXForms } from '../../src/runtime/core/plugin'
+
+/**
+ * `fieldErrors` is a Proxy that wraps a ComputedRef. The wrapper
+ * exists to fix a longstanding template footgun:
+ *
+ *   <template>
+ *     {{ form.fieldErrors.email }}        ✅ works (this file proves it)
+ *     {{ form.fieldErrors.value.email }}  ❌ no longer compiles, no .value
+ *   </template>
+ *
+ * Vue auto-unwraps refs when they are TOP-LEVEL setup-return bindings.
+ * Refs nested inside an API object (like `useForm()`'s return) do NOT
+ * auto-unwrap, so the previous `Readonly<ComputedRef<…>>` shape forced
+ * authors to write `.value` in templates — surprising, since every
+ * other "looks reactive in the template" thing they touch in Vue is
+ * auto-unwrapped.
+ *
+ * The Proxy delegates property access to the underlying ComputedRef so
+ * Vue's reactivity tracking still fires (template re-renders on error
+ * changes, watch effects re-run). The readonly contract is preserved
+ * via `set` / `deleteProperty` traps that reject writes at runtime.
+ */
+
+const schema = z.object({
+  email: z.string().email('bad email'),
+  password: z.string().min(8, 'min 8 chars'),
+})
+
+type Api = ReturnType<typeof useForm<typeof schema>>
+
+function mount(): { app: App; api: Api } {
+  const handle: { api?: Api } = {}
+  const App = defineComponent({
+    setup() {
+      handle.api = useForm({ schema, key: 'fielderrs-view' })
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createChemicalXForms({ override: true }))
+  const root = document.createElement('div')
+  document.body.appendChild(root)
+  app.mount(root)
+  return { app, api: handle.api as Api }
+}
+
+describe('fieldErrors — template-friendly Proxy view', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('reads errors via direct dot-access (no .value)', () => {
+    const { app, api } = mount()
+    apps.push(app)
+
+    api.setFieldErrors([{ path: ['email'], message: 'bad email', formKey: api.key }])
+
+    // The whole point of this change: dot-access returns the array directly.
+    expect(api.fieldErrors.email?.[0]?.message).toBe('bad email')
+  })
+
+  it('reflects updates after setFieldErrors / clearFieldErrors', () => {
+    const { app, api } = mount()
+    apps.push(app)
+
+    expect(api.fieldErrors.email).toBeUndefined()
+
+    api.setFieldErrors([{ path: ['email'], message: 'taken', formKey: api.key }])
+    expect(api.fieldErrors.email?.[0]?.message).toBe('taken')
+
+    api.clearFieldErrors('email')
+    expect(api.fieldErrors.email).toBeUndefined()
+  })
+
+  it('exposes only the keys present in the underlying record', () => {
+    const { app, api } = mount()
+    apps.push(app)
+
+    expect(Object.keys(api.fieldErrors)).toEqual([])
+
+    api.setFieldErrors([
+      { path: ['email'], message: 'bad email', formKey: api.key },
+      { path: ['password'], message: 'min 8', formKey: api.key },
+    ])
+
+    // Object.keys traverses the Proxy's ownKeys + getOwnPropertyDescriptor
+    // traps; the result must match the underlying record exactly.
+    expect(new Set(Object.keys(api.fieldErrors))).toEqual(new Set(['email', 'password']))
+  })
+
+  it('JSON.stringify produces the same shape as the underlying record', () => {
+    const { app, api } = mount()
+    apps.push(app)
+
+    api.setFieldErrors([{ path: ['email'], message: 'bad email', formKey: api.key }])
+
+    const serialised = JSON.parse(JSON.stringify(api.fieldErrors))
+    expect(serialised).toEqual({
+      email: [{ path: ['email'], message: 'bad email', formKey: api.key }],
+    })
+  })
+
+  it('`in` operator delegates to the underlying record', () => {
+    const { app, api } = mount()
+    apps.push(app)
+
+    expect('email' in api.fieldErrors).toBe(false)
+
+    api.setFieldErrors([{ path: ['email'], message: 'bad email', formKey: api.key }])
+    expect('email' in api.fieldErrors).toBe(true)
+    expect('password' in api.fieldErrors).toBe(false)
+  })
+})
+
+describe('fieldErrors — readonly contract', () => {
+  const apps: App[] = []
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+  })
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+    warnSpy.mockRestore()
+  })
+
+  it('rejects direct property assignment + warns in dev', () => {
+    const { app, api } = mount()
+    apps.push(app)
+
+    // The Proxy's `set` trap returns false. In sloppy mode the assignment
+    // is silently ignored; in strict mode (where ESM lives by default,
+    // including Vitest test files), the trap throws TypeError.
+    expect(() => {
+      // @ts-expect-error — fieldErrors is Readonly at the type level;
+      // we're proving the runtime trap matches the type promise.
+      api.fieldErrors.email = [{ path: ['email'], message: 'mutated directly', formKey: api.key }]
+    }).toThrow(TypeError)
+
+    // Underlying record must remain empty.
+    expect(api.fieldErrors.email).toBeUndefined()
+    expect(warnSpy).toHaveBeenCalled()
+  })
+
+  it('rejects delete + warns in dev', () => {
+    const { app, api } = mount()
+    apps.push(app)
+
+    api.setFieldErrors([{ path: ['email'], message: 'bad email', formKey: api.key }])
+
+    expect(() => {
+      // @ts-expect-error — see above.
+      delete api.fieldErrors.email
+    }).toThrow(TypeError)
+
+    // Entry survives the rejected delete.
+    expect(api.fieldErrors.email?.[0]?.message).toBe('bad email')
+    expect(warnSpy).toHaveBeenCalled()
+  })
+})
+
+describe('fieldErrors — reactivity in render scope', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('a component reading fieldErrors.email re-renders when the entry changes', async () => {
+    let api!: Api
+    let renderedMessage = ''
+    const Reader = defineComponent({
+      setup() {
+        api = useForm({ schema, key: 'fielderrs-reactive' })
+        return () => {
+          renderedMessage = api.fieldErrors.email?.[0]?.message ?? ''
+          return h('div', renderedMessage)
+        }
+      },
+    })
+    const app = createApp(Reader).use(createChemicalXForms({ override: true }))
+    apps.push(app)
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+
+    expect(renderedMessage).toBe('')
+
+    api.setFieldErrors([{ path: ['email'], message: 'bad email', formKey: api.key }])
+    await nextTick()
+    expect(renderedMessage).toBe('bad email')
+
+    api.clearFieldErrors('email')
+    await nextTick()
+    expect(renderedMessage).toBe('')
+  })
+
+  it('getter-form `watch` fires on entry changes', async () => {
+    const { app, api } = mount()
+    apps.push(app)
+
+    const observed: (string | undefined)[] = []
+    const stop = vi.fn()
+    const { watch } = await import('vue')
+    const watcher = watch(
+      () => api.fieldErrors.email?.[0]?.message,
+      (next) => {
+        observed.push(next)
+      }
+    )
+
+    api.setFieldErrors([{ path: ['email'], message: 'first', formKey: api.key }])
+    await nextTick()
+
+    api.setFieldErrors([{ path: ['email'], message: 'second', formKey: api.key }])
+    await nextTick()
+
+    api.clearFieldErrors('email')
+    await nextTick()
+
+    watcher()
+    stop()
+
+    // First (undefined → 'first'), second ('first' → 'second'), third ('second' → undefined).
+    expect(observed).toEqual(['first', 'second', undefined])
+  })
+})

--- a/test/composables/field-validation.test.ts
+++ b/test/composables/field-validation.test.ts
@@ -67,14 +67,14 @@ describe('fieldValidation: { on: "change", debounceMs }', () => {
     api.setValue('email', 'no')
     api.setValue('email', 'notanemail')
     // Nothing written yet — debounce hasn't elapsed.
-    expect(api.fieldErrors.value.email).toBeUndefined()
+    expect(api.fieldErrors.email).toBeUndefined()
 
     // Advance past the debounce and flush microtasks to let the async
     // safeParseAsync settle.
     await vi.advanceTimersByTimeAsync(250)
     await drainMicrotasks()
 
-    const err = api.fieldErrors.value.email?.[0]
+    const err = api.fieldErrors.email?.[0]
     expect(err?.message).toBe('bad email')
   })
 
@@ -86,12 +86,12 @@ describe('fieldValidation: { on: "change", debounceMs }', () => {
     api.setValue('email', 'not-email')
     await vi.advanceTimersByTimeAsync(100)
     await drainMicrotasks()
-    expect(api.fieldErrors.value.email?.[0]?.message).toBe('bad email')
+    expect(api.fieldErrors.email?.[0]?.message).toBe('bad email')
 
     api.setValue('email', 'fixed@example.com')
     await vi.advanceTimersByTimeAsync(100)
     await drainMicrotasks()
-    expect(api.fieldErrors.value.email).toBeUndefined()
+    expect(api.fieldErrors.email).toBeUndefined()
   })
 
   it('submit entry aborts pending field runs — submit result wins', async () => {
@@ -113,8 +113,8 @@ describe('fieldValidation: { on: "change", debounceMs }', () => {
     // Submit's full-form validation has populated errors for every
     // failing field — including email ('bad email') and password
     // ('min 8 chars').
-    expect(api.fieldErrors.value.email?.[0]?.message).toBe('bad email')
-    expect(api.fieldErrors.value.password?.[0]?.message).toBe('min 8 chars')
+    expect(api.fieldErrors.email?.[0]?.message).toBe('bad email')
+    expect(api.fieldErrors.password?.[0]?.message).toBe('min 8 chars')
   })
 
   it('on="none" (default): writes never schedule a field run', async () => {
@@ -125,7 +125,7 @@ describe('fieldValidation: { on: "change", debounceMs }', () => {
     api.setValue('email', 'not-an-email')
     await vi.advanceTimersByTimeAsync(1000)
     await drainMicrotasks()
-    expect(api.fieldErrors.value.email).toBeUndefined()
+    expect(api.fieldErrors.email).toBeUndefined()
   })
 })
 
@@ -142,7 +142,7 @@ describe('fieldValidation: { on: "blur" }', () => {
     api.setValue('email', 'invalid')
     await drainMicrotasks()
     // No write-path validation in blur mode.
-    expect(api.fieldErrors.value.email).toBeUndefined()
+    expect(api.fieldErrors.email).toBeUndefined()
   })
 })
 
@@ -163,6 +163,6 @@ describe('fieldValidation: reset cancels pending runs', () => {
     await vi.advanceTimersByTimeAsync(500)
     await drainMicrotasks()
     // Reset cleared the timer — no field-run wrote anything to errors.
-    expect(api.fieldErrors.value.email).toBeUndefined()
+    expect(api.fieldErrors.email).toBeUndefined()
   })
 })

--- a/test/composables/history.test.ts
+++ b/test/composables/history.test.ts
@@ -119,12 +119,12 @@ describe('history — default (history: true)', () => {
     // snapshot captures the cleared state.
     api.clearFieldErrors('email')
     api.setValue('email', 'c')
-    expect(api.fieldErrors.value.email).toBeUndefined()
+    expect(api.fieldErrors.email).toBeUndefined()
     // Undo once — snapshot taken at the 'b' mutation carried the
     // errors that were set just before it.
     api.undo()
     expect(api.getValue('email').value).toBe('b')
-    expect(api.fieldErrors.value.email?.[0]?.message).toBe('bad')
+    expect(api.fieldErrors.email?.[0]?.message).toBe('bad')
   })
 })
 

--- a/test/composables/reset.test.ts
+++ b/test/composables/reset.test.ts
@@ -87,7 +87,7 @@ describe('useForm — reset()', () => {
 
     form.reset()
     expect(form.isValid.value).toBe(true)
-    expect(form.fieldErrors.value).toEqual({})
+    expect(form.fieldErrors).toEqual({})
   })
 
   it('flips isDirty back to false after a mutation + reset', () => {
@@ -156,8 +156,8 @@ describe('useForm — resetField(path)', () => {
     ])
 
     form.resetField('email')
-    expect(form.fieldErrors.value).not.toHaveProperty('email')
-    expect(form.fieldErrors.value.password).toHaveLength(1)
+    expect(form.fieldErrors).not.toHaveProperty('email')
+    expect(form.fieldErrors.password).toHaveLength(1)
   })
 
   it('restores an entire sub-tree when path names a container', () => {

--- a/test/composables/type-inference.test.ts
+++ b/test/composables/type-inference.test.ts
@@ -205,8 +205,12 @@ describe('useForm type inference — getFieldState + fieldErrors', () => {
     expectTypeOf(fs.value.errors).toMatchTypeOf<ReadonlyArray<{ message: string }>>()
   })
 
-  it('fieldErrors is a ComputedRef<FormErrorRecord>', () => {
-    expectTypeOf(form.fieldErrors.value).toMatchTypeOf<Record<string, unknown>>()
+  it('fieldErrors is a Readonly<FormFieldErrors<Form>> (Proxy view, no .value)', () => {
+    // Internally backed by a ComputedRef + Proxy; the public type is
+    // the unwrapped record so templates can dot-access without `.value`.
+    expectTypeOf(form.fieldErrors).toMatchTypeOf<Record<string, unknown>>()
+    // @ts-expect-error — fieldErrors is no longer a Ref, so `.value` is gone.
+    void form.fieldErrors.value
   })
 })
 

--- a/test/composables/use-form-v3-forwarding.test.ts
+++ b/test/composables/use-form-v3-forwarding.test.ts
@@ -75,7 +75,7 @@ describe('v3 useForm forwards opt-in options to useAbstractForm', () => {
     await wait(60)
     await drain()
 
-    expect(api.fieldErrors.value.email?.[0]?.message).toBe('bad email')
+    expect(api.fieldErrors.email?.[0]?.message).toBe('bad email')
   })
 
   it('forwards persist — custom FormStorage receives setItem calls', async () => {


### PR DESCRIPTION
## Summary

- Replaces `fieldErrors: Readonly<ComputedRef<FormFieldErrors<Form>>>` with `fieldErrors: Readonly<FormFieldErrors<Form>>` — a Proxy view over the same underlying ComputedRef.
- Templates and scripts both dot-access uniformly: `form.fieldErrors.email` instead of the old asymmetric `fieldErrors.value.email` (script) / `fieldErrors.email` (template).
- Read-only contract preserved at compile time (the type) **and** at runtime (Proxy traps reject writes + emit a dev-mode warning pointing at `setFieldErrors` / `clearFieldErrors`).
- Laziness + dependency tracking preserved — reads inside a render or `watchEffect` still track the underlying ComputedRef exactly as `.value` would.

**Stack position: bottom (1 of 3).** The next two PRs build on this:
1. This PR — fieldErrors Proxy.
2. `claude/state-bundle` — bundle 9 form-level scalars onto a `state` object (same template-auto-unwrap class of bug).
3. `claude/default-values-rename` — rename `initialState` → `defaultValues` so the config key doesn't collide with the new `state` property.

All three together form the 0.11 breaking-change window.

## Test plan

- [x] `pnpm test` — 649/649 green (+9 new cases in `field-errors-view.test.ts` covering Proxy semantics: dot-access, key enumeration, JSON.stringify, `in` operator, readonly enforcement in strict mode, render-scope reactivity, watch-via-getter)
- [x] `pnpm typecheck` — clean
- [x] Consumer-side verified via `cubic-forms/frontend/app/pages/spike-cx.vue` — the original `fieldErrors.value.email` vue-tsc error is fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * `fieldErrors` now accessible directly in templates without `.value` (e.g., `fieldErrors.email` instead of `fieldErrors.value.email`).
  * Type signature simplified: direct readonly object instead of computed reference wrapper.
  * Mutations blocked at runtime with development mode warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->