### PR TITLE
feat: app-level defaults on createChemicalXForms + Nuxt module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,16 @@ for the full set of changes.
   takes precedence over the seed when present. Mostly a quality-of-
   life win for SSR — `<pre>{{ form.fieldErrors }}</pre>` now
   matches the client's first frame.
+- **New — app-level defaults on the plugin.** Pass
+  `createChemicalXForms({ defaults: { ... } })` (or
+  `chemicalX: { defaults: { ... } }` on the Nuxt module) to set
+  cx-wide preferences once instead of repeating them at every
+  `useForm` call. Supported defaults: `validationMode`,
+  `onInvalidSubmit`, `fieldValidation`, `history`. Per-form options
+  always win; `fieldValidation` shallow-merges at the field level so
+  consumers can set `debounceMs` globally and override `on` per-form.
+  See [recipe](./docs/recipes/app-defaults.md). Additive — existing
+  apps that don't pass `defaults` are unchanged.
 
 ## v0.11.1
 **Dev-mode ergonomics for the ambient `useFormContext` warning.**

--- a/docs/api.md
+++ b/docs/api.md
@@ -114,10 +114,11 @@ createApp(App).use(createChemicalXForms()).mount('#app')
 
 Options:
 
-| Field      | Type      | Description                                                                          |
-| ---------- | --------- | ------------------------------------------------------------------------------------ |
-| `override` | `boolean` | Force `isSSR` to `true` / `false`. Auto-detected otherwise.                          |
-| `devtools` | `boolean` | Enable the Vue DevTools plugin. Default `true`. See [recipe](./recipes/devtools.md). |
+| Field      | Type                     | Description                                                                                         |
+| ---------- | ------------------------ | --------------------------------------------------------------------------------------------------- |
+| `override` | `boolean`                | Force `isSSR` to `true` / `false`. Auto-detected otherwise.                                         |
+| `devtools` | `boolean`                | Enable the Vue DevTools plugin. Default `true`. See [recipe](./recipes/devtools.md).                |
+| `defaults` | `ChemicalXFormsDefaults` | App-level option defaults applied to every `useForm` call. See [recipe](./recipes/app-defaults.md). |
 
 ### `useForm<Form>({ schema, key, ... })`
 

