### PR TITLE
feat!: validation refactor — errors as data, live by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,56 @@
 
 ## Unreleased
 
-_No unreleased changes yet._
+**Validation refactor: errors as a pure function of `(value, schema) +
+injected user errors`.** The data layer (errors as state) is now fully
+separable from the rendering layer (when to show them). Schema-driven
+errors and consumer-injected errors live in distinct internal stores;
+each has its own lifecycle, and the merged read view stays unchanged
+for consumers. See the [migration guide](./docs/migration/0.11-to-0.12.md)
+for the full set of changes.
+
+- **Breaking — live validation by default.** `fieldValidation.on`
+  defaulted to `'none'` in 0.11; it now defaults to `'change'`.
+  Errors track the live `(value, schema)` instead of going stale
+  until the next submit. `'none'` remains as the explicit opt-out
+  for "submit-only" workflows. Migration: pass
+  `fieldValidation: { on: 'none' }` to keep the old behaviour.
+- **Breaking — errors split by source.** `setFieldErrors` /
+  `addFieldErrors` / `setFieldErrorsFromApi` write to a separate
+  user-error store internally; their entries now SURVIVE schema
+  revalidation AND successful submits (only `clearFieldErrors` /
+  `reset` / `resetField` remove them). Public surfaces (`fieldErrors`,
+  `state.isValid`, `getFieldState(path).errors`) merge schema +
+  user transparently — schema first, user second.
+  `clearFieldErrors(path?)` deliberately clears both stores at the
+  given path (pragmatic "make these errors go away" semantic).
+- **Breaking — persistence payload v2.** `PersistConfig.version`
+  defaults to `2` (was `1`). On-disk shape: `data.errors` is gone,
+  replaced by `data.schemaErrors` + `data.userErrors`. Old v1
+  payloads are dropped silently on read; users see one fresh-defaults
+  render after upgrading.
+- **Breaking — SSR / hydration payload split.** `SerializedFormData`
+  and `FormStoreHydration` types now carry `schemaErrors` +
+  `userErrors` separately. Nuxt + bare-Vue serialize/hydrate
+  bridges handle this transparently; only consumers reading the
+  payload struct directly need to update.
+- **Breaking — legacy `state.errors` writers removed.** The `errors`
+  Map alias and `setErrorsForPath` / `setAllErrors` / `addErrors` /
+  `clearErrors` methods on `FormStore` are gone. Replacements:
+  `state.schemaErrors` + `state.userErrors` for direct access;
+  `state.setSchemaErrorsForPath` + `state.setAllSchemaErrors` /
+  `state.setAllUserErrors` / `state.addUserErrors` /
+  `state.clearSchemaErrors` / `state.clearUserErrors` for writes.
+  Most consumers never touched these — the public
+  `setFieldErrors*` + `clearFieldErrors` surfaces still cover the
+  standard use cases.
+- **New — construction-time schema-error seed.** Strict-mode forms
+  whose default values fail schema validation now report errors
+  immediately at construction (no user mutation or `validateAsync`
+  call required). Lax-mode forms still skip the seed; hydration
+  takes precedence over the seed when present. Mostly a quality-of-
+  life win for SSR — `<pre>{{ form.fieldErrors }}</pre>` now
+  matches the client's first frame.
 
 ## v0.11.1
 **Dev-mode ergonomics for the ambient `useFormContext` warning.**

