### PR TITLE
Claude/optimistic isconnected ssr

### DIFF
--- a/src/nuxt.ts
+++ b/src/nuxt.ts
@@ -1,6 +1,7 @@
 import { addImports, addPlugin, addTypeTemplate, createResolver, defineNuxtModule } from '@nuxt/kit'
 import { inputTextAreaNodeTransform } from './runtime/lib/core/transforms/input-text-area-transform'
 import { selectNodeTransform } from './runtime/lib/core/transforms/select-transform'
+import { vRegisterHintTransform } from './runtime/lib/core/transforms/v-register-hint-transform'
 
 // Module options TypeScript interface definition
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
@@ -19,7 +20,8 @@ export default defineNuxtModule<CXModuleOptions>({
     nuxt.options.vue.compilerOptions.nodeTransforms ??= []
     nuxt.options.vue.compilerOptions.nodeTransforms.push(
       selectNodeTransform,
-      inputTextAreaNodeTransform
+      inputTextAreaNodeTransform,
+      vRegisterHintTransform
     )
 
     const resolver = createResolver(import.meta.url)

--- a/src/nuxt.ts
+++ b/src/nuxt.ts
@@ -2,6 +2,7 @@ import { addImports, addPlugin, addTypeTemplate, createResolver, defineNuxtModul
 import { inputTextAreaNodeTransform } from './runtime/lib/core/transforms/input-text-area-transform'
 import { selectNodeTransform } from './runtime/lib/core/transforms/select-transform'
 import { vRegisterHintTransform } from './runtime/lib/core/transforms/v-register-hint-transform'
+import { vRegisterPreambleTransform } from './runtime/lib/core/transforms/v-register-preamble-transform'
 
 // Module options TypeScript interface definition
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
@@ -17,10 +18,13 @@ export default defineNuxtModule<CXModuleOptions>({
   },
   defaults: {},
   setup(_options, nuxt) {
+    // vRegisterPreambleTransform MUST come before vRegisterHintTransform
+    // — see src/vite.ts for the ordering rationale.
     nuxt.options.vue.compilerOptions.nodeTransforms ??= []
     nuxt.options.vue.compilerOptions.nodeTransforms.push(
       selectNodeTransform,
       inputTextAreaNodeTransform,
+      vRegisterPreambleTransform,
       vRegisterHintTransform
     )
 

--- a/src/runtime/composables/use-abstract-form.ts
+++ b/src/runtime/composables/use-abstract-form.ts
@@ -171,6 +171,7 @@ function buildFreshState<F extends GenericForm, G extends GenericForm = F>(
     validationMode: configuration.validationMode,
     hydration: pending,
     fieldValidation: configuration.fieldValidation,
+    isSSR: registry.isSSR,
   })
   // Storage type is FormStore<GenericForm>; the lookup above narrows
   // back to the caller's (F, G) via the `existing as FormStore<Form,

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -62,6 +62,14 @@ export type FormStore<F extends GenericForm, G extends GenericForm = F> = {
   readonly originals: Map<PathKey, OriginalsRecord>
   readonly schema: AbstractSchema<F, G>
 
+  /**
+   * Server-side flag, plumbed in from `registry.isSSR`. The
+   * `register()`-returned `markConnectedOptimistically()` reads this
+   * before flipping `isConnected: true`; on the client it's a no-op so
+   * the eventual directive lifecycle remains the source of truth.
+   */
+  readonly isSSR: boolean
+
   // --- submission lifecycle ---
   // Driven by buildProcessForm's handleSubmit wrapper. See use-abstract-form.ts
   // for the public readonly surface. Mutations happen in exactly one place
@@ -115,6 +123,15 @@ export type FormStore<F extends GenericForm, G extends GenericForm = F> = {
   deregisterElement(path: Path, element: HTMLElement): number
   markFocused(path: Path, focused: boolean): void
   markTouched(path: Path): void
+  /**
+   * SSR-only optimistic mark: flip `isConnected: true` on the field
+   * record without an actual DOM element. Called by the `vRegisterHint`
+   * compile-time transform via `RegisterValue.markConnectedOptimistically()`
+   * for every element rendered with `v-register`. Idempotent + no-op on
+   * the client (the directive's `created` hook is the authoritative
+   * source there).
+   */
+  markConnectedOptimistically(path: Path): void
 
   // --- derived ---
   /**
@@ -231,12 +248,14 @@ export type CreateFormStoreOptions<F extends GenericForm, G extends GenericForm 
   readonly validationMode?: ValidationMode | undefined
   readonly hydration?: FormStoreHydration | undefined
   readonly fieldValidation?: FieldValidationConfig | undefined
+  readonly isSSR?: boolean | undefined
 }
 
 export function createFormStore<F extends GenericForm, G extends GenericForm = F>(
   options: CreateFormStoreOptions<F, G>
 ): FormStore<F, G> {
   const { formKey, schema, defaultValues, validationMode = 'lax', hydration } = options
+  const isSSR = options.isSSR === true
   const fieldValidationMode: FieldValidationMode = options.fieldValidation?.on ?? 'none'
   const fieldValidationDebounceMs: number = options.fieldValidation?.debounceMs ?? 200
 
@@ -596,6 +615,18 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     return remaining
   }
 
+  function markConnectedOptimistically(path: Path): void {
+    // Client-side: the directive's `created` / `beforeUnmount` hooks are
+    // authoritative for `isConnected`, so this is a no-op there. SSR is
+    // the only environment where we can't observe the DOM and need an
+    // upfront hint that the field WILL be wired up after hydration.
+    if (!isSSR) return
+    const { key } = canonicalizePath(path)
+    const current = fields.get(key)
+    if (current?.isConnected === true) return
+    touchFieldRecord(key, path, { isConnected: true })
+  }
+
   function markFocused(path: Path, focused: boolean): void {
     const { key } = canonicalizePath(path)
     touchFieldRecord(key, path, {
@@ -818,6 +849,7 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     errors,
     originals,
     schema,
+    isSSR,
     isSubmitting,
     activeSubmissions,
     submitCount,
@@ -842,6 +874,7 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     deregisterElement,
     markFocused,
     markTouched,
+    markConnectedOptimistically,
 
     isPristineAtPath,
     getFieldRecord,

--- a/src/runtime/core/register-api.ts
+++ b/src/runtime/core/register-api.ts
@@ -84,6 +84,18 @@ export function buildRegister<F extends GenericForm>(state: FormStore<F>) {
         state.setValueAtPath(segments, value)
         return true
       },
+
+      // Called by the `vRegisterHint` compile-time transform's wrapping
+      // IIFE on every server-side render of `<element v-register="…">`.
+      // Without it, every SSR'd FieldState serialises `isConnected: false`
+      // (because Vue skips directive lifecycle during SSR) and the client
+      // briefly shows that stale flag until hydration runs the directive's
+      // `created` hook. The mark only takes effect when `state.isSSR` is
+      // true; on the client this is a no-op so the directive lifecycle
+      // remains the source of truth.
+      markConnectedOptimistically: (): void => {
+        state.markConnectedOptimistically(segments)
+      },
     }
   }
 }

--- a/src/runtime/lib/core/transforms/v-register-hint-transform.ts
+++ b/src/runtime/lib/core/transforms/v-register-hint-transform.ts
@@ -1,0 +1,103 @@
+import {
+  createCompoundExpression,
+  NodeTypes,
+  type CompoundExpressionNode,
+  type ExpressionNode,
+  type NodeTransform,
+  type SourceLocation,
+} from '@vue/compiler-core'
+
+/**
+ * `vRegisterHintTransform` — for every `<element v-register="<expr>">`,
+ * rewrite the directive's binding expression to wrap `<expr>` in an
+ * IIFE that calls `markConnectedOptimistically()` on the resulting
+ * `RegisterValue` and returns the same object:
+ *
+ *   ((__cxRv) => (__cxRv?.markConnectedOptimistically?.(), __cxRv))(<expr>)
+ *
+ * Why this exists: Vue intentionally skips directive lifecycle hooks
+ * during SSR (see `core/directive.ts`'s top comment). That means the
+ * `v-register` directive's `created` hook — the one that flips
+ * `isConnected: true` for the field — never fires server-side. Every
+ * SSR'd FieldState therefore serialises `isConnected: false`, and on
+ * hydration the directive runs and the flag flickers to `true`. Anyone
+ * reading `getFieldState(path).isConnected` in a server-rendered
+ * template sees the stale value baked into the static HTML.
+ *
+ * The wrapping IIFE captures the `RegisterValue` produced by `<expr>`,
+ * fires the optimistic mark (which itself is guarded by `state.isSSR`,
+ * so client-side it's a free no-op), and returns the same object so
+ * the directive receives exactly what the author wrote.
+ *
+ * The transform is deliberately agnostic to the shape of `<expr>`:
+ *
+ *   - inline:   `v-register="form.register('email')"`
+ *   - hoisted:  `v-register="emailReg"` (where `emailReg = form.register(...)`)
+ *   - dynamic:  `v-register="form.register(`${prefix}.email`)"`
+ *
+ * All three produce a `RegisterValue` at runtime, and the wrapper
+ * doesn't need to know the path string. Setup-time `register()` calls
+ * that are NEVER bound to `v-register` get no wrapper, no optimistic
+ * mark, and stay `isConnected: false` post-hydration — exactly the
+ * desired negative case (those calls don't represent a rendered DOM
+ * element).
+ *
+ * Idempotent: if the transform runs twice on the same AST (some
+ * bundler configurations do this), the second pass detects the marker
+ * and skips re-wrapping.
+ */
+
+const dummyLoc: SourceLocation = {
+  start: { column: 0, line: 0, offset: 0 },
+  end: { column: 0, line: 0, offset: 0 },
+  source: '',
+}
+
+const HINT_MARKER = '__cxRv'
+const HINT_PREFIX = `((${HINT_MARKER}) => (${HINT_MARKER}?.markConnectedOptimistically?.(), ${HINT_MARKER}))(`
+const HINT_SUFFIX = `)`
+
+export const vRegisterHintTransform: NodeTransform = (node) => {
+  try {
+    if (node.type !== NodeTypes.ELEMENT) return
+    for (const prop of node.props) {
+      if (prop.type !== NodeTypes.DIRECTIVE) continue
+      if (prop.name !== 'register') continue
+      if (prop.exp === undefined) continue
+      if (isAlreadyWrapped(prop.exp)) continue
+      prop.exp = wrapWithOptimisticHint(prop.exp)
+    }
+  } catch (err) {
+    // AST shape drift across @vue/compiler-core versions or a malformed
+    // directive: skip this transform entirely. The runtime mark is
+    // fail-safe — without the wrapper, we just get the existing
+    // false→true flicker on first paint, never an incorrect render.
+    console.error('[@chemical-x/forms] v-register hint transform failed, skipping:', err)
+  }
+}
+
+function isAlreadyWrapped(exp: ExpressionNode): boolean {
+  if (exp.type === NodeTypes.SIMPLE_EXPRESSION) {
+    return exp.content.includes(HINT_MARKER)
+  }
+  // Compound expression: scan only the string children. Nested
+  // SimpleExpressionNodes were copied verbatim from the user's
+  // expression and won't contain our marker; the marker only ever
+  // appears in the literal prefix/suffix strings we add.
+  for (const child of exp.children) {
+    if (typeof child === 'string' && child.includes(HINT_MARKER)) return true
+  }
+  return false
+}
+
+function wrapWithOptimisticHint(exp: ExpressionNode): CompoundExpressionNode {
+  // For a SimpleExpression we keep the node intact as a child so any
+  // later `processExpression` pass (identifier prefixing for setup
+  // refs) still walks it. For a CompoundExpression we splice its
+  // children in — prepending the prefix string and appending the
+  // suffix preserves the post-prefix shape downstream transforms
+  // expect.
+  const innerChildren: CompoundExpressionNode['children'] =
+    exp.type === NodeTypes.SIMPLE_EXPRESSION ? [exp] : [...exp.children]
+  return createCompoundExpression([HINT_PREFIX, ...innerChildren, HINT_SUFFIX], dummyLoc)
+}

--- a/src/runtime/lib/core/transforms/v-register-preamble-transform.ts
+++ b/src/runtime/lib/core/transforms/v-register-preamble-transform.ts
@@ -1,0 +1,274 @@
+import {
+  createSimpleExpression,
+  NodeTypes,
+  type DirectiveNode,
+  type ElementNode,
+  type ExpressionNode,
+  type NodeTransform,
+  type RootNode,
+  type SimpleExpressionNode,
+  type SourceLocation,
+} from '@vue/compiler-core'
+
+/**
+ * `vRegisterPreambleTransform` — closes the render-order edge that
+ * `vRegisterHintTransform` alone leaves open.
+ *
+ * The hint transform wraps each `v-register` directive expression in an
+ * IIFE that calls `markConnectedOptimistically()` when the element's
+ * vnode is created. That works for any expression evaluated AT or AFTER
+ * the input in render order. But Vue's SSR is single-pass top-to-bottom,
+ * so a template like:
+ *
+ *   <pre>{{ form.getFieldState('password').value }}</pre>
+ *   <input v-register="form.register('password')" />
+ *
+ * evaluates the `<pre>` first, BEFORE the v-register wrapper has had a
+ * chance to fire. The serialized HTML carries `isConnected: false` for
+ * password — and the post-hydration steady state shows `true`, leaving
+ * a one-tick `false → true` flicker visible to the user.
+ *
+ * Fix: hoist the marks one level up. We walk the entire template AST,
+ * collect every static `v-register` binding (skipping descendants of
+ * `v-for`, since those reference loop locals not available at root
+ * scope), and prepend a synthetic `:data-cx-pre-mark` directive on the
+ * first root element. Vue evaluates element prop bindings before
+ * recursing into children, so the IIFE inside `:data-cx-pre-mark` fires
+ * every collected mark BEFORE any descendant template expression runs.
+ *
+ * The binding's expression resolves to `undefined`, which Vue's SSR
+ * renderer drops (no `data-cx-pre-mark` attribute appears in the
+ * rendered HTML). The side effect — flipping `isConnected: true` on
+ * each field record — is the only output we want.
+ *
+ * Companion to `vRegisterHintTransform`: register both, with this one
+ * BEFORE the hint transform. The pre-order pass here captures each
+ * `v-register` expression's original (un-wrapped) text into a
+ * per-template state map; the hint transform then wraps the in-place
+ * directive expression. The exit hook on the first root element
+ * builds the preamble using the captured originals — exit hooks on
+ * an element fire before `transformElement`'s codegen exit, so the
+ * injected prop lands in the rendered output.
+ *
+ * For `v-for` descendants the per-element wrapper from
+ * `vRegisterHintTransform` is still load-bearing — those bindings can't
+ * be hoisted because their path expressions reference loop-scoped
+ * identifiers (e.g. `form.register(`item.${i}`)`).
+ */
+
+const dummyLoc: SourceLocation = {
+  start: { column: 0, line: 0, offset: 0 },
+  end: { column: 0, line: 0, offset: 0 },
+  source: '',
+}
+
+/**
+ * Per-root traversal state. Keyed by the RootNode object — stable for
+ * the duration of one compile pass and GC-friendly across pipelines.
+ *   - `captured`: collected pre-wrap expression strings, in template
+ *     visit order.
+ *   - `vForDepth`: nesting count for `v-for` ancestry, bumped on FOR
+ *     entry / decremented on FOR exit, so element visits in between
+ *     can skip captures cheaply.
+ *   - `firstRootElementVisited`: ensures we only register the
+ *     injection exit-hook on the very first root element (templates
+ *     with multiple top-level elements still have one "first" — Vue
+ *     wraps multi-root in a fragment, but the FIRST element's props
+ *     evaluate before any sibling).
+ */
+type TraversalState = {
+  readonly captured: string[]
+  /**
+   * Elements whose v-register binding has already been captured for
+   * THIS root traversal. Guards against double-capture when the same
+   * transform is registered twice in the `nodeTransforms` array (some
+   * bundler chains do this) — without it, every binding's mark call
+   * would be duplicated in the injected expression.
+   */
+  readonly capturedElements: WeakSet<ElementNode>
+  vForDepth: number
+  firstRootElementVisited: boolean
+}
+const stateByRoot: WeakMap<RootNode, TraversalState> = new WeakMap()
+
+const PREAMBLE_ATTR = 'data-cx-pre-mark'
+
+export const vRegisterPreambleTransform: NodeTransform = (node, context) => {
+  try {
+    if (node.type === NodeTypes.ROOT) {
+      // If state already exists, a duplicate registration of this
+      // transform is at work — keep the first run's state intact.
+      // Otherwise its captures would get wiped by this re-init.
+      if (stateByRoot.has(node)) return
+      stateByRoot.set(node, {
+        captured: [],
+        capturedElements: new WeakSet<ElementNode>(),
+        vForDepth: 0,
+        firstRootElementVisited: false,
+      })
+      return () => {
+        // Cleanup on root exit. The actual injection happened on the
+        // first root element's exit (registered below) — by the time
+        // we get here, that element's transformElement codegen has
+        // already absorbed the injected prop.
+        stateByRoot.delete(node)
+      }
+    }
+
+    const state = stateByRoot.get(context.root)
+    if (state === undefined) return
+
+    if (node.type === NodeTypes.FOR) {
+      // The structural `transformFor` (built into compiler-core, runs
+      // before our transform) wraps any element carrying v-for in a
+      // NodeTypes.FOR node. Bumping the depth on entry / decrementing
+      // on exit gives us O(1) "am I inside a v-for ancestor?" checks
+      // during the element visits below.
+      state.vForDepth += 1
+      return () => {
+        state.vForDepth -= 1
+      }
+    }
+
+    if (node.type !== NodeTypes.ELEMENT) return
+
+    // Capture this element's v-register binding (if any) BEFORE
+    // deciding about exit-hook registration — that way the very first
+    // root element, which itself might carry v-register, contributes
+    // its binding to the preamble it hosts.
+    captureVRegisterIfStatic(node, state)
+
+    // First root element — register the exit hook that injects the
+    // preamble using the FINAL collected state. Exit hooks fire after
+    // children are traversed, so by then every descendant capture has
+    // landed in `state.captured`.
+    if (!state.firstRootElementVisited && context.parent?.type === NodeTypes.ROOT) {
+      state.firstRootElementVisited = true
+      return () => {
+        const finalState = stateByRoot.get(context.root)
+        if (finalState === undefined || finalState.captured.length === 0) return
+        injectPreamble(node, finalState.captured)
+      }
+    }
+    return
+  } catch (err) {
+    // AST shape drift or a malformed directive: skip this transform
+    // entirely. The per-element vRegisterHintTransform still covers
+    // the common case (read at-or-after the input). Failure here only
+    // affects the read-before-input edge.
+    console.error('[@chemical-x/forms] v-register preamble transform failed, skipping:', err)
+    return
+  }
+}
+
+function captureVRegisterIfStatic(node: ElementNode, state: TraversalState): void {
+  if (state.vForDepth > 0) return
+  // An element that itself carries v-for hasn't been wrapped yet by
+  // transformFor at the moment user transforms see it (transform
+  // ordering varies by bundler), so check the directive directly.
+  if (hasVForDirective(node)) return
+  // Idempotency: only one capture per element per root traversal.
+  // Without this, registering the transform twice in the
+  // `nodeTransforms` array would double every binding's mark call
+  // inside the injected expression.
+  if (state.capturedElements.has(node)) return
+
+  const exp = findVRegisterExpression(node)
+  if (exp === null) return
+  state.capturedElements.add(node)
+  // Pre-wrap capture. This transform is registered BEFORE
+  // vRegisterHintTransform, so prop.exp is still the original
+  // expression here; the hint's wrap happens after our pre-order
+  // returns from the same node.
+  state.captured.push(flattenExpression(exp))
+}
+
+function findVRegisterExpression(node: ElementNode): ExpressionNode | null {
+  for (const prop of node.props) {
+    if (prop.type !== NodeTypes.DIRECTIVE) continue
+    if (prop.name !== 'register') continue
+    if (prop.exp === undefined) continue
+    return prop.exp
+  }
+  return null
+}
+
+function hasVForDirective(node: ElementNode): boolean {
+  for (const prop of node.props) {
+    if (prop.type === NodeTypes.DIRECTIVE && prop.name === 'for') return true
+  }
+  return false
+}
+
+/**
+ * Flatten an ExpressionNode to its source text. The compiler-core AST
+ * stores expressions either as a SimpleExpressionNode (one piece of
+ * text) or a CompoundExpressionNode (a list of strings + nested
+ * SimpleExpressionNodes interleaved, which is what `processExpression`
+ * produces when prefixing identifiers). We can serialise either back
+ * to source by concatenating the textual content.
+ */
+function flattenExpression(exp: ExpressionNode): string {
+  if (exp.type === NodeTypes.SIMPLE_EXPRESSION) return exp.content
+  let out = ''
+  for (const child of exp.children) {
+    if (typeof child === 'string') {
+      out += child
+      continue
+    }
+    if (typeof child === 'symbol') continue
+    if ('content' in child) {
+      out += child.content
+      continue
+    }
+    out += flattenExpression(child as ExpressionNode)
+  }
+  return out
+}
+
+/**
+ * Build and prepend the `:data-cx-pre-mark` directive to the element's
+ * props. The expression is a comma-chain of
+ * `(<expr>)?.markConnectedOptimistically?.()` calls, ending in
+ * `undefined` so the attribute resolves to `undefined` and Vue's SSR
+ * renderer omits it entirely. Side effects (the marks) happen during
+ * evaluation; no observable HTML attribute appears.
+ *
+ * The exp is a SimpleExpressionNode with `isStatic: false` — when
+ * `transformElement`'s exit codegen processes it, identifiers like
+ * `form` get prefixed (`_ctx.form`) the same way every other dynamic
+ * binding does. This works because our exit hook runs BEFORE
+ * `transformElement`'s exit (we're registered later in the
+ * `nodeTransforms` array, so our exit fires earlier in the reverse
+ * pass).
+ */
+function injectPreamble(element: ElementNode, captured: readonly string[]): void {
+  if (hasPreamble(element)) return
+
+  const callList = captured
+    .map((source) => `(${source})?.markConnectedOptimistically?.()`)
+    .join(', ')
+  const expressionText = `(${callList}, undefined)`
+  const exp: SimpleExpressionNode = createSimpleExpression(expressionText, false /* not static */)
+
+  const directive: DirectiveNode = {
+    type: NodeTypes.DIRECTIVE,
+    name: 'bind',
+    arg: createSimpleExpression(PREAMBLE_ATTR, true /* static arg */),
+    exp,
+    modifiers: [],
+    loc: dummyLoc,
+  }
+  element.props.unshift(directive)
+}
+
+function hasPreamble(element: ElementNode): boolean {
+  for (const prop of element.props) {
+    if (prop.type !== NodeTypes.DIRECTIVE) continue
+    if (prop.name !== 'bind') continue
+    if (prop.arg === undefined) continue
+    if (prop.arg.type !== NodeTypes.SIMPLE_EXPRESSION) continue
+    if (prop.arg.content === PREAMBLE_ATTR) return true
+  }
+  return false
+}

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -426,6 +426,15 @@ export type RegisterValue<Value = unknown> = {
   registerElement: (el: HTMLElement) => void
   deregisterElement: (el: HTMLElement) => void
   setValueWithInternalPath: (value: unknown) => boolean
+  /**
+   * Optimistic SSR-only mark. Called by the `vRegisterHint` template
+   * transform's wrapping IIFE so that any field bound to `v-register`
+   * starts life with `isConnected: true` server-side, preventing the
+   * `false → true` flicker that would otherwise show up when the
+   * directive's `created` hook (skipped during SSR) finally runs on
+   * hydration. No-op on the client; see `FormStore.markConnectedOptimistically`.
+   */
+  markConnectedOptimistically: () => void
 }
 
 export type CustomDirectiveRegisterAssignerFn = (value: unknown) => void

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -10,8 +10,13 @@
  * Rspack, a custom Rollup pipeline, etc.) and needing to add the
  * transforms to Vue's template compiler manually:
  *
- *   import { selectNodeTransform, inputTextAreaNodeTransform } from '@chemical-x/forms/transforms'
+ *   import {
+ *     selectNodeTransform,
+ *     inputTextAreaNodeTransform,
+ *     vRegisterHintTransform,
+ *   } from '@chemical-x/forms/transforms'
  */
 
 export { inputTextAreaNodeTransform } from './runtime/lib/core/transforms/input-text-area-transform'
 export { selectNodeTransform } from './runtime/lib/core/transforms/select-transform'
+export { vRegisterHintTransform } from './runtime/lib/core/transforms/v-register-hint-transform'

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -13,10 +13,19 @@
  *   import {
  *     selectNodeTransform,
  *     inputTextAreaNodeTransform,
+ *     vRegisterPreambleTransform,
  *     vRegisterHintTransform,
  *   } from '@chemical-x/forms/transforms'
+ *
+ * Order matters: `vRegisterPreambleTransform` MUST run before
+ * `vRegisterHintTransform`. The preamble's pre-order captures each
+ * `v-register` expression in its un-wrapped form; the hint transform
+ * then mutates the directive's expression to wrap it in the
+ * optimistic-mark IIFE. Reverse order would leak the IIFE wrapper
+ * into the preamble's collected text.
  */
 
 export { inputTextAreaNodeTransform } from './runtime/lib/core/transforms/input-text-area-transform'
 export { selectNodeTransform } from './runtime/lib/core/transforms/select-transform'
 export { vRegisterHintTransform } from './runtime/lib/core/transforms/v-register-hint-transform'
+export { vRegisterPreambleTransform } from './runtime/lib/core/transforms/v-register-preamble-transform'

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -28,6 +28,7 @@ import type { Plugin } from 'vite'
 import { inputTextAreaNodeTransform } from './runtime/lib/core/transforms/input-text-area-transform'
 import { selectNodeTransform } from './runtime/lib/core/transforms/select-transform'
 import { vRegisterHintTransform } from './runtime/lib/core/transforms/v-register-hint-transform'
+import { vRegisterPreambleTransform } from './runtime/lib/core/transforms/v-register-preamble-transform'
 
 /** Reserved for future options. Empty at the moment. */
 export type ChemicalXVitePluginOptions = Record<string, never>
@@ -60,10 +61,17 @@ export function chemicalXForms(_options: ChemicalXVitePluginOptions = {}): Plugi
       api.options.template ??= {}
       api.options.template.compilerOptions ??= {}
       const existing = api.options.template.compilerOptions.nodeTransforms ?? []
+      // vRegisterPreambleTransform MUST come before vRegisterHintTransform
+      // — the preamble's pre-order captures each `v-register` expression
+      // in its raw (un-wrapped) form, and the hint then mutates the same
+      // directive's `exp` to wrap it. Reversing the order would have the
+      // preamble pick up an already-wrapped IIFE, double-wrapping it
+      // when injected at the root.
       api.options.template.compilerOptions.nodeTransforms = [
         ...existing,
         selectNodeTransform,
         inputTextAreaNodeTransform,
+        vRegisterPreambleTransform,
         vRegisterHintTransform,
       ]
     },

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -27,6 +27,7 @@
 import type { Plugin } from 'vite'
 import { inputTextAreaNodeTransform } from './runtime/lib/core/transforms/input-text-area-transform'
 import { selectNodeTransform } from './runtime/lib/core/transforms/select-transform'
+import { vRegisterHintTransform } from './runtime/lib/core/transforms/v-register-hint-transform'
 
 /** Reserved for future options. Empty at the moment. */
 export type ChemicalXVitePluginOptions = Record<string, never>
@@ -63,6 +64,7 @@ export function chemicalXForms(_options: ChemicalXVitePluginOptions = {}): Plugi
         ...existing,
         selectNodeTransform,
         inputTextAreaNodeTransform,
+        vRegisterHintTransform,
       ]
     },
   }

--- a/test/core/directive-cleanup.test.ts
+++ b/test/core/directive-cleanup.test.ts
@@ -32,6 +32,7 @@ function makeRegisterValue<T>(initial: T): {
     registerElement: register,
     deregisterElement: deregister,
     setValueWithInternalPath: setValue,
+    markConnectedOptimistically: () => undefined,
   }
   return { value, register, deregister, setValue }
 }

