### PR TITLE
test: silence Vue setup-error warns on the reserved-key reject tests

### DIFF
--- a/test/composables/anonymous-form.test.ts
+++ b/test/composables/anonymous-form.test.ts
@@ -420,6 +420,17 @@ describe('reserved key namespace', () => {
       },
     })
     const app = createApp(App).use(createChemicalXForms({ override: true }))
+    // The throw IS the test's signal — vitest captures it via
+    // `.toThrow(...)`. Vue still emits a `[Vue warn]: Unhandled error
+    // during execution of setup function` to stderr before re-throwing,
+    // which makes CI output noisy and obscures real warnings in the
+    // log. Silence the per-app handlers; the error continues to
+    // propagate to the caller as expected (errorHandler re-throws,
+    // matching Vue's default behaviour minus the warn).
+    app.config.warnHandler = () => {}
+    app.config.errorHandler = (err) => {
+      throw err
+    }
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)


### PR DESCRIPTION
## Summary

The four \`reserved key namespace\` tests in \`anonymous-form.test.ts\` mount a component whose \`setup()\` is *expected* to throw — vitest captures the throw via \`.toThrow(...)\` and the tests pass. But Vue also emits a \`[Vue warn]: Unhandled error during execution of setup function\` to stderr before re-throwing, which clutters CI output:

\`\`\`
stderr | test/composables/anonymous-form.test.ts > reserved key namespace > error message names the offending key so the developer can find it
[Vue warn]: Unhandled error during execution of setup function
  at <App>
\`\`\`

Three lines of those per test is enough to obscure any real warnings in the CI log.

## Fix

Set \`app.config.warnHandler = () => {}\` to silence the noise, and \`app.config.errorHandler = (err) => { throw err }\` to preserve the rethrow path that \`.toThrow\` relies on. Scoped to the \`mountWithKey\` helper inside the reserved-key describe — other tests in the file keep Vue's defaults, so any genuine setup error there still shouts loudly.

## Test plan
- [x] \`pnpm test test/composables/anonymous-form.test.ts\` — 15 passed, no \`[Vue warn]\` in stderr
- [x] \`pnpm test\` — 717 passed
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)