### PR TITLE
fix: honor setValue callback form at runtime

### DIFF
--- a/src/runtime/core/build-form-api.ts
+++ b/src/runtime/core/build-form-api.ts
@@ -95,11 +95,19 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
 
   function setValueImpl(pathOrValue: unknown, maybeValue?: unknown): boolean {
     if (arguments.length === 1) {
-      state.applyFormReplacement(pathOrValue as Form)
+      const next =
+        typeof pathOrValue === 'function'
+          ? (pathOrValue as (prev: unknown) => unknown)(state.form.value)
+          : pathOrValue
+      state.applyFormReplacement(next as Form)
       return true
     }
     const segments = canonicalizePath(pathOrValue as string | Path).segments
-    state.setValueAtPath(segments, maybeValue)
+    const resolvedValue =
+      typeof maybeValue === 'function'
+        ? (maybeValue as (prev: unknown) => unknown)(state.getValueAtPath(segments))
+        : maybeValue
+    state.setValueAtPath(segments, resolvedValue)
     return true
   }
 

--- a/test/composables/set-value.test.ts
+++ b/test/composables/set-value.test.ts
@@ -1,0 +1,187 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, type App } from 'vue'
+import { useForm } from '../../src'
+import { attachRegistryToApp, createRegistry } from '../../src/runtime/core/registry'
+import type { UseAbstractFormReturnType } from '../../src/runtime/types/types-api'
+import { fakeSchema } from '../utils/fake-schema'
+
+/**
+ * Runtime coverage for `setValue` — both signatures, both forms.
+ *
+ * The type system has long advertised the callback form
+ * (`SetValuePayload<X> = X | (X => X)`) but the runtime silently stuffed
+ * the function into form state. These tests pin the restored behaviour:
+ * functions are invoked with the current value, the return value is
+ * applied. The value form is unchanged.
+ *
+ * Sequential-freshness coverage proves the callback reads the live ref,
+ * not a captured snapshot — this is the property that makes
+ * `setValue('n', n => n + 1)` safe under back-to-back invocations.
+ */
+
+type SignupForm = {
+  email: string
+  counter: number
+  profile: {
+    name: string
+    age: number
+  }
+  posts: { title: string; views: number }[]
+}
+
+const defaults: SignupForm = {
+  email: '',
+  counter: 0,
+  profile: { name: '', age: 0 },
+  posts: [{ title: 'first', views: 0 }],
+}
+
+function harness() {
+  let captured!: UseAbstractFormReturnType<SignupForm>
+  const Probe = defineComponent({
+    setup() {
+      captured = useForm<SignupForm>({
+        schema: fakeSchema<SignupForm>(defaults),
+        key: `set-value-${Math.random().toString(36).slice(2)}`,
+      })
+      return () => h('div')
+    },
+  })
+  const app = createApp(Probe)
+  attachRegistryToApp(app, createRegistry())
+  app.mount(document.createElement('div'))
+  return { app, form: captured }
+}
+
+describe('setValue — value form (existing behaviour)', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('replaces the whole form when called with a single object', () => {
+    const { app, form } = harness()
+    apps.push(app)
+    const next: SignupForm = {
+      email: 'alice@example.com',
+      counter: 5,
+      profile: { name: 'alice', age: 30 },
+      posts: [{ title: 'hello', views: 42 }],
+    }
+    const result = form.setValue(next)
+    expect(result).toBe(true)
+    expect(form.getValue().value).toEqual(next)
+  })
+
+  it('writes a leaf when called with (path, value)', () => {
+    const { app, form } = harness()
+    apps.push(app)
+    const result = form.setValue('email', 'bob@example.com')
+    expect(result).toBe(true)
+    expect(form.getValue('email').value).toBe('bob@example.com')
+  })
+
+  it('writes a nested leaf', () => {
+    const { app, form } = harness()
+    apps.push(app)
+    form.setValue('profile.name', 'carol')
+    expect(form.getValue('profile.name').value).toBe('carol')
+  })
+
+  it('writes an array-index nested leaf', () => {
+    const { app, form } = harness()
+    apps.push(app)
+    form.setValue('posts.0.views', 99)
+    expect(form.getValue('posts.0.views').value).toBe(99)
+  })
+})
+
+describe('setValue — callback form', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('whole-form callback receives the current form and applies the return', () => {
+    const { app, form } = harness()
+    apps.push(app)
+    form.setValue('email', 'alice@example.com')
+
+    let received: SignupForm | undefined
+    const result = form.setValue((prev) => {
+      received = prev as SignupForm
+      return { ...(prev as SignupForm), email: 'changed@example.com' }
+    })
+
+    expect(result).toBe(true)
+    expect(received?.email).toBe('alice@example.com')
+    expect(form.getValue('email').value).toBe('changed@example.com')
+    // Other paths preserved by the spread.
+    expect(form.getValue('counter').value).toBe(0)
+  })
+
+  it('path callback receives the leaf value and applies the return', () => {
+    const { app, form } = harness()
+    apps.push(app)
+    form.setValue('email', 'alice@example.com')
+
+    let received: unknown
+    const result = form.setValue('email', (prev) => {
+      received = prev
+      return prev + '!'
+    })
+
+    expect(result).toBe(true)
+    expect(received).toBe('alice@example.com')
+    expect(form.getValue('email').value).toBe('alice@example.com!')
+  })
+
+  it('nested-path callback receives the nested leaf', () => {
+    const { app, form } = harness()
+    apps.push(app)
+    form.setValue('profile.name', 'carol')
+
+    form.setValue('profile.name', (prev) => prev.toUpperCase())
+    expect(form.getValue('profile.name').value).toBe('CAROL')
+  })
+
+  it('array-index nested callback receives the indexed leaf', () => {
+    const { app, form } = harness()
+    apps.push(app)
+
+    form.setValue('posts.0.views', (prev) => prev + 7)
+    expect(form.getValue('posts.0.views').value).toBe(7)
+  })
+
+  it('sequential callback invocations each see the latest committed value', () => {
+    const { app, form } = harness()
+    apps.push(app)
+
+    form.setValue('counter', (n) => n + 1)
+    form.setValue('counter', (n) => n + 1)
+    form.setValue('counter', (n) => n + 1)
+
+    // Each call read the prior committed value, not a stale snapshot.
+    expect(form.getValue('counter').value).toBe(3)
+  })
+
+  it('callback return value flows through reactivity (getValue ref updates)', () => {
+    const { app, form } = harness()
+    apps.push(app)
+    const ref = form.getValue('counter')
+    expect(ref.value).toBe(0)
+    form.setValue('counter', (n) => n + 41)
+    expect(ref.value).toBe(41)
+  })
+
+  it('does not store the function itself in form state', () => {
+    const { app, form } = harness()
+    apps.push(app)
+
+    form.setValue('email', (prev) => prev + 'x')
+    const stored = form.getValue('email').value
+    expect(typeof stored).toBe('string')
+    expect(stored).toBe('x')
+  })
+})