--- a/test/core/optimistic-is-connected.test.ts
+++ b/test/core/optimistic-is-connected.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+import { createFormStore } from '../../src/runtime/core/create-form-store'
+import { buildRegister } from '../../src/runtime/core/register-api'
+import { fakeSchema } from '../utils/fake-schema'
+
+type F = { email: string; note: string }
+
+function makeForm(opts: { isSSR: boolean }) {
+  const state = createFormStore<F>({
+    formKey: 'opt',
+    schema: fakeSchema<F>({ email: '', note: '' }),
+    isSSR: opts.isSSR,
+  })
+  return { state, register: buildRegister(state) }
+}
+
+describe('optimistic isConnected — FormStore.markConnectedOptimistically', () => {
+  it('flips isConnected: true for the path when isSSR is true', () => {
+    const { state } = makeForm({ isSSR: true })
+    expect(state.getFieldRecord(['email'])?.isConnected).toBe(false)
+    state.markConnectedOptimistically(['email'])
+    expect(state.getFieldRecord(['email'])?.isConnected).toBe(true)
+  })
+
+  it('is a no-op when isSSR is false (client lifecycle is authoritative)', () => {
+    // On the client, the directive's `created` hook is the source of
+    // truth for isConnected. The optimistic-mark would be a stale
+    // override risk if it fired here, so it MUST early-return.
+    const { state } = makeForm({ isSSR: false })
+    state.markConnectedOptimistically(['email'])
+    expect(state.getFieldRecord(['email'])?.isConnected).toBe(false)
+  })
+
+  it('is idempotent — repeat calls keep isConnected: true without touching unrelated fields', () => {
+    const { state } = makeForm({ isSSR: true })
+    state.markConnectedOptimistically(['email'])
+    state.markConnectedOptimistically(['email'])
+    expect(state.getFieldRecord(['email'])?.isConnected).toBe(true)
+    // Note: the transform never wraps a binding for `note`, so its record stays as-init.
+    expect(state.getFieldRecord(['note'])?.isConnected).toBe(false)
+  })
+
+  it('preserves existing focus/touch flags when flipping isConnected', () => {
+    // touchFieldRecord merges patches. The optimistic-mark flow must
+    // not reset focused/touched/blurred state (in tests that path is
+    // unlikely, but in real SSR a future patch could land in either order).
+    const { state } = makeForm({ isSSR: true })
+    state.markFocused(['email'], true)
+    expect(state.getFieldRecord(['email'])?.focused).toBe(true)
+    state.markConnectedOptimistically(['email'])
+    expect(state.getFieldRecord(['email'])?.focused).toBe(true)
+    expect(state.getFieldRecord(['email'])?.isConnected).toBe(true)
+  })
+})
+
+describe('optimistic isConnected — RegisterValue.markConnectedOptimistically', () => {
+  it('flips the path it was built for, not other paths', () => {
+    const { state, register } = makeForm({ isSSR: true })
+    const rv = register(['email'])
+    rv.markConnectedOptimistically()
+    expect(state.getFieldRecord(['email'])?.isConnected).toBe(true)
+    expect(state.getFieldRecord(['note'])?.isConnected).toBe(false)
+  })
+
+  it('does nothing on the client even when called from a RegisterValue', () => {
+    // Mirrors the FormStore-level no-op test, exercised via the public
+    // surface that the AST-rewritten template actually invokes.
+    const { state, register } = makeForm({ isSSR: false })
+    const rv = register(['email'])
+    rv.markConnectedOptimistically()
+    expect(state.getFieldRecord(['email'])?.isConnected).toBe(false)
+  })
+
+  it('a register() call without the optimistic mark does NOT flip the flag', () => {
+    // Negative case: register() called from setup that's never bound to
+    // v-register receives no transform-injected markConnectedOptimistically()
+    // invocation. Its field record stays isConnected: false on the
+    // server. This keeps the flag honest for paths that aren't
+    // actually rendered as DOM elements.
+    const { state, register } = makeForm({ isSSR: true })
+    register(['email']) // create RegisterValue but don't call the mark
+    expect(state.getFieldRecord(['email'])?.isConnected).toBe(false)
+  })
+})

