### PR TITLE
docs: hoist npm install above the framework split

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
 
 ## Installation
 
-**Nuxt 3 / 4**
-
 ```bash
 npm install @chemical-x/forms zod
 ```
+
+**Nuxt 3 / 4**
 
 ```ts
 // nuxt.config.ts
@@ -23,8 +23,7 @@ export default defineNuxtConfig({
 })
 ```
 
-<details>
-<summary><strong>Bare Vue 3</strong></summary>
+**Bare Vue 3**
 
 ```ts
 // main.ts
@@ -43,8 +42,6 @@ export default defineConfig({
   plugins: [vue(), chemicalXForms()],
 })
 ```
-
-</details>
 
 ## Quick start
 


### PR DESCRIPTION
## Summary

- Lift `npm install @chemical-x/forms zod` out from under the Nuxt header — it's a shared first step for both frameworks
- Drop the `<details>` collapse around bare Vue 3; show it openly

## Test plan
- [x] `pnpm format:check` passes
- [x] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)