### PR TITLE
feat!: useFormContext returns null + dev-warn on miss

### DIFF
--- a/src/runtime/composables/use-form-context.ts
+++ b/src/runtime/composables/use-form-context.ts
@@ -2,6 +2,7 @@ import { getCurrentInstance, getCurrentScope, inject, onScopeDispose } from 'vue
 import { buildFormApi } from '../core/build-form-api'
 import type { FormStore } from '../core/create-form-store'
 import { __DEV__ } from '../core/dev'
+import { captureUserCallSite } from '../core/dev-stack-trace'
 import type { HistoryModule } from '../core/history'
 import { kFormContext, useRegistry, type ChemicalXRegistry } from '../core/registry'
 import type { FormKey, UseAbstractFormReturnType } from '../types/types-api'
@@ -14,17 +15,22 @@ import { ambientProvideHistory } from './use-abstract-form'
  *
  * - `useFormContext<Form>()` — resolves via `inject(kFormContext)`, the
  *   FormStore that the nearest ancestor `useForm()` call provided.
- *   Throws a clear error if there's no ancestor form.
+ *   Anonymous forms fill the ambient slot; keyed forms do not.
  *
  * - `useFormContext<Form>(key)` — looks the form up by its key in the
- *   app registry. Lets a distant component reach a specific form without
- *   being a descendant of its `useForm` owner. Throws if the key isn't
- *   registered.
+ *   app registry. Lets a distant component reach a specific form
+ *   without being a descendant of its `useForm` owner.
+ *
+ * Both modes return `null` on miss (no ambient form, or the named key
+ * isn't registered) and emit a dev-mode `console.warn` pointing at the
+ * call site. Production is silent. The nullable return forces narrowing
+ * — `if (ctx) ctx.register(...)` — so a typo'd key or a parent that
+ * unmounts mid-render degrades gracefully instead of throwing.
  *
  * The consumer supplies the `Form` generic — Vue's InjectionKey erases
  * generics across the provide/inject boundary, so the library can't
- * recover the shape on the caller's behalf. The returned API is
- * type-identical to `useForm`'s return.
+ * recover the shape on the caller's behalf. The returned API (when
+ * non-null) is type-identical to `useForm`'s return.
  *
  * Both resolution modes ref-count the consumer, so the FormStore stays
  * alive for this component's effect scope and is released back to the
@@ -36,10 +42,11 @@ import { ambientProvideHistory } from './use-abstract-form'
 export function useFormContext<
   Form extends GenericForm,
   GetValueFormType extends GenericForm = Form,