--- a/test/ssr-bare-vue/optimistic-is-connected.test.ts
+++ b/test/ssr-bare-vue/optimistic-is-connected.test.ts
@@ -223,3 +223,126 @@ describe('SSR isConnected — read-before-input (preamble) via both transforms',
     expect(html).not.toContain('data-cx-pre-mark')
   })
 })
+
+describe('SSR isConnected — fields the template never binds', () => {
+  it('a schema field with no matching v-register stays isConnected: false', async () => {
+    // The schema declares both `email` and `password`, but the
+    // template only renders `<input v-register="form.register('email')">`.
+    // The transforms (preamble + hint) have NO way to know about
+    // `password` — there's no binding to capture, no IIFE to evaluate.
+    // Result: email is optimistically marked, password is correctly
+    // left at its init-time `false`.
+    //
+    // Why this matters: marking a path as connected when no DOM
+    // element will ever back it is a lie. A later read of
+    // `getFieldState('password').isConnected` would mislead a
+    // consumer into thinking the field is rendered when it isn't.
+    const template = `<div>
+      <input v-register="form.register('email')" />
+    </div>`
+    const app = makeAppWithTemplate(template, 'preamble+hint')
+    await renderToString(app)
+    const registry = getRegistryFromApp(app)
+    const state = registry.forms.get('connected-test')
+    expect(state).toBeDefined()
+    if (state === undefined) return
+    expect(state.getFieldRecord(['email'])?.isConnected).toBe(true)
+    expect(state.getFieldRecord(['password'])?.isConnected).toBe(false)
+  })
+})
+
+describe('SSR isConnected — cross-component sync via shared form key', () => {
+  /**
+   * Two sibling components consume the same FormStore by key. One
+   * binds a field via `v-register`; the other reads `getFieldState`
+   * for that field. The optimistic mark fires on the SHARED store
+   * during the writer's render, and the reader's render — happening
+   * later in template-traversal order — sees the marked state.
+   *
+   * This is the proof that cx's by-key sharing semantics actually
+   * round-trip the optimistic mark correctly: the FormStore
+   * registered under `key: 'shared'` is one object across every
+   * `useForm` / `useFormContext` consumer in the app, so any mark
+   * fired by one consumer is visible to every other.
+   *
+   * Render-order caveat: Vue's SSR is single-pass top-to-bottom, so
+   * if the parent template rendered the reader BEFORE the writer,
+   * the reader's read would happen against an unmarked store. That's
+   * the same render-order limitation the preamble transform fixes
+   * within a SINGLE template — across components it's still up to
+   * the parent to render the writer first. We use that order here
+   * (writer → reader) because it's the natural composition.
+   */
+  it('reader sees isConnected: true when writer is rendered first under the same form key', async () => {
+    type SharedForm = { email: string; password: string }
+    const sharedSchema = () => fakeSchema<SharedForm>({ email: '', password: '' })
+    const SHARED_KEY = 'shared-form'
+
+    const writerRender = compileTemplate(
+      `<div><input v-register="form.register('email')" /></div>`,
+      'preamble+hint'
+    )
+    const Writer = defineComponent({
+      name: 'Writer',
+      setup() {
+        const form = useForm<SharedForm>({ schema: sharedSchema(), key: SHARED_KEY })
+        return { form }
+      },
+      render: writerRender,
+    })
+
+    const readerRender = compileTemplate(
+      `<div class="reader">{{ JSON.stringify(form.getFieldState('email').value) }}</div>`,
+      'preamble+hint'
+    )
+    const Reader = defineComponent({
+      name: 'Reader',
+      setup() {
+        // Same key → useForm returns the existing FormStore. The
+        // schema fingerprint matches (factory returns an equivalent
+        // shape) so no warning fires.
+        const form = useForm<SharedForm>({ schema: sharedSchema(), key: SHARED_KEY })
+        return { form }
+      },
+      render: readerRender,
+    })
+
+    const Parent = defineComponent({
+      name: 'Parent',
+      components: { Writer, Reader },
+      setup() {
+        return {}
+      },
+      // Render writer FIRST so its preamble has fired before the
+      // reader's render evaluates getFieldState. Reverse order would
+      // surface a stale `false` — that's a render-order limitation
+      // across components, not a sync problem.
+      render: compileTemplate(`<div><Writer /><Reader /></div>`, 'preamble+hint'),
+    })
+    const app = createSSRApp(Parent)
+    app.use(createChemicalXForms({ override: true }))
+
+    const html = await renderToString(app)
+    // Reader's div serialises the email field state. Both forms are
+    // backed by the shared FormStore, so the writer's optimistic
+    // mark is visible here.
+    const readerMatch = html.match(/<div class="reader">([\s\S]*?)<\/div>/)
+    expect(readerMatch).not.toBeNull()
+    if (readerMatch === null) return
+    const readerBody = readerMatch[1] ?? ''
+    const containsTrue =
+      readerBody.includes('"isConnected":true') || readerBody.includes('isConnected&quot;:true')
+    expect(containsTrue).toBe(true)
+
+    // Both consumers point at the same FormStore — a single registry
+    // entry under SHARED_KEY, with email marked.
+    const registry = getRegistryFromApp(app)
+    expect(registry.forms.size).toBe(1)
+    const state = registry.forms.get(SHARED_KEY)
+    expect(state?.getFieldRecord(['email'])?.isConnected).toBe(true)
+    // Password is in the schema but never bound — stays false (and
+    // both Writer and Reader observe the same false here, because
+    // there's only one store).
+    expect(state?.getFieldRecord(['password'])?.isConnected).toBe(false)
+  })
+})