--- a/docs/recipes/app-defaults.md
+++ b/docs/recipes/app-defaults.md
@@ -1,0 +1,133 @@
+# App-level defaults
+
+cx ships sensible library defaults (`fieldValidation: { on: 'change',
+debounceMs: 125 }`, `validationMode: 'strict'`, `onInvalidSubmit:
+'none'`) that fit most apps out of the box. Set app-wide overrides
+once via the plugin instead of repeating them at every `useForm` call.
+
+## Setup
+
+### Bare Vue 3
+
+```ts
+// main.ts
+import { createApp } from 'vue'
+import { createChemicalXForms } from '@chemical-x/forms'
+
+createApp(App)
+  .use(
+    createChemicalXForms({
+      defaults: {
+        fieldValidation: { debounceMs: 100 },
+        onInvalidSubmit: 'focus-first-error',
+      },
+    })
+  )
+  .mount('#app')
+```
+
+### Nuxt 3 / 4
+
+```ts
+// nuxt.config.ts
+export default defineNuxtConfig({
+  modules: ['@chemical-x/forms/nuxt'],
+  chemicalX: {
+    defaults: {
+      fieldValidation: { debounceMs: 100 },
+      onInvalidSubmit: 'focus-first-error',
+    },
+  },
+})
+```
+
+## Resolution order
+
+For each option, the resolved value is the first defined among:
+
+```
+useForm({ … })  >  createChemicalXForms({ defaults })  >  library default
+```
+
+So a per-form value always wins, an app-level default fills in when
+omitted, and the library's built-in default is the final fallback.
+
+## Merge semantics
+
+| Option            | Merge                                                                      |
+| ----------------- | -------------------------------------------------------------------------- |
+| `validationMode`  | Per-form replaces default outright.                                        |
+| `onInvalidSubmit` | Per-form replaces default outright.                                        |
+| `history`         | Per-form replaces default outright (whole config object, not field-level). |
+| `fieldValidation` | **Field-level merge** — see below.                                         |
+
+`fieldValidation` is the only deep-merged option. It's small (`on` +
+`debounceMs`) and the use case is real: set `debounceMs` once for the
+whole app, override `on` per-form when needed.
+
+```ts
+// Plugin side
+createChemicalXForms({
+  defaults: { fieldValidation: { debounceMs: 100 } },
+})
+
+// useForm calls
+useForm({ schema })
+// → fieldValidation: { on: 'change', debounceMs: 100 }
+//   (library default 'on' + app-level debounceMs)
+
+useForm({ schema, fieldValidation: { on: 'blur' } })
+// → fieldValidation: { on: 'blur', debounceMs: 100 }
+//   (per-form 'on' wins; app-level debounceMs carries over)
+
+useForm({ schema, fieldValidation: { debounceMs: 50 } })
+// → fieldValidation: { on: 'change', debounceMs: 50 }
+//   (library default 'on' + per-form debounceMs)
+```
+
+## What's supported
+
+`ChemicalXFormsDefaults` covers the form-shaping options:
+
+```ts
+type ChemicalXFormsDefaults = {
+  validationMode?: 'strict' | 'lax'
+  onInvalidSubmit?: 'none' | 'focus-first-error' | 'scroll-to-first-error' | 'both'
+  fieldValidation?: { on?: 'change' | 'blur' | 'none'; debounceMs?: number }
+  history?: true | { max?: number }
+}
+```
+
+What's **not** supported (and why):
+
+- `schema`, `key`, `defaultValues` — per-form by definition. A
+  cross-form schema doesn't make sense; per-form keys are identity.
+- `persist` — opt-in per form already; cross-form storage defaults
+  are ambiguous (key-prefix collisions, adapter selection). Set
+  `persist` per-form for now; this may land as a follow-up if a real
+  use case appears.
+
+## Alternative: userland wrapper
+
+If you need defaults but don't want to touch the plugin (third-party
+component library, opting in only for some forms), wrap `useForm` in
+your project:
+
+```ts
+// composables/useAppForm.ts
+import { useForm as cxUseForm } from '@chemical-x/forms/zod'
+import type { z } from 'zod'
+
+export function useAppForm<S extends z.ZodObject>(opts: Parameters<typeof cxUseForm<S>>[0]) {
+  return cxUseForm({
+    fieldValidation: { on: 'change', debounceMs: 100 },
+    ...opts,
+  })
+}
+```
+
+This is fully equivalent for the consumer — every `useAppForm` call
+gets your defaults; per-form options still win via the spread. The
+plugin-level approach is more idiomatic for first-party apps; the
+wrapper is right when you can't (or shouldn't) influence the plugin
+config from your call site.

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ export type {
   AbstractSchema,
   ApiErrorDetails,
   ApiErrorEnvelope,
+  ChemicalXFormsDefaults,
   DefaultValuesResponse,
   FieldState,
   FieldValidationConfig,

--- a/src/nuxt.ts
+++ b/src/nuxt.ts
@@ -3,10 +3,34 @@ import { inputTextAreaNodeTransform } from './runtime/lib/core/transforms/input-
 import { selectNodeTransform } from './runtime/lib/core/transforms/select-transform'
 import { vRegisterHintTransform } from './runtime/lib/core/transforms/v-register-hint-transform'
 import { vRegisterPreambleTransform } from './runtime/lib/core/transforms/v-register-preamble-transform'
+import type { ChemicalXFormsDefaults } from './runtime/types/types-api'
 
 // Module options TypeScript interface definition
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface CXModuleOptions {}
+export interface CXModuleOptions {
+  /**
+   * App-level defaults applied to every `useForm` call. Per-form
+   * options always win. See `ChemicalXFormsDefaults` for the
+   * supported option set and merge semantics.
+   *
+   * Configure via `nuxt.config.ts`:
+   *
+   *   export default defineNuxtConfig({
+   *     modules: ['@chemical-x/forms/nuxt'],
+   *     chemicalX: {
+   *       defaults: { fieldValidation: { debounceMs: 100 } },
+   *     },
+   *   })
+   */
+  defaults?: ChemicalXFormsDefaults
+}
+
+/**
+ * Shape of the Nuxt runtime-config slot the module populates. Read by
+ * `runtime/plugins/chemical-x.ts` via `useRuntimeConfig().public.chemicalX`.
+ */
+export type CXRuntimeConfig = {
+  defaults: ChemicalXFormsDefaults
+}
 
 export default defineNuxtModule<CXModuleOptions>({
   meta: {
@@ -27,6 +51,15 @@ export default defineNuxtModule<CXModuleOptions>({
       vRegisterPreambleTransform,
       vRegisterHintTransform
     )
+
+    // Publish module options to public runtime config so the plugin can
+    // read them at install time on both server and client. Frozen-empty
+    // by default — the plugin's merge code reads this slot directly
+    // without a `?? {}` guard at every call site.
+    const runtimePublic = nuxt.options.runtimeConfig.public as Record<string, unknown>
+    runtimePublic['chemicalX'] = {
+      defaults: _options.defaults ?? {},
+    } satisfies CXRuntimeConfig
 
     const resolver = createResolver(import.meta.url)
 

--- a/src/runtime/composables/use-abstract-form.ts
+++ b/src/runtime/composables/use-abstract-form.ts
@@ -16,6 +16,7 @@ import {
 import { kFormContext, useRegistry } from '../core/registry'
 import type {
   AbstractSchema,
+  ChemicalXFormsDefaults,
   FormKey,
   PersistConfig,
   UseAbstractFormReturnType,
@@ -66,6 +67,14 @@ export function useAbstractForm<
   // key resolve to the same instance — matches the pre-rewrite "shared
   // store" semantic that forms with the same key were intended to share.
   const registry = useRegistry()
+
+  // Merge app-level defaults from the registry over per-form options.
+  // Per-form values always win for scalars; `fieldValidation` is
+  // shallow-merged at the field level so consumers can set
+  // `debounceMs` globally and override `on` per-form. Every downstream
+  // read uses `merged` so the merge happens exactly once.
+  const merged = mergeWithDefaults(registry.defaults, configuration)
+
   const existing = registry.forms.get(key) as FormStore<Form, GetValueFormType> | undefined
   if (__DEV__ && existing !== undefined) {
     // Shared-key semantics are a feature when consumers OPT in to them
@@ -81,8 +90,7 @@ export function useAbstractForm<
     warnOnSchemaFingerprintMismatch(key, existing.schema, resolvedSchema)
   }
   const state: FormStore<Form, GetValueFormType> =
-    existing ??
-    buildFreshState<Form, GetValueFormType>(key, resolvedSchema, configuration, registry)
+    existing ?? buildFreshState<Form, GetValueFormType>(key, resolvedSchema, merged, registry)
 
   // Ref-count this consumer. When the component's effect scope tears down,
   // release the count; the registry evicts the FormStore once the last
@@ -101,8 +109,8 @@ export function useAbstractForm<
   // persistence survives any single consumer unmounting — it tears
   // down only when the last consumer releases and the registry evicts
   // the state.
-  if (existing === undefined && configuration.persist !== undefined && !registry.isSSR) {
-    const disposePersist = wirePersistence(state, configuration.persist)
+  if (existing === undefined && merged.persist !== undefined && !registry.isSSR) {
+    const disposePersist = wirePersistence(state, merged.persist)
     state.registerCleanup(disposePersist)
   }
 
@@ -112,8 +120,8 @@ export function useAbstractForm<
   // `useForm` / `useFormContext` calls for the same key retrieve the
   // SAME instance, keeping `canUndo` / `canRedo` / `historySize` /
   // `undo` / `redo` consistent across mount order.
-  if (existing === undefined && configuration.history !== undefined) {
-    const historyModule = createHistoryModule(state, configuration.history)
+  if (existing === undefined && merged.history !== undefined) {
+    const historyModule = createHistoryModule(state, merged.history)
     state.modules.set(HISTORY_MODULE_KEY, historyModule)
     state.registerCleanup(() => historyModule.dispose())
   }
@@ -141,14 +149,50 @@ export function useAbstractForm<
   }
 
   const apiOptions: Parameters<typeof buildFormApi<Form, GetValueFormType>>[1] = {}
-  if (configuration.onInvalidSubmit !== undefined) {
-    apiOptions.onInvalidSubmit = configuration.onInvalidSubmit
+  if (merged.onInvalidSubmit !== undefined) {
+    apiOptions.onInvalidSubmit = merged.onInvalidSubmit
   }
   const history = state.modules.get(HISTORY_MODULE_KEY) as HistoryModule | undefined
   if (history !== undefined) {
     apiOptions.history = history
   }
   return buildFormApi<Form, GetValueFormType>(state, apiOptions)
+}
+
+/**
+ * Merge app-level defaults from the registry over a per-form
+ * configuration. Per-form values always win for scalars; the
+ * `fieldValidation` field is shallow-merged so defaults like
+ * `{ debounceMs: 100 }` carry through even when the per-form call
+ * passes `{ on: 'blur' }`. See `ChemicalXFormsDefaults` for the full
+ * merge contract.
+ */
+function mergeWithDefaults<
+  Form extends GenericForm,
+  GetValueFormType extends GenericForm,
+  Schema extends AbstractSchema<Form, GetValueFormType>,
+  Defaults extends DeepPartial<Form>,
+>(
+  defaults: ChemicalXFormsDefaults,
+  configuration: UseFormConfiguration<Form, GetValueFormType, Schema, Defaults>
+): UseFormConfiguration<Form, GetValueFormType, Schema, Defaults> {
+  // exactOptionalPropertyTypes rejects explicit `undefined` on optional
+  // properties (different from omitting), so conditionally spread each
+  // resolved value rather than assigning undefined into the field.
+  const validationMode = configuration.validationMode ?? defaults.validationMode
+  const onInvalidSubmit = configuration.onInvalidSubmit ?? defaults.onInvalidSubmit
+  const history = configuration.history ?? defaults.history
+  const fieldValidation =
+    configuration.fieldValidation === undefined && defaults.fieldValidation === undefined
+      ? undefined
+      : { ...defaults.fieldValidation, ...configuration.fieldValidation }
+  return {
+    ...configuration,
+    ...(validationMode === undefined ? {} : { validationMode }),
+    ...(onInvalidSubmit === undefined ? {} : { onInvalidSubmit }),
+    ...(history === undefined ? {} : { history }),
+    ...(fieldValidation === undefined ? {} : { fieldValidation }),
+  }
 }
 
 /**

--- a/src/runtime/composables/use-abstract-form.ts
+++ b/src/runtime/composables/use-abstract-form.ts
@@ -1,6 +1,7 @@
 import { getCurrentInstance, getCurrentScope, onScopeDispose, provide, toRaw, useId } from 'vue'
 import { buildFormApi } from '../core/build-form-api'
 import { createFormStore, type FormStore } from '../core/create-form-store'
+import { ANONYMOUS_FORM_KEY_PREFIX, DEFAULT_PERSISTENCE_DEBOUNCE_MS } from '../core/defaults'
 import { __DEV__ } from '../core/dev'
 import type { FieldStateView } from '../core/field-state-api'
 import { getComputedSchema } from '../core/get-computed-schema'
@@ -346,11 +347,11 @@ function resolveFormKey(key: FormKey | undefined): FormKey {
   // so server-rendered and client-hydrated trees agree on the same
   // synthetic key.
   if (getCurrentInstance() !== null) {
-    return `cx:anon:${useId()}`
+    return `${ANONYMOUS_FORM_KEY_PREFIX}${useId()}`
   }
   // Outside setup (tests, ad-hoc composable use) there's no Vue
   // instance to draw from; fall back to a module-local counter.
-  return `cx:anon:${anonCounter++}`
+  return `${ANONYMOUS_FORM_KEY_PREFIX}${anonCounter++}`
 }
 
 /**
@@ -407,7 +408,7 @@ function wirePersistence<F extends GenericForm>(
   config: PersistConfig
 ): () => void {
   const key = resolveStorageKey(config, state.formKey)
-  const debounceMs = config.debounceMs ?? 300
+  const debounceMs = config.debounceMs ?? DEFAULT_PERSISTENCE_DEBOUNCE_MS
   const include = config.include ?? 'form'
   // Default version bumped 1 → 2 in the 0.12 release: errors split into
   // schemaErrors + userErrors at the payload level. Old v1 payloads

--- a/src/runtime/composables/use-form.ts
+++ b/src/runtime/composables/use-form.ts
@@ -53,12 +53,14 @@ export function useForm<
 
   // Spread the full configuration so opt-in options (`onInvalidSubmit`,
   // `fieldValidation`, `persist`, `history`) reach useAbstractForm.
-  // The explicit overrides below narrow schema / defaultValues /
-  // validationMode to the shapes useAbstractForm expects. `key` is
-  // intentionally NOT re-listed — the spread carries it through, and
-  // writing `key: configuration.key` would re-introduce an explicit
-  // `undefined` that `exactOptionalPropertyTypes` rejects against the
-  // optional-key contract.
+  // The explicit overrides below narrow schema / defaultValues to the
+  // shapes useAbstractForm expects. `key` and `validationMode` are
+  // intentionally NOT re-listed — the spread carries them through, and
+  // writing `validationMode: configuration.validationMode ?? 'strict'`
+  // here would short-circuit the registry's app-level defaults
+  // (`createChemicalXForms({ defaults: { validationMode: 'lax' } })`).
+  // The library-level fallback to `'strict'` lives downstream in
+  // `createFormStore`, where it can apply *after* the registry merge.
   return useAbstractForm<Form, GetValueFormType>({
     ...(configuration as UseFormConfiguration<
       Form,
@@ -68,6 +70,5 @@ export function useForm<
     >),
     schema: abstractSchema,
     defaultValues: configuration.defaultValues as DeepPartial<Form>,
-    validationMode: configuration.validationMode ?? 'strict',
   })
 }

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -9,6 +9,7 @@ import type {
   ValidationMode,
 } from '../types/types-api'
 import type { DeepPartial, GenericForm } from '../types/types-core'
+import { DEFAULT_FIELD_VALIDATION_DEBOUNCE_MS } from './defaults'
 import { diffAndApply } from './diff-apply'
 import { canonicalizePath, type Path, type PathKey, type Segment } from './paths'
 import { getAtPath, setAtPath } from './path-walker'
@@ -291,7 +292,8 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
   const { formKey, schema, defaultValues, validationMode = 'strict', hydration } = options
   const isSSR = options.isSSR === true
   const fieldValidationMode: FieldValidationMode = options.fieldValidation?.on ?? 'change'
-  const fieldValidationDebounceMs: number = options.fieldValidation?.debounceMs ?? 125
+  const fieldValidationDebounceMs: number =
+    options.fieldValidation?.debounceMs ?? DEFAULT_FIELD_VALIDATION_DEBOUNCE_MS
 
   type FieldValidationEntry = {
     controller: AbortController

--- a/src/runtime/core/defaults.ts
+++ b/src/runtime/core/defaults.ts
@@ -1,0 +1,54 @@
+/**
+ * Library-level default constants. All consumer-facing fallbacks for
+ * the bundled options (`fieldValidation.debounceMs`, `persist.debounceMs`,
+ * `history.max`, etc.) resolve to one of these — extracting them here
+ * keeps the JSDoc on the public option type and the runtime fallback
+ * in lockstep, and gives reviewers a single file to scan when tuning
+ * timing/policy defaults.
+ *
+ * Per-form `useForm({ ... })` options always win over these. App-level
+ * `createChemicalXForms({ defaults: ... })` options sit between the
+ * two: per-form > app-level > library default.
+ */
+
+/**
+ * Field-validation debounce (`fieldValidation.debounceMs`). 125 ms is
+ * below the perceptual threshold for most typists while still
+ * coalescing rapid bursts so the schema doesn't re-run on every
+ * keystroke.
+ */
+export const DEFAULT_FIELD_VALIDATION_DEBOUNCE_MS = 125
+
+/**
+ * Persistence write debounce (`persist.debounceMs`). 300 ms is
+ * generous on purpose — the goal is "draft survives accidental
+ * navigation," not "every keystroke hits storage." Lower if your
+ * storage adapter is in-memory; raise for slow IndexedDB or remote
+ * adapters.
+ */
+export const DEFAULT_PERSISTENCE_DEBOUNCE_MS = 300
+
+/**
+ * Undo/redo stack ceiling (`history.max`). 50 covers a generous
+ * editing session without unbounded memory growth from long-lived
+ * forms. Snapshots are shallow, so the per-snapshot cost is small;
+ * the cap exists more for predictability than memory pressure.
+ */
+export const DEFAULT_HISTORY_MAX_SNAPSHOTS = 50
+
+/**
+ * Storage-key namespace for persistence. Resolved once at
+ * `resolveStorageKey` to `${PERSISTENCE_KEY_PREFIX}${formKey}` unless
+ * the consumer passes an explicit `persist.key`. Kept as a separate
+ * constant so multi-tenant deployments can audit or reserve their
+ * own prefix without grepping for the literal.
+ */
+export const PERSISTENCE_KEY_PREFIX = 'chemical-x-forms:'
+
+/**
+ * Synthetic-key prefix for `useForm()` calls without an explicit
+ * `key`. Reserved namespace — collisions with consumer-supplied keys
+ * are possible only if the consumer also uses `cx:anon:…`, which
+ * isn't documented as a supported pattern.
+ */
+export const ANONYMOUS_FORM_KEY_PREFIX = 'cx:anon:'

--- a/src/runtime/core/history.ts
+++ b/src/runtime/core/history.ts
@@ -2,6 +2,7 @@ import { computed, shallowRef, type ComputedRef } from 'vue'
 import type { HistoryConfig, ValidationError } from '../types/types-api'
 import type { GenericForm } from '../types/types-core'
 import type { FormStore } from './create-form-store'
+import { DEFAULT_HISTORY_MAX_SNAPSHOTS } from './defaults'
 import type { PathKey } from './paths'
 
 /**
@@ -44,7 +45,10 @@ export function createHistoryModule<F extends GenericForm>(
   state: FormStore<F>,
   config: HistoryConfig
 ): HistoryModule {
-  const max = typeof config === 'object' ? (config.max ?? 50) : 50
+  const max =
+    typeof config === 'object'
+      ? (config.max ?? DEFAULT_HISTORY_MAX_SNAPSHOTS)
+      : DEFAULT_HISTORY_MAX_SNAPSHOTS
 
   // undoStack[-1] is the CURRENT state. undo() pops that onto redo
   // and restores undoStack[-2]. redoStack[-1] is the next-available

--- a/src/runtime/core/persistence/index.ts
+++ b/src/runtime/core/persistence/index.ts
@@ -4,6 +4,7 @@ import type {
   PersistConfig,
   ValidationError,
 } from '../../types/types-api'
+import { PERSISTENCE_KEY_PREFIX } from '../defaults'
 
 /**
  * Resolve a `FormStorage` adapter for the given storage kind. Built-in
@@ -149,5 +150,5 @@ export function createDebouncedWriter(
  * namespace (multi-tenant app, per-user prefix) pass `persist.key`.
  */
 export function resolveStorageKey(config: PersistConfig, formKey: string): string {
-  return config.key ?? `chemical-x-forms:${formKey}`
+  return config.key ?? `${PERSISTENCE_KEY_PREFIX}${formKey}`
 }

--- a/src/runtime/core/plugin.ts
+++ b/src/runtime/core/plugin.ts
@@ -2,6 +2,7 @@ import type { App, Plugin } from 'vue'
 import { attachRegistryToApp, createRegistry } from './registry'
 import { vRegister } from './directive'
 import type { SSRDetectOptions } from './ssr'
+import type { ChemicalXFormsDefaults } from '../types/types-api'
 
 /**
  * Create the `@chemical-x/forms` Vue plugin. Install once per app:
@@ -28,6 +29,12 @@ export type ChemicalXFormsPluginOptions = SSRDetectOptions & {
    * you're shipping a minified build with DevTools disabled).
    */
   devtools?: boolean
+  /**
+   * App-level defaults applied to every `useForm` call in this app.
+   * Per-form options always win. See `ChemicalXFormsDefaults` for the
+   * supported option set and the merge semantics.
+   */
+  defaults?: ChemicalXFormsDefaults
 }
 
 export function createChemicalXForms(options: ChemicalXFormsPluginOptions = {}): Plugin {

--- a/src/runtime/core/registry.ts
+++ b/src/runtime/core/registry.ts
@@ -1,6 +1,6 @@
 import type { App, InjectionKey } from 'vue'
 import { getCurrentInstance, inject, shallowReactive } from 'vue'
-import type { FormKey } from '../types/types-api'
+import type { ChemicalXFormsDefaults, FormKey } from '../types/types-api'
 import type { GenericForm } from '../types/types-core'
 import type { FormStore } from './create-form-store'
 import { RegistryNotInstalledError } from './errors'
@@ -44,6 +44,12 @@ export type ChemicalXRegistry = {
   readonly pendingHydration: PendingHydration
   readonly isSSR: boolean
   /**
+   * App-level defaults applied to every `useForm` call. Frozen-empty
+   * when the consumer doesn't pass `defaults` — `useAbstractForm`
+   * always reads from this slot, so a sentinel beats `?.` everywhere.
+   */
+  readonly defaults: ChemicalXFormsDefaults
+  /**
    * Ref-counts `useForm` consumers per key. Each `useForm` call pairs a
    * `trackConsumer(key)` on mount with the returned dispose on unmount.
    * When the last consumer for a key disposes, the FormStore is evicted
@@ -78,8 +84,23 @@ declare module 'vue' {
   }
 }
 
-export function createRegistry(options: SSRDetectOptions = {}): ChemicalXRegistry {
+export type CreateRegistryOptions = SSRDetectOptions & {
+  /**
+   * App-level defaults stored on the registry and merged into every
+   * `useForm` call. Per-form options always win. Omit to use the
+   * library-level fallbacks (an empty object is equivalent).
+   */
+  defaults?: ChemicalXFormsDefaults
+}
+
+export function createRegistry(options: CreateRegistryOptions = {}): ChemicalXRegistry {
   const isSSR = detectSSR(options)
+  // Frozen so accidental writes downstream throw in dev. Public surface
+  // (`createChemicalXForms({ defaults })`) treats this as data, not as
+  // a mutation point — there's no public API to update defaults after
+  // install, and adding one would invite race conditions with already-
+  // mounted forms.
+  const defaults: ChemicalXFormsDefaults = Object.freeze({ ...(options.defaults ?? {}) })
   // The outer object is plain (it holds references we never rebind); inner
   // Maps are reactive via Vue's collection handlers so per-key reads track
   // per-key. `shallowReactive` avoids Vue's deep Ref-unwrapping, which would
@@ -113,7 +134,7 @@ export function createRegistry(options: SSRDetectOptions = {}): ChemicalXRegistr
     }
   }
 
-  return { forms, pendingHydration, isSSR, trackConsumer }
+  return { forms, pendingHydration, isSSR, defaults, trackConsumer }
 }
 
 /**

--- a/src/runtime/plugins/chemical-x.ts
+++ b/src/runtime/plugins/chemical-x.ts
@@ -8,10 +8,11 @@
  * for directive lifecycle hooks, so the same plugin works on both sides
  * without a stub.
  */
-import { defineNuxtPlugin } from 'nuxt/app'
+import { defineNuxtPlugin, useRuntimeConfig } from 'nuxt/app'
 import { createChemicalXForms } from '../core/plugin'
 import { hydrateChemicalXState, renderChemicalXState } from '../core/serialize'
 import type { SerializedChemicalXState } from '../core/serialize'
+import type { ChemicalXFormsDefaults } from '../types/types-api'
 
 export default defineNuxtPlugin({
   // `enforce: 'pre'` makes the "we run before any component's setup" claim
@@ -22,7 +23,23 @@ export default defineNuxtPlugin({
   enforce: 'pre',
   setup(nuxtApp) {
     const isServer = import.meta.server
-    nuxtApp.vueApp.use(createChemicalXForms({ override: isServer }))
+
+    // Read app-level defaults from the Nuxt module's runtime config slot
+    // (populated in src/nuxt.ts). The slot is always present when this
+    // plugin runs — the module installs both — but type the access
+    // defensively so the plugin doesn't assume a Nuxt-side change before
+    // the corresponding cx version is installed.
+    const runtimeConfig = useRuntimeConfig().public as
+      | { chemicalX?: { defaults?: ChemicalXFormsDefaults } }
+      | undefined
+    const defaults = runtimeConfig?.chemicalX?.defaults
+
+    nuxtApp.vueApp.use(
+      createChemicalXForms({
+        override: isServer,
+        ...(defaults === undefined ? {} : { defaults }),
+      })
+    )
 
     if (isServer) {
       // After the app renders, capture every FormStore into the Nuxt payload

--- a/src/runtime/plugins/chemical-x.ts
+++ b/src/runtime/plugins/chemical-x.ts
@@ -24,22 +24,14 @@ export default defineNuxtPlugin({
   setup(nuxtApp) {
     const isServer = import.meta.server
 
-    // Read app-level defaults from the Nuxt module's runtime config slot
-    // (populated in src/nuxt.ts). The slot is always present when this
-    // plugin runs — the module installs both — but type the access
-    // defensively so the plugin doesn't assume a Nuxt-side change before
-    // the corresponding cx version is installed.
-    const runtimeConfig = useRuntimeConfig().public as
-      | { chemicalX?: { defaults?: ChemicalXFormsDefaults } }
-      | undefined
-    const defaults = runtimeConfig?.chemicalX?.defaults
+    // Read app-level defaults from the Nuxt module's runtime-config slot
+    // (populated in src/nuxt.ts). The module ships in the same package
+    // as this plugin, so the slot is always present and well-typed.
+    const { defaults } = (
+      useRuntimeConfig().public as { chemicalX: { defaults: ChemicalXFormsDefaults } }
+    ).chemicalX
 
-    nuxtApp.vueApp.use(
-      createChemicalXForms({
-        override: isServer,
-        ...(defaults === undefined ? {} : { defaults }),
-      })
-    )
+    nuxtApp.vueApp.use(createChemicalXForms({ override: isServer, defaults }))
 
     if (isServer) {
       // After the app renders, capture every FormStore into the Nuxt payload

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -361,6 +361,40 @@ export type UseFormConfiguration<
   history?: HistoryConfig
 }
 
+/**
+ * App-level defaults — the subset of `useForm` options that make sense
+ * to set once per Vue app rather than per-form. Pass via
+ * `createChemicalXForms({ defaults })` (bare Vue) or the Nuxt module's
+ * `chemicalX.defaults` config option.
+ *
+ * Resolution order (per-form wins):
+ *
+ *   useForm({ … })  >  createChemicalXForms({ defaults })  >  library default
+ *
+ * Merge semantics:
+ * - Scalars (`validationMode`, `onInvalidSubmit`, `history`): per-form
+ *   value replaces the default outright.
+ * - `fieldValidation`: shallow-merged at the field level so consumers
+ *   can set `debounceMs` globally and override `on` per-form without
+ *   losing the global debounce. Example:
+ *
+ *     defaults: { fieldValidation: { debounceMs: 100 } }
+ *     useForm({ schema, fieldValidation: { on: 'blur' } })
+ *       // → { on: 'blur', debounceMs: 100 }
+ *
+ * Options NOT supported as app-level defaults:
+ * - `schema`, `key`, `defaultValues` — per-form by definition.
+ * - `persist` — opt-in per form already; cross-form storage defaults
+ *   are ambiguous (key-prefix collisions, adapter selection). May be
+ *   added in a follow-up if a use case appears.
+ */
+export type ChemicalXFormsDefaults = {
+  validationMode?: ValidationMode
+  onInvalidSubmit?: OnInvalidSubmitPolicy
+  fieldValidation?: FieldValidationConfig
+  history?: HistoryConfig
+}
+
 export type FormStore<TData extends GenericForm> = Map<FormKey, TData>
 
 export type FormSummaryValue = {

--- a/test/composables/app-defaults.test.ts
+++ b/test/composables/app-defaults.test.ts
@@ -1,0 +1,269 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, type App } from 'vue'
+import { z } from 'zod'
+import { useForm as useFormV3 } from '../../src/zod-v3'
+import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import type { UseAbstractFormReturnType } from '../../src/runtime/types/types-api'
+import { useForm } from '../../src/zod'
+import { z as zV3 } from 'zod-v3'
+
+/**
+ * App-level defaults: `createChemicalXForms({ defaults: ... })` lets
+ * consumers configure cx-wide preferences once. Per-form options
+ * always win.
+ *
+ * Invariants locked here:
+ *   1. Default applied when per-form omits the option.
+ *   2. Per-form value wins for each scalar.
+ *   3. `fieldValidation` shallow-merges at the field level
+ *      (consumer can set `debounceMs` globally and override `on`
+ *      per-form without losing the global debounce).
+ *   4. Anonymous `useForm()` (no key) picks up defaults.
+ *   5. Multiple useForm calls in the same app share the defaults.
+ *   6. v3 wrapper picks up app-level `validationMode` (regression
+ *      lock for the dropped `?? 'strict'` resolution).
+ */
+
+const tightSchema = z.object({
+  email: z.email('bad email'),
+  password: z.string().min(8, 'min 8 chars'),
+})
+
+type Tight = z.infer<typeof tightSchema>
+type API = ReturnType<typeof useForm<typeof tightSchema>>
+
+function mountWithDefaults(
+  defaults: Parameters<typeof createChemicalXForms>[0] extends infer T
+    ? T extends { defaults?: infer D }
+      ? D
+      : never
+    : never,
+  formOptions: {
+    validationMode?: 'strict' | 'lax'
+    fieldValidation?: { on?: 'change' | 'blur' | 'none'; debounceMs?: number }
+    defaultValues?: Partial<Tight>
+    key?: string
+  } = {}
+): { app: App; api: API } {
+  const handle: { api?: API } = {}
+  const App = defineComponent({
+    setup() {
+      handle.api = useForm({
+        schema: tightSchema,
+        ...(formOptions.key !== undefined ? { key: formOptions.key } : {}),
+        ...(formOptions.validationMode !== undefined
+          ? { validationMode: formOptions.validationMode }
+          : {}),
+        ...(formOptions.fieldValidation !== undefined
+          ? { fieldValidation: formOptions.fieldValidation }
+          : {}),
+        ...(formOptions.defaultValues !== undefined
+          ? { defaultValues: formOptions.defaultValues }
+          : {}),
+      })
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(
+    createChemicalXForms({
+      override: true,
+      ...(defaults !== undefined ? { defaults } : {}),
+    })
+  )
+  const root = document.createElement('div')
+  document.body.appendChild(root)
+  app.mount(root)
+  return { app, api: handle.api as API }
+}
+
+async function drainMicrotasks(rounds = 8): Promise<void> {
+  for (let i = 0; i < rounds; i++) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+describe('app-level defaults — validationMode', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it("applies the registry's default when per-form omits validationMode", () => {
+    // Default is 'lax'; without per-form override the form should NOT
+    // seed schemaErrors at construction (lax behavior), even though
+    // empty defaults fail .email() / .min(8). Without app-level
+    // defaults the library would have applied 'strict' and seeded the
+    // errors.
+    const { app, api } = mountWithDefaults({ validationMode: 'lax' }, {})
+    apps.push(app)
+    expect(api.fieldErrors.email).toBeUndefined()
+    expect(api.fieldErrors.password).toBeUndefined()
+    expect(api.state.isValid).toBe(true)
+  })
+
+  it('per-form validationMode wins over the registry default', () => {
+    // Registry says 'lax', but per-form says 'strict' — strict wins,
+    // errors get seeded.
+    const { app, api } = mountWithDefaults({ validationMode: 'lax' }, { validationMode: 'strict' })
+    apps.push(app)
+    expect(api.fieldErrors.email?.[0]?.message).toBe('bad email')
+    expect(api.fieldErrors.password?.[0]?.message).toBe('min 8 chars')
+    expect(api.state.isValid).toBe(false)
+  })
+
+  it('falls back to library default (strict) when neither registry nor per-form sets it', () => {
+    // No registry default for validationMode → library fallback in
+    // createFormStore applies → 'strict' → seed fires.
+    const { app, api } = mountWithDefaults({}, {})
+    apps.push(app)
+    expect(api.fieldErrors.email?.[0]?.message).toBe('bad email')
+    expect(api.state.isValid).toBe(false)
+  })
+})
+
+describe('app-level defaults — fieldValidation field-level merge', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+    vi.useRealTimers()
+  })
+
+  it('per-form on overrides while default debounceMs carries through', async () => {
+    // Default sets debounceMs = 50. Per-form passes only { on: 'change' }
+    // — the merged config should be { on: 'change', debounceMs: 50 }.
+    // Pin lax so the construction-time seed doesn't pre-populate the
+    // error we're trying to observe via debounced field-validation.
+    vi.useFakeTimers()
+    const { app, api } = mountWithDefaults(
+      { fieldValidation: { debounceMs: 50 } },
+      { fieldValidation: { on: 'change' }, validationMode: 'lax' }
+    )
+    apps.push(app)
+
+    api.setValue('email', 'not-an-email')
+    // Just past the default debounce (50ms). If the per-form `on:
+    // 'change'` didn't merge correctly with the default debounceMs,
+    // the test would either see no error (debounce never fired) or
+    // need to wait the library default (125ms).
+    await vi.advanceTimersByTimeAsync(75)
+    await drainMicrotasks()
+    expect(api.fieldErrors.email?.[0]?.message).toBe('bad email')
+  })
+
+  it('per-form debounceMs overrides default debounceMs', async () => {
+    vi.useFakeTimers()
+    const { app, api } = mountWithDefaults(
+      { fieldValidation: { on: 'change', debounceMs: 500 } },
+      { fieldValidation: { debounceMs: 25 }, validationMode: 'lax' }
+    )
+    apps.push(app)
+
+    api.setValue('email', 'nope')
+    // Per-form debounceMs wins → 25ms, not 500ms.
+    await vi.advanceTimersByTimeAsync(40)
+    await drainMicrotasks()
+    expect(api.fieldErrors.email?.[0]?.message).toBe('bad email')
+  })
+
+  it("default fieldValidation applies entirely when per-form doesn't pass any", async () => {
+    vi.useFakeTimers()
+    const { app, api } = mountWithDefaults(
+      { fieldValidation: { on: 'change', debounceMs: 30 } },
+      { validationMode: 'lax' }
+    )
+    apps.push(app)
+
+    api.setValue('password', 'x')
+    await vi.advanceTimersByTimeAsync(50)
+    await drainMicrotasks()
+    expect(api.fieldErrors.password?.[0]?.message).toBe('min 8 chars')
+  })
+})
+
+describe('app-level defaults — anonymous + multi-form', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('anonymous useForm() (no key) picks up app-level defaults', () => {
+    // No `key` passed → synthetic `cx:anon:` key allocated; defaults
+    // should still apply.
+    const { app, api } = mountWithDefaults({ validationMode: 'lax' }, {})
+    apps.push(app)
+    expect(api.fieldErrors.email).toBeUndefined()
+    // Sanity: this anonymous form's key starts with the reserved prefix.
+    expect(api.key.startsWith('cx:anon:')).toBe(true)
+  })
+
+  it('multiple useForm calls in the same app share the same defaults', () => {
+    // Two forms in one component, no per-form validationMode override
+    // — both should pick up the registry's 'lax' and BOTH should mount
+    // clean (no seeded errors).
+    type FormA = typeof tightSchema
+    type FormB = typeof tightSchema
+    const handles: {
+      a?: ReturnType<typeof useForm<FormA>>
+      b?: ReturnType<typeof useForm<FormB>>
+    } = {}
+    const App = defineComponent({
+      setup() {
+        handles.a = useForm({ schema: tightSchema, key: 'shared-defaults-a' })
+        handles.b = useForm({ schema: tightSchema, key: 'shared-defaults-b' })
+        return () => h('div')
+      },
+    })
+    const app = createApp(App).use(
+      createChemicalXForms({ override: true, defaults: { validationMode: 'lax' } })
+    )
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    apps.push(app)
+    expect(handles.a?.fieldErrors.email).toBeUndefined()
+    expect(handles.b?.fieldErrors.email).toBeUndefined()
+  })
+})
+
+describe('app-level defaults — v3 wrapper regression', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('zod v3 useForm picks up app-level validationMode (no eager ?? strict short-circuit)', () => {
+    // Regression lock for the dropped `validationMode: configuration.
+    // validationMode ?? 'strict'` line in src/runtime/composables/
+    // use-form.ts. Before the fix, the v3 wrapper would resolve `'strict'`
+    // before the merge could see the registry default — so an app-level
+    // `validationMode: 'lax'` would be silently overridden.
+    const v3Schema = zV3.object({
+      email: zV3.string().email(),
+      password: zV3.string().min(8),
+    })
+    type V3Form = { email: string; password: string }
+    type V3API = UseAbstractFormReturnType<V3Form, V3Form>
+    const handle: { api?: V3API } = {}
+    const App = defineComponent({
+      setup() {
+        handle.api = useFormV3({
+          schema: v3Schema,
+          key: 'v3-defaults',
+        } as never) as V3API
+        return () => h('div')
+      },
+    })
+    const app = createApp(App).use(
+      createChemicalXForms({ override: true, defaults: { validationMode: 'lax' } })
+    )
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    apps.push(app)
+    // Lax → no construction-time seed → fieldErrors empty.
+    expect(handle.api?.fieldErrors.email).toBeUndefined()
+    expect(handle.api?.fieldErrors.password).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

Today every \`useForm({ schema, ... })\` call carries its own configuration. Consumers who want a project-wide preference — e.g. "all forms in cubic-forms should debounce at 100ms" — have to either repeat the option at every call site or write a userland \`useAppForm\` wrapper. This PR adds **first-class app-level defaults** so the plugin can carry those preferences once.

Resolution order (per-form wins):

\`\`\`
useForm({ ... })  >  createChemicalXForms({ defaults })  >  library default
\`\`\`

## Surface

\`\`\`ts
// Bare Vue
createChemicalXForms({
  defaults: {
    fieldValidation: { debounceMs: 100 },
    validationMode: 'lax',
    onInvalidSubmit: 'focus-first-error',
  },
})

// Nuxt
chemicalX: {
  defaults: { fieldValidation: { debounceMs: 100 } },
}
\`\`\`

\`ChemicalXFormsDefaults\` covers \`validationMode\`, \`onInvalidSubmit\`, \`fieldValidation\`, \`history\`. Excluded: \`schema\`/\`key\`/\`defaultValues\` (per-form by definition); \`persist\` (opt-in per form, cross-form storage defaults are ambiguous, defer).

## Merge semantics

- **Scalars** (\`validationMode\`, \`onInvalidSubmit\`, \`history\`) — per-form replaces default outright.
- **\`fieldValidation\`** — shallow-merged at the field level so a global \`debounceMs\` carries over even when the per-form call passes \`{ on: 'blur' }\`. The only deep-merged option; the use case (debounce sweep + per-form mode override) is real and the shape is small (2 fields).

## What's in the diff

**Commit 1 — extract library-level constants** (pure refactor, zero behavior change). Five inline literals lifted into \`src/runtime/core/defaults.ts\`: \`DEFAULT_FIELD_VALIDATION_DEBOUNCE_MS\`, \`DEFAULT_PERSISTENCE_DEBOUNCE_MS\`, \`DEFAULT_HISTORY_MAX_SNAPSHOTS\`, \`PERSISTENCE_KEY_PREFIX\`, \`ANONYMOUS_FORM_KEY_PREFIX\`. They were already implicit in JSDoc; co-locating them gives commit 2 a single import point and makes "the standard debounce" obvious to find.

**Commit 2 — the app-level defaults feature.** Plumbing through plugin → registry → useAbstractForm; merge helper at the top of useAbstractForm; Nuxt module pass-through via runtimeConfig.public. The v3 \`useForm\` wrapper drops its eager \`validationMode ?? 'strict'\` resolution — that line short-circuited the registry lookup, so an app-level \`validationMode: 'lax'\` was silently overridden. The library-level fallback to \`'strict'\` lives downstream in \`createFormStore\` where it applies *after* the registry merge.

## Backward compatibility

Purely additive. Existing apps that don't pass \`defaults\` see no behavior change — registry holds an empty defaults object, merge is a no-op.

## Test plan

- [x] \`pnpm test\` — 713 passed (+9 in \`test/composables/app-defaults.test.ts\`)
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — clean
- [x] \`pnpm check:size\` — \`dist/index.mjs\` 13.28 kB, \`dist/zod.mjs\` 13.47 kB, \`dist/zod-v3.mjs\` 13.18 kB (all under 14.7 kB cap)
- [x] cubic-forms link-cx + restart — spike-cx loads HTTP 200, no behavior change since chemicalX defaults aren't configured (backward-compat path)

## Follow-ups noted in conversation

- Reserve \`cx:anon:\` prefix at consumer-key entry to prevent collision with synthetic anonymous keys (deferred per user direction).
- \`persist\` as an app-level default — defer until a real consumer asks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Applications can now configure default form settings (validation mode, submit behavior, field validation, undo/redo history) at the plugin level, applied to all forms. Per-form options override app defaults.

* **Documentation**
  * New recipe guide explaining how to set application-wide form defaults, including merge semantics, resolution order, and Vue/Nuxt configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->