->(key?: FormKey): UseAbstractFormReturnType<Form, GetValueFormType> {
+>(key?: FormKey): UseAbstractFormReturnType<Form, GetValueFormType> | null {
   const registry = useRegistry()
 
-  const state: FormStore<Form> = resolveState<Form>(key, registry)
+  const state = resolveState<Form>(key, registry)
+  if (state === null) return null
 
   // Ref-count this consumer so the FormStore survives until every nested
   // component that reached it has torn down. Mirrors the behaviour in
@@ -63,32 +70,43 @@ export function useFormContext<
 }
 
 /**
- * Split out so each branch `return`s — lets the caller hold `state` as
- * a plain `const` and keeps ESLint's `no-useless-assignment` rule
- * happy (the prior shape declared `let state = null` and re-assigned
- * in both branches).
+ * Resolves the FormStore for the requested key (or the ambient slot
+ * when no key was passed). Returns `null` on miss; the caller propagates
+ * that null straight out to the consumer.
+ *
+ * Both miss modes log a dev-mode warning carrying the user's call-site
+ * frame — a typo'd key reads as "[cx] useFormContext: no form registered
+ * for key 'userz'. Returning null. (pages/profile.vue:42)" rather than
+ * as a stack trace from inside cx internals.
  */
 function resolveState<Form extends GenericForm>(
   key: FormKey | undefined,
   registry: ChemicalXRegistry
-): FormStore<Form> {
+): FormStore<Form> | null {
   if (key !== undefined) {
     const stored = registry.forms.get(key) as FormStore<Form> | undefined
     if (stored === undefined) {
-      throw new Error(
-        `[@chemical-x/forms] useFormContext: no form registered for key '${key}'. Call useForm({ key }) first.`
-      )
+      warnMiss(`no form registered for key '${key}'`)
+      return null
     }
     return stored
   }
   const ambient = inject(kFormContext, null) as FormStore<Form> | null
   if (ambient === null) {
-    throw new Error(
-      '[@chemical-x/forms] useFormContext: no ambient form context. Call useForm(...) in an ancestor or pass a key.'
-    )
+    warnMiss('no ambient form context')
+    return null
   }
   warnIfAmbientProviderHadDuplicates()
   return ambient
+}
+
+function warnMiss(detail: string): void {
+  if (!__DEV__) return
+  const frame = captureUserCallSite()
+  console.warn(
+    `[@chemical-x/forms] useFormContext: ${detail}. Returning null.` +
+      (frame !== undefined ? ` ${frame}` : '')
+  )
 }
 
 /**

--- a/src/runtime/composables/use-form-context.ts
+++ b/src/runtime/composables/use-form-context.ts
@@ -86,22 +86,30 @@ function resolveState<Form extends GenericForm>(
   if (key !== undefined) {
     const stored = registry.forms.get(key) as FormStore<Form> | undefined
     if (stored === undefined) {
-      warnMiss(`no form registered for key '${key}'`)
+      warnMiss(`no form registered for key '${key}'`, registry.isSSR)
       return null
     }
     return stored
   }
   const ambient = inject(kFormContext, null) as FormStore<Form> | null
   if (ambient === null) {
-    warnMiss('no ambient form context')
+    warnMiss('no ambient form context', registry.isSSR)
     return null
   }
   warnIfAmbientProviderHadDuplicates()
   return ambient
 }
 
-function warnMiss(detail: string): void {
-  if (!__DEV__) return
+/**
+ * Skipped on SSR — Nuxt's `dev:ssr-logs` hook forwards server warns to
+ * the browser console alongside the client-side warn that fires from
+ * the hydration setup, so the same miss would surface twice per page
+ * load. The signal is identical on both passes (registry state is
+ * deterministic across SSR/client), so emitting only on the client is
+ * lossless and halves dev-mode noise. Production stays silent on both.
+ */
+function warnMiss(detail: string, isSSR: boolean): void {
+  if (!__DEV__ || isSSR) return
   const frame = captureUserCallSite()
   console.warn(
     `[@chemical-x/forms] useFormContext: ${detail}. Returning null.` +

--- a/src/runtime/lib/core/transforms/v-register-preamble-transform.ts
+++ b/src/runtime/lib/core/transforms/v-register-preamble-transform.ts
@@ -245,8 +245,16 @@ function flattenExpression(exp: ExpressionNode): string {
 function injectPreamble(element: ElementNode, captured: readonly string[]): void {
   if (hasPreamble(element)) return
 
+  // Each entry is wrapped in a try/catch IIFE: the preamble is best-
+  // effort optimisation (only matters for the read-before-input edge,
+  // see the file header), and any throw inside one entry must not
+  // prevent the rest from firing or break SSR. Common throw paths the
+  // catch covers: a v-register against a null `ctx` (e.g. when
+  // `useFormContext` returned null and the input is gated by a v-if
+  // the AST walker can't see — the v-if check fires later, so the
+  // preamble would otherwise dereference null here).
   const callList = captured
-    .map((source) => `(${source})?.markConnectedOptimistically?.()`)
+    .map((source) => `(()=>{try{(${source})?.markConnectedOptimistically?.()}catch{}})()`)
     .join(', ')
   const expressionText = `(${callList}, undefined)`
   const exp: SimpleExpressionNode = createSimpleExpression(expressionText, false /* not static */)

--- a/test/composables/anonymous-form.test.ts
+++ b/test/composables/anonymous-form.test.ts
@@ -73,7 +73,7 @@ describe('anonymous useForm — independent state per setup call', () => {
 describe('anonymous useForm — ambient useFormContext access', () => {
   it('descendant composable reads the same FormStore via provide/inject', async () => {
     type Api = ReturnType<typeof useForm<Form>>
-    const captured: { owner?: Api; consumer?: Api } = {}
+    const captured: { owner?: Api; consumer?: Api | null } = {}
 
     const Child = defineComponent({
       setup() {

--- a/test/composables/use-form-context.test.ts
+++ b/test/composables/use-form-context.test.ts
@@ -1,11 +1,13 @@
 // @vitest-environment jsdom
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h } from 'vue'
 import { useForm } from '../../src'
 import { useFormContext } from '../../src/runtime/composables/use-form-context'
 import { ANONYMOUS_FORM_KEY_PREFIX } from '../../src/runtime/core/defaults'
 import { createChemicalXForms } from '../../src/runtime/core/plugin'
 import { fakeSchema } from '../utils/fake-schema'
+
+const NULL_WARN_MARKER = '[@chemical-x/forms] useFormContext'
 
 type Form = {
   email: string
@@ -60,11 +62,11 @@ describe('useFormContext — ambient provide/inject', () => {
   })
 
   it('parent and child handles share the same synthetic key', () => {
-    const shared: { parent?: string; child?: string } = {}
+    const shared: { parent?: string; child?: string | undefined } = {}
 
     const Child = defineComponent({
       setup() {
-        shared.child = useFormContext<Form>().key
+        shared.child = useFormContext<Form>()?.key
         return () => h('div')
       },
     })
@@ -85,63 +87,93 @@ describe('useFormContext — ambient provide/inject', () => {
     app.unmount()
   })
 
-  it('throws a clear error when there is no ancestor form', () => {
-    let captured: unknown
-    const Child = defineComponent({
-      setup() {
-        try {
-          useFormContext<Form>()
-        } catch (err) {
-          captured = err
-        }
-        return () => h('div')
-      },
+  describe('miss modes — return null + dev warn', () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    })
+    afterEach(() => {
+      warnSpy.mockRestore()
     })
 
-    const app = createApp(Child).use(createChemicalXForms({ override: true }))
-    app.mount(document.createElement('div'))
-    expect(captured).toBeInstanceOf(Error)
-    expect((captured as Error).message).toMatch(/no ambient form context/)
-    app.unmount()
-  })
+    const matchingWarnCalls = (): readonly unknown[][] =>
+      warnSpy.mock.calls.filter((args: readonly unknown[]) =>
+        String(args[0] ?? '').includes(NULL_WARN_MARKER)
+      )
 
-  it('throws when the only ancestor form is keyed (ambient slot empty)', () => {
-    // Keyed useForm() does NOT fill the ambient slot — descendants must
-    // address it explicitly by key. A naive `useFormContext()` (no key)
-    // call inside such a subtree gets the same "no ambient" throw it
-    // would get with no parent at all.
-    let captured: unknown
-    const Child = defineComponent({
-      setup() {
-        try {
-          useFormContext<Form>()
-        } catch (err) {
-          captured = err
-        }
-        return () => h('div')
-      },
+    it('returns null and warns when there is no ancestor form', () => {
+      let captured: ReturnType<typeof useFormContext<Form>> | undefined
+      const Child = defineComponent({
+        setup() {
+          captured = useFormContext<Form>()
+          return () => h('div')
+        },
+      })
+
+      const app = createApp(Child).use(createChemicalXForms({ override: true }))
+      app.mount(document.createElement('div'))
+      expect(captured).toBeNull()
+      const calls = matchingWarnCalls()
+      expect(calls).toHaveLength(1)
+      expect(String(calls[0]?.[0] ?? '')).toMatch(/no ambient form context/)
+      app.unmount()
     })
-    const Parent = defineComponent({
-      setup() {
-        useForm<Form>({ schema: fakeSchema(defaults), key: 'named-only' })
-        return () => h(Child)
-      },
+
+    it('returns null and warns when the only ancestor form is keyed', () => {
+      // Keyed useForm() does NOT fill the ambient slot — descendants must
+      // address it explicitly by key. A naive `useFormContext()` (no key)
+      // call inside such a subtree gets the same "no ambient" warn + null
+      // it would get with no parent at all.
+      let captured: ReturnType<typeof useFormContext<Form>> | undefined
+      const Child = defineComponent({
+        setup() {
+          captured = useFormContext<Form>()
+          return () => h('div')
+        },
+      })
+      const Parent = defineComponent({
+        setup() {
+          useForm<Form>({ schema: fakeSchema(defaults), key: 'named-only' })
+          return () => h(Child)
+        },
+      })
+      const app = createApp(Parent).use(createChemicalXForms({ override: true }))
+      app.mount(document.createElement('div'))
+      expect(captured).toBeNull()
+      const calls = matchingWarnCalls()
+      expect(calls).toHaveLength(1)
+      expect(String(calls[0]?.[0] ?? '')).toMatch(/no ambient form context/)
+      app.unmount()
     })
-    const app = createApp(Parent).use(createChemicalXForms({ override: true }))
-    app.mount(document.createElement('div'))
-    expect(captured).toBeInstanceOf(Error)
-    expect((captured as Error).message).toMatch(/no ambient form context/)
-    app.unmount()
+
+    it("warning message names the missing key when it's an explicit-key miss", () => {
+      let captured: ReturnType<typeof useFormContext<Form>> | undefined
+      const Orphan = defineComponent({
+        setup() {
+          captured = useFormContext<Form>('never-registered')
+          return () => h('div')
+        },
+      })
+      const app = createApp(Orphan).use(createChemicalXForms({ override: true }))
+      app.mount(document.createElement('div'))
+      expect(captured).toBeNull()
+      const calls = matchingWarnCalls()
+      expect(calls).toHaveLength(1)
+      const message = String(calls[0]?.[0] ?? '')
+      expect(message).toMatch(/no form registered/)
+      expect(message).toContain("'never-registered'")
+      app.unmount()
+    })
   })
 
   it('mixed keyed + anonymous: ambient resolves to the (only) anonymous form', () => {
     // A parent that mixes keyed and anonymous useForm() calls: the keyed
     // ones bypass ambient entirely, so a descendant's `useFormContext()`
     // sees only the (single) anonymous form and resolves to it.
-    const shared: { childKey?: string } = {}
+    const shared: { childKey?: string | undefined } = {}
     const Child = defineComponent({
       setup() {
-        shared.childKey = useFormContext<Form>().key
+        shared.childKey = useFormContext<Form>()?.key
         return () => h('div')
       },
     })
@@ -198,23 +230,25 @@ describe('useFormContext — explicit key resolution', () => {
     app.unmount()
   })
 
-  it('throws when the explicit key is not registered', () => {
-    let captured: unknown
+  it('returns null and warns when the explicit key is not registered', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    let captured: ReturnType<typeof useFormContext<Form>> | undefined
     const Orphan = defineComponent({
       setup() {
-        try {
-          useFormContext<Form>('never-registered')
-        } catch (err) {
-          captured = err
-        }
+        captured = useFormContext<Form>('never-registered')
         return () => h('div')
       },
     })
     const app = createApp(Orphan).use(createChemicalXForms({ override: true }))
     app.mount(document.createElement('div'))
-    expect(captured).toBeInstanceOf(Error)
-    expect((captured as Error).message).toMatch(/no form registered for key 'never-registered'/)
+    expect(captured).toBeNull()
+    const matching = warnSpy.mock.calls.filter((args: readonly unknown[]) =>
+      String(args[0] ?? '').includes(NULL_WARN_MARKER)
+    )
+    expect(matching).toHaveLength(1)
+    expect(String(matching[0]?.[0] ?? '')).toMatch(/no form registered/)
     app.unmount()
+    warnSpy.mockRestore()
   })
 })
 

--- a/test/composables/use-form-context.test.ts
+++ b/test/composables/use-form-context.test.ts
@@ -164,6 +164,14 @@ describe('useFormContext — ambient provide/inject', () => {
       expect(message).toContain("'never-registered'")
       app.unmount()
     })
+
+    // The warn embeds a `(<path>:<line>)` user call-site frame via
+    // `captureUserCallSite()`. We don't unit-test that here: the
+    // capture's regex deliberately skips any frame matching
+    // `/chemical-x[/-]forms?/i`, which includes this very test file
+    // — there's no "user frame" outside the lib workspace to attach.
+    // End-to-end verification lives in the cubic-forms spike, where
+    // the warn renders as e.g. `(.../SpikeCxChild.vue:19)`.
   })
 
   it('mixed keyed + anonymous: ambient resolves to the (only) anonymous form', () => {

--- a/test/composables/use-form-context.test.ts
+++ b/test/composables/use-form-context.test.ts
@@ -110,7 +110,11 @@ describe('useFormContext — ambient provide/inject', () => {
         },
       })
 
-      const app = createApp(Child).use(createChemicalXForms({ override: true }))
+      // No `override: true` — the warn is suppressed in SSR mode (see
+      // warnMiss in use-form-context.ts). JSDOM has `window`, so the
+      // default detectSSR resolves to false and the warn fires as
+      // intended for client-side coverage.
+      const app = createApp(Child).use(createChemicalXForms())
       app.mount(document.createElement('div'))
       expect(captured).toBeNull()
       const calls = matchingWarnCalls()
@@ -137,7 +141,7 @@ describe('useFormContext — ambient provide/inject', () => {
           return () => h(Child)
         },
       })
-      const app = createApp(Parent).use(createChemicalXForms({ override: true }))
+      const app = createApp(Parent).use(createChemicalXForms())
       app.mount(document.createElement('div'))
       expect(captured).toBeNull()
       const calls = matchingWarnCalls()
@@ -154,7 +158,7 @@ describe('useFormContext — ambient provide/inject', () => {
           return () => h('div')
         },
       })
-      const app = createApp(Orphan).use(createChemicalXForms({ override: true }))
+      const app = createApp(Orphan).use(createChemicalXForms())
       app.mount(document.createElement('div'))
       expect(captured).toBeNull()
       const calls = matchingWarnCalls()
@@ -247,7 +251,7 @@ describe('useFormContext — explicit key resolution', () => {
         return () => h('div')
       },
     })
-    const app = createApp(Orphan).use(createChemicalXForms({ override: true }))
+    const app = createApp(Orphan).use(createChemicalXForms())
     app.mount(document.createElement('div'))
     expect(captured).toBeNull()
     const matching = warnSpy.mock.calls.filter((args: readonly unknown[]) =>

--- a/test/ssr-bare-vue/preamble-null-context.test.ts
+++ b/test/ssr-bare-vue/preamble-null-context.test.ts
@@ -1,0 +1,118 @@
+import { baseCompile } from '@vue/compiler-core'
+import { renderToString } from '@vue/server-renderer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as Vue from 'vue'
+import { createSSRApp, defineComponent } from 'vue'
+import { useFormContext } from '../../src'
+import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { vRegisterHintTransform } from '../../src/runtime/lib/core/transforms/v-register-hint-transform'
+import { vRegisterPreambleTransform } from '../../src/runtime/lib/core/transforms/v-register-preamble-transform'
+
+/**
+ * SSR null-safety for the v-register preamble.
+ *
+ * The preamble transform hoists every captured `v-register` expression
+ * to a `:data-cx-pre-mark` directive on the first root element so the
+ * mark fires before any descendant template expression evaluates.
+ * That hoist runs unconditionally — a `v-if` guard on the input itself
+ * fires LATER in render order, so a nullable `useFormContext()`
+ * return that the consumer guarded around the input would still
+ * dereference null in the preamble.
+ *
+ * Each preamble entry is therefore wrapped in a try/catch IIFE: if the
+ * underlying expression throws (e.g. `null.register('foo')`), the
+ * catch absorbs it and the rest of the preamble + the surrounding
+ * render still proceeds. Documented contract on the transform is
+ * "best-effort optimisation"; the catch encodes that.
+ *
+ * These tests prove the encoding holds end-to-end through
+ * @vue/server-renderer with realistic v-if + null-context shapes.
+ */
+
+type Form = { name: string }
+
+function compileTemplate(template: string): (this: unknown, ctx: unknown) => unknown {
+  const result = baseCompile(template, {
+    nodeTransforms: [vRegisterPreambleTransform, vRegisterHintTransform],
+    mode: 'function',
+    prefixIdentifiers: true,
+    hoistStatic: false,
+  })
+  const fn = new Function('Vue', `${result.code}\nreturn render`)
+  return fn(Vue) as (this: unknown, ctx: unknown) => unknown
+}
+
+describe('SSR preamble null-safety', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+  })
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  it('SSR does not throw when an input is gated by v-if against a null useFormContext', async () => {
+    // Mirror the spike pattern: <SpikeCxChild form-key="totally-fake" />
+    // resolves to null; the input is wrapped in v-if="ctx" so the v-if
+    // branch never runs, but the preamble's hoisted call would still
+    // try `ctx.register(...)` on null without the try/catch fix.
+    const render = compileTemplate(
+      `<div>
+         <p>before</p>
+         <input v-if="ctx" v-register="ctx.register('name')" />
+         <p>after</p>
+       </div>`
+    )
+    const App = defineComponent({
+      setup() {
+        const ctx = useFormContext<Form>('this-key-was-never-registered')
+        return { ctx }
+      },
+      render,
+    })
+    const app = createSSRApp(App)
+    app.use(createChemicalXForms({ override: true }))
+
+    // The catchable failure mode pre-fix was an unhandled rejection
+    // bubbling out of `_sfc_ssrRender`. If that ever returns, this
+    // resolves to a thrown Error and the test fails noisily.
+    const html = await renderToString(app)
+    expect(html).toContain('before')
+    expect(html).toContain('after')
+    // The v-if guard meant the input never entered the rendered tree.
+    expect(html).not.toContain('<input')
+  })
+
+  it('SSR continues evaluating later preamble entries even when an earlier one throws', async () => {
+    // Two v-register sites in one template: the first against a null
+    // context, the second against a (parent-provided) form context. The
+    // try/catch must absorb the first throw without preventing the
+    // second mark from firing — the per-entry isolation is the whole
+    // point of wrapping each call individually rather than the whole
+    // chain in one try.
+    //
+    // We don't introspect the field record here (that's covered by
+    // optimistic-is-connected.test.ts); the load-bearing assertion is
+    // that renderToString completes and the surrounding HTML renders.
+    const render = compileTemplate(
+      `<div>
+         <input v-if="bad" v-register="bad.register('name')" />
+         <input v-register="good.register('name')" />
+       </div>`
+    )
+    const App = defineComponent({
+      setup() {
+        return {
+          bad: useFormContext<Form>('totally-fake'),
+          good: { register: () => ({ markConnectedOptimistically: () => undefined }) },
+        }
+      },
+      render,
+    })
+    const app = createSSRApp(App)
+    app.use(createChemicalXForms({ override: true }))
+
+    const html = await renderToString(app)
+    expect(html).toContain('<input')
+  })
+})

--- a/test/ssr-bare-vue/preamble-null-context.test.ts
+++ b/test/ssr-bare-vue/preamble-null-context.test.ts
@@ -81,6 +81,14 @@ describe('SSR preamble null-safety', () => {
     expect(html).toContain('after')
     // The v-if guard meant the input never entered the rendered tree.
     expect(html).not.toContain('<input')
+
+    // SSR-side warn is suppressed — see warnMiss in use-form-context.ts.
+    // The client-hydration setup re-runs and surfaces the same warn
+    // there, so silencing the SSR pass is lossless and halves dev noise.
+    const ourWarns = warnSpy.mock.calls.filter((args: readonly unknown[]) =>
+      String(args[0] ?? '').includes('useFormContext')
+    )
+    expect(ourWarns).toHaveLength(0)
   })
 
   it('SSR continues evaluating later preamble entries even when an earlier one throws', async () => {


### PR DESCRIPTION
## Summary

- Replace `useFormContext`'s throw-on-miss with `null` + a dev-mode `console.warn` carrying the user's call-site frame.
- Forces `if (ctx) ctx.register(...)` narrowing at every call site, so a typo'd key, a parent that unmounts mid-render, or a hot-reload race no longer takes down the page.
- Pre-1.0, full replacement — no backward-compat shim.

## Why

The pre-existing throw was a footgun. A composable that genuinely needs to handle a missing context — the parent could be unmounted, the registry could be in flux during HMR, the key could be wrong — should degrade gracefully, not crash. Match Vue's own `inject(key, default)` idiom and React Hook Form's `useFormContext` shape.

## Three commits

1. **`feat!: useFormContext returns null + dev-warn on miss`** — the breaking change. Both miss modes (no ambient, missing explicit key) symmetrically return `null` and warn. Existing throw-tests in `use-form-context.test.ts:88-106 / 108-135 / 201-218` flip to expects-null + warn-fired, plus one new positive coverage that the warning names the missing key.

2. **`test: ssr null-safety for v-register preamble`** — the v-register preamble transform hoists every captured expression to a `:data-cx-pre-mark` directive on the first root element so the mark fires before any descendant template expression evaluates. With nullable contexts, that hoist would dereference null on every SSR pass even when the input itself was guarded by `v-if`. Each captured entry is now wrapped in a per-entry try/catch IIFE — matches the documented "best-effort optimisation" contract on the preamble. New tests in `test/ssr-bare-vue/preamble-null-context.test.ts` cover the v-if + null shape and the multi-entry isolation case.

3. **`fix: skip useFormContext miss-warn on ssr to dedupe`** — the dev warn previously fired twice per page load (once SSR-side, forwarded via Nuxt's `dev:ssr-logs` hook, once client-side). Same signal both passes, so emit only on the client. Matches the persist-warn pattern. Four lib tests passed `createChemicalXForms({ override: true })` (force-SSR-mode) into `createApp` (CSR mount) — drop `override: true` from those four so the harness's mode matches what it's testing.

## Stacked on

PR #144 (`fix: honor setValue callback form at runtime`). When that merges to main, GitHub rebases this PR's base.

## Test plan

- [x] `pnpm test` — 776 / 776 passing
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` (incl. prettier) — clean
- [x] `pnpm check:size` — under cap
- [x] Manually verified end-to-end on `cubic-forms/spike-cx` — bad-key child renders the "no resolved form" UI, single warn per page load with correct call-site frame, no SSR errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)