--- a/test/ssr-bare-vue/optimistic-is-connected.test.ts
+++ b/test/ssr-bare-vue/optimistic-is-connected.test.ts
@@ -345,4 +345,169 @@ describe('SSR isConnected — cross-component sync via shared form key', () => {
     // there's only one store).
     expect(state?.getFieldRecord(['password'])?.isConnected).toBe(false)
   })
+
+  /**
+   * Case A: a sibling component does setup-only `register('email')`
+   * (no template binding) AND another sibling has the v-register
+   * binding. Sharing a form key means there's exactly one
+   * FormStore; the binding sibling's preamble fires the mark on the
+   * shared store, and the setup-only sibling — even though IT
+   * never called the optimistic mark itself — observes
+   * `isConnected: true`. This is the "implicit cross-component
+   * acknowledgement" working as the user intuited: not because
+   * setup-only register() has any opinion of its own, but because
+   * the store is genuinely shared and someone else established
+   * the DOM presence.
+   */
+  it('Case A: setup-only register() in one SFC sees isConnected: true when a sibling SFC v-registers the same path', async () => {
+    type SharedForm = { email: string }
+    const sharedSchema = () => fakeSchema<SharedForm>({ email: '' })
+    const SHARED_KEY = 'case-a-shared'
+
+    // Sibling 1: v-registers email in its template (the "real"
+    // binding — its preamble fires the mark on the shared store).
+    const Binder = defineComponent({
+      name: 'Binder',
+      setup() {
+        const form = useForm<SharedForm>({ schema: sharedSchema(), key: SHARED_KEY })
+        return { form }
+      },
+      render: compileTemplate(
+        `<div><input v-register="form.register('email')" /></div>`,
+        'preamble+hint'
+      ),
+    })
+
+    // Sibling 2: calls `register('email')` from setup (creates a
+    // RegisterValue) and reads getFieldState in its template, but
+    // never binds via v-register. With cross-component store
+    // sharing, this sibling's read of `isConnected` reflects the
+    // OTHER sibling's binding state.
+    const SetupOnlyReader = defineComponent({
+      name: 'SetupOnlyReader',
+      setup() {
+        const form = useForm<SharedForm>({ schema: sharedSchema(), key: SHARED_KEY })
+        // Setup-only register call. On its own this does NOT mark
+        // anything (it just constructs a RegisterValue closure). But
+        // because the Binder sibling's preamble already fired the
+        // mark on the shared store, when the template below reads
+        // getFieldState, it observes the marked value.
+        form.register('email')
+        return { form }
+      },
+      render: compileTemplate(
+        `<div class="setup-only-reader">{{ JSON.stringify(form.getFieldState('email').value) }}</div>`,
+        'preamble+hint'
+      ),
+    })
+
+    const Parent = defineComponent({
+      name: 'Parent',
+      components: { Binder, SetupOnlyReader },
+      setup() {
+        return {}
+      },
+      // Binder must render first so its preamble has fired before
+      // SetupOnlyReader's getFieldState evaluates.
+      render: compileTemplate(`<div><Binder /><SetupOnlyReader /></div>`, 'preamble+hint'),
+    })
+    const app = createSSRApp(Parent)
+    app.use(createChemicalXForms({ override: true }))
+
+    const html = await renderToString(app)
+    const readerMatch = html.match(/<div class="setup-only-reader">([\s\S]*?)<\/div>/)
+    expect(readerMatch).not.toBeNull()
+    if (readerMatch === null) return
+    const readerBody = readerMatch[1] ?? ''
+    const containsTrue =
+      readerBody.includes('"isConnected":true') || readerBody.includes('isConnected&quot;:true')
+    expect(containsTrue).toBe(true)
+
+    // One shared store, mark recorded once on it.
+    const registry = getRegistryFromApp(app)
+    expect(registry.forms.size).toBe(1)
+    const state = registry.forms.get(SHARED_KEY)
+    expect(state?.getFieldRecord(['email'])?.isConnected).toBe(true)
+  })
+
+  /**
+   * Case B: every SFC that touches the path uses setup-only
+   * `register()`, and NOT ONE binds via v-register. There's no DOM
+   * element anywhere — `isConnected: true` would be a lie. Multiple
+   * components agreeing in setup doesn't add up to a real DOM
+   * presence; the flag has to stay `false`.
+   *
+   * This guards the invariant that `markConnectedOptimistically`
+   * only fires from the AST-visible v-register binding path. If a
+   * future change starts marking on `register()` invocation
+   * (the path that was tempting in early design discussions),
+   * this test would catch the regression.
+   */
+  it('Case B: multiple SFCs all calling setup-only register() with no template binding stays isConnected: false', async () => {
+    type SharedForm = { email: string }
+    const sharedSchema = () => fakeSchema<SharedForm>({ email: '' })
+    const SHARED_KEY = 'case-b-shared'
+
+    const SetupOnlyA = defineComponent({
+      name: 'SetupOnlyA',
+      setup() {
+        const form = useForm<SharedForm>({ schema: sharedSchema(), key: SHARED_KEY })
+        form.register('email')
+        return { form }
+      },
+      render: compileTemplate(`<div class="a">A</div>`, 'preamble+hint'),
+    })
+
+    const SetupOnlyB = defineComponent({
+      name: 'SetupOnlyB',
+      setup() {
+        const form = useForm<SharedForm>({ schema: sharedSchema(), key: SHARED_KEY })
+        form.register('email')
+        return { form }
+      },
+      render: compileTemplate(`<div class="b">B</div>`, 'preamble+hint'),
+    })
+
+    // Reader reads the shared store's email field — should observe
+    // `isConnected: false` because nobody v-registered it.
+    const Reader = defineComponent({
+      name: 'Reader',
+      setup() {
+        const form = useForm<SharedForm>({ schema: sharedSchema(), key: SHARED_KEY })
+        return { form }
+      },
+      render: compileTemplate(
+        `<div class="case-b-reader">{{ JSON.stringify(form.getFieldState('email').value) }}</div>`,
+        'preamble+hint'
+      ),
+    })
+
+    const Parent = defineComponent({
+      name: 'Parent',
+      components: { SetupOnlyA, SetupOnlyB, Reader },
+      setup() {
+        return {}
+      },
+      render: compileTemplate(`<div><SetupOnlyA /><SetupOnlyB /><Reader /></div>`, 'preamble+hint'),
+    })
+    const app = createSSRApp(Parent)
+    app.use(createChemicalXForms({ override: true }))
+
+    const html = await renderToString(app)
+    const readerMatch = html.match(/<div class="case-b-reader">([\s\S]*?)<\/div>/)
+    expect(readerMatch).not.toBeNull()
+    if (readerMatch === null) return
+    const readerBody = readerMatch[1] ?? ''
+    const containsFalse =
+      readerBody.includes('"isConnected":false') || readerBody.includes('isConnected&quot;:false')
+    expect(containsFalse).toBe(true)
+
+    // Direct assertion on the shared store: no marker fired, flag
+    // stays at the init-time default. This is the canonical "no
+    // implicit registration" invariant.
+    const registry = getRegistryFromApp(app)
+    expect(registry.forms.size).toBe(1)
+    const state = registry.forms.get(SHARED_KEY)
+    expect(state?.getFieldRecord(['email'])?.isConnected).toBe(false)
+  })
 })