--- a/test/composables/type-inference.test.ts
+++ b/test/composables/type-inference.test.ts
@@ -161,6 +161,26 @@ describe('useForm type inference — setValue', () => {
     // @ts-expect-error - path not in schema
     form.setValue('missing', 'x')
   })
+
+  it('accepts callbacks whose signature matches the path leaf', () => {
+    form.setValue('email', (prev) => prev + '!')
+    form.setValue('age', (prev) => prev + 1)
+    form.setValue('active', (prev) => !prev)
+    form.setValue('profile.name', (prev) => prev.trim())
+    form.setValue('tags.0', (prev) => prev.toUpperCase())
+    form.setValue('posts.0.views', (prev) => prev + 1)
+    // Whole-form callback: receives DeepPartial<Form>, returns same.
+    form.setValue((prev) => ({ ...prev, email: 'z@z.z' }))
+  })
+
+  it('rejects callbacks whose return type does not match the path leaf', () => {
+    // @ts-expect-error - email is string, callback returns number
+    form.setValue('email', () => 123)
+    // @ts-expect-error - age is number, callback returns string
+    form.setValue('age', () => '30')
+    // @ts-expect-error - whole-form callback must return an object, not a string
+    form.setValue(() => 'not an object')
+  })
 })
 
 describe('useForm type inference — register', () => {


### PR DESCRIPTION
## Summary

- Restore the runtime callback form of `setValue` that the type system advertised but the runtime silently dropped — `form.setValue('counter', n => n + 1)` no longer stuffs the function into form state; it invokes the callback with the current value and applies the return.
- Pure bug fix: zero callback-form call sites exist in the repo today (grep-confirmed), so this is purely additive at the consumer surface.
- New runtime suite + extended type-inference suite to lock the behaviour in.

## Why

`SetValuePayload<X> = X | (X => X)` is wired through both `setValue` arities in `types-api.ts:667-668, 844-849`, and `docs/api.md` documents the callback form. But `setValueImpl` in `build-form-api.ts` passed `maybeValue` straight to `state.setValueAtPath` without checking whether it was a function. The fix is a thin `typeof === 'function'` guard in both arms; the function is invoked with the current whole form (single-arg) or `state.getValueAtPath(segments)` (path arg).

`form.setValue` continues to write with `meta: undefined` — the programmatic-write path that bypasses per-element persistence opt-in. Callback restoration preserves that invariant.

## Stacked on

This PR targets `claude/per-element-persistence-opt-in` (PR #143) so reviewers see only the setValue diff. When #143 merges to main, GitHub auto-rebases this PR's base.

## Test plan

- [x] `pnpm test test/composables/set-value.test.ts` — 11 new tests pass
- [x] `pnpm test test/composables/type-inference.test.ts` — 35 pass (existing 29 + 2 new `it` blocks: positive callback signatures + `@ts-expect-error` negatives)
- [x] `pnpm test` — full suite green (773 passed)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` (incl. prettier) — clean
- [x] `pnpm check:size` — all bundles under cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)