--- a/bench/persistence.bench.ts
+++ b/bench/persistence.bench.ts
@@ -74,7 +74,7 @@ function makeForm(leafCount: number, depth: number): Record<string, unknown> {
 }
 
 async function benchOneWrite(adapter: FormStorage, form: Record<string, unknown>): Promise<void> {
-  const payload = buildPersistedPayload(form, 'form', new Map(), 1)
+  const payload = buildPersistedPayload(form, 'form', new Map(), new Map(), 1)
   await adapter.setItem('bench-key', payload)
 }
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -44,7 +44,7 @@ Options:
 | `defaultValues`   | `DeepPartial<Form>`                                                         | no       | Constraints applied over schema defaults.                                                                                                                                                                                                                                                   |
 | `validationMode`  | `'lax'` \| `'strict'`                                                       | no       | Defaults to `'lax'`. See [Types](#types).                                                                                                                                                                                                                                                   |
 | `onInvalidSubmit` | `'none'` \| `'focus-first-error'` \| `'scroll-to-first-error'` \| `'both'`  | no       | What to do when submit fails validation. See [recipe](./recipes/focus-on-error.md).                                                                                                                                                                                                         |
-| `fieldValidation` | `{ on, debounceMs }`                                                        | no       | Enable live field validation. See [recipe](./recipes/field-level-validation.md).                                                                                                                                                                                                            |
+| `fieldValidation` | `{ on, debounceMs }`                                                        | no       | Live field validation. Default `{ on: 'change', debounceMs: 200 }` — errors track live. Pass `{ on: 'none' }` to opt out (submit-only). See [recipe](./recipes/field-level-validation.md).                                                                                                  |
 | `persist`         | `{ storage, key?, debounceMs?, include?, version?, clearOnSubmitSuccess? }` | no       | Persist draft state. See [recipe](./recipes/persistence.md).                                                                                                                                                                                                                                |
 | `history`         | `true` \| `{ max?: number }`                                                | no       | Enable undo/redo. See [recipe](./recipes/undo-redo.md).                                                                                                                                                                                                                                     |
 
@@ -264,13 +264,21 @@ piece of form state as a named field. Grouped by concern:
 
 ### Error store
 
+Errors are stored source-segregated under the hood — `schemaErrors`
+(written by the validation pipeline) and `userErrors` (written by the
+APIs below). The public surfaces below merge both transparently
+(schema-first, user-second). User-injected errors **survive** schema
+revalidation and successful submits — the consumer owns their lifecycle
+explicitly. See the [migration guide](./migration/0.11-to-0.12.md) for
+the rationale.
+
 | Member                                    | Type                                                                                      |
 | ----------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `fieldErrors`                             | `Readonly<FormFieldErrors<Form>>` — Proxy view; dot-access leaves directly, no `.value`.  |
-| `setFieldErrors(errors)`                  | `(ValidationError[]) => void`                                                             |
-| `addFieldErrors(errors)`                  | `(ValidationError[]) => void`                                                             |
-| `clearFieldErrors(path?)`                 | `(path?) => void`                                                                         |
-| `setFieldErrorsFromApi(payload, limits?)` | Hydrates a server error envelope. See [server-errors recipe](./recipes/server-errors.md). |
+| `fieldErrors`                             | `Readonly<FormFieldErrors<Form>>` — Proxy view; dot-access leaves directly, no `.value`. Merges schema + user; schema entries first. |
+| `setFieldErrors(errors)`                  | `(ValidationError[]) => void` — replaces the user-error store.                            |
+| `addFieldErrors(errors)`                  | `(ValidationError[]) => void` — appends to the user-error store.                          |
+| `clearFieldErrors(path?)`                 | `(path?) => void` — clears BOTH stores at the given path (or all paths if omitted). With live validation, the schema half re-populates on the next mutation if the value is still invalid. |
+| `setFieldErrorsFromApi(payload, limits?)` | Hydrates a server error envelope into the user-error store. Survives subsequent schema revalidation. See [server-errors recipe](./recipes/server-errors.md). |
 
 ### Form-level state
 
@@ -283,7 +291,7 @@ exported `FormState` interface.
 | Member               | Type      | What it does                                                                        |
 | -------------------- | --------- | ----------------------------------------------------------------------------------- |
 | `state.isDirty`      | `boolean` | `true` iff any leaf's current value differs from its original.                      |
-| `state.isValid`      | `boolean` | `true` iff `fieldErrors` is empty.                                                  |
+| `state.isValid`      | `boolean` | `true` iff both the schema-error and user-error stores are empty.                   |
 | `state.isSubmitting` | `boolean` | `true` while the submit handler is running.                                         |
 | `state.isValidating` | `boolean` | `true` while any validation run is in flight (reactive, imperative, or pre-submit). |
 | `state.submitCount`  | `number`  | Incremented once per call, regardless of outcome.                                   |

--- a/docs/migration/0.11-to-0.12.md
+++ b/docs/migration/0.11-to-0.12.md
@@ -1,0 +1,218 @@
+# Migrating from 0.11.x to 0.12.x
+
+The validation refactor. Errors are now a pure function of
+`(value, schema) + injected user errors`, and the data layer that
+holds them is fully separable from the rendering layer that decides
+when to show them.
+
+Five breaking changes:
+
+1. `fieldValidation.on` defaults to `'change'` (was `'none'`).
+2. Errors are split: `setFieldErrors` / `addFieldErrors` /
+   `setFieldErrorsFromApi` write to a separate user-error store and
+   survive both schema revalidation AND successful submits.
+3. Persisted payloads bumped to `v: 2` — the wire format carries
+   `schemaErrors` + `userErrors` instead of a single flat `errors`
+   field.
+4. SSR / `FormStoreHydration` + `SerializedFormData` types split
+   into `schemaErrors` + `userErrors` — bare-Vue SSR consumers who
+   read these types directly need to update their hand-rolled
+   payload extraction.
+5. The legacy `state.errors` / `setErrorsForPath` / `setAllErrors` /
+   `addErrors` / `clearErrors` surface on `FormStore` is gone.
+   These were internal escape hatches but technically callable from
+   user code.
+
+Plus one new behaviour worth knowing:
+
+6. Construction-time validation seed: forms with `validationMode:
+   'strict'` whose default values fail validation now report errors
+   immediately, before any user interaction.
+
+## Breaking: live validation by default
+
+**0.11:** `fieldValidation.on` defaulted to `'none'`. Errors only
+updated at submit time. Type "abc" into an `min(8)` field, hit
+submit, see the error, type "abcd12345", and the error stuck around
+until the next submit — because the data layer held a snapshot of
+"errors as of the last submit," not "errors as of the current
+value."
+
+**0.12:** the default is `'change'` (still 200 ms debounced). Errors
+are continuously a function of `(value, schema)`. The UI decides
+when to **show** them — gate on `state.touched`, `state.submitCount`,
+or whatever — but the data layer is always current.
+
+If you want the old behaviour for a specific form (validate only on
+submit), opt out explicitly:
+
+```diff
+  useForm({
+    schema,
+    key: 'signup',
++   fieldValidation: { on: 'none' },
+  })
+```
+
+The `'none'` mode is still supported; it just isn't the default
+anymore.
+
+## Breaking: errors split by source — API entries persist
+
+**0.11:** the form held one `errors` Map. Schema validation,
+`setFieldErrors`, `addFieldErrors`, and `setFieldErrorsFromApi` all
+wrote to it. A successful submit cleared everything; a submit failure
+clobbered everything with the schema's result. The submit-success
+clear was the silent killer of API warnings written via
+`addFieldErrors` immediately before submit.
+
+**0.12:** errors are stored under two distinct internal Maps:
+
+- `schemaErrors` — written ONLY by the schema validation pipeline
+  (`scheduleFieldValidation`, `handleSubmit`, the construction-time
+  seed, history restore, hydration replay). Cleared by `reset` /
+  `resetField` and by a successful submit.
+- `userErrors` — written ONLY by the public `setFieldErrors*` APIs
+  (and history / hydration replay). **Survives** schema revalidation
+  AND successful submits — the consumer owns its lifecycle
+  explicitly.
+
+The public `fieldErrors` view, `getFieldState(path).errors`, and
+`state.isValid` all see the merged result (schema first, user
+second). For consumers, the visible behaviour change is that
+API-injected errors now stick around:
+
+```ts
+form.addFieldErrors([{ path: ['email'], message: 'soft warning', formKey: form.key }])
+form.setValue('email', 'new@example.com')
+// 0.11: schema revalidation cleared the warning.
+// 0.12: warning still in form.fieldErrors.email until you call
+//       clearFieldErrors('email') (or unmount).
+```
+
+`clearFieldErrors(path?)` deliberately clears BOTH stores at the
+given path — the strict reading would be "user-only" but the
+pragmatic reading is "make the errors at this path go away," which
+is what consumers reach for. With live validation the schema half
+re-populates on the next mutation if the value is still invalid, so
+the inconsistency is short-lived.
+
+## Breaking: persistence payload v2
+
+`PersistConfig.version` defaulted to `1` in 0.11; it now defaults to
+`2`. The on-disk shape changed: the `data.errors` flat list is
+replaced by `data.schemaErrors` + `data.userErrors`.
+
+Old v1 payloads are dropped silently on read (the existing
+version-mismatch path in `readPersistedPayload`), so users will see a
+single fresh-defaults render the first time they reload after
+upgrading. No data is lost in the form value itself — the next
+mutation re-persists under v2.
+
+If your consumer pinned an explicit `version`, bump it past the old
+number to invalidate the old shape:
+
+```diff
+  persist: {
+    storage: 'local',
+-   version: 3,
++   version: 4,
+  }
+```
+
+If you parse the persisted payload externally (uncommon — most
+consumers go through cx's reader), update field references:
+
+```diff
+- payload.data.errors
++ payload.data.schemaErrors  // validation-owned
++ payload.data.userErrors    // API-injected
+```
+
+## Breaking: SSR / FormStoreHydration shape
+
+`SerializedFormData` (in the `renderChemicalXState` payload) and
+`FormStoreHydration` (the construction-time hydration payload) both
+split their `errors` field into `schemaErrors` + `userErrors`.
+
+Nuxt consumers using the auto-wired plugin don't need to touch
+anything — the plugin's serialize/hydrate bridge handles it.
+
+Bare-Vue SSR consumers calling `renderChemicalXState` /
+`hydrateChemicalXState` directly are unaffected too; the payload
+shape is internal to the bridge.
+
+The only break is for code that read the payload struct directly
+(unusual — typically only test utilities and custom inspector
+tooling):
+
+```diff
+- const errors = data.errors
++ const all = [...data.schemaErrors, ...data.userErrors]
+```
+
+## Breaking: `state.errors` and the legacy writers are gone
+
+These existed on the `FormStore` type but weren't intended for
+direct consumer use; they were internal escape hatches. Removed:
+
+- `state.errors` — replaced by `state.schemaErrors` and
+  `state.userErrors` (or read via `state.getErrorsForPath(path)`,
+  which returns the merged array).
+- `state.setErrorsForPath(path, errors)` — replaced by
+  `state.setSchemaErrorsForPath(path, errors)` (validation pipeline)
+  or wire the user-side via the public `setFieldErrors*` APIs.
+- `state.setAllErrors(errors)` — replaced by
+  `state.setAllSchemaErrors(errors)` /
+  `state.setAllUserErrors(errors)`.
+- `state.addErrors(errors)` — replaced by `state.addUserErrors(errors)`
+  (the merge-append semantic only made sense for user-injected
+  entries; schema validation always replaces wholesale).
+- `state.clearErrors(path?)` — replaced by
+  `state.clearSchemaErrors(path?)` / `state.clearUserErrors(path?)`.
+
+If you hit any of these, the typechecker will tell you exactly which
+call site needs to migrate. Most consumers never touched these — the
+public `fieldErrors`, `setFieldErrors`, `addFieldErrors`,
+`clearFieldErrors`, `setFieldErrorsFromApi`, and `state.isValid`
+surfaces still cover the standard use cases.
+
+## New: construction-time schema-error seed (strict mode)
+
+Today's `createFormStore` calls `schema.getDefaultValues(...)` and
+silently dropped the `.errors` slot. A strict-mode form whose default
+values failed validation reported `state.isValid: true` and an empty
+`fieldErrors` until the consumer mutated a field or called
+`validateAsync` explicitly.
+
+After: when `validationMode === 'strict'` AND no hydration is
+provided AND the schema rejected the defaults, `schemaErrors` is
+populated immediately at construction.
+
+This is mostly relevant for SSR — a `<pre>{{ form.fieldErrors }}</pre>`
+now shows the construction-time errors in the initial HTML so the
+user-visible state matches client-side from the first frame.
+
+Lax-mode forms still skip the seed (lax explicitly opts out of
+construction-time enforcement). Hydration takes precedence over the
+seed — the server's snapshot is authoritative when present.
+
+If you have a strict-mode form whose tests previously asserted
+`state.isValid === true` despite invalid defaults, those tests will
+flip. Either update the assertion or pass valid `defaultValues`.
+
+## What didn't change
+
+- `ValidationError` shape stays identical — no `source` discriminator
+  on the public type. Consumers see one merged array per path.
+- Public surfaces: `fieldErrors`, `setFieldErrors`, `addFieldErrors`,
+  `clearFieldErrors`, `setFieldErrorsFromApi`, `state.isValid`, and
+  `getFieldState(path).errors` all keep their signatures. Only the
+  underlying lifecycles are different.
+- Devtools tab still works; the inspector now shows two sections
+  ("Schema Errors" + "User Errors") instead of one.
+- History (undo/redo) still snapshots the error state; both Maps
+  round-trip.
+- `validate()` reactive ref still returns schema-only results — its
+  contract is unchanged. Use `fieldErrors` or
+  `getFieldState(path).errors` for the merged view.

--- a/docs/recipes/field-level-validation.md
+++ b/docs/recipes/field-level-validation.md
@@ -1,17 +1,33 @@
 # Live field validation
 
-By default, validation runs on submit. Opt into per-field validation
-when you want inline feedback — "passwords don't match", "email
-looks invalid", "this username is taken" — before the user clicks
-submit.
+cx validates as you type by default — `fieldValidation: { on: 'change',
+debounceMs: 200 }` is implicit. Errors at any path reflect the live
+`(value, schema)` continuously, so consumers can render inline feedback
+without reaching for a separate "is this field valid?" query.
 
-## Turn it on
+The data layer (errors as a function of value) and the rendering layer
+(when to **show** errors) are separate concerns: the merged `fieldErrors`
+store is always current; gating display on `state.touched` /
+`state.submitCount` / etc. is your call.
+
+## Default in action
+
+No configuration needed:
+
+```ts
+useForm({ schema, key: 'signup' })
+```
+
+Type into an `<input v-register="register('email')" />`, see
+`fieldErrors.email` populate (or clear) within 200 ms of stopping.
+
+## Tune or opt out
 
 ```ts
 useForm({
   schema,
   key: 'signup',
-  fieldValidation: { on: 'change', debounceMs: 200 },
+  fieldValidation: { on: 'change', debounceMs: 500 },  // slower debounce
 })
 ```
 
@@ -19,18 +35,22 @@ Three modes:
 
 | `on`       | When it fires                                    | Debounced?          |
 | ---------- | ------------------------------------------------ | ------------------- |
-| `'none'`   | Never (default). Submit is the only validator.   | —                   |
-| `'change'` | Every mutation: register input, `setValue`, etc. | Yes — `debounceMs`. |
+| `'change'` | (default) Every mutation: register input, `setValue`, etc. | Yes — `debounceMs`. |
 | `'blur'`   | Tab away from a field.                           | No — immediate.     |
+| `'none'`   | Explicit opt-out — submit is the only validator. | —                   |
 
 ## Which mode?
 
-- **`'change'`** — best when your schema includes async checks
-  (email uniqueness, username lookup). Users get immediate
-  feedback; the server isn't hit on every keystroke.
-- **`'blur'`** — best for simple field rules (required, min length,
-  format). No wait, but only after the user leaves the field.
-- **`'none'`** — default. Small forms + fast-to-submit flows.
+- **`'change'`** — the default. Inline feedback as the user types;
+  expensive async refines (email uniqueness, server-side lookups)
+  ride on the same `debounceMs` window so the network isn't hit on
+  every keystroke.
+- **`'blur'`** — quieter — feedback only after the user leaves the
+  field. Best when the schema is simple and per-keystroke checks
+  feel noisy.
+- **`'none'`** — the explicit opt-out. Submit is the only validator.
+  Use for small forms + fast-to-submit flows where live feedback
+  would distract.
 
 ## What you get
 

--- a/docs/recipes/server-errors.md
+++ b/docs/recipes/server-errors.md
@@ -52,8 +52,20 @@ payment provider" — and those come back as `fieldErrors` via
 
 By the time your callback runs, client-side schema validation has
 already passed — `setFieldErrorsFromApi` is genuinely for server-
-only failures. The previous run's errors stay put until you
-explicitly clear them or the user interacts.
+only failures.
+
+**API-injected errors persist** across schema revalidation and
+successful submits. `setFieldErrors`, `addFieldErrors`, and
+`setFieldErrorsFromApi` all write to a separate user-error store
+(internally distinct from the schema-validation pipeline's store);
+nothing automatically clears them. The user's next keystroke will
+re-run schema validation against the field — that updates the
+schema-error half, but your API entries stay until you call
+`clearFieldErrors(path)` (or unmount the form).
+
+The two flavours surface together in `fieldErrors[path]` (schema
+entries first, user entries second), so templates render both
+without branching.
 
 ## Payload shapes
 

--- a/src/runtime/composables/use-abstract-form.ts
+++ b/src/runtime/composables/use-abstract-form.ts
@@ -409,7 +409,11 @@ function wirePersistence<F extends GenericForm>(
   const key = resolveStorageKey(config, state.formKey)
   const debounceMs = config.debounceMs ?? 300
   const include = config.include ?? 'form'
-  const version = config.version ?? 1
+  // Default version bumped 1 → 2 in the 0.12 release: errors split into
+  // schemaErrors + userErrors at the payload level. Old v1 payloads
+  // (single flat `errors` field) get rejected by readPersistedPayload's
+  // version-mismatch check, falling back to schema defaults on next load.
+  const version = config.version ?? 2
   const clearOnSubmitSuccess = config.clearOnSubmitSuccess ?? true
 
   // Single shared adapter promise — both the hydration path and the
@@ -428,7 +432,13 @@ function wirePersistence<F extends GenericForm>(
     // proxies (DATA_CLONE_ERR), and local/session stringify the
     // proxy's own-enumerable keys anyway.
     const rawForm = toRaw(state.form.value)
-    const payload = buildPersistedPayload(rawForm, include, state.errors, version)
+    const payload = buildPersistedPayload(
+      rawForm,
+      include,
+      state.schemaErrors,
+      state.userErrors,
+      version
+    )
     await adapter.setItem(key, payload)
   }, debounceMs)
 
@@ -467,12 +477,18 @@ function wirePersistence<F extends GenericForm>(
       if (payload === null) return
       if (disposed) return
       state.applyFormReplacement(payload.data.form)
-      if (payload.data.errors !== undefined && include === 'form+errors') {
-        // Flatten to a ValidationError[] so setAllErrors rebuilds the
-        // Map by path. Consumers who bumped `version` already had
-        // their payload rejected above.
-        const flat = payload.data.errors.flatMap(([, errs]) => errs)
-        state.setAllErrors(flat)
+      if (include === 'form+errors') {
+        // Each store rebuilds independently from its persisted entries.
+        // Consumers who bumped `version` already had their payload
+        // rejected above.
+        if (payload.data.schemaErrors !== undefined) {
+          const flat = payload.data.schemaErrors.flatMap(([, errs]) => errs)
+          state.setAllSchemaErrors(flat)
+        }
+        if (payload.data.userErrors !== undefined) {
+          const flat = payload.data.userErrors.flatMap(([, errs]) => errs)
+          state.setAllUserErrors(flat)
+        }
       }
     } catch {
       // Adapter IO errors shouldn't surface; storage adapters are

--- a/src/runtime/core/build-form-api.ts
+++ b/src/runtime/core/build-form-api.ts
@@ -348,8 +348,8 @@ function contextualiseValue<F extends GenericForm>(
  *     scope, so Vue tracks the dependency exactly as it would for a
  *     direct `.value` read. Templates re-render on error changes.
  *   - Laziness is preserved: the underlying ComputedRef only recomputes
- *     when its inputs (state.errors) change AND a trap that reads
- *     `source.value` fires.
+ *     when its inputs (state.schemaErrors / state.userErrors) change
+ *     AND a trap that reads `source.value` fires.
  */
 function createReadonlyErrorView<T extends FormErrorRecord>(source: ComputedRef<T>): T {
   const target: T = Object.create(null) as T

--- a/src/runtime/core/build-form-api.ts
+++ b/src/runtime/core/build-form-api.ts
@@ -113,16 +113,21 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
   }
 
   // --- Error store API — dotted-key record for back-compat ---
-  // `state.errors` is keyed by canonical `PathKey` (JSON-stringified
-  // Segment[]), so every entry here already represents a distinct
-  // structured path. The dotted-key derivation is best-effort: paths
-  // with a literal `.` inside a single segment (`['user.name']`)
-  // produce the same record key as the sibling pair (`['user',
-  // 'name']`). This collision only surfaces in pathological schemas
-  // that declare both shapes on the same form — in that case the
-  // errors merge under the shared dotted key. Consumers who need
-  // collision-free access read from `state.errors` via the validate()
-  // / getFieldState() paths instead of the legacy dotted record.
+  // The view merges `schemaErrors` (validation-owned) and `userErrors`
+  // (API-injected) into a single dotted-key record per path. Iteration
+  // order is schema-first then user — matching the "structural validation
+  // before business logic" UX expectation. Consumers reading
+  // `fieldErrors.email` see schema issues at index 0 and any user-injected
+  // entries appended after.
+  //
+  // The dotted-key derivation is best-effort: paths with a literal `.`
+  // inside a single segment (`['user.name']`) produce the same record key
+  // as the sibling pair (`['user', 'name']`). This collision only surfaces
+  // in pathological schemas that declare both shapes on the same form —
+  // in that case the errors merge under the shared dotted key. Consumers
+  // who need collision-free access read via `getFieldState(path).errors`
+  // (or the underlying `state.getErrorsForPath`) instead of the legacy
+  // dotted record.
   //
   // The internal computed stays — laziness + dependency tracking are
   // useful. The public surface wraps it in a Proxy (see fieldErrorsView
@@ -130,34 +135,36 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
   // the readonly contract is enforced at runtime via set/delete traps.
   const fieldErrorsComputed = computed<FormErrorRecord>(() => {
     const record: FormErrorRecord = {}
-    for (const [, entries] of state.errors) {
-      for (const err of entries) {
-        const dottedKey = (err.path as ReadonlyArray<Segment>).map(String).join('.')
-        const existingForKey = record[dottedKey]
-        if (existingForKey === undefined) record[dottedKey] = [err]
-        else existingForKey.push(err)
-      }
-    }
+    appendStoreToRecord(record, state.schemaErrors)
+    appendStoreToRecord(record, state.userErrors)
     return record
   })
 
   const fieldErrors = createReadonlyErrorView(fieldErrorsComputed)
 
   function setFieldErrors(errors: ValidationError[]): void {
-    state.setAllErrors(errors)
+    state.setAllUserErrors(errors)
   }
 
   function addFieldErrors(errors: ValidationError[]): void {
-    state.addErrors(errors)
+    state.addUserErrors(errors)
   }
 
   function clearFieldErrors(path?: string | (string | number)[]): void {
+    // Pragmatic semantic: "make the errors at this path go away" —
+    // clears both the schema-owned and user-owned stores. With always-on
+    // validation the schema half re-populates on the next mutation if
+    // the value is still invalid, so the inconsistency is short-lived
+    // and confined to "before the next keystroke / submit." See
+    // docs/migration/0.11-to-0.12.md for the rationale.
     if (path === undefined) {
-      state.clearErrors()
+      state.clearSchemaErrors()
+      state.clearUserErrors()
       return
     }
     const segments = canonicalizePath(path as string | Path).segments
-    state.clearErrors(segments)
+    state.clearSchemaErrors(segments)
+    state.clearUserErrors(segments)
   }
 
   // --- Form-level aggregates ---
@@ -171,7 +178,9 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
     return false
   })
 
-  const isValid = computed<boolean>(() => state.errors.size === 0)
+  const isValid = computed<boolean>(
+    () => state.schemaErrors.size === 0 && state.userErrors.size === 0
+  )
 
   // --- Submission lifecycle ---
   const isSubmitting = computed<boolean>(() => state.isSubmitting.value)
@@ -278,6 +287,29 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
     swap: fieldArrays.swap as UseAbstractFormReturnType<Form, GetValueFormType>['swap'],
     move: fieldArrays.move as UseAbstractFormReturnType<Form, GetValueFormType>['move'],
     replace: fieldArrays.replace as UseAbstractFormReturnType<Form, GetValueFormType>['replace'],
+  }
+}
+
+/**
+ * Append every entry in `store` to `record`, keyed by the entry's dotted
+ * path. Used by the merged `fieldErrors` view: callers invoke it twice —
+ * first with `schemaErrors`, then with `userErrors` — so each per-key
+ * array reflects schema-first-then-user order.
+ *
+ * Mutates `record` in place to avoid allocating an intermediate per call;
+ * the wrapping computed allocates one record per recompute.
+ */
+function appendStoreToRecord(
+  record: FormErrorRecord,
+  store: Map<unknown, ValidationError[]>
+): void {
+  for (const [, entries] of store) {
+    for (const err of entries) {
+      const dottedKey = (err.path as ReadonlyArray<Segment>).map(String).join('.')
+      const existingForKey = record[dottedKey]
+      if (existingForKey === undefined) record[dottedKey] = [err]
+      else existingForKey.push(err)
+    }
   }
 }
 

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -276,7 +276,17 @@ export type FormStore<F extends GenericForm, G extends GenericForm = F> = {
  */
 export type FormStoreHydration = {
   readonly form: unknown
-  readonly errors: ReadonlyArray<readonly [string, unknown]>
+  /**
+   * Schema-driven errors snapshot. Replayed into `schemaErrors` at
+   * construction; takes precedence over the construction-time seed.
+   */
+  readonly schemaErrors: ReadonlyArray<readonly [string, unknown]>
+  /**
+   * User-injected errors snapshot. Replayed into `userErrors` at
+   * construction. Allows server-side `setFieldErrorsFromApi` /
+   * `addFieldErrors` calls to round-trip through hydration.
+   */
+  readonly userErrors: ReadonlyArray<readonly [string, unknown]>
   readonly fields: ReadonlyArray<readonly [string, unknown]>
 }
 
@@ -387,14 +397,16 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     for (const [rawKey, record] of hydration.fields) {
       fields.set(rawKey as PathKey, record as FieldRecord)
     }
-    // Hydration's flat `errors` field maps to schemaErrors for now —
-    // step 5 expands the payload to carry schemaErrors + userErrors
-    // separately so hydrated user errors round-trip cleanly. Hydration
-    // takes precedence over the construction-time seed below: the
-    // server already authored whatever error state the client should
-    // mirror, including (deliberately) the empty case.
-    for (const [rawKey, errs] of hydration.errors) {
+    // Hydration takes precedence over the construction-time seed
+    // below: the server already authored whatever error state the
+    // client should mirror, including (deliberately) the empty case.
+    // Each store replays from its own snapshot so the source-segregation
+    // invariant is preserved across SSR round-trip.
+    for (const [rawKey, errs] of hydration.schemaErrors) {
       schemaErrors.set(rawKey as PathKey, errs as ValidationError[])
+    }
+    for (const [rawKey, errs] of hydration.userErrors) {
+      userErrors.set(rawKey as PathKey, errs as ValidationError[])
     }
   } else {
     diffAndApply({}, initialData, [], (patch) => {

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -295,7 +295,7 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
 ): FormStore<F, G> {
   const { formKey, schema, defaultValues, validationMode = 'lax', hydration } = options
   const isSSR = options.isSSR === true
-  const fieldValidationMode: FieldValidationMode = options.fieldValidation?.on ?? 'none'
+  const fieldValidationMode: FieldValidationMode = options.fieldValidation?.on ?? 'change'
   const fieldValidationDebounceMs: number = options.fieldValidation?.debounceMs ?? 200
 
   type FieldValidationEntry = {

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -58,6 +58,24 @@ export type FormStore<F extends GenericForm, G extends GenericForm = F> = {
   readonly form: Ref<F>
   readonly fields: Map<PathKey, FieldRecord>
   readonly elements: Map<PathKey, ElementRecord>
+  /**
+   * Schema-driven errors. Written ONLY by the schema validation pipeline:
+   * `scheduleFieldValidation`, `handleSubmit`, the construction-time seed,
+   * history restore, and hydration. Cleared by `reset` / `resetField` and by
+   * a successful submit. `setFieldErrors*` APIs do NOT touch this Map.
+   */
+  readonly schemaErrors: Map<PathKey, ValidationError[]>
+  /**
+   * User-injected errors. Written ONLY by the `setFieldErrors*` API surfaces
+   * (and history / hydration replay). Survives schema revalidation and
+   * successful submits — the consumer owns its lifetime explicitly.
+   */
+  readonly userErrors: Map<PathKey, ValidationError[]>
+  /**
+   * Compat alias for `schemaErrors` — same Map reference, same writes.
+   * Removed once the validation refactor lands fully (see migration guide
+   * 0.11 → 0.12).
+   */
   readonly errors: Map<PathKey, ValidationError[]>
   readonly originals: Map<PathKey, OriginalsRecord>
   readonly schema: AbstractSchema<F, G>
@@ -112,11 +130,32 @@ export type FormStore<F extends GenericForm, G extends GenericForm = F> = {
   resetField(path: Path): void
 
   // --- errors ---
+  // Schema-driven writers. Used by the validation pipeline + handleSubmit.
+  setSchemaErrorsForPath(path: Path, errors: ValidationError[]): void
+  setAllSchemaErrors(errors: readonly ValidationError[]): void
+  clearSchemaErrors(path?: Path): void
+
+  // User-driven writers. Used by build-form-api's setFieldErrors* surfaces.
+  setAllUserErrors(errors: readonly ValidationError[]): void
+  addUserErrors(errors: readonly ValidationError[]): void
+  clearUserErrors(path?: Path): void
+
+  /**
+   * Merged read — returns `[...schemaErrors[path], ...userErrors[path]]`.
+   * Schema errors come first (structural validation before business logic),
+   * matching the iteration order for `getFirstErrorElement` and the
+   * top-level `fieldErrors` view.
+   */
+  getErrorsForPath(path: Path): ValidationError[]
+
+  // Compat shims — removed in 0.12. Each routes to the schema-store
+  // equivalent so build-form-api keeps working through step 1; step 2
+  // rewires its callers (setFieldErrors / addFieldErrors / clearFieldErrors)
+  // to the user-store writers above.
   setErrorsForPath(path: Path, errors: ValidationError[]): void
   setAllErrors(errors: readonly ValidationError[]): void
   addErrors(errors: readonly ValidationError[]): void
   clearErrors(path?: Path): void
-  getErrorsForPath(path: Path): ValidationError[]
 
   // --- DOM ---
   registerElement(path: Path, element: HTMLElement): boolean
@@ -297,7 +336,21 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
   // doesn't invalidate computeds watching another.
   const fields = reactive(new Map<PathKey, FieldRecord>()) as Map<PathKey, FieldRecord>
   const elements = reactive(new Map<PathKey, ElementRecord>()) as Map<PathKey, ElementRecord>
-  const errors = reactive(new Map<PathKey, ValidationError[]>()) as Map<PathKey, ValidationError[]>
+  // Errors are split by source so each writer touches exactly one slot.
+  // Schema validation owns `schemaErrors`; the `setFieldErrors*` APIs own
+  // `userErrors`. The two stores merge on read via `getErrorsForPath` and
+  // the top-level `fieldErrors` view in build-form-api.
+  const schemaErrors = reactive(new Map<PathKey, ValidationError[]>()) as Map<
+    PathKey,
+    ValidationError[]
+  >
+  const userErrors = reactive(new Map<PathKey, ValidationError[]>()) as Map<
+    PathKey,
+    ValidationError[]
+  >
+  // Compat alias: same Map reference as `schemaErrors`. Step 6 of the
+  // refactor removes this from the FormStore type entirely.
+  const errors = schemaErrors
 
   // Originals are captured at init and on first appearance of a path; never
   // re-assigned. Not reactive — the set is append-only per form's lifetime.
@@ -334,8 +387,11 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     for (const [rawKey, record] of hydration.fields) {
       fields.set(rawKey as PathKey, record as FieldRecord)
     }
+    // Hydration's flat `errors` field maps to schemaErrors for now —
+    // step 5 expands the payload to carry schemaErrors + userErrors
+    // separately so hydrated user errors round-trip cleanly.
     for (const [rawKey, errs] of hydration.errors) {
-      errors.set(rawKey as PathKey, errs as ValidationError[])
+      schemaErrors.set(rawKey as PathKey, errs as ValidationError[])
     }
   } else {
     diffAndApply({}, initialData, [], (patch) => {
@@ -449,7 +505,7 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
                 ...err,
                 path: [...path, ...(err.path as Segment[])],
               }))
-          setErrorsForPath(path, nextErrors)
+          setSchemaErrorsForPath(path, nextErrors)
         })
         .catch(() => {
           // Adapter contract forbids throws — swallow here so a misbehaving
@@ -538,53 +594,121 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
   }
 
   // --- Errors ---
+  // Two source-segregated stores: `schemaErrors` (validation-owned) and
+  // `userErrors` (API-injected). Writers below are strict — each function
+  // touches exactly one Map. The merged view is exposed via
+  // `getErrorsForPath` and the top-level `fieldErrors` computed.
 
-  function setErrorsForPath(path: Path, entries: ValidationError[]): void {
+  /**
+   * Append every entry in `entries` to its target Map at the canonical
+   * path key. Existing entries at that key are preserved (merge-append),
+   * which matches the documented `addFieldErrors` semantics. Allocates a
+   * fresh array per target key to keep the reactive trigger surface
+   * obvious — Vue's collection handlers fire on `.set`, not on in-place
+   * push.
+   */
+  function appendErrorsTo(
+    map: Map<PathKey, ValidationError[]>,
+    entries: readonly ValidationError[]
+  ): void {
+    for (const err of entries) {
+      const { key } = canonicalizePath(err.path as Path)
+      const current = map.get(key)
+      if (current === undefined) {
+        map.set(key, [err])
+      } else {
+        map.set(key, [...current, err])
+      }
+    }
+  }
+
+  /**
+   * Clear `map` and rebuild it from `entries`. Two reactive notifications
+   * fire (one for `.clear`, one per `.set`), but Vue's microtask batching
+   * collapses the burst so subscribers see one re-render. A diff-and-patch
+   * variant is a deferred follow-up — profile first.
+   */
+  function replaceErrorsIn(
+    map: Map<PathKey, ValidationError[]>,
+    entries: readonly ValidationError[]
+  ): void {
+    map.clear()
+    appendErrorsTo(map, entries)
+  }
+
+  function clearErrorsIn(map: Map<PathKey, ValidationError[]>, path: Path | undefined): void {
+    if (path === undefined) {
+      map.clear()
+      return
+    }
+    const { key } = canonicalizePath(path)
+    map.delete(key)
+  }
+
+  // --- Schema writers (validation pipeline + handleSubmit + history/hydration) ---
+
+  function setSchemaErrorsForPath(path: Path, entries: ValidationError[]): void {
     const { key } = canonicalizePath(path)
     if (entries.length === 0) {
-      errors.delete(key)
+      schemaErrors.delete(key)
       return
     }
-    errors.set(key, [...entries])
+    schemaErrors.set(key, [...entries])
   }
 
-  function setAllErrors(entries: readonly ValidationError[]): void {
-    errors.clear()
-    for (const err of entries) {
-      const { key } = canonicalizePath(err.path as Path)
-      const current = errors.get(key)
-      if (current === undefined) {
-        errors.set(key, [err])
-      } else {
-        errors.set(key, [...current, err])
-      }
-    }
+  function setAllSchemaErrors(entries: readonly ValidationError[]): void {
+    replaceErrorsIn(schemaErrors, entries)
   }
 
-  function addErrors(entries: readonly ValidationError[]): void {
-    for (const err of entries) {
-      const { key } = canonicalizePath(err.path as Path)
-      const current = errors.get(key)
-      if (current === undefined) {
-        errors.set(key, [err])
-      } else {
-        errors.set(key, [...current, err])
-      }
-    }
+  function clearSchemaErrors(path?: Path): void {
+    clearErrorsIn(schemaErrors, path)
   }
 
-  function clearErrors(path?: Path): void {
-    if (path === undefined) {
-      errors.clear()
-      return
-    }
-    const { key } = canonicalizePath(path)
-    errors.delete(key)
+  // --- User writers (setFieldErrors* surfaces + history/hydration) ---
+
+  function setAllUserErrors(entries: readonly ValidationError[]): void {
+    replaceErrorsIn(userErrors, entries)
   }
+
+  function addUserErrors(entries: readonly ValidationError[]): void {
+    appendErrorsTo(userErrors, entries)
+  }
+
+  function clearUserErrors(path?: Path): void {
+    clearErrorsIn(userErrors, path)
+  }
+
+  // --- Merged read ---
 
   function getErrorsForPath(path: Path): ValidationError[] {
     const { key } = canonicalizePath(path)
-    return errors.get(key) ?? []
+    const schema = schemaErrors.get(key)
+    const user = userErrors.get(key)
+    if (schema === undefined) return user === undefined ? [] : [...user]
+    if (user === undefined) return [...schema]
+    return [...schema, ...user]
+  }
+
+  // --- Compat shims (removed in 0.12) ---
+  // Each one routes to the schema-store equivalent so existing callers
+  // (build-form-api, tests) keep working through step 1. Step 2 rewires
+  // setFieldErrors / addFieldErrors / clearFieldErrors / setFieldErrorsFromApi
+  // directly to the user-store writers above; step 6 deletes these.
+
+  function setErrorsForPath(path: Path, entries: ValidationError[]): void {
+    setSchemaErrorsForPath(path, entries)
+  }
+
+  function setAllErrors(entries: readonly ValidationError[]): void {
+    setAllSchemaErrors(entries)
+  }
+
+  function addErrors(entries: readonly ValidationError[]): void {
+    appendErrorsTo(schemaErrors, entries)
+  }
+
+  function clearErrors(path?: Path): void {
+    clearSchemaErrors(path)
   }
 
   // --- DOM ---
@@ -669,7 +793,11 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
       originals.set(key, { segments: patch.path, value: patch.newValue })
     })
     // Drop every recorded error — the form is a fresh surface again.
-    errors.clear()
+    // Both stores clear: reset is "fresh start" semantics, so user-injected
+    // errors are not preserved across a reset (different from submit-success,
+    // which preserves them).
+    schemaErrors.clear()
+    userErrors.clear()
     // Blow away touched/focused/blurred per field. isConnected stays as-is
     // (the DOM elements haven't detached — that's a separate concern from
     // form state) and updatedAt stamps to now.
@@ -720,7 +848,8 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     const leafEntry = originals.get(targetKey)
     if (leafEntry !== undefined) {
       setValueAtPath(targetSegments, leafEntry.value)
-      errors.delete(targetKey)
+      schemaErrors.delete(targetKey)
+      userErrors.delete(targetKey)
       clearFieldRecordFlags(targetKey)
       return
     }
@@ -756,16 +885,26 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     // Clear errors and reset field-record flags for the target + every
     // descendant. Segments come from the stored records (each ValidationError
     // carries its own `path`, each FieldRecord carries `path`), so neither
-    // loop has to `JSON.parse` the Map key.
-    for (const [errorKey, errs] of Array.from(errors.entries())) {
-      const first = errs[0]
-      if (first === undefined) continue
-      if (isPathPrefix(targetSegments, first.path as readonly Segment[])) {
-        errors.delete(errorKey)
-      }
-    }
+    // loop has to `JSON.parse` the Map key. Both error stores walk in
+    // parallel — resetField is "fresh start at this subtree" semantics, so
+    // user-injected errors under the prefix go too.
+    deleteErrorsUnderPrefix(schemaErrors, targetSegments)
+    deleteErrorsUnderPrefix(userErrors, targetSegments)
     for (const [fieldKey, record] of Array.from(fields.entries())) {
       if (isPathPrefix(targetSegments, record.path)) clearFieldRecordFlags(fieldKey)
+    }
+  }
+
+  function deleteErrorsUnderPrefix(
+    map: Map<PathKey, ValidationError[]>,
+    prefix: readonly Segment[]
+  ): void {
+    for (const [errorKey, errs] of Array.from(map.entries())) {
+      const first = errs[0]
+      if (first === undefined) continue
+      if (isPathPrefix(prefix, first.path as readonly Segment[])) {
+        map.delete(errorKey)
+      }
     }
   }
 
@@ -817,11 +956,19 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
   }
 
   function getFirstErrorElement(): { path: Path; element: HTMLElement } | null {
-    // Iterate errors in insertion-order (Map preserves it). Insertion
-    // order matches the order the schema reported issues, so the "first
-    // error" is the one the user would most-likely expect to be scrolled
-    // to: the topmost failing field on the form.
-    for (const [, errs] of errors) {
+    // Walk schema errors first, then user errors. Within each Map,
+    // insertion order matches the order the schema (or the consumer)
+    // reported issues. Schema-first matches the "structural validation
+    // first, business-logic second" UX expectation: a missing-required
+    // error should focus before a custom server warning at the same path.
+    const hit = firstAttachedErrorElement(schemaErrors) ?? firstAttachedErrorElement(userErrors)
+    return hit
+  }
+
+  function firstAttachedErrorElement(
+    map: Map<PathKey, ValidationError[]>
+  ): { path: Path; element: HTMLElement } | null {
+    for (const [, errs] of map) {
       const first = errs[0]
       if (first === undefined) continue // defensive — invariant says non-empty
       const { key } = canonicalizePath(first.path as readonly Segment[])
@@ -846,6 +993,8 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     form,
     fields,
     elements,
+    schemaErrors,
+    userErrors,
     errors,
     originals,
     schema,
@@ -864,11 +1013,18 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     reset,
     resetField,
 
+    setSchemaErrorsForPath,
+    setAllSchemaErrors,
+    clearSchemaErrors,
+    setAllUserErrors,
+    addUserErrors,
+    clearUserErrors,
+    getErrorsForPath,
+
     setErrorsForPath,
     setAllErrors,
     addErrors,
     clearErrors,
-    getErrorsForPath,
 
     registerElement,
     deregisterElement,

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -71,12 +71,6 @@ export type FormStore<F extends GenericForm, G extends GenericForm = F> = {
    * successful submits — the consumer owns its lifetime explicitly.
    */
   readonly userErrors: Map<PathKey, ValidationError[]>
-  /**
-   * Compat alias for `schemaErrors` — same Map reference, same writes.
-   * Removed once the validation refactor lands fully (see migration guide
-   * 0.11 → 0.12).
-   */
-  readonly errors: Map<PathKey, ValidationError[]>
   readonly originals: Map<PathKey, OriginalsRecord>
   readonly schema: AbstractSchema<F, G>
 
@@ -147,15 +141,6 @@ export type FormStore<F extends GenericForm, G extends GenericForm = F> = {
    * top-level `fieldErrors` view.
    */
   getErrorsForPath(path: Path): ValidationError[]
-
-  // Compat shims — removed in 0.12. Each routes to the schema-store
-  // equivalent so build-form-api keeps working through step 1; step 2
-  // rewires its callers (setFieldErrors / addFieldErrors / clearFieldErrors)
-  // to the user-store writers above.
-  setErrorsForPath(path: Path, errors: ValidationError[]): void
-  setAllErrors(errors: readonly ValidationError[]): void
-  addErrors(errors: readonly ValidationError[]): void
-  clearErrors(path?: Path): void
 
   // --- DOM ---
   registerElement(path: Path, element: HTMLElement): boolean
@@ -358,9 +343,6 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     PathKey,
     ValidationError[]
   >
-  // Compat alias: same Map reference as `schemaErrors`. Step 6 of the
-  // refactor removes this from the FormStore type entirely.
-  const errors = schemaErrors
 
   // Originals are captured at init and on first appearance of a path; never
   // re-assigned. Not reactive — the set is append-only per form's lifetime.
@@ -718,28 +700,6 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     return [...schema, ...user]
   }
 
-  // --- Compat shims (removed in 0.12) ---
-  // Each one routes to the schema-store equivalent so existing callers
-  // (build-form-api, tests) keep working through step 1. Step 2 rewires
-  // setFieldErrors / addFieldErrors / clearFieldErrors / setFieldErrorsFromApi
-  // directly to the user-store writers above; step 6 deletes these.
-
-  function setErrorsForPath(path: Path, entries: ValidationError[]): void {
-    setSchemaErrorsForPath(path, entries)
-  }
-
-  function setAllErrors(entries: readonly ValidationError[]): void {
-    setAllSchemaErrors(entries)
-  }
-
-  function addErrors(entries: readonly ValidationError[]): void {
-    appendErrorsTo(schemaErrors, entries)
-  }
-
-  function clearErrors(path?: Path): void {
-    clearSchemaErrors(path)
-  }
-
   // --- DOM ---
 
   function registerElement(path: Path, element: HTMLElement): boolean {
@@ -1024,7 +984,6 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     elements,
     schemaErrors,
     userErrors,
-    errors,
     originals,
     schema,
     isSSR,
@@ -1049,11 +1008,6 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     addUserErrors,
     clearUserErrors,
     getErrorsForPath,
-
-    setErrorsForPath,
-    setAllErrors,
-    addErrors,
-    clearErrors,
 
     registerElement,
     deregisterElement,

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -389,7 +389,10 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     }
     // Hydration's flat `errors` field maps to schemaErrors for now —
     // step 5 expands the payload to carry schemaErrors + userErrors
-    // separately so hydrated user errors round-trip cleanly.
+    // separately so hydrated user errors round-trip cleanly. Hydration
+    // takes precedence over the construction-time seed below: the
+    // server already authored whatever error state the client should
+    // mirror, including (deliberately) the empty case.
     for (const [rawKey, errs] of hydration.errors) {
       schemaErrors.set(rawKey as PathKey, errs as ValidationError[])
     }
@@ -406,6 +409,20 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
         touched: null,
       })
     })
+    // No hydration — seed schemaErrors from the construction-time
+    // validation result IF the schema rejected the defaults AND the
+    // form was constructed in strict mode. Lax mode treats default
+    // values as "best-effort," so populating errors there would
+    // surprise consumers who explicitly opted out of strict checks.
+    //
+    // Async refines won't fire here — `getDefaultValues` is sync
+    // (`safeParse`, not `safeParseAsync`); they only fire on the
+    // first user mutation that re-triggers `scheduleFieldValidation`.
+    // Consumers needing async refines at construction can call
+    // `validateAsync()` once after mount.
+    if (validationMode === 'strict' && !schemaResponse.success) {
+      setAllSchemaErrors(schemaResponse.errors)
+    }
   }
 
   function touchFieldRecord(

--- a/src/runtime/core/devtools.ts
+++ b/src/runtime/core/devtools.ts
@@ -217,8 +217,19 @@ function wire(api: UnsafeDevtoolsApi, app: App, registry: ChemicalXRegistry): vo
     payload.state['Form value'] = [
       { key: 'form', value: state.form.value as unknown, editable: true },
     ]
-    payload.state['Errors'] = [
-      ...[...state.errors.entries()].map(([k, v]) => ({
+    // Schema-driven and user-injected errors land in separate inspector
+    // sections so devs can see the source distinction at a glance — a
+    // user-injected entry surviving a successful submit, or a schema
+    // entry that should have cleared after a value fix, are immediately
+    // visible without cross-referencing call sites.
+    payload.state['Schema Errors'] = [
+      ...[...state.schemaErrors.entries()].map(([k, v]) => ({
+        key: String(k),
+        value: v as unknown,
+      })),
+    ]
+    payload.state['User Errors'] = [
+      ...[...state.userErrors.entries()].map(([k, v]) => ({
         key: String(k),
         value: v as unknown,
       })),

--- a/src/runtime/core/field-state-api.ts
+++ b/src/runtime/core/field-state-api.ts
@@ -38,6 +38,21 @@ export function buildFieldStateAccessor<F extends GenericForm>(state: FormStore<
       const value = state.getValueAtPath(segments)
       const original = state.originals.get(key)?.value
       const pristine = state.isPristineAtPath(segments)
+      // Read both schema + user errors at this key directly so this
+      // computed depends only on the two specific Map keys (Vue's
+      // collection handlers track per-key reads). Going through
+      // `state.getErrorsForPath` would work too, but inline reads keep
+      // the dependency graph trivially obvious.
+      const schemaForKey = state.schemaErrors.get(key)
+      const userForKey = state.userErrors.get(key)
+      const errors =
+        schemaForKey === undefined
+          ? userForKey === undefined
+            ? []
+            : [...userForKey]
+          : userForKey === undefined
+            ? [...schemaForKey]
+            : [...schemaForKey, ...userForKey]
       return {
         value,
         original,
@@ -48,7 +63,7 @@ export function buildFieldStateAccessor<F extends GenericForm>(state: FormStore<
         touched: record?.touched ?? null,
         isConnected: record?.isConnected ?? false,
         updatedAt: record?.updatedAt ?? null,
-        errors: state.errors.get(key) ?? [],
+        errors,
         path: segments,
       }
     })

--- a/src/runtime/core/history.ts
+++ b/src/runtime/core/history.ts
@@ -7,16 +7,17 @@ import type { PathKey } from './paths'
 /**
  * Bounded undo/redo snapshot stack for a FormStore. Subscribes to
  * `onFormChange` to push a snapshot on every mutation; `undo` /
- * `redo` restore via `applyFormReplacement` and `setAllErrors`.
- * `onReset` clears both stacks and seeds a fresh baseline.
+ * `redo` restore via `applyFormReplacement` plus the schema + user
+ * error writers. `onReset` clears both stacks and seeds a fresh baseline.
  *
  * Snapshots include:
  *  - `form` — the whole form value, captured by reference. Vue's
  *    form ref is replaced wholesale on every mutation, so the
  *    snapshot reference is stable: old references don't mutate.
- *  - `errors` — shallow-cloned Map entries. Consumers who have
- *    stale errors from before an undo want to see those errors
- *    again after the undo restores the prior form state.
+ *  - `schemaErrors` + `userErrors` — shallow-cloned Map entries from
+ *    each source-segregated store. Captured separately so undo
+ *    preserves the lifecycle distinction (schema errors are validation
+ *    output; user errors are consumer-owned).
  *
  * Field record state (touched / focused / blurred / isConnected) is
  * deliberately NOT snapshotted. Those flags represent UI
@@ -26,7 +27,8 @@ import type { PathKey } from './paths'
 
 export type HistorySnapshot<F> = {
   readonly form: F
-  readonly errors: ReadonlyArray<readonly [PathKey, ValidationError[]]>
+  readonly schemaErrors: ReadonlyArray<readonly [PathKey, ValidationError[]]>
+  readonly userErrors: ReadonlyArray<readonly [PathKey, ValidationError[]]>
 }
 
 export type HistoryModule = {
@@ -69,7 +71,8 @@ export function createHistoryModule<F extends GenericForm>(
     // the generic parameter the caller bound.
     return {
       form: state.form.value as unknown as F,
-      errors: [...state.errors.entries()].map(([k, v]) => [k, [...v]] as const),
+      schemaErrors: [...state.schemaErrors.entries()].map(([k, v]) => [k, [...v]] as const),
+      userErrors: [...state.userErrors.entries()].map(([k, v]) => [k, [...v]] as const),
     }
   }
 
@@ -109,10 +112,15 @@ export function createHistoryModule<F extends GenericForm>(
   function restore(snap: HistorySnapshot<F>): void {
     suppressNext = true
     state.applyFormReplacement(snap.form)
-    // Rebuild the error store from the snapshot. setAllErrors
-    // clears + repopulates in one shot.
-    const flat = snap.errors.flatMap(([, errs]) => errs)
-    state.setAllErrors(flat)
+    // Rebuild both error stores from the snapshot. Each writer clears +
+    // repopulates its own Map; the two sources stay isolated. Order is
+    // arbitrary because the writers touch separate Maps with no
+    // cross-dependency, but writing schema first keeps the per-key
+    // insertion order matching the schema-first iteration invariant.
+    const schemaFlat = snap.schemaErrors.flatMap(([, errs]) => errs)
+    const userFlat = snap.userErrors.flatMap(([, errs]) => errs)
+    state.setAllSchemaErrors(schemaFlat)
+    state.setAllUserErrors(userFlat)
   }
 
   function undo(): boolean {

--- a/src/runtime/core/persistence/index.ts
+++ b/src/runtime/core/persistence/index.ts
@@ -40,12 +40,23 @@ export async function getStorageAdapter(
  * invalidates every existing entry — the reader drops entries whose
  * `v` doesn't match. `data` mirrors the SSR `SerializedFormData`
  * shape so one deserialiser handles both.
+ *
+ * Errors are stored source-segregated (matching FormStore's split):
+ *   - `schemaErrors` is validation-owned; cleared by reset / submit-success.
+ *   - `userErrors` is consumer-owned (written via setFieldErrors* APIs);
+ *     persists across schema revalidation and successful submits.
+ *
+ * The two are surfaced separately on the persisted payload so the
+ * lifecycle distinction round-trips through reload. Default
+ * `PersistConfig.version` bumped to 2 for the 0.12 release — older v1
+ * payloads (single flat `errors` field) are dropped silently on read.
  */
 export type PersistedPayload<Form> = {
   readonly v: number
   readonly data: {
     readonly form: Form
-    readonly errors?: ReadonlyArray<readonly [string, ValidationError[]]>
+    readonly schemaErrors?: ReadonlyArray<readonly [string, ValidationError[]]>
+    readonly userErrors?: ReadonlyArray<readonly [string, ValidationError[]]>
   }
 }
 
@@ -68,14 +79,19 @@ export function readPersistedPayload<Form>(
 export function buildPersistedPayload<Form>(
   form: Form,
   include: 'form' | 'form+errors',
-  errors: ReadonlyMap<string, ValidationError[]>,
+  schemaErrors: ReadonlyMap<string, ValidationError[]>,
+  userErrors: ReadonlyMap<string, ValidationError[]>,
   version: number
 ): PersistedPayload<Form> {
-  const data: PersistedPayload<Form>['data'] =
-    include === 'form+errors'
-      ? { form, errors: [...errors.entries()].map(([k, v]) => [k, [...v]] as const) }
-      : { form }
-  return { v: version, data }
+  if (include === 'form') return { v: version, data: { form } }
+  return {
+    v: version,
+    data: {
+      form,
+      schemaErrors: [...schemaErrors.entries()].map(([k, v]) => [k, [...v]] as const),
+      userErrors: [...userErrors.entries()].map(([k, v]) => [k, [...v]] as const),
+    },
+  }
 }
 
 /**

--- a/src/runtime/core/process-form.ts
+++ b/src/runtime/core/process-form.ts
@@ -204,7 +204,10 @@ export function buildProcessForm<F extends GenericForm>(
         validationSettled = true
         if (!result.success) {
           const errors = result.errors
-          state.setAllErrors(errors)
+          // Schema-only writer: user-injected errors (from setFieldErrors,
+          // addFieldErrors, setFieldErrorsFromApi) live in a separate store
+          // and are NOT clobbered by the submit-time validation result.
+          state.setAllSchemaErrors(errors)
           // Apply the invalid-submit focus/scroll policy AFTER populating
           // the error store (so getFirstErrorElement walks the fresh
           // entries) and BEFORE the user's onError callback (so consumer
@@ -219,7 +222,11 @@ export function buildProcessForm<F extends GenericForm>(
           }
           return
         }
-        state.clearErrors()
+        // Schema-only clear: a successful submit means schema validation
+        // passed, so the schema-error store goes empty. User-injected
+        // errors persist — consumers managing their own warning/info
+        // state via setFieldErrors keep ownership of that lifecycle.
+        state.clearSchemaErrors()
         await onSubmit(result.data)
         // Notify subscribers (persistence's clear-on-success handler,
         // future hooks). Fires only when the user callback resolved —

--- a/src/runtime/core/process-form.ts
+++ b/src/runtime/core/process-form.ts
@@ -285,7 +285,12 @@ export function buildProcessForm<F extends GenericForm>(
       ...(limits ?? {}),
     })
     if (result.ok) {
-      state.setAllErrors(result.errors)
+      // API-injected errors go to the user store so they survive schema
+      // revalidation + successful submits. Consumers managing API
+      // warning/info state via this surface keep ownership of its
+      // lifecycle — clear them explicitly via clearFieldErrors when
+      // they're no longer relevant.
+      state.setAllUserErrors(result.errors)
     }
     return result
   }

--- a/src/runtime/core/registry.ts
+++ b/src/runtime/core/registry.ts
@@ -21,7 +21,19 @@ import { detectSSR, type SSRDetectOptions } from './ssr'
 
 export type SerializedFormData = {
   readonly form: unknown
-  readonly errors: ReadonlyArray<readonly [string, unknown]>
+  /**
+   * Schema-driven errors at SSR snapshot time. Replays into the
+   * client's `schemaErrors` Map at hydration. Cleared by reset and
+   * by submit-success on the client side.
+   */
+  readonly schemaErrors: ReadonlyArray<readonly [string, unknown]>
+  /**
+   * User-injected errors at SSR snapshot time (typically populated
+   * by `setFieldErrorsFromApi` or `addFieldErrors` during the server
+   * render). Replays into `userErrors` at hydration; persists across
+   * client-side schema revalidation and successful submits.
+   */
+  readonly userErrors: ReadonlyArray<readonly [string, unknown]>
   readonly fields: ReadonlyArray<readonly [string, unknown]>
 }
 

--- a/src/runtime/core/serialize.ts
+++ b/src/runtime/core/serialize.ts
@@ -27,7 +27,8 @@ export function renderChemicalXState(app: App): SerializedChemicalXState {
       key,
       {
         form: state.form.value,
-        errors: Array.from(state.errors.entries()),
+        schemaErrors: Array.from(state.schemaErrors.entries()),
+        userErrors: Array.from(state.userErrors.entries()),
         fields: Array.from(state.fields.entries()),
       },
     ])

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -150,20 +150,22 @@ export type OnInvalidSubmitPolicy = 'none' | 'focus-first-error' | 'scroll-to-fi
 /**
  * Field-level validation trigger mode.
  *
- * - `'none'` (default): no field-level validation. `handleSubmit` and
- *   explicit `validate()` / `validateAsync()` calls are the only
- *   validation surface.
- * - `'change'`: on every mutation via `setValueAtPath` (register,
- *   `setValue(path, ...)`, array helpers), schedule a debounced
- *   validation for the written path.
+ * - `'change'` (default): on every mutation via `setValueAtPath`
+ *   (register, `setValue(path, ...)`, array helpers), schedule a
+ *   debounced validation for the written path. Errors track the
+ *   live `(value, schema)` continuously so consumers can render
+ *   inline feedback without waiting for submit.
  * - `'blur'`: on `markFocused(path, false)` — i.e. when the user
  *   tabs away from a field — validate immediately (no debounce) for
  *   that path.
+ * - `'none'`: explicit opt-out. `handleSubmit` and explicit
+ *   `validate()` / `validateAsync()` calls are the only validation
+ *   surface; the per-keystroke / per-blur path is disabled entirely.
  */
 export type FieldValidationMode = 'change' | 'blur' | 'none'
 
 export type FieldValidationConfig = {
-  /** Trigger mode. Default `'none'`. */
+  /** Trigger mode. Default `'change'`. */
   on?: FieldValidationMode
   /**
    * Debounce window for `on: 'change'`. Ignored when `on` is `'blur'`

--- a/test/composables/field-validation.test.ts
+++ b/test/composables/field-validation.test.ts
@@ -6,11 +6,12 @@ import { z } from 'zod'
 import { createChemicalXForms } from '../../src/runtime/core/plugin'
 
 /**
- * Phase 5.7 — debounced field-level validation.
+ * Debounced field-level validation.
  *
- * `fieldValidation: { on: 'change', debounceMs }` schedules validation
- * on every `setValueAtPath` write; `on: 'blur'` fires immediately on
- * blur; `on: 'none'` (default) disables the path entirely.
+ * `fieldValidation: { on: 'change', debounceMs }` (default) schedules
+ * validation on every `setValueAtPath` write; `on: 'blur'` fires
+ * immediately on blur; `on: 'none'` is the explicit opt-out — writes
+ * never schedule a field run, errors only update at submit time.
  *
  * Runs concurrently with handleSubmit — submit-entry aborts in-flight
  * field runs so submit's full-form result is authoritative.
@@ -117,9 +118,21 @@ describe('fieldValidation: { on: "change", debounceMs }', () => {
     expect(api.fieldErrors.password?.[0]?.message).toBe('min 8 chars')
   })
 
-  it('on="none" (default): writes never schedule a field run', async () => {
+  it('on="change" is the default: writes schedule a debounced field run', async () => {
     vi.useFakeTimers()
     const { app, api } = mountWith({})
+    apps.push(app)
+
+    api.setValue('email', 'not-an-email')
+    // Default debounceMs is 200; advance past it.
+    await vi.advanceTimersByTimeAsync(250)
+    await drainMicrotasks()
+    expect(api.fieldErrors.email?.[0]?.message).toBe('bad email')
+  })
+
+  it('explicit on="none" opts out: writes never schedule a field run', async () => {
+    vi.useFakeTimers()
+    const { app, api } = mountWith({ fieldValidation: { on: 'none' } })
     apps.push(app)
 
     api.setValue('email', 'not-an-email')

--- a/test/composables/focus-scroll.test.ts
+++ b/test/composables/focus-scroll.test.ts
@@ -17,8 +17,9 @@ const defaults: Form = { email: '', password: '', nickname: '' }
  * The focus/scroll helpers operate on the DOM elements registered via
  * v-register. This suite mounts a real tree against jsdom so
  * registerElement sees actual HTMLElements; the helpers walk
- * state.errors → state.elements to pick the first visible, connected
- * target.
+ * schemaErrors → userErrors → state.elements to pick the first visible,
+ * connected target. Schema errors take focus priority over user errors
+ * at the same path (matches the merged-read iteration order).
  */
 
 function mountWith(options: {

--- a/test/composables/form-aggregates.test.ts
+++ b/test/composables/form-aggregates.test.ts
@@ -12,9 +12,10 @@ import { fakeSchema } from '../utils/fake-schema'
  * test/composables/type-inference.test.ts.
  *
  * The aggregates are thin wrappers around existing reactive stores
- * (`state.originals` for dirty comparisons, `state.errors` for the
- * validity check) — the tests pin their semantics so a future refactor
- * of those stores can't silently break the aggregates.
+ * (`state.originals` for dirty comparisons, `state.schemaErrors` +
+ * `state.userErrors` for the validity check) — the tests pin their
+ * semantics so a future refactor of those stores can't silently break
+ * the aggregates.
  */
 
 type SignupForm = {

--- a/test/composables/initial-validation-seed.test.ts
+++ b/test/composables/initial-validation-seed.test.ts
@@ -126,10 +126,11 @@ describe('initial validation seed — hydration takes precedence', () => {
       validationMode: 'strict',
       hydration: {
         form: { email: 'server@x.com', password: 'serverpw' },
-        // Empty errors — hydration says the server saw a valid form.
+        // Empty stores — hydration says the server saw a valid form.
         // The seed must NOT fire and overwrite this with the schema's
         // errors-on-empty-defaults.
-        errors: [],
+        schemaErrors: [],
+        userErrors: [],
         fields: [],
       },
     })
@@ -164,7 +165,8 @@ describe('initial validation seed — hydration takes precedence', () => {
       validationMode: 'strict',
       hydration: {
         form: { email: 'a@a', password: 'irrelevant' },
-        errors: [[emailKey, onlyServerError]],
+        schemaErrors: [[emailKey, onlyServerError]],
+        userErrors: [],
         fields: [],
       },
     })

--- a/test/composables/initial-validation-seed.test.ts
+++ b/test/composables/initial-validation-seed.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, type App } from 'vue'
+import { z } from 'zod'
+import { createFormStore } from '../../src/runtime/core/create-form-store'
+import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { canonicalizePath } from '../../src/runtime/core/paths'
+import { useForm } from '../../src/zod'
+import { fakeSchema } from '../utils/fake-schema'
+
+/**
+ * Initial validation seed: when a form is constructed in strict mode
+ * and its default values fail schema validation, `schemaErrors` is
+ * populated immediately at construction time (without requiring a user
+ * mutation or an explicit `validateAsync` call).
+ *
+ * Three invariants locked here:
+ *   1. STRICT mode + invalid defaults  → seed populates schemaErrors.
+ *   2. LAX mode    + invalid defaults  → no seed (lax explicitly opts
+ *      out of construction-time validation).
+ *   3. Hydration provided              → hydration replaces the seed
+ *      wholesale; the server's snapshot is authoritative.
+ */
+
+const tightSchema = z.object({
+  email: z.email('bad email'),
+  password: z.string().min(8, 'min 8 chars'),
+})
+
+type Tight = z.infer<typeof tightSchema>
+
+function mountWithZod(options: {
+  validationMode?: 'strict' | 'lax'
+  defaultValues?: Partial<Tight>
+}): { app: App; api: ReturnType<typeof useForm<typeof tightSchema>> } {
+  type API = ReturnType<typeof useForm<typeof tightSchema>>
+  const handle: { api?: API } = {}
+  const App = defineComponent({
+    setup() {
+      handle.api = useForm({
+        schema: tightSchema,
+        key: 'init-seed',
+        ...(options.validationMode ? { validationMode: options.validationMode } : {}),
+        ...(options.defaultValues ? { defaultValues: options.defaultValues } : {}),
+      })
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createChemicalXForms({ override: true }))
+  const root = document.createElement('div')
+  document.body.appendChild(root)
+  app.mount(root)
+  return { app, api: handle.api as API }
+}
+
+describe('initial validation seed — strict mode', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('populates schemaErrors at construction when defaults fail validation', () => {
+    const { app, api } = mountWithZod({ validationMode: 'strict' })
+    apps.push(app)
+    // Empty defaults: '' fails .email(), '' fails .min(8). Both errors
+    // surface in fieldErrors before any user interaction.
+    expect(api.fieldErrors.email?.[0]?.message).toBe('bad email')
+    expect(api.fieldErrors.password?.[0]?.message).toBe('min 8 chars')
+    expect(api.state.isValid).toBe(false)
+  })
+
+  it('does NOT seed when defaults validate cleanly', () => {
+    const { app, api } = mountWithZod({
+      validationMode: 'strict',
+      defaultValues: { email: 'a@a.com', password: 'longenough' },
+    })
+    apps.push(app)
+    expect(api.fieldErrors.email).toBeUndefined()
+    expect(api.fieldErrors.password).toBeUndefined()
+    expect(api.state.isValid).toBe(true)
+  })
+})
+
+describe('initial validation seed — lax mode', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('does NOT populate schemaErrors at construction even when defaults fail', () => {
+    // Lax mode is the explicit opt-out: "best-effort defaults, no
+    // construction-time enforcement." A consumer who picked lax would
+    // be surprised to see errors before they've touched anything.
+    const { app, api } = mountWithZod({ validationMode: 'lax' })
+    apps.push(app)
+    expect(api.fieldErrors.email).toBeUndefined()
+    expect(api.fieldErrors.password).toBeUndefined()
+    expect(api.state.isValid).toBe(true)
+  })
+})
+
+describe('initial validation seed — hydration takes precedence', () => {
+  it('skips the seed when hydration is provided (server is authoritative)', () => {
+    // Hand-roll a fakeSchema whose getDefaultValues reports a failure
+    // — proves the seed code path WOULD fire if hydration weren't
+    // taking precedence. Hydration carries an explicit empty errors
+    // slot, modelling "the server validated and decided it was OK."
+    type Form = { email: string; password: string }
+    const failingDefaultsSchema = fakeSchema<Form>({ email: '', password: '' })
+    failingDefaultsSchema.getDefaultValues = (config) => ({
+      data: {
+        email: config.constraints?.email ?? '',
+        password: config.constraints?.password ?? '',
+      },
+      errors: [
+        { path: ['email'], message: 'seeded email error', formKey: 'hyd' },
+        { path: ['password'], message: 'seeded password error', formKey: 'hyd' },
+      ],
+      success: false,
+      formKey: 'hyd',
+    })
+
+    const state = createFormStore<Form>({
+      formKey: 'hyd',
+      schema: failingDefaultsSchema,
+      validationMode: 'strict',
+      hydration: {
+        form: { email: 'server@x.com', password: 'serverpw' },
+        // Empty errors — hydration says the server saw a valid form.
+        // The seed must NOT fire and overwrite this with the schema's
+        // errors-on-empty-defaults.
+        errors: [],
+        fields: [],
+      },
+    })
+
+    expect(state.schemaErrors.size).toBe(0)
+  })
+
+  it('replays hydrated schema errors verbatim, ignoring the seed', () => {
+    // Same schema (would seed two errors on empty defaults), but
+    // hydration carries ONE error at a different path. The hydrated
+    // shape wins — the seed doesn't get to add its own entries on top.
+    type Form = { email: string; password: string }
+    const failingDefaultsSchema = fakeSchema<Form>({ email: '', password: '' })
+    failingDefaultsSchema.getDefaultValues = () => ({
+      data: { email: '', password: '' },
+      errors: [
+        { path: ['email'], message: 'seed should not appear', formKey: 'hyd2' },
+        { path: ['password'], message: 'seed should not appear', formKey: 'hyd2' },
+      ],
+      success: false,
+      formKey: 'hyd2',
+    })
+
+    const onlyServerError = [
+      { path: ['email'] as const, message: 'server email rejection', formKey: 'hyd2' },
+    ]
+    const emailKey = canonicalizePath(['email']).key
+
+    const state = createFormStore<Form>({
+      formKey: 'hyd2',
+      schema: failingDefaultsSchema,
+      validationMode: 'strict',
+      hydration: {
+        form: { email: 'a@a', password: 'irrelevant' },
+        errors: [[emailKey, onlyServerError]],
+        fields: [],
+      },
+    })
+
+    expect(state.schemaErrors.size).toBe(1)
+    expect(state.schemaErrors.get(emailKey)?.[0]?.message).toBe('server email rejection')
+  })
+})

--- a/test/composables/persistence.test.ts
+++ b/test/composables/persistence.test.ts
@@ -132,14 +132,14 @@ describe('persistence — localStorage backend', () => {
     const raw = await waitUntil(() => localStorage.getItem('test-local'))
     expect(raw).not.toBeNull()
     const payload = JSON.parse(raw as string) as { v: number; data: { form: { email: string } } }
-    expect(payload.v).toBe(1)
+    expect(payload.v).toBe(2)
     expect(payload.data.form.email).toBe('alice@example.com')
   })
 
   it('hydrates from a persisted payload on mount', async () => {
     localStorage.setItem(
       'test-hydrate',
-      JSON.stringify({ v: 1, data: { form: { email: 'seed@example.com', password: 'pw' } } })
+      JSON.stringify({ v: 2, data: { form: { email: 'seed@example.com', password: 'pw' } } })
     )
     const { app, api } = mountForm({ storage: 'local', key: 'test-hydrate', debounceMs: 20 })
     apps.push(app)
@@ -172,7 +172,7 @@ describe('persistence — localStorage backend', () => {
   it('clears the persisted entry on submit success', async () => {
     localStorage.setItem(
       'test-clear',
-      JSON.stringify({ v: 1, data: { form: { email: 'pre@x.com', password: 'pw' } } })
+      JSON.stringify({ v: 2, data: { form: { email: 'pre@x.com', password: 'pw' } } })
     )
     const { app, api } = mountForm({ storage: 'local', key: 'test-clear', debounceMs: 20 })
     apps.push(app)
@@ -270,7 +270,7 @@ describe('persistence — include=form+errors', () => {
     localStorage.clear()
   })
 
-  it('persists fieldErrors when include=form+errors is set', async () => {
+  it('persists user-injected errors under userErrors when include=form+errors is set', async () => {
     const { app, api } = mountForm({
       storage: 'local',
       key: 'test-form-errors',
@@ -287,10 +287,21 @@ describe('persistence — include=form+errors', () => {
     const raw = await waitUntil(() => localStorage.getItem('test-form-errors'))
     expect(raw).not.toBeNull()
     const payload = JSON.parse(raw as string) as {
-      data: { errors?: ReadonlyArray<readonly [string, { message: string }[]]> }
+      data: {
+        schemaErrors?: ReadonlyArray<readonly [string, { message: string }[]]>
+        userErrors?: ReadonlyArray<readonly [string, { message: string }[]]>
+      }
     }
-    expect(payload.data.errors).toBeDefined()
-    const flatMessages = payload.data.errors!.flatMap(([, errs]) => errs.map((e) => e.message))
-    expect(flatMessages).toContain('bad')
+    // setFieldErrors routes to the user-error store, so the persisted
+    // payload carries the entry under `userErrors`. Schema errors stay
+    // an empty array (no validation errors fired here).
+    expect(payload.data.userErrors).toBeDefined()
+    const userMessages = payload.data.userErrors!.flatMap(([, errs]) => errs.map((e) => e.message))
+    expect(userMessages).toContain('bad')
+    expect(payload.data.schemaErrors).toBeDefined()
+    const schemaMessages = payload.data.schemaErrors!.flatMap(([, errs]) =>
+      errs.map((e) => e.message)
+    )
+    expect(schemaMessages).not.toContain('bad')
   })
 })

--- a/test/composables/use-form-v3-forwarding.test.ts
+++ b/test/composables/use-form-v3-forwarding.test.ts
@@ -103,7 +103,7 @@ describe('v3 useForm forwards opt-in options to useAbstractForm', () => {
     const [key, payload] = setItem.mock.calls[0] ?? []
     expect(key).toBe('chemical-x-forms:v3-persist')
     expect(payload).toMatchObject({
-      v: 1,
+      v: 2,
       data: { form: { email: 'alice@example.com' } },
     })
   })

--- a/test/core/create-form-store.test.ts
+++ b/test/core/create-form-store.test.ts
@@ -83,7 +83,10 @@ describe('createFormStore', () => {
     it('errors in one form do not leak into another form with the same field name', () => {
       const stateA = makeState({ formKey: 'formA' })
       const stateB = makeState({ formKey: 'formB' })
-      stateA.setErrorsForPath(['email'], [{ message: 'bad', path: ['email'], formKey: 'formA' }])
+      stateA.setSchemaErrorsForPath(
+        ['email'],
+        [{ message: 'bad', path: ['email'], formKey: 'formA' }]
+      )
       expect(stateA.getErrorsForPath(['email'])).toHaveLength(1)
       expect(stateB.getErrorsForPath(['email'])).toHaveLength(0)
     })
@@ -157,48 +160,111 @@ describe('createFormStore', () => {
   })
 
   describe('errors', () => {
-    it('setErrorsForPath stores and clears per path', () => {
+    it('setSchemaErrorsForPath stores and clears per path', () => {
       const state = makeState()
       const errs: ValidationError[] = [{ message: 'bad', path: ['email'], formKey: 'test' }]
-      state.setErrorsForPath(['email'], errs)
+      state.setSchemaErrorsForPath(['email'], errs)
       expect(state.getErrorsForPath(['email'])).toEqual(errs)
-      state.setErrorsForPath(['email'], [])
+      state.setSchemaErrorsForPath(['email'], [])
       expect(state.getErrorsForPath(['email'])).toEqual([])
     })
 
-    it('setAllErrors replaces the entire error set', () => {
+    it('setAllSchemaErrors replaces the entire schema-error set', () => {
       const state = makeState()
-      state.setErrorsForPath(['email'], [{ message: 'old', path: ['email'], formKey: 'test' }])
-      state.setAllErrors([{ message: 'new', path: ['password'], formKey: 'test' }])
+      state.setSchemaErrorsForPath(
+        ['email'],
+        [{ message: 'old', path: ['email'], formKey: 'test' }]
+      )
+      state.setAllSchemaErrors([{ message: 'new', path: ['password'], formKey: 'test' }])
       expect(state.getErrorsForPath(['email'])).toEqual([])
       expect(state.getErrorsForPath(['password'])).toEqual([
         { message: 'new', path: ['password'], formKey: 'test' },
       ])
     })
 
-    it('addErrors appends to existing entries at the same path', () => {
+    it('addUserErrors appends to existing user entries at the same path', () => {
       const state = makeState()
-      state.addErrors([{ message: 'first', path: ['email'], formKey: 'test' }])
-      state.addErrors([{ message: 'second', path: ['email'], formKey: 'test' }])
+      state.addUserErrors([{ message: 'first', path: ['email'], formKey: 'test' }])
+      state.addUserErrors([{ message: 'second', path: ['email'], formKey: 'test' }])
       expect(state.getErrorsForPath(['email'])).toHaveLength(2)
     })
 
-    it('clearErrors() with no args removes all errors for this form', () => {
+    it('clearSchemaErrors() with no args removes all schema errors for this form', () => {
       const state = makeState()
-      state.setErrorsForPath(['email'], [{ message: 'a', path: ['email'], formKey: 'test' }])
-      state.setErrorsForPath(['password'], [{ message: 'b', path: ['password'], formKey: 'test' }])
-      state.clearErrors()
+      state.setSchemaErrorsForPath(['email'], [{ message: 'a', path: ['email'], formKey: 'test' }])
+      state.setSchemaErrorsForPath(
+        ['password'],
+        [{ message: 'b', path: ['password'], formKey: 'test' }]
+      )
+      state.clearSchemaErrors()
       expect(state.getErrorsForPath(['email'])).toEqual([])
       expect(state.getErrorsForPath(['password'])).toEqual([])
     })
 
-    it('clearErrors(path) targets a specific path', () => {
+    it('clearSchemaErrors(path) targets a specific path', () => {
       const state = makeState()
-      state.setErrorsForPath(['email'], [{ message: 'a', path: ['email'], formKey: 'test' }])
-      state.setErrorsForPath(['password'], [{ message: 'b', path: ['password'], formKey: 'test' }])
-      state.clearErrors(['email'])
+      state.setSchemaErrorsForPath(['email'], [{ message: 'a', path: ['email'], formKey: 'test' }])
+      state.setSchemaErrorsForPath(
+        ['password'],
+        [{ message: 'b', path: ['password'], formKey: 'test' }]
+      )
+      state.clearSchemaErrors(['email'])
       expect(state.getErrorsForPath(['email'])).toEqual([])
       expect(state.getErrorsForPath(['password'])).toHaveLength(1)
+    })
+
+    // --- Source-isolation locks ---
+    // The whole point of the schemaErrors / userErrors split: each
+    // writer touches exactly one Map. The asserts below fail loudly if
+    // a future refactor accidentally cross-routes a writer.
+
+    it('setSchemaErrorsForPath does NOT touch userErrors', () => {
+      const state = makeState()
+      state.setAllUserErrors([{ message: 'user', path: ['email'], formKey: 'test' }])
+      state.setSchemaErrorsForPath(
+        ['email'],
+        [{ message: 'schema', path: ['email'], formKey: 'test' }]
+      )
+      expect(state.userErrors.size).toBe(1)
+      expect(state.schemaErrors.size).toBe(1)
+      // Merged read returns schema first, then user (per the documented
+      // ordering invariant exercised throughout the public API).
+      expect(state.getErrorsForPath(['email']).map((e) => e.message)).toEqual(['schema', 'user'])
+    })
+
+    it('setAllUserErrors does NOT touch schemaErrors', () => {
+      const state = makeState()
+      state.setSchemaErrorsForPath(
+        ['email'],
+        [{ message: 'schema', path: ['email'], formKey: 'test' }]
+      )
+      state.setAllUserErrors([{ message: 'user', path: ['email'], formKey: 'test' }])
+      expect(state.schemaErrors.size).toBe(1)
+      expect(state.userErrors.size).toBe(1)
+    })
+
+    it('clearSchemaErrors leaves userErrors intact', () => {
+      const state = makeState()
+      state.setSchemaErrorsForPath(
+        ['email'],
+        [{ message: 'schema', path: ['email'], formKey: 'test' }]
+      )
+      state.setAllUserErrors([{ message: 'user', path: ['email'], formKey: 'test' }])
+      state.clearSchemaErrors()
+      expect(state.schemaErrors.size).toBe(0)
+      expect(state.userErrors.size).toBe(1)
+    })
+
+    it('clearUserErrors leaves schemaErrors intact', () => {
+      const state = makeState()
+      state.setSchemaErrorsForPath(
+        ['email'],
+        [{ message: 'schema', path: ['email'], formKey: 'test' }]
+      )
+      state.setAllUserErrors([{ message: 'user', path: ['email'], formKey: 'test' }])
+      state.clearUserErrors()
+      expect(state.userErrors.size).toBe(0)
+      expect(state.schemaErrors.size).toBe(1)
     })
   })
 
@@ -266,7 +332,7 @@ describe('createFormStore', () => {
   describe('structured-path key collisions', () => {
     it("treats 'user.name' (dotted) and ['user', 'name'] (array) as the same path", () => {
       const state = makeState()
-      state.setErrorsForPath(
+      state.setSchemaErrorsForPath(
         ['profile', 'name'],
         [{ message: 'x', path: ['profile', 'name'], formKey: 'test' }]
       )
@@ -279,7 +345,7 @@ describe('createFormStore', () => {
       const oddDefaults: OddForm = { 'profile.name': 'literal-dot-key' }
       const oddSchema = fakeSchema<OddForm>(oddDefaults)
       const state = createFormStore({ formKey: 'odd', schema: oddSchema })
-      state.setErrorsForPath(
+      state.setSchemaErrorsForPath(
         ['profile.name'],
         [{ message: 'x', path: ['profile.name'], formKey: 'odd' }]
       )

--- a/test/core/field-state-api.test.ts
+++ b/test/core/field-state-api.test.ts
@@ -45,7 +45,7 @@ describe('buildFieldStateAccessor', () => {
 
   it('reflects errors set on the state', () => {
     const { state, getFieldState } = makeAccessor()
-    state.setErrorsForPath(['email'], [{ message: 'bad', path: ['email'], formKey: 'fs' }])
+    state.setSchemaErrorsForPath(['email'], [{ message: 'bad', path: ['email'], formKey: 'fs' }])
     expect(getFieldState(['email']).value.errors).toHaveLength(1)
   })
 

--- a/test/core/process-form.test.ts
+++ b/test/core/process-form.test.ts
@@ -143,7 +143,10 @@ describe('buildProcessForm', () => {
     it('clears errors on successful submit', async () => {
       const state = alwaysValid()
       const { handleSubmit } = buildProcessForm(state)
-      state.setErrorsForPath(['email'], [{ message: 'stale', path: ['email'], formKey: 'pf' }])
+      state.setSchemaErrorsForPath(
+        ['email'],
+        [{ message: 'stale', path: ['email'], formKey: 'pf' }]
+      )
 
       await handleSubmit(async () => {})()
       expect(state.getErrorsForPath(['email'])).toEqual([])
@@ -440,10 +443,9 @@ describe('buildProcessForm', () => {
     it('returns ok:false with reason on malformed payload and does not mutate state', () => {
       const state = alwaysValid()
       const { setFieldErrorsFromApi } = buildProcessForm(state)
-      state.setErrorsForPath(
-        ['password'],
-        [{ message: 'existing', path: ['password'], formKey: 'pf' }]
-      )
+      // Existing user-injected error — proves a malformed payload bail
+      // doesn't accidentally clobber prior state.
+      state.setAllUserErrors([{ message: 'existing', path: ['password'], formKey: 'pf' }])
       const result = setFieldErrorsFromApi(
         'oops' as unknown as Parameters<typeof setFieldErrorsFromApi>[0]
       )

--- a/test/core/serialize.test.ts
+++ b/test/core/serialize.test.ts
@@ -22,9 +22,16 @@ function seedServerApp(formKey: string, initialEmail: string) {
 }
 
 describe('renderChemicalXState', () => {
-  it('extracts form data and errors for every registered form', () => {
+  it('extracts form data and source-segregated errors for every registered form', () => {
     const { app, state } = seedServerApp('signup', 'a@a')
-    state.setErrorsForPath(['email'], [{ message: 'taken', path: ['email'], formKey: 'signup' }])
+    // Schema validation populates the schema-error store directly via
+    // setSchemaErrorsForPath. setFieldErrors-style API calls would
+    // populate userErrors; here we test both round-trip independently.
+    state.setSchemaErrorsForPath(
+      ['email'],
+      [{ message: 'taken', path: ['email'], formKey: 'signup' }]
+    )
+    state.setAllUserErrors([{ message: 'banned-domain', path: ['email'], formKey: 'signup' }])
     const payload = renderChemicalXState(app)
     expect(payload.forms).toHaveLength(1)
     const entry = payload.forms[0]
@@ -33,7 +40,8 @@ describe('renderChemicalXState', () => {
     const [key, data] = entry
     expect(key).toBe('signup')
     expect(data.form).toEqual({ email: 'a@a', password: '' })
-    expect(data.errors).toHaveLength(1)
+    expect(data.schemaErrors).toHaveLength(1)
+    expect(data.userErrors).toHaveLength(1)
   })
 
   it('does not include originals or elements in the payload', () => {


### PR DESCRIPTION
## Summary

- **Live validation by default.** `fieldValidation.on` defaults to `'change'` (was `'none'`). Type "abc" into a `min(8)` field, see the error live; type "abcd12345" and watch it disappear without a second submit. `'none'` is now the explicit opt-out.
- **Errors as a pure function of `(value, schema) + injected user errors`.** Schema-driven and user-injected errors live in distinct internal stores. The merged `fieldErrors` view stays unchanged for consumers, but the lifecycles separate cleanly: API-injected errors now survive schema revalidation AND successful submits.
- **Construction-time schema-error seed (strict mode only).** SSR-rendered forms whose default values fail validation now show errors in the initial HTML — the client's first frame matches.

## Motivation

cx already exposes `setValue` / `getValue` / `setFieldErrors*` as a complete data layer — you can simulate a whole form without rendering anything. Errors belong in that data layer. Today they were partly UI-coupled (stale until submit) AND tangled (one Map held both schema-derived and user-injected entries; submit-time `setAllErrors` clobbered both classes indiscriminately).

The user reported the visible symptom: type "abc" in section 1's password → submit → "At least 8 characters." → type "abcd12345" → error didn't disappear until the next submit. The architectural framing they pushed for: _"the data/informational layer is no longer always accurate (errors array easily becomes stale because we're mixing the informational state with the UI state). I think the errors array should always be current, regardless of how we choose to render the UI."_ Display gating (touched, submitCount, etc.) is a presentation concern; the data layer should always be current.

## What changed

Internal storage on `FormStore`:

```diff
- readonly errors: Map<PathKey, ValidationError[]>
+ readonly schemaErrors: Map<PathKey, ValidationError[]>  // validation-pipeline-owned
+ readonly userErrors:   Map<PathKey, ValidationError[]>  // setFieldErrors*-owned
```

Strict-by-construction writers — each touches exactly one Map. Public surfaces (`fieldErrors`, `getFieldState(path).errors`, `state.isValid`) merge schema-first-then-user transparently. `setFieldErrors` / `addFieldErrors` / `setFieldErrorsFromApi` all route to the user store and survive submit-success. `clearFieldErrors(path?)` deliberately clears both stores at the path (pragmatic "make this go away" semantic).

Other surfaces touched by the sweep:
- **History** (undo/redo) — snapshot captures + restores both Maps independently
- **Persistence** — `PersistedPayload` v2 carries `schemaErrors` + `userErrors`; default `version` bumped 1 → 2 (old payloads dropped silently on read)
- **SSR** — `SerializedFormData` + `FormStoreHydration` types split; round-trip preserves both stores
- **Devtools** — single "Errors" inspector section split into "Schema Errors" + "User Errors"
- **Construction** — strict-mode forms with invalid defaults seed `schemaErrors` immediately (lax mode still skips; hydration takes precedence over the seed)

The legacy `state.errors` Map alias and the `setErrorsForPath` / `setAllErrors` / `addErrors` / `clearErrors` writers on `FormStore` are removed (replaced by the new schema/user variants).

7 commits, one per execution-plan step, each test-green between boundaries:

| # | Commit | Scope |
|---|--------|-------|
| 1 | `c859ac0` | Split internal storage; new schema/user writers; compat shims keep public API working |
| 2 | `831a786` | Route user-API surfaces to user store; merge reads (+ history + persistence pulled forward) |
| 3 | `f2c6158` | Default flip `'none'` → `'change'` |
| 4 | `b73bf47` | Construction-time schema-error seed (strict mode only) |
| 5 | `c8d5f81` | SSR / hydration / devtools split |
| 6 | `225c96c` | Drop legacy compat shims; +4 source-isolation lock tests |
| 7 | `234beaf` | Migration guide, recipes, CHANGELOG, JSDoc |

## Migration

Five breaking changes for consumers — see [`docs/migration/0.11-to-0.12.md`](./docs/migration/0.11-to-0.12.md) for details + diff snippets:

1. `fieldValidation.on` default `'none'` → `'change'`. Pass `{ on: 'none' }` to keep submit-only behaviour.
2. Errors split: `setFieldErrors*` entries persist across schema revalidation AND successful submits.
3. Persistence payload v2 — old v1 payloads dropped silently on read; users see one fresh-defaults render after upgrading.
4. `SerializedFormData` + `FormStoreHydration` types: `errors` field replaced by `schemaErrors` + `userErrors`.
5. Legacy `state.errors` writers (`setErrorsForPath` / `setAllErrors` / `addErrors` / `clearErrors`) and the `errors` Map alias are removed.

Plus one new behaviour: strict-mode forms with invalid defaults now report errors at construction (lax mode still skips).

## Test plan

- [x] `pnpm test` — 691 → 701 (+10 covering seed behaviour, isolation locks, persistence v2 round-trip)
- [x] `pnpm typecheck` — clean; type-level isolation is enforced (schema-writer signatures don't accept user-error inputs)
- [x] `pnpm lint` — clean
- [x] `pnpm check:size` — `dist/index.mjs` 13.03 kB / `dist/zod.mjs` 13.28 kB (cap 14.7 kB)
- [x] `pnpm prepack` — dist builds clean

### cubic-forms verification (link-cx)

- [x] `make link-cx` + `bin/dc restart frontend` — frontend boots clean, no runtime errors in container logs
- [x] `https://cubicforms.test/spike-cx` returns 200; embedded `__NUXT_DATA__` payload shows `schemaErrors` + `userErrors` per form (not the old flat `errors`)
- [x] **Manual** — type "abc" in section 1's password → submit → "At least 8 characters." → type "abcd12345" → error disappears live (no second submit needed)
- [x] **Manual** — section 9 (apiForm — `setFieldErrorsFromApi`) — submit, observe API errors, mutate other fields, confirm API errors persist until explicitly cleared
- [x] **Manual** — section 1's `<pre>{{ getFieldState('password').value }}</pre>` shows the merged errors array updating live as you type

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Field validation now defaults to live validation (`'change'`) instead of submit-only, catching errors as users type (configurable via `fieldValidation: { on: 'none' }` to restore previous behavior).
  * API-injected errors now persist across schema revalidation and successful submissions until explicitly cleared.
  * Persisted form data payload format updated (version 2); legacy payloads are not migrated.
  * Strict-mode forms now populate validation errors at initialization if default values fail validation.

* **Documentation**
  * Added comprehensive migration guide for upgrading from 0.11.x to 0.12.x.
  * Updated API and recipe documentation to reflect error handling improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->