--- a/test/ssr-bare-vue/optimistic-is-connected.test.ts
+++ b/test/ssr-bare-vue/optimistic-is-connected.test.ts
@@ -8,6 +8,7 @@ import { createChemicalXForms } from '../../src/runtime/core/plugin'
 import { getRegistryFromApp } from '../../src/runtime/core/registry'
 import { renderChemicalXState } from '../../src/runtime/core/serialize'
 import { vRegisterHintTransform } from '../../src/runtime/lib/core/transforms/v-register-hint-transform'
+import { vRegisterPreambleTransform } from '../../src/runtime/lib/core/transforms/v-register-preamble-transform'
 import { fakeSchema } from '../utils/fake-schema'
 
 /**
@@ -28,17 +29,25 @@ import { fakeSchema } from '../utils/fake-schema'
 
 type Form = { email: string; password: string }
 
+type CxTransformMode = 'none' | 'hint-only' | 'preamble+hint'
+
 function compileTemplate(
   template: string,
-  withHintTransform: boolean
+  mode: CxTransformMode
 ): (this: unknown, ctx: unknown) => unknown {
   // baseCompile (compiler-core) is sufficient for our directive-only
   // templates — we don't need the DOM-specific transforms (class/style
   // normalisation, v-html, etc.) that @vue/compiler-dom layers on top.
   // mode: 'function' produces a `const { … } = Vue ... return function render(...)`
   // string we evaluate in a scope where Vue resolves to the runtime module.
+  const transforms =
+    mode === 'none'
+      ? []
+      : mode === 'hint-only'
+        ? [vRegisterHintTransform]
+        : [vRegisterPreambleTransform, vRegisterHintTransform]
   const result = baseCompile(template, {
-    nodeTransforms: withHintTransform ? [vRegisterHintTransform] : [],
+    nodeTransforms: transforms,
     mode: 'function',
     prefixIdentifiers: true,
     hoistStatic: false,
@@ -47,8 +56,8 @@ function compileTemplate(
   return fn(Vue) as (this: unknown, ctx: unknown) => unknown
 }
 
-function makeAppWithTemplate(template: string, withHintTransform: boolean) {
-  const render = compileTemplate(template, withHintTransform)
+function makeAppWithTemplate(template: string, mode: CxTransformMode) {
+  const render = compileTemplate(template, mode)
   const App = defineComponent({
     setup() {
       const form = useForm<Form>({
@@ -71,7 +80,7 @@ describe('SSR isConnected via vRegisterHintTransform', () => {
          <input v-register="form.register('email')" />
          <input v-register="form.register('password')" />
        </div>`,
-      /* withHintTransform */ true
+      'hint-only'
     )
     await renderToString(app)
     const registry = getRegistryFromApp(app)
@@ -85,11 +94,11 @@ describe('SSR isConnected via vRegisterHintTransform', () => {
   it('without the transform, the same template leaves isConnected: false (regression baseline)', async () => {
     // This is the bug the transform fixes. If this test ever flips to
     // `true` without the transform, it means Vue started running
-    // directive lifecycle in SSR and the transform isn't load-bearing
-    // anymore — at which point we can rip it out.
+    // directive lifecycle in SSR and the transforms aren't load-bearing
+    // anymore — at which point we can rip them out.
     const app = makeAppWithTemplate(
       `<div><input v-register="form.register('email')" /></div>`,
-      /* withHintTransform */ false
+      'none'
     )
     await renderToString(app)
     const registry = getRegistryFromApp(app)
@@ -128,7 +137,7 @@ describe('SSR isConnected via vRegisterHintTransform', () => {
     // will reset to false and the flicker comes back.
     const app = makeAppWithTemplate(
       `<div><input v-register="form.register('email')" /></div>`,
-      /* withHintTransform */ true
+      'hint-only'
     )
     await renderToString(app)
     const payload = renderChemicalXState(app)
@@ -143,5 +152,74 @@ describe('SSR isConnected via vRegisterHintTransform', () => {
     )
     expect(emailField).toBeDefined()
     expect(emailField?.[1].isConnected).toBe(true)
+  })
+})
+
+describe('SSR isConnected — read-before-input (preamble) via both transforms', () => {
+  /**
+   * The hint transform alone fires marks at v-register evaluation
+   * time. If a template reads `getFieldState(path)` BEFORE the bound
+   * input renders (single-pass top-to-bottom SSR), the read still
+   * captures `isConnected: false` — the user observes a `false → true`
+   * flicker on hydration when the post-render steady state corrects.
+   *
+   * The preamble transform hoists the marks to the root element's
+   * props, which Vue evaluates BEFORE recursing into children. With
+   * both transforms registered, every static v-register-bound path
+   * is `isConnected: true` before the first descendant template
+   * expression runs.
+   */
+  it('serializes the read-before-input value as true with both transforms', async () => {
+    // Component reads its own field's state via a setup-returned ref
+    // (the ref reads getFieldState at render time). With the preamble,
+    // by the time the render expression evaluates, the mark has fired.
+    // We capture what the SSR-rendered HTML serialises by reading the
+    // FormStore's record directly after renderToString — which is
+    // exactly the state that gets serialised into the hydration
+    // payload.
+    const template = `<div>
+      <span class="readout">{{ JSON.stringify(form.getFieldState('password').value) }}</span>
+      <input v-register="form.register('password')" />
+    </div>`
+    const app = makeAppWithTemplate(template, 'preamble+hint')
+    const html = await renderToString(app)
+    // The text inside <span> goes through Vue's HTML escaping, so the
+    // JSON's quotes are entity-encoded. Match against either form to
+    // stay robust if Vue ever changes the escape policy.
+    const containsTrue =
+      html.includes('"isConnected":true') || html.includes('isConnected&quot;:true')
+    const containsFalse =
+      html.includes('"isConnected":false') || html.includes('isConnected&quot;:false')
+    expect(containsTrue).toBe(true)
+    expect(containsFalse).toBe(false)
+  })
+
+  it('without the preamble, the same template serialises false in the read-before-input span', async () => {
+    // Regression baseline: this is the flicker case the preamble
+    // fixes. Hint-only correctly marks the field by render-end, but
+    // an expression that reads the field state earlier in the
+    // top-to-bottom render pass captures the still-false value.
+    const template = `<div>
+      <span class="readout">{{ JSON.stringify(form.getFieldState('password').value) }}</span>
+      <input v-register="form.register('password')" />
+    </div>`
+    const app = makeAppWithTemplate(template, 'hint-only')
+    const html = await renderToString(app)
+    // The readout span captures the field BEFORE the input below
+    // renders, so without the preamble it serialises false.
+    const containsFalse =
+      html.includes('"isConnected":false') || html.includes('isConnected&quot;:false')
+    expect(containsFalse).toBe(true)
+  })
+
+  it('the data-cx-pre-mark attribute is dropped from the output (undefined → no attr)', async () => {
+    // The preamble's binding evaluates to undefined so Vue's SSR
+    // renderer omits the attribute. The user-visible HTML is unchanged
+    // — only the side effects of evaluating the binding (the marks)
+    // remain.
+    const template = `<div><input v-register="form.register('password')" /></div>`
+    const app = makeAppWithTemplate(template, 'preamble+hint')
+    const html = await renderToString(app)
+    expect(html).not.toContain('data-cx-pre-mark')
   })
 })

--- a/test/ssr-bare-vue/optimistic-is-connected.test.ts
+++ b/test/ssr-bare-vue/optimistic-is-connected.test.ts
@@ -1,0 +1,147 @@
+import { baseCompile } from '@vue/compiler-core'
+import { renderToString } from '@vue/server-renderer'
+import { describe, expect, it } from 'vitest'
+import * as Vue from 'vue'
+import { createSSRApp, defineComponent } from 'vue'
+import { useForm } from '../../src'
+import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { getRegistryFromApp } from '../../src/runtime/core/registry'
+import { renderChemicalXState } from '../../src/runtime/core/serialize'
+import { vRegisterHintTransform } from '../../src/runtime/lib/core/transforms/v-register-hint-transform'
+import { fakeSchema } from '../utils/fake-schema'
+
+/**
+ * End-to-end proof that the `vRegisterHintTransform` resolves the
+ * SSR `isConnected` flicker. Compiles a real template through
+ * @vue/compiler-core's `baseCompile` with the hint transform
+ * registered, evaluates the resulting render function, mounts it
+ * via createSSRApp, runs @vue/server-renderer over it, and asserts
+ * that the FormStore's field record landed at `isConnected: true`
+ * server-side — the same state that gets serialized into the
+ * hydration payload and read by `getFieldState()` on the client's
+ * first paint.
+ *
+ * Without the transform applied, the same template would leave
+ * `isConnected: false` server-side (Vue skips directive lifecycle
+ * during SSR), which is exactly the flicker we're closing.
+ */
+
+type Form = { email: string; password: string }
+
+function compileTemplate(
+  template: string,
+  withHintTransform: boolean
+): (this: unknown, ctx: unknown) => unknown {
+  // baseCompile (compiler-core) is sufficient for our directive-only
+  // templates — we don't need the DOM-specific transforms (class/style
+  // normalisation, v-html, etc.) that @vue/compiler-dom layers on top.
+  // mode: 'function' produces a `const { … } = Vue ... return function render(...)`
+  // string we evaluate in a scope where Vue resolves to the runtime module.
+  const result = baseCompile(template, {
+    nodeTransforms: withHintTransform ? [vRegisterHintTransform] : [],
+    mode: 'function',
+    prefixIdentifiers: true,
+    hoistStatic: false,
+  })
+  const fn = new Function('Vue', `${result.code}\nreturn render`)
+  return fn(Vue) as (this: unknown, ctx: unknown) => unknown
+}
+
+function makeAppWithTemplate(template: string, withHintTransform: boolean) {
+  const render = compileTemplate(template, withHintTransform)
+  const App = defineComponent({
+    setup() {
+      const form = useForm<Form>({
+        schema: fakeSchema<Form>({ email: '', password: '' }),
+        key: 'connected-test',
+      })
+      return { form }
+    },
+    render,
+  })
+  const app = createSSRApp(App)
+  app.use(createChemicalXForms({ override: true /* SSR */ }))
+  return app
+}
+
+describe('SSR isConnected via vRegisterHintTransform', () => {
+  it('marks v-register-bound fields as isConnected: true server-side', async () => {
+    const app = makeAppWithTemplate(
+      `<div>
+         <input v-register="form.register('email')" />
+         <input v-register="form.register('password')" />
+       </div>`,
+      /* withHintTransform */ true
+    )
+    await renderToString(app)
+    const registry = getRegistryFromApp(app)
+    const state = registry.forms.get('connected-test')
+    expect(state).toBeDefined()
+    if (state === undefined) return
+    expect(state.getFieldRecord(['email'])?.isConnected).toBe(true)
+    expect(state.getFieldRecord(['password'])?.isConnected).toBe(true)
+  })
+
+  it('without the transform, the same template leaves isConnected: false (regression baseline)', async () => {
+    // This is the bug the transform fixes. If this test ever flips to
+    // `true` without the transform, it means Vue started running
+    // directive lifecycle in SSR and the transform isn't load-bearing
+    // anymore — at which point we can rip it out.
+    const app = makeAppWithTemplate(
+      `<div><input v-register="form.register('email')" /></div>`,
+      /* withHintTransform */ false
+    )
+    await renderToString(app)
+    const registry = getRegistryFromApp(app)
+    const state = registry.forms.get('connected-test')
+    expect(state?.getFieldRecord(['email'])?.isConnected).toBe(false)
+  })
+
+  it('paths register()ed in setup but not bound to v-register stay isConnected: false', async () => {
+    // Negative case: a setup-only register() call (e.g. exploratory
+    // code, devtools) doesn't render an element. The transform never
+    // sees that call and the optimistic mark never fires — the field
+    // record correctly reports "not connected" because there's no
+    // DOM element to back the claim.
+    const App = defineComponent({
+      setup() {
+        const form = useForm<Form>({
+          schema: fakeSchema<Form>({ email: '', password: '' }),
+          key: 'setup-only',
+        })
+        // Reach into register() but never bind it to v-register.
+        form.register('email')
+        return () => Vue.h('div', 'no inputs here')
+      },
+    })
+    const app = createSSRApp(App)
+    app.use(createChemicalXForms({ override: true }))
+    await renderToString(app)
+    const registry = getRegistryFromApp(app)
+    const state = registry.forms.get('setup-only')
+    expect(state?.getFieldRecord(['email'])?.isConnected).toBe(false)
+  })
+
+  it('isConnected survives serialize → JSON round-trip', async () => {
+    // Last gate: the optimistic flag has to actually ride the
+    // hydration payload. If it gets lost in serialize.ts, the client
+    // will reset to false and the flicker comes back.
+    const app = makeAppWithTemplate(
+      `<div><input v-register="form.register('email')" /></div>`,
+      /* withHintTransform */ true
+    )
+    await renderToString(app)
+    const payload = renderChemicalXState(app)
+    const serialised = JSON.parse(JSON.stringify(payload)) as typeof payload
+    const formEntry = serialised.forms.find(([k]) => k === 'connected-test')
+    expect(formEntry).toBeDefined()
+    if (formEntry === undefined) return
+    const [, data] = formEntry
+    type FieldRow = readonly [string, { readonly isConnected: boolean }]
+    const emailField = (data.fields as ReadonlyArray<FieldRow>).find(([key]) =>
+      key.includes('email')
+    )
+    expect(emailField).toBeDefined()
+    expect(emailField?.[1].isConnected).toBe(true)
+  })
+})

--- a/test/transforms/v-register-hint.test.ts
+++ b/test/transforms/v-register-hint.test.ts
@@ -1,0 +1,94 @@
+import { baseCompile } from '@vue/compiler-core'
+import { describe, expect, it } from 'vitest'
+import { vRegisterHintTransform } from '../../src/runtime/lib/core/transforms/v-register-hint-transform'
+
+/**
+ * Compile a template through @vue/compiler-core with the hint transform
+ * registered, then assert against the generated render code string.
+ * Source-level inspection — same posture as input-text-area.test.ts.
+ */
+function compileWithTransform(template: string): string {
+  const result = baseCompile(template, {
+    nodeTransforms: [vRegisterHintTransform],
+    mode: 'module',
+  })
+  return result.code
+}
+
+describe('vRegisterHintTransform', () => {
+  describe('happy path', () => {
+    it('wraps an inline form.register(path) binding', () => {
+      const code = compileWithTransform(`<input v-register="form.register('email')" />`)
+      // The wrapping IIFE must appear AND retain the original call inside.
+      expect(code).toContain('markConnectedOptimistically')
+      expect(code).toContain("form.register('email')")
+    })
+
+    it('wraps a hoisted RegisterValue identifier', () => {
+      // emailReg = form.register(...) at setup; v-register receives the
+      // pre-built RegisterValue. The wrapper still fires the optimistic
+      // mark because the method lives on the RegisterValue object.
+      const code = compileWithTransform(`<input v-register="emailReg" />`)
+      expect(code).toContain('markConnectedOptimistically')
+      expect(code).toContain('emailReg')
+    })
+
+    it('wraps a binding on textarea + select', () => {
+      const codeTextarea = compileWithTransform(`<textarea v-register="note" />`)
+      const codeSelect = compileWithTransform(`<select v-register="role"><option/></select>`)
+      expect(codeTextarea).toContain('markConnectedOptimistically')
+      expect(codeSelect).toContain('markConnectedOptimistically')
+    })
+
+    it('wraps a dynamic-path register call (template literal)', () => {
+      // The transform doesn't inspect the path string — any expression
+      // returning a RegisterValue is wrapped uniformly.
+      const code = compileWithTransform('<input v-register="form.register(`${prefix}.email`)" />')
+      expect(code).toContain('markConnectedOptimistically')
+    })
+  })
+
+  describe('non-targets', () => {
+    it('does NOT wrap elements without v-register', () => {
+      const code = compileWithTransform(`<input :value="x" />`)
+      expect(code).not.toContain('markConnectedOptimistically')
+    })
+
+    it('does NOT match user props whose name contains "register" as a substring', () => {
+      // Exact directive-name match — `register-id` is a custom prop, not v-register.
+      const code = compileWithTransform(`<input :data-register-id="'x'" />`)
+      expect(code).not.toContain('markConnectedOptimistically')
+    })
+  })
+
+  describe('idempotency', () => {
+    it('does not double-wrap when applied twice', () => {
+      // Some bundler configurations register the same transform twice.
+      // The second pass must detect the marker and skip — otherwise
+      // every render path would carry an arbitrarily deep IIFE chain.
+      const result = baseCompile(`<input v-register="form.register('email')" />`, {
+        nodeTransforms: [vRegisterHintTransform, vRegisterHintTransform],
+        mode: 'module',
+      })
+      const occurrences = result.code.match(/markConnectedOptimistically/g)?.length ?? 0
+      expect(occurrences).toBe(1)
+    })
+  })
+
+  describe('coexistence with other v-register transforms', () => {
+    it('does not break inputTextAreaNodeTransform', async () => {
+      // The hint transform must run alongside the other transforms in
+      // the chain without producing malformed output. We register both
+      // in the canonical order and just assert the compile succeeds and
+      // contains both signals.
+      const { inputTextAreaNodeTransform } =
+        await import('../../src/runtime/lib/core/transforms/input-text-area-transform')
+      const result = baseCompile(`<input v-register="form.register('email')" />`, {
+        nodeTransforms: [inputTextAreaNodeTransform, vRegisterHintTransform],
+        mode: 'module',
+      })
+      expect(result.code).toContain('markConnectedOptimistically')
+      expect(result.code).toContain('innerRef')
+    })
+  })
+})

--- a/test/transforms/v-register-preamble.test.ts
+++ b/test/transforms/v-register-preamble.test.ts
@@ -1,0 +1,159 @@
+import { baseCompile } from '@vue/compiler-core'
+import { describe, expect, it } from 'vitest'
+import { vRegisterHintTransform } from '../../src/runtime/lib/core/transforms/v-register-hint-transform'
+import { vRegisterPreambleTransform } from '../../src/runtime/lib/core/transforms/v-register-preamble-transform'
+
+/**
+ * Compile a template through @vue/compiler-core with both the preamble
+ * AND the hint transform registered (in canonical order — preamble
+ * first), then assert against the generated render code string.
+ */
+function compileWithTransforms(template: string): string {
+  const result = baseCompile(template, {
+    nodeTransforms: [vRegisterPreambleTransform, vRegisterHintTransform],
+    mode: 'module',
+  })
+  return result.code
+}
+
+function compileWithPreambleOnly(template: string): string {
+  const result = baseCompile(template, {
+    nodeTransforms: [vRegisterPreambleTransform],
+    mode: 'module',
+  })
+  return result.code
+}
+
+describe('vRegisterPreambleTransform', () => {
+  describe('happy path', () => {
+    it('emits a data-cx-pre-mark prop on the root element when v-register bindings exist', () => {
+      const code = compileWithTransforms(
+        `<div>
+           <pre>{{ form.getFieldState('password').value }}</pre>
+           <input v-register="form.register('password')" />
+         </div>`
+      )
+      expect(code).toContain('data-cx-pre-mark')
+      // The preamble's collected expression must reference the user's
+      // path-bearing call. processExpression prefixes free identifiers
+      // with `_ctx.`, so we look for the prefixed form.
+      expect(code).toMatch(/_ctx\.form\.register\(['"]password['"]\)/)
+      // markConnectedOptimistically gets called from BOTH the preamble
+      // (every captured binding fires it) and the hint transform's
+      // per-element wrapper. At least 2 occurrences for one binding.
+      const occurrences = code.match(/markConnectedOptimistically/g)?.length ?? 0
+      expect(occurrences).toBeGreaterThanOrEqual(2)
+    })
+
+    it('captures multiple v-register bindings into a single preamble', () => {
+      const code = compileWithTransforms(
+        `<div>
+           <input v-register="form.register('email')" />
+           <input v-register="form.register('password')" />
+           <textarea v-register="form.register('note')" />
+         </div>`
+      )
+      expect(code).toContain('data-cx-pre-mark')
+      // All three paths appear once in the preamble call list, plus
+      // once each in their per-element directive bindings.
+      expect(code).toMatch(/_ctx\.form\.register\(['"]email['"]\)/)
+      expect(code).toMatch(/_ctx\.form\.register\(['"]password['"]\)/)
+      expect(code).toMatch(/_ctx\.form\.register\(['"]note['"]\)/)
+    })
+
+    it('captures un-wrapped expressions when registered before the hint transform', () => {
+      // Critical ordering invariant: preamble's pre-order capture must
+      // see the original expression, not the IIFE-wrapped form. If this
+      // breaks, the preamble's text would contain `__cxRv` references
+      // pointing at a free identifier (the wrapper's parameter is gone
+      // by the time the preamble injects).
+      const code = compileWithPreambleOnly(
+        `<div><input v-register="form.register('email')" /></div>`
+      )
+      // Preamble references markConnectedOptimistically once per
+      // captured binding. With only the preamble registered, there's
+      // no per-element wrapper in the directive expression.
+      const occurrences = code.match(/markConnectedOptimistically/g)?.length ?? 0
+      expect(occurrences).toBe(1)
+      // The captured expression in the preamble does NOT contain the
+      // hint wrapper's marker (`__cxRv`), proving we captured pre-wrap.
+      expect(code).not.toContain('__cxRv')
+    })
+  })
+
+  describe('v-for filtering', () => {
+    it('does NOT capture bindings on elements with v-for directly', () => {
+      const code = compileWithTransforms(
+        `<div>
+           <input v-for="i in 10" v-register="form.register('item.' + i)" :key="i" />
+         </div>`
+      )
+      // No data-cx-pre-mark emitted because the only v-register is on
+      // an iterated element — its path expression references the loop
+      // local `i`, which isn't in scope at root level. Hoisting it
+      // would produce a runtime ReferenceError.
+      expect(code).not.toContain('data-cx-pre-mark')
+    })
+
+    it('does NOT capture bindings nested inside a v-for ancestor', () => {
+      const code = compileWithTransforms(
+        `<div>
+           <div v-for="item in items" :key="item.id">
+             <input v-register="form.register('field-' + item.id)" />
+           </div>
+         </div>`
+      )
+      expect(code).not.toContain('data-cx-pre-mark')
+    })
+
+    it('still captures static bindings in templates that ALSO have v-for elsewhere', () => {
+      // A page with both static and v-for bindings: the static one gets
+      // hoisted; the v-for one stays handled by the per-element wrapper.
+      const code = compileWithTransforms(
+        `<div>
+           <input v-register="form.register('header')" />
+           <input v-for="i in 10" v-register="form.register('item.' + i)" :key="i" />
+         </div>`
+      )
+      expect(code).toContain('data-cx-pre-mark')
+      expect(code).toMatch(/_ctx\.form\.register\(['"]header['"]\)/)
+    })
+  })
+
+  describe('emptiness / no-ops', () => {
+    it('does not inject when there are no v-register bindings', () => {
+      const code = compileWithTransforms(`<div><input type="text" /></div>`)
+      expect(code).not.toContain('data-cx-pre-mark')
+    })
+
+    it('does not inject when the only root content is text', () => {
+      // No element to host the preamble — bail silently rather than
+      // synthesizing a wrapper element.
+      const code = compileWithTransforms(`hello world`)
+      expect(code).not.toContain('data-cx-pre-mark')
+    })
+  })
+
+  describe('idempotency', () => {
+    it('does not double-capture when the preamble transform runs twice', () => {
+      // When the same transform is registered twice in the
+      // `nodeTransforms` array (some bundler chains do this), the
+      // pre-order runs twice per node. Without idempotency each
+      // capture would land in `state.captured` twice, doubling the
+      // mark calls inside the injected expression.
+      //
+      // Counting `data-cx-pre-mark` is misleading: Vue codegen lists
+      // dynamic prop names in its PROPS patch flag too (e.g.
+      // `["data-cx-pre-mark"]`), so the literal appears at least
+      // twice in compiled output regardless. We instead count
+      // `markConnectedOptimistically` invocations — exactly one per
+      // collected binding when idempotent.
+      const result = baseCompile(`<div><input v-register="form.register('email')" /></div>`, {
+        nodeTransforms: [vRegisterPreambleTransform, vRegisterPreambleTransform],
+        mode: 'module',
+      })
+      const occurrences = result.code.match(/markConnectedOptimistically/g)?.length ?? 0
+      expect(occurrences).toBe(1)
+    })
+  })
+})


### PR DESCRIPTION
AST transform update that allows the isConnected boolean on the `getFieldState` function call to be correct from the first render during SSR. Tiny detail I wanted to take care of.