### PR TITLE
feat!: structural-completeness invariant + fingerprint persistence + read/write type honesty

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -28,7 +28,15 @@ export default [
     // in build-form-api, syncPersistOptIn lifecycle in directive,
     // PersistenceModule + PERSISTENCE_MODULE_KEY plumbing. Measured
     // at 15.08 KB; ~1 KB headroom for the docs/test follow-up commit.
-    limit: '16 KB',
+    //
+    // Raised 16 → 17 KB on the structural-completeness +
+    // fingerprint-persistence branch: mergeStructural +
+    // setAtPathWithSchemaFill in path-walker, schema.getDefaultAtPath
+    // plumbing, cleanupOrphanKeys + sweepNonConfiguredStandardStores-
+    // ForOrphans + sweepAllOrphansAcrossStandardStores, FormStorage
+    // listKeys across three backends, fingerprint-suffixed key
+    // composition.
+    limit: '17 KB',
     gzip: true,
     modifyEsbuildConfig: asEsm,
   },
@@ -41,7 +49,10 @@ export default [
     //
     // Raised 14.7 → 16 KB on per-element-persistence-opt-in (mirrors
     // index.mjs — same shared core chunk). Measured at 15.03 KB.
-    limit: '16 KB',
+    //
+    // Raised 16 → 17 KB tracking index.mjs's structural-completeness +
+    // fingerprint-persistence bump.
+    limit: '17 KB',
     gzip: true,
     ignore: ['zod'],
     modifyEsbuildConfig: asEsm,
@@ -55,7 +66,10 @@ export default [
     //
     // Raised 14.7 → 16 KB on per-element-persistence-opt-in (mirrors
     // index.mjs). Measured at 14.71 KB.
-    limit: '16 KB',
+    //
+    // Raised 16 → 17 KB tracking index.mjs's structural-completeness +
+    // fingerprint-persistence bump.
+    limit: '17 KB',
     gzip: true,
     ignore: ['zod', 'lodash-es'],
     modifyEsbuildConfig: asEsm,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,130 @@ for the full set of changes.
   of the wire-up problem produce a clear signal at the right call
   site. Production is silent.
 
+**Structural-completeness invariant + fingerprint persistence + read-
+type honesty.** Three intertwined gaps closed in one pass — every
+`setValue` write now leaves the form satisfying the slim schema (so
+consumer code can read `prev.first.toUpperCase()` without optional-
+chaining), persisted-draft keys carry a schema fingerprint that
+auto-invalidates across deploys with no manual `version` bump, and
+the read-type for `getValue` / `register` now reports `T | undefined`
+once the path crosses an array index (out-of-bounds is an honest
+runtime case, not a type-system lie). See the
+[migration guide](./docs/migration/0.11-to-0.12.md) for the full set
+of related changes.
+
+- **Breaking — `AbstractSchema.getDefaultAtPath(path)` is now
+  required.** Custom-adapter authors implement a fifth method that
+  returns the schema-prescribed default at a structured path
+  (object property → property's default; array index → element
+  default; tuple position → position default; optional/nullable
+  around a structural inner → inner default; primitive
+  optional/nullable → `undefined`/`null`). The runtime calls this
+  on every `setValue` to fill structural gaps; without it, partial
+  writes leak through and break the new invariant. Migration: see
+  [custom-adapter recipe](./docs/recipes/custom-adapter.md). Both
+  Zod adapters ship the implementation out of the box.
+- **Breaking — `FormStorage.listKeys(prefix)` is now required.**
+  Custom storage adapters implement a fourth method that returns
+  every key whose name starts with `prefix`. The persistence layer
+  uses it to find and clean up orphaned fingerprint-suffixed keys
+  on mount. Adapters that can't enumerate (HTTP-backed drafts,
+  cookie-backed) can return `[]` — orphan cleanup degrades
+  gracefully on those backends.
+- **Breaking — `setValue` drops `DeepPartial` from both forms.**
+  `setValue(value)` and `setValue(path, value)` now expect the full
+  write shape at the type level, both for direct writes and for the
+  callback form's return. Runtime mergeStructural still completes
+  partials so dynamic / typecast inputs don't crash, but the type
+  system now leads with strictness — the IDE points consumers at
+  the canonical "give me the whole shape" pattern. Path-form
+  callback `prev` is now `NonNullable<T>` (the runtime auto-defaults
+  missing slots from the schema before invoking the callback);
+  whole-form callback `prev` is `WithIndexedUndefined<Form>` (array
+  reads are honest about returning `Item | undefined`). Migration:
+  switch partial value-form writes to the callback form, or spread
+  the existing value (`setValue('user', { ...prev, name: 'X' })`).
+- **Breaking — `getValue` and `register` use `NestedReadType<F, P>`
+  instead of `NestedType<F, P>`.** Once a path crosses an array
+  index segment (e.g. `'posts.0.title'`), every result is
+  `T | undefined`. Strict (no taint) for paths that don't cross
+  arrays. Tuple positions stay strict — a tuple's length is static
+  so out-of-bounds is a compile error, not a runtime case. Whole-
+  form `getValue()` returns `Readonly<Ref<WithIndexedUndefined<Form>>>`
+  (every unbounded array's elements get `| undefined`). Migration:
+  consumers narrow at array-crossing paths with `?.` / `??` or a
+  conditional check; non-crossing paths are unchanged.
+- **Breaking — `PersistConfig.version` is gone.** The schema's
+  `fingerprint()` is the canonical "shape changed" signal — passing
+  a manual version is redundant and decoupled from the actual
+  schema state. Storage keys now resolve to
+  `${base}:${fingerprint}` automatically; a schema change produces
+  a different fingerprint, the old key becomes orphaned, and the
+  next mount's `listKeys`-driven cleanup pass wipes it. Migration:
+  delete the `version: N` line from your `persist:` config; the
+  typechecker flags it. The cx-internal envelope version (the `v`
+  field on serialized payloads) stays as an internal storage-format
+  invariant — bumped only when cx itself changes the on-disk shape,
+  never by consumers.
+- **Breaking — `AbstractSchema` parameter rename: `getInitialState`
+  → `getDefaultValues`** has already shipped (0.11.0); the new
+  break is `getDefaultAtPath`'s required-method status. The
+  five-method contract is now: `fingerprint`, `getDefaultValues`,
+  `getDefaultAtPath`, `getSchemasAtPath`, `validateAtPath`.
+- **New — structural-completeness invariant on every `setValue`.**
+  After every `setValue` write, the form is guaranteed to satisfy
+  the slim schema (objects/arrays/primitives without refines).
+  Three concrete consequences:
+  - Sparse array writes (`setValue('posts.21', cb)` against an
+    empty array) auto-pad indices `0..20` with the schema's
+    element default. The runtime walks the path, fills missing
+    intermediates from `getDefaultAtPath`, and writes the value at
+    the leaf.
+  - Partial value-form writes (`setValue('user', { name: 'X' })`
+    when the schema requires `{ name, age, email }`) get
+    structurally completed via `mergeStructural` against the
+    schema's default — sibling keys appear with their schema-
+    prescribed defaults. Consumer-only keys (validation flags,
+    metadata) are preserved.
+  - Path-form callback writes (`setValue('user', prev => ({ ...prev,
+    name: 'X' }))`) now receive a strict, fully-defaulted `prev` —
+    even when the slot was previously empty. The callback no
+    longer needs `prev?.name ?? ''` defensive reads.
+  Performance: the fast path (writes to existing slots) skips the
+  schema entirely. Schema lookups fire only when a write actually
+  hits a structural gap, with element-default caching to keep
+  sparse-array padding O(N) instead of O(N×schema-traversal).
+- **New — fingerprint-keyed persistence + active orphan cleanup.**
+  Storage keys are now `${base}:${fingerprint}` automatically —
+  changing the schema produces a different fingerprint, the old
+  key becomes unreachable, and on the next mount the new
+  `listKeys`-driven cleanup pass removes the orphaned entry. No
+  manual `version` bumps, no stale drafts accumulating across
+  redeploys. Cleanup uses exact-or-`:`-prefix match scoped to
+  `${PERSISTENCE_KEY_PREFIX}${formKey}` (or the consumer's custom
+  `key`) — sibling forms with overlapping prefixes (e.g.
+  `'my-form'` vs `'my-form-2'`) don't collide. Cross-store
+  cleanup on the non-configured standard backends extends to
+  orphan-key sweeping symmetrically.
+- **New — `WithIndexedUndefined<T>`, `NestedReadType<F, P>`, and
+  `IsTuple<T>` type transforms** are exported from
+  `@chemical-x/forms`. `WithIndexedUndefined` taints every
+  unbounded array's element type with `| undefined`; tuples,
+  `Date`, `RegExp`, `Map`, `Set`, and functions pass through
+  untouched. `NestedReadType` walks a `FlatPath` and tracks
+  whether a numeric segment was crossed — once tainted, all
+  subsequent results are `T | undefined`. Use these directly when
+  building wrappers / utility types around the form API.
+- **New — `SetValuePayload<Write, Read = Write>` is parameterised**
+  to support honest read-vs-write shape distinction in callbacks.
+  `Write` is what the callback returns / what direct writes
+  accept; `Read` is what the callback's `prev` receives. The
+  whole-form `setValue` parameterises `Read` to
+  `WithIndexedUndefined<Form>` so consumer reads of `prev.posts[5]`
+  are honest. The path-form parameterises `Read` to
+  `NonNullable<NestedType<Form, Path>>` because the runtime
+  auto-defaults missing slots before the callback fires.
+
 ## v0.11.1
 **Dev-mode ergonomics for the ambient `useFormContext` warning.**
 

--- a/bench/persistence.bench.ts
+++ b/bench/persistence.bench.ts
@@ -74,7 +74,7 @@ function makeForm(leafCount: number, depth: number): Record<string, unknown> {
 }
 
 async function benchOneWrite(adapter: FormStorage, form: Record<string, unknown>): Promise<void> {
-  const payload = buildPersistedPayload(form, 'form', new Map(), new Map(), 1)
+  const payload = buildPersistedPayload(form, 'form', new Map(), new Map())
   await adapter.setItem('bench-key', payload)
 }
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -37,16 +37,16 @@ const form = useForm({ schema, key: 'signup' })
 
 Options:
 
-| Field             | Type                                                                                                          | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| ----------------- | ------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `schema`          | `z.ZodType`                                                                                                   | yes      | The Zod schema describing the form shape.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| `key`             | `string`                                                                                                      | no       | Form identity. Omit for one-off forms (runtime allocates a synthetic `__cx:anon:<id>` via `useId()`). Pass a string when you need cross-component lookup via `useFormContext(key)`, shared state across call-sites, a stable `persist` storage-key default, or a recognisable DevTools label. Keys starting with `__cx:` are reserved for the library's internal synthetic-key namespace; passing one throws `ReservedFormKeyError`.                                                                                                                                |
-| `defaultValues`   | `DeepPartial<Form>`                                                                                           | no       | Constraints applied over schema defaults.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| `validationMode`  | `'lax'` \| `'strict'`                                                                                         | no       | Defaults to `'strict'` — defaults that fail the schema seed `schemaErrors` at construction. Pass `'lax'` to opt out (multi-step wizards, placeholder rows). See [Types](#types).                                                                                                                                                                                                                                                                                                                                                                                    |
-| `onInvalidSubmit` | `'none'` \| `'focus-first-error'` \| `'scroll-to-first-error'` \| `'both'`                                    | no       | What to do when submit fails validation. See [recipe](./recipes/focus-on-error.md).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| `fieldValidation` | `{ on, debounceMs }`                                                                                          | no       | Live field validation. Default `{ on: 'change', debounceMs: 125 }` — errors track live. Pass `{ on: 'none' }` to opt out (submit-only). See [recipe](./recipes/field-level-validation.md).                                                                                                                                                                                                                                                                                                                                                                          |
-| `persist`         | `FormStorageKind \| FormStorage \| { storage, key?, debounceMs?, include?, version?, clearOnSubmitSuccess? }` | no       | Operational config for the persistence pipeline. Three input forms: a string shorthand (`'local'` / `'session'` / `'indexeddb'`), a custom `FormStorage` adapter passed directly, or the full options bag. Per-field opt-in lives at every `register('foo', { persist: true })` call site — this config alone never causes any field to persist. At mount, stale entries under the same key in non-configured standard backends are wiped (cross-store cleanup); version-mismatched / malformed payloads are wiped on read. See [recipe](./recipes/persistence.md). |
-| `history`         | `true` \| `{ max?: number }`                                                                                  | no       | Enable undo/redo. See [recipe](./recipes/undo-redo.md).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| Field             | Type                                                                                                | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| ----------------- | --------------------------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `schema`          | `z.ZodType`                                                                                         | yes      | The Zod schema describing the form shape.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `key`             | `string`                                                                                            | no       | Form identity. Omit for one-off forms (runtime allocates a synthetic `__cx:anon:<id>` via `useId()`). Pass a string when you need cross-component lookup via `useFormContext(key)`, shared state across call-sites, a stable `persist` storage-key default, or a recognisable DevTools label. Keys starting with `__cx:` are reserved for the library's internal synthetic-key namespace; passing one throws `ReservedFormKeyError`.                                                                                                                                                                                                                                                                                                       |
+| `defaultValues`   | `DeepPartial<Form>`                                                                                 | no       | Constraints applied over schema defaults.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `validationMode`  | `'lax'` \| `'strict'`                                                                               | no       | Defaults to `'strict'` — defaults that fail the schema seed `schemaErrors` at construction. Pass `'lax'` to opt out (multi-step wizards, placeholder rows). See [Types](#types).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `onInvalidSubmit` | `'none'` \| `'focus-first-error'` \| `'scroll-to-first-error'` \| `'both'`                          | no       | What to do when submit fails validation. See [recipe](./recipes/focus-on-error.md).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `fieldValidation` | `{ on, debounceMs }`                                                                                | no       | Live field validation. Default `{ on: 'change', debounceMs: 125 }` — errors track live. Pass `{ on: 'none' }` to opt out (submit-only). See [recipe](./recipes/field-level-validation.md).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `persist`         | `FormStorageKind \| FormStorage \| { storage, key?, debounceMs?, include?, clearOnSubmitSuccess? }` | no       | Operational config for the persistence pipeline. Three input forms: a string shorthand (`'local'` / `'session'` / `'indexeddb'`), a custom `FormStorage` adapter passed directly, or the full options bag. Per-field opt-in lives at every `register('foo', { persist: true })` call site — this config alone never causes any field to persist. Storage keys carry the schema's fingerprint (`${base}:${fingerprint}`) so schema changes auto-invalidate old drafts; the orphan-cleanup pass on mount sweeps stale-fingerprint entries on the configured backend AND wipes any matching keys on the non-configured standard backends (cross-store cleanup). Malformed payloads are wiped on read. See [recipe](./recipes/persistence.md). |
+| `history`         | `true` \| `{ max?: number }`                                                                        | no       | Enable undo/redo. See [recipe](./recipes/undo-redo.md).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 
 ### `zodAdapter(schema)`
 
@@ -262,20 +262,43 @@ piece of form state as a named field. Grouped by concern:
 
 ### Reading values
 
-| Member                   | Type                            | What it does                                                        |
-| ------------------------ | ------------------------------- | ------------------------------------------------------------------- |
-| `getValue()`             | `Readonly<Ref<Form>>`           | Whole form reactive ref.                                            |
-| `getValue(path)`         | `Readonly<Ref<LeafOf<path>>>`   | Single-field ref. Path is `FlatPath<Form>`.                         |
-| `getValue({ withMeta })` | `CurrentValueWithContext<Form>` | Whole form with meta.                                               |
-| `getFieldState(path)`    | `Ref<FieldState>`               | Per-field errors + touched / focused / blurred / isConnected flags. |
+Reads use `NestedReadType<Form, Path>` — once the path crosses a
+numeric segment (e.g. `'posts.0.title'`), every result is
+`T | undefined`. Strict for paths that don't cross arrays; tuple
+positions stay strict (their length is static). Whole-form reads
+return `Readonly<Ref<WithIndexedUndefined<Form>>>` — every unbounded
+array's element type carries `| undefined`. Narrow with `?.` /
+optional checks at array-crossing paths.
+
+| Member                   | Type                                                  | What it does                                                                                                                            |
+| ------------------------ | ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `getValue()`             | `Readonly<Ref<WithIndexedUndefined<Form>>>`           | Whole form reactive ref. Array elements typed `Item \| undefined`.                                                                      |
+| `getValue(path)`         | `Readonly<Ref<NestedReadType<Form, Path>>>`           | Single-field ref. Strict for non-array-crossing paths; `T \| undefined` once a numeric segment is crossed. Tuple positions stay strict. |
+| `getValue({ withMeta })` | `CurrentValueWithContext<WithIndexedUndefined<Form>>` | Whole form with meta. Same read-shape taint.                                                                                            |
+| `getFieldState(path)`    | `Ref<FieldState>`                                     | Per-field errors + touched / focused / blurred / isConnected flags.                                                                     |
 
 ### Writing values
 
-| Member                     | Signature                                                          | What it does                                                                                                                                                                                                                                                     |
-| -------------------------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `setValue(value)`          | `(value: Form) => boolean`                                         | Replace the whole form. Programmatic — does NOT trigger persistence.                                                                                                                                                                                             |
-| `setValue(path, value)`    | `(path, value) => boolean`                                         | Replace a single leaf or sub-tree. Programmatic — does NOT trigger persistence.                                                                                                                                                                                  |
-| `register(path, options?)` | `(path, options?: RegisterOptions) => RegisterValue<LeafOf<path>>` | Produces the binding the `v-register` directive consumes. `options.persist: true` opts the field into the persistence pipeline; `options.acknowledgeSensitive: true` overrides the sensitive-name heuristic. See [persistence recipe](./recipes/persistence.md). |
+Write APIs lead with strictness — `DeepPartial` is gone from both
+forms of `setValue`. Direct writes and the callback form's return
+value need the full write shape at the type level. Runtime
+mergeStructural still completes partials so dynamic / typecast
+inputs don't crash, but the type system points consumers at the
+canonical "give me the whole shape" pattern.
+
+After every `setValue`, the form satisfies the slim schema (the
+structural-completeness invariant): sparse array writes auto-pad
+intermediate indices from the schema's element default, and partial
+object writes get sibling keys filled from the schema. Path-form
+callback `prev` is `NonNullable<NestedType<Form, Path>>` — fully
+defaulted before the callback fires, so consumer code reads
+`prev.first.toUpperCase()` without optional-chaining.
+
+| Member                     | Signature                                                                                                                                    | What it does                                                                                                                                                                                                                                                                                                                                                           |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `setValue(value)`          | `<V extends SetValuePayload<Form, WithIndexedUndefined<Form>>>(value: V) => boolean`                                                         | Replace the whole form. Callback form's `prev` is `WithIndexedUndefined<Form>` (honest about array-index reads). Programmatic — does NOT trigger persistence.                                                                                                                                                                                                          |
+| `setValue(path, value)`    | `<P extends FlatPath<Form>, V extends SetValuePayload<NestedType<Form, P>, NonNullable<NestedType<Form, P>>>>(path: P, value: V) => boolean` | Replace a single leaf or sub-tree. Callback form's `prev` is `NonNullable<NestedType<Form, P>>` — runtime auto-defaults missing slots before the callback fires. Programmatic — does NOT trigger persistence.                                                                                                                                                          |
+| `register(path, options?)` | `(path: P, options?: RegisterOptions) => RegisterValue<NestedReadType<Form, P>>`                                                             | Produces the binding the `v-register` directive consumes. Read shape carries `T \| undefined` at array-crossing paths; the directive renders `undefined` as empty correctly. `options.persist: true` opts the field into persistence; `options.acknowledgeSensitive: true` overrides the sensitive-name heuristic. See [persistence recipe](./recipes/persistence.md). |
 
 ### Validation + submission
 
@@ -414,6 +437,8 @@ import type {
   HandleSubmit,
   HistoryConfig,
   DefaultValuesResponse,
+  IsTuple,
+  NestedReadType,
   NestedType,
   OnError,
   OnInvalidSubmitPolicy,
@@ -426,6 +451,8 @@ import type {
   PersistIncludeMode,
   ReactiveValidationStatus,
   RegisterValue,
+  SetValueCallback,
+  SetValuePayload,
   SettledValidationStatus,
   SubmitHandler,
   UseAbstractFormReturnType,
@@ -434,6 +461,7 @@ import type {
   ValidationMode,
   ValidationResponse,
   ValidationResponseWithoutValue,
+  WithIndexedUndefined,
 } from '@chemical-x/forms'
 ```
 
@@ -441,7 +469,30 @@ The ones you'll touch most:
 
 - **`FlatPath<Form>`** — union of every addressable path for the
   form. Dotted strings.
-- **`NestedType<Form, Path>`** — the leaf type at `Path`.
+- **`NestedType<Form, Path>`** — the strict leaf type at `Path`.
+  Used for write-side APIs (`setValue` value argument) and for
+  the path-form callback's `prev` (the runtime auto-defaults the
+  slot before invoking the callback).
+- **`NestedReadType<Form, Path>`** — the read-side leaf type. Walks
+  the path tracking whether a numeric segment was crossed; once
+  tainted, all subsequent results are `T | undefined`. Tuple
+  positions stay strict. Used by `getValue` and `register`'s
+  return type.
+- **`WithIndexedUndefined<T>`** — recursive transform that taints
+  every unbounded array's element type with `| undefined`. Tuples,
+  `Date`, `RegExp`, `Map`, `Set`, and functions pass through
+  untouched. Whole-form reads use this shape.
+- **`IsTuple<T>`** — `true` for tuples (literal `length`), `false`
+  for unbounded arrays (`length: number`). Used internally by
+  `WithIndexedUndefined` and `NestedReadType` to decide whether to
+  taint.
+- **`SetValuePayload<Write, Read = Write>`** — union of `Write` and
+  `SetValueCallback<Read>`. The whole-form `setValue`
+  parameterises `Read` to `WithIndexedUndefined<Form>`; the path-
+  form parameterises `Read` to `NonNullable<NestedType<F, P>>`.
+- **`SetValueCallback<Read>`** — `(prev: Read) => Read`. The
+  callback's return shape matches its input shape; runtime
+  mergeStructural completes any structural gaps.
 - **`ArrayPath<Form>`** — `FlatPath<Form>` filtered to array-leaf
   paths. Used by `append` / `remove` / etc.
 - **`ArrayItem<Form, Path>`** — the element type of the array at
@@ -454,5 +505,10 @@ focused, blurred, updatedAt }`.
   the data layer reports schema errors immediately when defaults fail.
   Use `'lax'` to opt out (multi-step wizards, placeholder rows in field
   arrays, any case where mounting with invalid data is expected).
-- **`AbstractSchema`** — the schema contract. See
+- **`AbstractSchema`** — the schema contract (5 methods:
+  `fingerprint`, `getDefaultValues`, `getDefaultAtPath`,
+  `getSchemasAtPath`, `validateAtPath`). See
   [custom-adapter recipe](./recipes/custom-adapter.md).
+- **`FormStorage`** — the storage contract (4 methods: `getItem`,
+  `setItem`, `removeItem`, `listKeys`). See
+  [persistence recipe](./recipes/persistence.md).

--- a/docs/migration/0.11-to-0.12.md
+++ b/docs/migration/0.11-to-0.12.md
@@ -1,11 +1,20 @@
 # Migrating from 0.11.x to 0.12.x
 
-The validation refactor. Errors are now a pure function of
-`(value, schema) + injected user errors`, and the data layer that
-holds them is fully separable from the rendering layer that decides
-when to show them.
+Two themes:
 
-Eight breaking changes:
+- **Validation refactor.** Errors are now a pure function of
+  `(value, schema) + injected user errors`, and the data layer that
+  holds them is fully separable from the rendering layer that
+  decides when to show them.
+- **Structural-completeness invariant + read-type honesty.** Every
+  `setValue` write now leaves the form satisfying the slim schema
+  (so consumer code can read `prev.first.toUpperCase()` without
+  optional-chaining), persisted-draft keys carry a schema
+  fingerprint that auto-invalidates across deploys with no manual
+  `version` bump, and `getValue` / `register` return `T | undefined`
+  once the path crosses an array index segment.
+
+Thirteen breaking changes:
 
 1. `fieldValidation.on` defaults to `'change'` (was `'none'`).
 2. `validationMode` defaults to `'strict'` (was `'lax'`) — combined
@@ -14,9 +23,9 @@ Eight breaking changes:
 3. Errors are split: `setFieldErrors` / `addFieldErrors` write to
    a separate user-error store and survive both schema revalidation
    AND successful submits.
-4. Persisted payloads bumped to `v: 2` — the wire format carries
-   `schemaErrors` + `userErrors` instead of a single flat `errors`
-   field.
+4. Persisted payloads bumped to `v: 2` (cx-internal envelope) —
+   the wire format carries `schemaErrors` + `userErrors` instead of
+   a single flat `errors` field.
 5. SSR / `FormStoreHydration` + `SerializedFormData` types split
    into `schemaErrors` + `userErrors` — bare-Vue SSR consumers who
    read these types directly need to update their hand-rolled
@@ -37,13 +46,47 @@ Eight breaking changes:
    form's setter surface is now just `setFieldErrors` /
    `addFieldErrors` / `clearFieldErrors`; shape adapters compose on
    top.
+9. **`PersistConfig.version` removed.** Schema-change invalidation
+   now flows from the schema's `fingerprint()`. Storage keys
+   resolve to `${base}:${fingerprint}` automatically; the orphan
+   cleanup pass on mount wipes any pre-fingerprint or stale-
+   fingerprint entries. Delete the `version: N` line from your
+   `persist:` config.
+10. **`AbstractSchema.getDefaultAtPath(path)` is now required.**
+    Custom-adapter authors implement a fifth method that returns
+    the schema-prescribed default at a structured path. The
+    runtime calls it on every `setValue` to fill structural gaps.
+11. **`FormStorage.listKeys(prefix)` is now required.** Custom
+    storage adapters implement a fourth method returning every key
+    whose name starts with `prefix`. Used by the orphan-cleanup
+    pass to find stale fingerprint-suffixed entries. Adapters that
+    can't enumerate (HTTP-backed drafts) can return `[]`.
+12. **`setValue` drops `DeepPartial`** in both forms. Direct writes
+    and the callback's return value now need the full write shape
+    at the type level. Runtime mergeStructural still completes
+    partials so dynamic / typecast inputs don't crash, but the
+    type system now leads with strictness.
+13. **`getValue` and `register` use `NestedReadType<F, P>` instead
+    of `NestedType<F, P>`.** Once a path crosses an array index
+    segment, every result is `T | undefined`. Tuple positions stay
+    strict. Whole-form reads are tainted via
+    `WithIndexedUndefined<Form>` (every unbounded array element
+    becomes `Item | undefined`).
 
-Plus one new behaviour worth knowing:
+Plus two new behaviours worth knowing:
 
-9. Construction-time validation seed: strict-mode forms whose
-   default values fail validation now report errors immediately,
-   before any user interaction. Combined with #2, this is the new
-   default behaviour.
+14. Construction-time validation seed: strict-mode forms whose
+    default values fail validation now report errors immediately,
+    before any user interaction. Combined with #2, this is the new
+    default behaviour.
+15. **Structural-completeness invariant on every `setValue`.**
+    Sparse array writes auto-pad missing indices from the schema's
+    element default; partial value-form writes get
+    structurally-completed via `mergeStructural`; path-form
+    callbacks receive a strict, fully-defaulted `prev` even when
+    the slot was previously empty. See the new
+    [structural-completeness section](#new-structural-completeness-invariant-on-every-setvalue)
+    below.
 
 ## Breaking: live validation by default
 
@@ -161,28 +204,20 @@ is what consumers reach for. With live validation the schema half
 re-populates on the next mutation if the value is still invalid, so
 the inconsistency is short-lived.
 
-## Breaking: persistence payload v2
+## Breaking: persistence payload v2 (cx-internal envelope)
 
-`PersistConfig.version` defaulted to `1` in 0.11; it now defaults to
-`2`. The on-disk shape changed: the `data.errors` flat list is
-replaced by `data.schemaErrors` + `data.userErrors`.
+The on-disk envelope's internal `v` field — written and read by cx
+itself, never set by consumers — bumped from `1` to `2` to carry
+`data.schemaErrors` + `data.userErrors` instead of a single flat
+`data.errors` field. Old v1 payloads are dropped silently on read,
+so users will see a single fresh-defaults render the first time they
+reload after upgrading. No data is lost in the form value itself —
+the next mutation re-persists under v2.
 
-Old v1 payloads are dropped silently on read (the existing
-version-mismatch path in `readPersistedPayload`), so users will see a
-single fresh-defaults render the first time they reload after
-upgrading. No data is lost in the form value itself — the next
-mutation re-persists under v2.
-
-If your consumer pinned an explicit `version`, bump it past the old
-number to invalidate the old shape:
-
-```diff
-  persist: {
-    storage: 'local',
--   version: 3,
-+   version: 4,
-  }
-```
+The `v` field stays as an internal storage-format invariant. We bump
+it only when the on-disk shape changes; consumers don't (and now
+can't) set it. See the next section for what replaced the old
+consumer-facing `version` knob.
 
 If you parse the persisted payload externally (uncommon — most
 consumers go through cx's reader), update field references:
@@ -192,6 +227,346 @@ consumers go through cx's reader), update field references:
 + payload.data.schemaErrors  // validation-owned
 + payload.data.userErrors    // API-injected
 ```
+
+## Breaking: `PersistConfig.version` removed — fingerprint takes over
+
+**0.11:** consumers passed `persist: { storage: 'local', version: 3 }`
+and bumped `version` whenever the schema changed shape. The library
+treated `version` mismatch as a "different shape" signal and dropped
+the old payload on read. The coupling was manual — consumers had to
+remember to bump on every relevant schema edit, and forgetting it
+left stale data on disk that wouldn't deserialize cleanly into the
+new shape. Bumping more often than needed (defensively, per release)
+silently dropped users' draft state when nothing about the form had
+actually changed.
+
+**0.12:** the schema's `fingerprint()` is the canonical "shape
+changed" signal. Storage keys now resolve to `${base}:${fingerprint}`
+automatically — a schema change produces a different fingerprint, the
+old key becomes unreachable, and the orphan-cleanup pass on the next
+mount wipes the stale entry. No manual bump, no possibility of
+forgetting it, no dropped drafts when only refinement logic changed.
+
+```diff
+  persist: {
+    storage: 'local',
+-   version: 3,
+  }
+```
+
+The `version` field is gone — pass it and the typechecker rejects.
+Any code path that read the consumer-facing `version` config now
+goes through `state.schema.fingerprint()` instead.
+
+The cx-internal envelope `v` (see the previous section) stays at
+`2` — it's a different number that flips on internal storage-format
+changes only. Consumers shouldn't (and now can't) set it.
+
+### What this looks like on disk
+
+```text
+0.11: chemical-x-forms:signup     (one key, payload contains v: 1)
+0.12: chemical-x-forms:signup:7c3a0b  (key carries fingerprint suffix)
+```
+
+A schema change in 0.12 produces a different fingerprint:
+
+```text
+chemical-x-forms:signup:7c3a0b   (old, orphaned at next mount)
+chemical-x-forms:signup:9d2b1f   (new, current — written on first mutation)
+```
+
+The orphan cleanup pass on mount enumerates keys under
+`chemical-x-forms:signup` (via the new `FormStorage.listKeys`
+method), keeps the current-fingerprint entry, and removes the rest.
+Pre-0.12 keys without a fingerprint suffix are also treated as
+orphans and swept.
+
+### Migration
+
+Three concrete changes:
+
+```diff
+  useForm({
+    schema,
+    key: 'signup',
+    persist: {
+      storage: 'local',
+-     version: 3,
+    },
+  })
+```
+
+If you parse persisted payloads outside cx (custom inspectors, server-
+side draft replication, etc.), the storage key is no longer the bare
+configured key — read keys via `listKeys('chemical-x-forms:signup')`
+and pick the one matching your current schema's fingerprint, OR
+delegate to cx's reader (it already does this).
+
+If your custom `FormStorage` adapter can't enumerate (HTTP-backed,
+cookie-backed, etc.), implement `listKeys` to return `[]`. Orphan
+cleanup degrades gracefully on those backends — the `${base}` key no
+longer exists in 0.12 (everything carries a fingerprint suffix), so
+there's nothing for cleanup to find anyway.
+
+## Breaking: `AbstractSchema.getDefaultAtPath(path)` is now required
+
+Custom-adapter authors must implement a fifth method:
+
+```ts
+type AbstractSchema<Form, GetValueFormType = Form> = {
+  fingerprint(): string
+  getDefaultValues(config): DefaultValuesResponse<Form>
++ getDefaultAtPath(path: Path): unknown
+  getSchemasAtPath(path: Path): AbstractSchema<unknown, GetValueFormType>[]
+  validateAtPath(data, path): Promise<ValidationResponse<Form>>
+}
+```
+
+Returns the schema-prescribed default at a structured path:
+
+| Schema position at `path`        | Returns                                              |
+| -------------------------------- | ---------------------------------------------------- |
+| Object property                  | The property's default                               |
+| Array index                      | The element schema's default                         |
+| Tuple position                   | The position's default                               |
+| Optional / nullable + structural | Inner default (peel the wrapper)                     |
+| Optional + primitive             | `undefined` (preserve the "absent allowed" semantic) |
+| Nullable + primitive             | `null`                                               |
+| `.default(x)` wrapper            | `x` (the explicit default wins)                      |
+| Discriminated union              | First variant's default                              |
+| Path doesn't exist in schema     | `undefined`                                          |
+
+The Zod adapters ship the implementation out of the box. For custom
+adapters, see the
+[custom-adapter recipe](../recipes/custom-adapter.md) for the full
+contract and an example. Both adapter test suites
+(`test/adapters/zod-v4/get-default-at-path.test.ts` and the v3
+mirror) double as a behavioural spec — port the cases to your
+adapter's test suite.
+
+The runtime calls `getDefaultAtPath` on every `setValue` to fill
+structural gaps; without it, partial writes leak through and break
+the new structural-completeness invariant. Throwing or returning the
+wrong shape will surface immediately as a failing
+mergeStructural / setAtPathWithSchemaFill in any consumer code that
+exercises sparse array writes or partial object writes.
+
+## Breaking: `FormStorage.listKeys(prefix)` is now required
+
+Custom storage adapters implement a fourth method:
+
+```ts
+interface FormStorage {
+  getItem(key: string): Promise<unknown>
+  setItem(key: string, value: unknown): Promise<void>
+  removeItem(key: string): Promise<void>
++ listKeys(prefix: string): Promise<string[]>
+}
+```
+
+Returns every key in the backend whose name starts with `prefix`.
+Used by the orphan-cleanup pass to find stale fingerprint-suffixed
+entries on mount.
+
+Built-in backends (`'local'`, `'session'`, `'indexeddb'`) ship
+implementations. Custom adapters that can't enumerate (HTTP-backed
+drafts behind a server, cookie-backed storage, native-mobile bridges
+without a list API) can return `[]`:
+
+```ts
+const restAdapter: FormStorage = {
+  async getItem(k) {
+    /* ... */
+  },
+  async setItem(k, v) {
+    /* ... */
+  },
+  async removeItem(k) {
+    /* ... */
+  },
+  async listKeys(_prefix) {
+    return []
+  },
+}
+```
+
+Returning `[]` disables orphan cleanup on that backend — schema
+changes still pick up new fingerprint keys (writes go to the new
+key), but old keys aren't actively swept. For HTTP backends with a
+list endpoint, implementing it is straightforward and worth doing.
+
+## Breaking: `setValue` drops `DeepPartial`
+
+**0.11:** both `setValue(value)` and `setValue(path, value)` typed
+their value argument as `DeepPartial<Form>` / `DeepPartial<Leaf>`.
+Consumers could write `setValue('user', { name: 'X' })` even when
+the schema required `{ name, age, email }` — the runtime padded
+missing keys with `undefined`. That worked in some cases, broke in
+others, and the type system never warned at the call site.
+
+**0.12:** `setValue` types lead with strictness. Direct writes and
+the callback's return value now need the full write shape:
+
+```diff
+  // Schema: { name: string, age: number, email: string }
+- form.setValue('user', { name: 'Carol' })  // 0.11: typechecks, runtime backfills age + email
++ form.setValue('user', { name: 'Carol', age: 0, email: '' })  // explicit
++ form.setValue('user', prev => ({ ...prev, name: 'Carol' }))  // spread the existing value
+```
+
+Runtime mergeStructural still completes partials at runtime — dynamic
+inputs from `JSON.parse`, server payloads, and similar typecast
+sources don't crash. The type system just stops endorsing the partial
+shape at the call site.
+
+Path-form callback `prev` is `NonNullable<NestedType<Form, Path>>` —
+the runtime auto-defaults missing slots from the schema before
+invoking the callback, so consumer code doesn't need
+`prev?.first ?? ''` defensive reads:
+
+```diff
+- form.setValue('user.name', prev => (prev ?? '').toUpperCase())
++ form.setValue('user.name', prev => prev.toUpperCase())  // strict — prev is string
+```
+
+Whole-form callback `prev` is `WithIndexedUndefined<Form>` — array
+reads narrow to `Item | undefined`:
+
+```ts
+form.setValue((prev) => {
+  // prev.posts is ReadonlyArray<Post | undefined>
+  const head = prev.posts[0] // Post | undefined — narrow before use
+  if (!head) return prev
+  return { ...prev, lastTitle: head.title }
+})
+```
+
+For genuine partial writes (the common "I want to update one key
+and inherit the rest"), the callback form is the typed-correct
+pattern — `prev` is fully defaulted and you spread the rest:
+
+```ts
+form.setValue('user', (prev) => ({ ...prev, name: 'Carol' }))
+```
+
+## Breaking: `getValue` and `register` use `NestedReadType<F, P>`
+
+**0.11:** `getValue('posts.0.title')` was typed `Readonly<Ref<string>>`
+even when `posts[0]` could be undefined at runtime (sparse array,
+deleted index, fresh-mount empty). The type lied — consumer code
+wrote `.toUpperCase()` against a value that could be `undefined` and
+crashed at runtime.
+
+**0.12:** every read API uses `NestedReadType<F, P>`, which walks the
+path tracking whether a numeric segment was crossed. Once tainted,
+all subsequent results carry `| undefined`:
+
+```ts
+form.getValue('email') // Readonly<Ref<string>> — no array crossing
+form.getValue('posts.0.title') // Readonly<Ref<string | undefined>> — tainted
+form.getValue('coords.0') // Readonly<Ref<string>> — tuple position, NOT tainted
+form.getValue() // Readonly<Ref<WithIndexedUndefined<Form>>>
+```
+
+Tuple positions stay strict — a tuple's length is a static literal,
+so out-of-bounds is a type-system error rather than a runtime case.
+
+`register('posts.0.title')` returns
+`RegisterValue<string | undefined>` similarly. The directive's
+binding handles `undefined` correctly (renders as empty), so most
+consumers never notice.
+
+Migration: where you read array-crossing paths, narrow:
+
+```diff
+  const title = form.getValue('posts.0.title')
+
+- // 0.11: title.value is `string`. Wrong — could be undefined.
+- const upper = title.value.toUpperCase()
+
++ // 0.12: title.value is `string | undefined`. Narrow first.
++ const upper = title.value?.toUpperCase() ?? ''
+```
+
+For paths that don't cross an array, no change is needed.
+
+The path-form callback's `prev` is the only "honest read" exception:
+it's `NonNullable<NestedType<Form, Path>>` because the runtime
+auto-defaults the slot before the callback fires.
+
+## New: structural-completeness invariant on every `setValue`
+
+After every `setValue` write, the form is guaranteed to satisfy the
+slim schema (objects/arrays/primitives without refines). Three
+concrete consequences:
+
+### Sparse array writes auto-pad
+
+```ts
+const form = useForm({
+  schema: z.object({ posts: z.array(z.object({ title: z.string() })) }),
+  key: 'blog',
+})
+
+// posts is initially []
+form.setValue('posts.21.title', 'twenty-second')
+
+// After: posts.length === 22
+// posts[0..20] are filled with the schema's element default ({ title: '' })
+// posts[21] is { title: 'twenty-second' }
+```
+
+The runtime walks the path, fills missing intermediates from
+`getDefaultAtPath`, and writes the value at the leaf. No more
+`undefined` holes between known indices.
+
+### Partial value-form writes get structurally completed
+
+```ts
+const form = useForm({
+  schema: z.object({ user: z.object({ name: z.string(), age: z.number() }) }),
+  key: 'profile',
+})
+
+form.setValue('user', { name: 'Carol' } as User) // type-cast to bypass strict typing
+
+// After: user is { name: 'Carol', age: 0 } — `age` filled from schema default
+```
+
+`mergeStructural` walks the consumer's value and the schema's
+default in parallel, filling missing keys with their defaults.
+Consumer-only keys (validation flags, metadata) are preserved.
+Date / Map / Set / class instances pass through whole — no recursion
+into opaque structural types.
+
+### Path-form callback `prev` is strict
+
+```ts
+const form = useForm({
+  schema: z.object({
+    user: z.object({ name: z.string(), age: z.number() }).optional(),
+  }),
+  key: 'profile',
+})
+
+// user is initially undefined
+form.setValue('user', (prev) => ({ ...prev, name: 'Carol' }))
+// prev is { name: '', age: 0 } — auto-defaulted from the schema before the callback fires
+// Result: user is { name: 'Carol', age: 0 }
+```
+
+The callback no longer needs `prev?.name ?? ''` defensive reads —
+`prev` is `NonNullable<NestedType<Form, Path>>` and runtime-correct.
+
+### Performance
+
+The fast path (writes to slots that already exist) skips schema
+lookups entirely — the runtime walks the existing tree and writes
+the leaf. Schema lookups fire only when a write actually hits a
+structural gap. Sparse-array padding caches the element default
+once per call (so a write to `posts.21` against an empty array is
+O(N) array fills + 1 schema lookup, not O(N×schema-traversal)).
 
 ## Breaking: SSR / FormStoreHydration shape
 
@@ -382,11 +757,10 @@ In dev mode, cx logs a one-time warning if `persist:` is configured
 but no field opts in within the first frame — the common confusion
 mode where the framework is wired up but drafts never save.
 
-The shipped `persist.version` default stayed at `2`; old payloads
-(written before this change) stay readable because they're a
-superset of the new sparse shape — you'll see one fresh-defaults
-render the first time you reload, then on the next mutation the
-payload re-persists as sparse.
+Old payloads (written before this change) stay readable because
+they're a superset of the new sparse shape — you'll see one fresh-
+defaults render the first time you reload, then on the next mutation
+the payload re-persists as sparse.
 
 ### Shorthand `persist:` config
 
@@ -400,7 +774,7 @@ useForm({ persist: encryptedStorage }) // = { storage: encryptedStorage }
 ```
 
 Pass the full options bag whenever you need to override `key`,
-`debounceMs`, `version`, etc.
+`debounceMs`, `include`, or `clearOnSubmitSuccess`.
 
 ### Cross-store cleanup at mount + auto-wipe of stale entries
 
@@ -408,17 +782,20 @@ The configured `storage` is the source of truth for "where the draft
 lives now." On every mount:
 
 - Standard backends (`'local'`, `'session'`, `'indexeddb'`) NOT
-  matching the configured one get a `removeItem(key)` (fire-and-
-  forget). A migration `'local'` → `'session'` (or
-  `'local'` → encrypted custom adapter) can no longer orphan PII /
-  sensitive fields in the abandoned backend. Configuring a custom
-  `FormStorage` sweeps all three standard backends — we can't reach
-  custom adapters by enumeration, so a custom→custom migration is on
-  the consumer.
-- A non-empty raw value that fails to parse (version mismatch,
-  malformed envelope, corrupted JSON) is wiped from the configured
-  backend on the read. Bumping `persist.version` no longer leaves the
-  old payload bytes sitting in storage indefinitely.
+  matching the configured one get scanned via `listKeys` and any
+  matching keys are `removeItem`'d (fire-and-forget). A migration
+  `'local'` → `'session'` (or `'local'` → encrypted custom adapter)
+  can no longer orphan PII / sensitive fields in the abandoned
+  backend. Configuring a custom `FormStorage` sweeps all three
+  standard backends — we can't reach custom adapters by enumeration,
+  so a custom→custom migration is on the consumer.
+- The configured backend itself is also scanned for stale-fingerprint
+  orphans under the same key prefix. Schema changes produce a new
+  fingerprint suffix; old entries become unreachable and are cleaned
+  up by the same pass.
+- A non-empty raw value that fails to parse (cx-internal envelope-
+  version mismatch, malformed envelope, corrupted JSON) is wiped
+  from the configured backend on the read.
 
 "Truly absent" entries (the key was never set) are a no-op — the
 wipe only fires when there's actually something to clean.
@@ -503,6 +880,20 @@ for the full pattern.
 - `validate()` reactive ref still returns schema-only results — its
   contract is unchanged. Use `fieldErrors` or
   `getFieldState(path).errors` for the merged view.
-- Storage adapter contracts (`FormStorage`), the storage-key
-  namespace (`PERSISTENCE_KEY_PREFIX`), `clearOnSubmitSuccess`, the
-  SSR / hydration bridge — all unchanged.
+- The storage-key namespace (`PERSISTENCE_KEY_PREFIX`),
+  `clearOnSubmitSuccess`, the SSR / hydration bridge — all unchanged.
+  (Note: `FormStorage` itself gained a required `listKeys(prefix)`
+  method — see the breaking-changes list above. The other three
+  methods on the contract are unchanged.)
+- The runtime data shape (`form.value`) is unchanged. The
+  `setValue` / `getValue` / `register` _types_ tightened (no more
+  `DeepPartial` writes; reads carry `| undefined` after array
+  crossings), but the values flowing through at runtime are the
+  same — the structural-completeness invariant guarantees the form
+  never holds a partially-filled object that the type system
+  promises is whole.
+- Reset semantics (`reset(next?)`, `resetField(path)`) keep
+  `DeepPartial<Form>` for the override argument — reset is
+  intentionally partial (override-by-key against schema defaults).
+  Same for `UseFormConfiguration.defaultValues` and the
+  `getDefaultValues` adapter method's `constraints` argument.

--- a/docs/recipes/custom-adapter.md
+++ b/docs/recipes/custom-adapter.md
@@ -7,12 +7,13 @@ without forking the library.
 
 ## The contract
 
-Four methods:
+Five methods:
 
 ```ts
 type AbstractSchema<Form, GetValueFormType = Form> = {
   fingerprint(): string
   getDefaultValues(config): DefaultValuesResponse<Form>
+  getDefaultAtPath(path: Path): unknown
   getSchemasAtPath(path: Path): AbstractSchema<unknown, GetValueFormType>[]
   validateAtPath(data: unknown, path: Path | undefined): Promise<ValidationResponse<Form>>
 }
@@ -21,11 +22,16 @@ type AbstractSchema<Form, GetValueFormType = Form> = {
 - **`fingerprint()`** — structural signature of the schema. Two
   schemas with the same shape must return the same string; two
   schemas with different shapes should (best-effort) return
-  different strings. Used to detect shared-key mismatches — see
+  different strings. Used to detect shared-key mismatches AND to
+  key persisted drafts — see
   [Fingerprint implementation](#fingerprint-implementation).
 - **`getDefaultValues({ useDefaultSchemaValues, constraints, validationMode })`**
   — returns `{ data, errors, success, formKey }`. Called at form
   creation and on `reset()`.
+- **`getDefaultAtPath(path)`** — returns the schema-prescribed
+  default at a structured path. The runtime calls this on every
+  `setValue` to fill structural gaps. See
+  [getDefaultAtPath](#getdefaultatpath) below.
 - **`getSchemasAtPath(path)`** — returns the list of sub-schemas
   at `path`. `path` is the canonical `Segment[]`, not a dotted
   string. Advanced introspection hook; return `[]` if you don't
@@ -42,7 +48,14 @@ error only if your parser is genuinely misbehaving.
 catches the exception, logs it via `console.error` in dev, and
 skips the shared-key mismatch check for that call. An opaque
 stable string (`'custom-adapter:v1'`) is a valid fallback when
-your schema library is hard to introspect.
+your schema library is hard to introspect — note that opaque
+fingerprints disable schema-change auto-invalidation for
+persisted drafts (the key never changes), so prefer a real
+structural hash if your library exposes the metadata.
+
+`getDefaultAtPath` must NOT throw. Return `undefined` for paths
+that don't exist in the schema; the runtime treats that as
+"don't fill" and falls back to the existing data.
 
 ## A minimal Valibot-ish adapter
 
@@ -78,6 +91,22 @@ export function myLibAdapter<F extends GenericForm>(schema: MyLibSchema<F>): Abs
       const defaults = schema.defaultValues()
       const merged = mergeDeepPartial(defaults, constraints)
       return { data: merged, errors: undefined, success: true, formKey: '' }
+    },
+
+    getDefaultAtPath(path) {
+      // Walk the schema to `path` and return the default at that
+      // node. The runtime uses this to fill structural gaps on
+      // every setValue (sparse array writes, partial object writes,
+      // path-form callback prev auto-default).
+      //
+      // Concretely: empty path → whole-form default; object property
+      // → property's default; array index → element default; tuple
+      // position → position's default; optional/nullable around a
+      // structural inner → inner default; optional/nullable around
+      // a primitive → undefined / null (preserve the wrapper's
+      // semantic); .default(x) wrapper → x. Return undefined for
+      // paths that don't exist in the schema.
+      return walkSchemaToDefault(schema, path)
     },
 
     getSchemasAtPath(_path) {
@@ -183,6 +212,85 @@ See `src/runtime/adapters/zod-v4/fingerprint.ts` for a full
 walker with factory-default idempotence and shared-reference
 handling.
 
+## getDefaultAtPath
+
+The runtime's structural-completeness invariant — every `setValue`
+write leaves the form satisfying the slim schema — depends on this
+method returning a sane default at any path. Three concrete
+runtime callers:
+
+- **`mergeStructural`**, when a partial value-form write hits a
+  schema key the consumer didn't supply. Asks for the default at
+  the missing sub-path and fills it in.
+- **`setAtPathWithSchemaFill`**, when a sparse array write
+  (`setValue('posts.21', cb)` against an empty array) needs to pad
+  intermediate indices. Asks for the element default once and reuses
+  it.
+- **Path-form callback prev auto-default**, when the consumer
+  writes `setValue('user', prev => ({ ...prev, name: 'X' }))` and
+  the slot was previously empty. The runtime calls
+  `getDefaultAtPath(['user'])` and feeds the result to the callback.
+
+### The peeling rule
+
+Wrappers around _structural_ types peel; wrappers around
+_primitive_ leaves don't:
+
+```ts
+// schema.profile is z.object({...}).optional()
+getDefaultAtPath(['profile']) // returns { name: '', age: 0 }  — peel
+getDefaultAtPath(['profile', 'name']) // returns ''            — peel + descend
+
+// schema.notes is z.string().optional()
+getDefaultAtPath(['notes']) // returns undefined  — DO NOT peel
+// (peeling would return '' and break mergeStructural — the wrapper's
+// "absent allowed" semantic gets lost when filling sibling keys)
+
+// schema.role is z.string().default('user')
+getDefaultAtPath(['role']) // returns 'user'  — explicit default wins
+```
+
+If your library exposes wrapper introspection, classify each
+wrapper-inner combo: `OptionalString` / `NullableNumber` /
+`OptionalBoolean` etc. preserve the wrapper semantic; everything
+else peels to the inner default.
+
+### Return values for special positions
+
+| Position                     | Return                                      |
+| ---------------------------- | ------------------------------------------- |
+| Empty path `[]`              | The whole-form default                      |
+| Object property `['user']`   | The property's default                      |
+| Array index `['posts', 0]`   | Element schema's default — same for any `N` |
+| Tuple position `['xy', 1]`   | Position-specific default                   |
+| Tuple past length            | `undefined` (signal: don't pad)             |
+| Discriminated union root     | First variant's default                     |
+| Discriminated union sub-path | Matching variant's value (or first variant) |
+| Path doesn't exist in schema | `undefined`                                 |
+
+### Testing
+
+The Zod adapter test suites
+(`test/adapters/zod-v4/get-default-at-path.test.ts` and the v3
+mirror) double as a behavioural spec — port the cases to your
+adapter's test suite. Minimum coverage:
+
+- Object property path returns property's default.
+- `.default(x)` wrapper returns `x`.
+- Array index path returns element default for any `N`.
+- Nested defaults through array → object → array.
+- Tuple position-specific defaults; tuple-past-length →
+  `undefined`.
+- Optional/Nullable around structural inner peels.
+- Optional/Nullable around primitive PRESERVES wrapper semantic
+  (`undefined`/`null`).
+- Discriminated union returns first variant's default at the union
+  root.
+- Discriminated union descends into the matching variant for
+  variant-specific keys.
+- Record returns value-type default for any string key.
+- Non-existent paths return `undefined`.
+
 ## Validating a single path
 
 When the library needs to re-check just one field, it passes a
@@ -220,6 +328,13 @@ Minimum coverage:
 
 - `getDefaultValues` returns schema defaults when no `constraints`.
 - `getDefaultValues` merges `constraints` over defaults.
+- `getDefaultAtPath` returns the property default for object paths.
+- `getDefaultAtPath` returns the element default for array indices.
+- `getDefaultAtPath` returns the inner default through structural
+  wrappers (peels Optional/Nullable around objects; preserves them
+  around primitives).
+- `getDefaultAtPath` returns `undefined` for paths not in the
+  schema.
 - `validateAtPath` returns `{ success: true }` for valid input.
 - `validateAtPath` returns structured `ValidationError[]` for invalid input.
 - `validateAtPath(undefined)` validates the whole form.
@@ -233,4 +348,9 @@ Minimum coverage:
 The v4 adapter's test suite (`test/adapters/zod-v4/`) is the
 template. Add a fast-check property test over random forms if your
 adapter does non-trivial path walking —
-`test/core/diff-apply.property.test.ts` shows the pattern.
+`test/core/diff-apply.property.test.ts` shows the pattern. Pair the
+adapter tests with the runtime structural-completeness regressions
+at `test/composables/set-value-schema-fill-regression.test.ts` —
+those drive `getDefaultAtPath` end-to-end through `setValue`, so a
+broken adapter implementation surfaces as a test failure with a
+clear "schema didn't fill X" diagnostic.

--- a/docs/recipes/dynamic-field-arrays.md
+++ b/docs/recipes/dynamic-field-arrays.md
@@ -113,8 +113,11 @@ are OK.
 
 ## getValue vs getFieldState
 
-- `getValue('posts.0.title')` → `Readonly<Ref<string>>`. Use for the
-  value.
+- `getValue('posts.0.title')` → `Readonly<Ref<string | undefined>>`.
+  Reads carry `| undefined` once a path crosses an array index — at
+  runtime, `posts[0]` could be missing (sparse, deleted, fresh-mount
+  empty). Narrow with `?.` / optional checks before non-null
+  operations. Tuple positions stay strict (their length is static).
 - `getFieldState('posts.0.title')` → `Ref<FieldState>`. Use for
   errors + touched / focused / blurred.
 
@@ -127,6 +130,16 @@ are OK.
     </span>
   </div>
 </template>
+```
+
+The directive's `v-register` binding handles `undefined` correctly
+(renders empty), so most templates don't need defensive narrowing.
+Defensive narrowing matters when scripts read the value:
+
+```ts
+const title = form.getValue('posts.0.title')
+// title.value is `string | undefined`.
+const upper = title.value?.toUpperCase() ?? ''
 ```
 
 ## Stale state on removal
@@ -152,3 +165,39 @@ the whole array. For a large seed, assign in one shot:
 ```ts
 form.setValue('items', nextArray) // O(N), one assignment
 ```
+
+`setValue` types lead with the full element shape — pass elements
+matching the schema's element type. If you have partial elements
+from a server payload (some keys missing), the runtime
+mergeStructural fills missing keys from the schema's element
+default, so the bulk assignment still produces a structurally
+complete array. The type system points the IDE at the canonical
+"give me the whole shape" pattern at the call site; the runtime
+backstop catches dynamic / server-shaped inputs.
+
+## Sparse-index writes auto-pad
+
+`setValue('posts.21', { ... })` against an empty `posts` array
+fills indices `0..20` with the schema's element default before
+writing index `21`. The structural-completeness invariant means
+the array is never sparse on disk — every index `< length` is a
+fully-shaped element matching the schema:
+
+```ts
+const form = useForm({
+  schema: z.object({ posts: z.array(z.object({ title: z.string() })) }),
+  key: 'blog',
+})
+
+// posts is initially []
+form.setValue('posts.5.title', 'sixth post')
+// posts.length === 6
+// posts[0..4] are { title: '' } (the schema's element default)
+// posts[5] is { title: 'sixth post' }
+```
+
+This makes `posts.length` honest and lets `v-for` over `posts`
+render N rows without filtering for `undefined`. Most consumers
+never write sparse indices intentionally — the invariant just
+means the framework no longer has to guess what to do when one
+slips through.

--- a/docs/recipes/persistence.md
+++ b/docs/recipes/persistence.md
@@ -21,8 +21,8 @@ sensitive-named paths throw at mount unless explicitly acknowledged.
 ## Setup
 
 Configure `useForm` with the operational settings (backend, key,
-debounce window, version, etc.). Three input forms — pick the one
-that reads best at the call site:
+debounce window, etc.). Three input forms — pick the one that reads
+best at the call site:
 
 ```ts
 // Shorthand: built-in backend with library defaults
@@ -35,7 +35,7 @@ useForm({ schema, key: 'signup', persist: encryptedStorage })
 useForm({
   schema,
   key: 'signup',
-  persist: { storage: 'local', debounceMs: 500, version: 3 },
+  persist: { storage: 'local', debounceMs: 500 },
 })
 ```
 
@@ -211,17 +211,19 @@ for the IndexedDB code.
 persist: {
   storage: 'local' | 'session' | 'indexeddb' | FormStorage,
   key?: string,                     // default: chemical-x-forms:${formKey}
+                                    // (the resolved storage key adds a :${fingerprint} suffix automatically)
   debounceMs?: number,              // default 300
   include?: 'form' | 'form+errors', // default 'form'
-  version?: number,                 // default 2 — bump to invalidate old entries
   clearOnSubmitSuccess?: boolean,   // default true
 }
 ```
 
 Note what's NOT here. There's no `fields:` allowlist, no `paths:`
-allowlist, no `redactFields:` blocklist. Persisted fields are
-announced at the `register()` call site — that's the entire opt-in
-surface. The form-level `persist:` config is operational only.
+allowlist, no `redactFields:` blocklist, and no `version:` knob.
+Persisted fields are announced at the `register()` call site —
+that's the entire opt-in surface. Schema-change invalidation flows
+from the schema's fingerprint, not a manual version field. The
+form-level `persist:` config is operational only.
 
 ## Sparse payloads
 
@@ -233,12 +235,16 @@ The persisted payload contains only opted-in paths:
 // register('phone', { persist: true })
 // register('cvv')                     ← no opt-in
 
-// Persisted payload:
+// Persisted payload, written under key chemical-x-forms:signup:${fingerprint}
 {
-  v: 2,
-  data: { form: { email: '…', phone: '…' } }   // no `cvv`
+  v: 2,                                          // cx-internal envelope version
+  data: { form: { email: '…', phone: '…' } }     // no `cvv`
 }
 ```
+
+The `v: 2` field on the envelope is internal to cx — it tracks the
+on-disk format and is bumped only when cx itself changes the
+serialised shape. Consumers don't (and now can't) set it.
 
 On hydration, opted-in fields restore from storage; non-opted fields
 come from schema defaults. The opt-in set can change between mounts
@@ -258,27 +264,55 @@ Errors on non-opted-in paths are dropped from the persisted envelope
 — a persisted error without a persisted value would dangle on
 rehydration.
 
-## Bumping the version on schema change
+## Auto-invalidation on schema change
 
-When you rename a field or change a type, bump `persist.version`.
-Old payloads are dropped on read — users start from schema defaults
-instead of crashing on a shape mismatch. The stale entry is wiped
-from storage at the same time, so old field values can't linger.
+Storage keys carry the schema's structural fingerprint:
 
-```ts
-persist: { storage: 'local', version: 3 }
+```text
+chemical-x-forms:signup:7c3a0b   ← key on disk
+                       └────┘
+                       fingerprint of the current schema
 ```
 
-The same auto-wipe handles malformed-shape entries (corrupted JSON,
-wrong envelope, anything that doesn't match the expected payload
-contract). "Truly absent" entries (the key was never set) are a
-no-op — the wipe only fires when there's actually something to clean.
+When the schema changes shape — adding / removing / renaming a
+field, changing a leaf type, restructuring nested objects — the
+fingerprint changes. New writes go to a new key
+(`chemical-x-forms:signup:9d2b1f`); the old key
+(`chemical-x-forms:signup:7c3a0b`) becomes unreachable.
+
+On the next mount, the orphan-cleanup pass enumerates keys under
+`chemical-x-forms:signup` (via `FormStorage.listKeys`), keeps the
+current-fingerprint entry, and removes the rest. No manual `version`
+bump, no possibility of forgetting it, no draft drops when only
+refinement logic changed (refinements collapse to opaque sentinels
+in the fingerprint).
+
+The same orphan pass also wipes pre-fingerprint legacy entries
+written by older library versions, so upgrading from 0.11 to 0.12
+cleans up cleanly on the next mount.
+
+Malformed-shape entries (corrupted JSON, cx-internal envelope-version
+mismatch, anything that doesn't match the expected payload contract)
+are wiped on read. "Truly absent" entries (the key was never set)
+are a no-op — the wipe only fires when there's actually something to
+clean.
+
+If you need to force-invalidate a draft without changing the schema
+(e.g. shipping an unrelated field-validation tweak that you want
+users to retest from scratch), call `form.clearPersistedDraft()` at
+mount or wrap the schema in a thin no-op layer that perturbs the
+fingerprint. The library deliberately doesn't expose a
+"force-version" knob — most consumers don't need it, and the schema
+fingerprint already captures every legitimate "shape changed"
+signal.
 
 ## Switching backends safely
 
 The configured `storage` is the source of truth for "where the draft
-lives now." Any standard backend NOT matching the configured one gets
-a `removeItem(key)` at mount, fire-and-forget. So if a form was
+lives now." On every mount, the orphan-cleanup pass scans the three
+standard backends (`'local'`, `'session'`, `'indexeddb'`) under the
+form's `key` prefix and removes anything that doesn't match the
+configured backend's current-fingerprint entry. So if a form was
 persisting to `'local'` and you switch to `'session'` (or to a custom
 encrypted adapter), the stale `'local'` entry can't orphan PII or
 sensitive fields.
@@ -291,14 +325,21 @@ useForm({ schema, key: 'signup', persist: 'local' })
 useForm({ schema, key: 'signup', persist: encryptedStorage })
 ```
 
-Custom adapters can't be enumerated, so a custom→custom migration is
-on the consumer. Configuring a custom adapter sweeps all three
-standard backends (the dev might have migrated away from any of them).
+Custom adapters can't be enumerated by the runtime, but cx still
+calls each custom adapter's `listKeys(prefix)` for orphan-suffix
+sweeping on the configured backend itself (see
+[Auto-invalidation on schema change](#auto-invalidation-on-schema-change)).
+Adapters that can't enumerate (HTTP-backed, cookie-backed) return
+`[]` and the sweep degrades gracefully on those backends.
+Configuring a custom adapter still sweeps all three standard
+backends — the dev might have migrated away from any of them.
 
-The cleanup runs once at mount, only touches the `key` your form
-resolves to (default `chemical-x-forms:${formKey}`), and never
-touches the configured backend. Entries other forms wrote to the
-same backend under different keys are untouched.
+The cleanup runs once at mount, only touches the `key` prefix your
+form resolves to (default `chemical-x-forms:${formKey}`), and never
+touches keys outside that prefix. Entries other forms wrote to the
+same backend under different keys are untouched. The exact-or-`:`-
+prefix match prevents collision with sibling forms whose keys share
+a string prefix (e.g. custom keys `my-form` vs `my-form-2`).
 
 ### Removing `persist:` entirely
 
@@ -322,7 +363,7 @@ review pages, or if submit might return a retryable server error).
 
 ## Custom backend
 
-The escape hatch — implement the three-method contract and pass the
+The escape hatch — implement the four-method contract and pass the
 object directly:
 
 ```ts
@@ -339,14 +380,32 @@ const encryptedStorage: FormStorage = {
   async removeItem(key) {
     await fetch(`/api/drafts/${key}`, { method: 'DELETE' })
   },
+  async listKeys(prefix) {
+    // Used by the orphan-cleanup pass to find stale fingerprint-suffixed keys.
+    // Return every key whose name starts with `prefix`. If your backend
+    // can't enumerate (no list endpoint, opaque cookies), return [].
+    const r = await fetch(`/api/drafts?prefix=${encodeURIComponent(prefix)}`)
+    return (await r.json()) as string[]
+  },
 }
 
 useForm({ schema, key: 'signup', persist: { storage: encryptedStorage } })
 ```
 
-All three methods are Promise-returning so sync and async backends
+All four methods are Promise-returning so sync and async backends
 share one shape. `getItem` returns `unknown` so your backend can
 hand back whatever `setItem` received.
+
+`listKeys(prefix)` is what powers schema-change auto-invalidation:
+when the schema's fingerprint changes, the orphan cleanup pass
+enumerates keys under the form's `${base}` prefix and removes any
+that don't match the current fingerprint. Adapters that can't
+enumerate (no list endpoint, cookie-backed, native bridges without
+a list API) return `[]` — orphan cleanup degrades gracefully on
+those backends. Keys still rotate cleanly because writes go to the
+new fingerprint key on every schema change; the only thing missed
+is active sweep of the old key, which the consumer can do manually
+via `form.clearPersistedDraft()` if it matters.
 
 ## Async backends + the "flash of default state"
 
@@ -397,10 +456,14 @@ without grepping.
 - **Cross-form coordination.** Each form persists independently.
   Multiple forms can share a key (and so a FormStore + a persistence
   entry), but they're still one form to the persistence layer.
-- **Schema migrations.** Bumping `version` drops old payloads
-  wholesale. If you need to rename a field without losing state,
-  read the raw entry yourself and massage it before calling
-  `reset()`.
+- **Schema migrations.** Schema changes auto-invalidate old payloads
+  via the fingerprint (the old key becomes unreachable and is swept
+  on the next mount). If you need to rename a field without losing
+  state, read the raw entry yourself before the schema change ships
+  and massage it into the new shape before calling `reset()`. The
+  library deliberately doesn't ship a renaming-aware migration
+  helper — schemas are the contract; renames are a write-once
+  transformation the consumer owns.
 
 ## Gotchas
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -121,9 +121,56 @@ See [0.6 → 0.7 migration](./migration/0.6-to-0.7.md).
 
 ## "Persisted state is gone after a schema change"
 
-Bump `persist.version` when you rename a field or change a type —
-old payloads with a mismatched version are dropped on read. See
-[persistence recipe](./recipes/persistence.md).
+Working as intended. As of 0.12, storage keys carry the schema's
+fingerprint (`${base}:${fingerprint}`). When the schema changes
+shape, the fingerprint changes, the old key becomes unreachable,
+and the orphan-cleanup pass on the next mount removes it. No
+manual `version` bump needed — it's automatic.
+
+If the schema didn't change shape but state was wiped anyway, the
+fingerprint is over-sensitive. Common causes in custom adapters:
+
+- The adapter's `fingerprint()` mixes function-valued metadata
+  (refinement bodies, transform fns) into the hash without
+  collapsing to a sentinel. Two refines of the same shape produce
+  different hashes; consumers see drafts vanish on every refine
+  edit. Collapse functions to `'fn:*'`.
+- The fingerprint includes a timestamp or per-call random ID. It
+  must be a pure function of the schema's structure.
+
+If you genuinely need to invalidate drafts without changing the
+schema (e.g. shipping a security fix that requires fresh state),
+call `form.clearPersistedDraft()` on mount or evict the registry
+entry programmatically.
+
+## "I see `prev?.first ?? ''` getting flagged as redundant"
+
+Working as intended. As of 0.12, the path-form `setValue` callback
+receives a fully-defaulted `prev` — the runtime calls
+`getDefaultAtPath` on missing slots before invoking the callback,
+so consumer code can read `prev.first.toUpperCase()` directly. Drop
+the optional chain.
+
+Whole-form callback `prev` is `WithIndexedUndefined<Form>`, so
+array reads (`prev.posts[5]`) DO carry `| undefined` and need
+narrowing — that's the only case where defensive reads are still
+correct.
+
+## "`getValue('posts.0.title').value.toUpperCase()` started type-erroring"
+
+`NestedReadType` lands in 0.12. Once a `getValue` / `register` path
+crosses an array index, the result carries `| undefined` (the
+runtime can return undefined for out-of-bounds reads). Narrow:
+
+```ts
+form.getValue('posts.0.title').value?.toUpperCase() ?? ''
+```
+
+Or use `getFieldState(...)` if you want errors + presence flags
+alongside the value.
+
+Tuple positions stay strict — out-of-bounds is a type-system error
+on tuples, not a runtime case.
 
 ## "Undo brought back stale field errors"
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,8 @@ export type {
   ReactiveValidationStatus,
   RegisterOptions,
   RegisterValue,
+  SetValueCallback,
+  SetValuePayload,
   SettledValidationStatus,
   SubmitHandler,
   UseAbstractFormReturnType,
@@ -86,7 +88,15 @@ export type {
   WriteMeta,
 } from './runtime/types/types-api'
 
-export type { DeepPartial, FlatPath, GenericForm, NestedType } from './runtime/types/types-core'
+export type {
+  DeepPartial,
+  FlatPath,
+  GenericForm,
+  IsTuple,
+  NestedReadType,
+  NestedType,
+  WithIndexedUndefined,
+} from './runtime/types/types-core'
 
 // Path primitives — exposed for consumers writing custom adapters that
 // need to canonicalise user-provided paths.

--- a/src/runtime/adapters/zod-v3/index.ts
+++ b/src/runtime/adapters/zod-v3/index.ts
@@ -437,24 +437,51 @@ function getNestedZodSchemasAtPath<Schema extends z.ZodSchema>(
 }
 
 /**
- * Peel `.optional()` / `.nullable()` wrappers off a leaf schema so
- * `getDefaultAtPath` returns the STRUCTURAL inner default — what the
- * runtime structural-completeness fill consumes. `.default(x)` and
- * `ZodEffects` stay intact so `getDefaultValuesFromZodSchema` resolves
- * the explicit default / effect-source default correctly.
+ * Peel `.optional()` / `.nullable()` wrappers off a leaf schema ONLY
+ * when the inner type is structurally fillable (object, array, tuple,
+ * record, discriminated/plain union — or itself a peelable wrapper
+ * that resolves to one of those). For primitive inner (ZodString,
+ * ZodNumber, etc.), the wrapper IS the meaningful schema:
+ * `.optional()` means "absent is allowed" → undefined; peeling to
+ * the inner string default `''` would let mergeStructural overwrite
+ * the optional's honest "absent" with a non-empty marker when filling
+ * sibling keys at the parent object. See v4's matching helper for
+ * the long-form rationale.
  */
 function unwrapStructuralLeafV3(schema: z.ZodTypeAny): z.ZodTypeAny {
   let current: z.ZodTypeAny = schema
   for (let i = 0; i < 64; i++) {
-    if (isZodSchemaType(current, 'ZodOptional') || isZodSchemaType(current, 'ZodNullable')) {
-      const inner = current._def.innerType as z.ZodTypeAny | undefined
-      if (!inner) return current
-      current = inner
-      continue
+    if (!(isZodSchemaType(current, 'ZodOptional') || isZodSchemaType(current, 'ZodNullable'))) {
+      break
     }
-    break
+    const inner = current._def.innerType as z.ZodTypeAny | undefined
+    if (!inner) return current
+    if (!isStructuralV3Kind(inner)) break
+    current = inner
   }
   return current
+}
+
+/**
+ * v3 mirror of v4's `isStructuralKind` — kinds for which the inner is
+ * recursable by mergeStructural. Anything else is a primitive leaf
+ * where the wrapper carries the meaningful default semantic.
+ */
+function isStructuralV3Kind(schema: z.ZodTypeAny): boolean {
+  return (
+    isZodSchemaType(schema, 'ZodObject') ||
+    isZodSchemaType(schema, 'ZodArray') ||
+    isZodSchemaType(schema, 'ZodRecord') ||
+    isZodSchemaType(schema, 'ZodTuple') ||
+    isZodSchemaType(schema, 'ZodUnion') ||
+    isZodSchemaType(schema, 'ZodDiscriminatedUnion') ||
+    // Wrappers that themselves resolve to a structural type — keep
+    // peeling at the next iteration.
+    isZodSchemaType(schema, 'ZodOptional') ||
+    isZodSchemaType(schema, 'ZodNullable') ||
+    isZodSchemaType(schema, 'ZodDefault') ||
+    isZodSchemaType(schema, 'ZodEffects')
+  )
 }
 
 /**

--- a/src/runtime/adapters/zod-v3/index.ts
+++ b/src/runtime/adapters/zod-v3/index.ts
@@ -229,6 +229,19 @@ export function zodAdapter<
           formKey: _formKey,
         }
       },
+      getDefaultAtPath(path) {
+        // Empty path → root default. Reuses the same generator used at
+        // form construction so refines / wrappers behave consistently.
+        if (path.length === 0) {
+          return getDefaultValuesFromZodSchema(_zodSchema, true, _formKey)
+        }
+        const leaf = walkV3ToLeafSchema(_zodSchema, path)
+        if (!leaf) return undefined
+        // The leaf may still carry ZodDefault / ZodOptional / etc.;
+        // generateValue handles those. Pass `true` for useDefaultSchemaValues
+        // so any nested .default(x) values are preserved.
+        return getDefaultValuesFromZodSchema(leaf as z.ZodSchema, true, _formKey)
+      },
       getSchemasAtPath(path) {
         const [strippedSchema] = stripRootSchema(_zodSchema, {
           stripDefaultValues: true,
@@ -418,6 +431,120 @@ function getNestedZodSchemasAtPath<Schema extends z.ZodSchema>(
 
   if (!currentSchema) return []
   return [currentSchema]
+}
+
+/**
+ * Peel transparent wrappers off a v3 schema to reach the structural
+ * "core" — used by the schema-aware path walker that powers
+ * `getDefaultAtPath`. Mirrors v4's `unwrapInner` chain so `getDefaultAtPath`
+ * resolves the same sub-schemas across both adapters for shapes like
+ * `{ profile: z.object({...}).optional() }`.
+ *
+ * Bounded by 64 iterations as a cycle/runaway guard. Returns the original
+ * schema unchanged if it has no peelable wrapper. ZodDefault / ZodOptional /
+ * ZodNullable / ZodEffects all peel; unrecognised wrappers (Catch /
+ * Pipeline / Branded / Readonly — rarer in form schemas) fall through and
+ * remain visible at the leaf, where `getDefaultValuesFromZodSchema`'s
+ * `generateValue` handles them best-effort.
+ */
+function peelV3Wrappers(schema: z.ZodTypeAny): z.ZodTypeAny {
+  let current: z.ZodTypeAny = schema
+  for (let i = 0; i < 64; i++) {
+    if (
+      isZodSchemaType(current, 'ZodOptional') ||
+      isZodSchemaType(current, 'ZodNullable') ||
+      isZodSchemaType(current, 'ZodDefault')
+    ) {
+      const inner = current._def.innerType as z.ZodTypeAny | undefined
+      if (!inner) return current
+      current = inner
+      continue
+    }
+    if (isZodSchemaType(current, 'ZodEffects')) {
+      // v3 ZodEffects: source schema is at `_def.schema`; v4 parity'd
+      // helpers also expose `.innerType()` on some shapes. Prefer the
+      // structural source.
+      const inner = current._def.schema as z.ZodTypeAny | undefined
+      if (!inner) return current
+      current = inner
+      continue
+    }
+    break
+  }
+  return current
+}
+
+/**
+ * Walk a structured path through a v3 schema, peeling wrappers at each
+ * step before descending. Returns the schema at the final segment, or
+ * `undefined` if the path doesn't exist in the schema (object key
+ * missing, tuple index out of range, leaf with segments remaining).
+ *
+ * Discriminated and plain unions: takes the first matching option (or
+ * first option when no match). Matches `validateAtPath`'s first-success
+ * semantic at the path-walker layer.
+ */
+function walkV3ToLeafSchema(
+  schema: z.ZodTypeAny,
+  segments: readonly (string | number)[]
+): z.ZodTypeAny | undefined {
+  let current: z.ZodTypeAny | undefined = schema
+  let i = 0
+  // Iteration cap prevents pathological unions / lazy loops from hanging.
+  let safetyTicks = 0
+  while (i < segments.length && current && safetyTicks < segments.length * 64 + 64) {
+    safetyTicks++
+    current = peelV3Wrappers(current)
+    const key = String(segments[i] ?? '')
+
+    if (isZodSchemaType(current, 'ZodObject')) {
+      const shape = current._def.shape() as z.ZodRawShape
+      current = shape[key]
+      i++
+      continue
+    }
+    if (isZodSchemaType(current, 'ZodArray')) {
+      current = current._def.type as z.ZodTypeAny
+      i++
+      continue
+    }
+    if (isZodSchemaType(current, 'ZodRecord')) {
+      current = current._def.valueType as z.ZodTypeAny
+      i++
+      continue
+    }
+    if (isZodSchemaType(current, 'ZodTuple')) {
+      const idx = Number(key)
+      if (!Number.isInteger(idx) || idx < 0) return undefined
+      const items = current._def.items as readonly z.ZodTypeAny[]
+      const item = items[idx]
+      if (!item) return undefined
+      current = item
+      i++
+      continue
+    }
+    if (isZodSchemaType(current, 'ZodDiscriminatedUnion')) {
+      const options = current._def.options as readonly z.AnyZodObject[]
+      const matching = options.filter((o) => key in o.shape)
+      const candidates = matching.length > 0 ? matching : options
+      const first = candidates[0]
+      if (!first) return undefined
+      current = first
+      // Don't advance i — re-process this segment within the option.
+      continue
+    }
+    if (isZodSchemaType(current, 'ZodUnion')) {
+      const options = current._def.options as readonly z.ZodTypeAny[]
+      const first = options[0]
+      if (!first) return undefined
+      current = first
+      // Don't advance i — re-process this segment within the option.
+      continue
+    }
+    // Leaf type with segments remaining — can't descend.
+    return undefined
+  }
+  return current
 }
 
 function unwrapToDiscriminatedUnion(

--- a/src/runtime/adapters/zod-v3/index.ts
+++ b/src/runtime/adapters/zod-v3/index.ts
@@ -237,10 +237,13 @@ export function zodAdapter<
         }
         const leaf = walkV3ToLeafSchema(_zodSchema, path)
         if (!leaf) return undefined
-        // The leaf may still carry ZodDefault / ZodOptional / etc.;
-        // generateValue handles those. Pass `true` for useDefaultSchemaValues
-        // so any nested .default(x) values are preserved.
-        return getDefaultValuesFromZodSchema(leaf as z.ZodSchema, true, _formKey)
+        // STRUCTURAL default: peel `.optional()` / `.nullable()` at the
+        // leaf so partial-object writes through optional sub-schemas
+        // (`{ profile: z.object({...}).optional() }`) get the inner
+        // shape's defaults filled in. `.default(x)` is preserved so
+        // `getDefaultValuesFromZodSchema` returns the explicit default.
+        const peeled = unwrapStructuralLeafV3(leaf)
+        return getDefaultValuesFromZodSchema(peeled as z.ZodSchema, true, _formKey)
       },
       getSchemasAtPath(path) {
         const [strippedSchema] = stripRootSchema(_zodSchema, {
@@ -431,6 +434,27 @@ function getNestedZodSchemasAtPath<Schema extends z.ZodSchema>(
 
   if (!currentSchema) return []
   return [currentSchema]
+}
+
+/**
+ * Peel `.optional()` / `.nullable()` wrappers off a leaf schema so
+ * `getDefaultAtPath` returns the STRUCTURAL inner default — what the
+ * runtime structural-completeness fill consumes. `.default(x)` and
+ * `ZodEffects` stay intact so `getDefaultValuesFromZodSchema` resolves
+ * the explicit default / effect-source default correctly.
+ */
+function unwrapStructuralLeafV3(schema: z.ZodTypeAny): z.ZodTypeAny {
+  let current: z.ZodTypeAny = schema
+  for (let i = 0; i < 64; i++) {
+    if (isZodSchemaType(current, 'ZodOptional') || isZodSchemaType(current, 'ZodNullable')) {
+      const inner = current._def.innerType as z.ZodTypeAny | undefined
+      if (!inner) return current
+      current = inner
+      continue
+    }
+    break
+  }
+  return current
 }
 
 /**

--- a/src/runtime/adapters/zod-v4/adapter.ts
+++ b/src/runtime/adapters/zod-v4/adapter.ts
@@ -5,7 +5,7 @@ import { assertSupportedKinds } from './assert-supported'
 import { zodIssuesToValidationErrors } from './errors'
 import { fingerprintZodSchema } from './fingerprint'
 import { deriveDefault, getDefaultValuesFromZodSchema } from './default-values'
-import { assertZodVersion } from './introspect'
+import { assertZodVersion, kindOf, unwrapInner } from './introspect'
 import { getNestedZodSchemasAtPath } from './path-walker'
 
 /**
@@ -24,6 +24,29 @@ import { getNestedZodSchemasAtPath } from './path-walker'
  */
 
 const PATH_SEPARATOR = '.'
+
+/**
+ * Peel `.optional()` / `.nullable()` wrappers off a leaf schema so
+ * `getDefaultAtPath` returns the STRUCTURAL inner default — the slim
+ * shape the runtime needs for structural-completeness fill — rather
+ * than the wrapper-aware `undefined`/`null`. `.default(x)` is left
+ * intact so `deriveDefault` returns the explicit default value.
+ * Bounded iteration cap as a runaway guard for pathological wrappers.
+ */
+function unwrapStructuralWrappers(schema: z.ZodType): z.ZodType {
+  let current: z.ZodType = schema
+  for (let i = 0; i < 64; i++) {
+    const k = kindOf(current)
+    if (k === 'optional' || k === 'nullable') {
+      const inner = unwrapInner(current)
+      if (inner === undefined) return current
+      current = inner
+      continue
+    }
+    break
+  }
+  return current
+}
 
 export function zodV4Adapter<FormSchema extends z.ZodObject, Form extends z.infer<FormSchema>>(
   rootSchema: FormSchema
@@ -88,13 +111,19 @@ export function zodV4Adapter<FormSchema extends z.ZodObject, Form extends z.infe
         if (path.length === 0) return deriveDefault(rootSchema, true)
         const [first] = getNestedZodSchemasAtPath(rootSchema, path)
         if (first === undefined) return undefined
+        // STRUCTURAL default: peel `.optional()` / `.nullable()` so the
+        // result is the inner shape's default (`''` for an optional
+        // string, `{ name: '' }` for an optional object). This is what
+        // the runtime structural-completeness invariant needs: when a
+        // consumer writes a partial object at an optional path, the lib
+        // fills missing keys from the inner shape's structural defaults.
+        // `.default(x)` is NOT peeled — the explicit default is the
+        // canonical "fresh" value at that path. ZodReadonly / ZodCatch /
+        // ZodPipe are handled inside `deriveDefault` itself.
         // First candidate matches validateAtPath's first-success semantic
         // and getDefaultValuesFromZodSchema's line-256 first-candidate
-        // behavior. For discriminated unions the candidate set is filtered
-        // by the path-walker; for plain unions the first option's default
-        // is the canonical "fresh" value (matches deriveDefault's union
-        // branch).
-        return deriveDefault(first, true)
+        // behavior.
+        return deriveDefault(unwrapStructuralWrappers(first), true)
       },
 
       getSchemasAtPath(path) {

--- a/src/runtime/adapters/zod-v4/adapter.ts
+++ b/src/runtime/adapters/zod-v4/adapter.ts
@@ -26,26 +26,70 @@ import { getNestedZodSchemasAtPath } from './path-walker'
 const PATH_SEPARATOR = '.'
 
 /**
- * Peel `.optional()` / `.nullable()` wrappers off a leaf schema so
- * `getDefaultAtPath` returns the STRUCTURAL inner default — the slim
- * shape the runtime needs for structural-completeness fill — rather
- * than the wrapper-aware `undefined`/`null`. `.default(x)` is left
- * intact so `deriveDefault` returns the explicit default value.
- * Bounded iteration cap as a runaway guard for pathological wrappers.
+ * Peel `.optional()` / `.nullable()` wrappers off a leaf schema ONLY
+ * when the inner type is structurally fillable (object, array, tuple,
+ * record, discriminated/plain union, intersection — or itself a
+ * peelable wrapper that resolves to one of those). Peeling exposes
+ * the inner shape's default so consumer-supplied partial writes
+ * through optional sub-schemas (`{ profile: z.object({...}).optional() }`,
+ * `setValue('profile', { name: 'X' })`) get the inner shape's
+ * structural defaults filled in.
+ *
+ * For PRIMITIVE inner (ZodString, ZodNumber, ZodBoolean, ZodLiteral,
+ * etc.), the wrapper IS the meaningful schema — `optional` means
+ * "missing is allowed", `nullable` means "null is allowed". Peeling
+ * an optional string to its inner string would default the leaf to
+ * `''` and cause mergeStructural to write `notes: ''` instead of
+ * `notes: undefined` when filling sibling keys at the parent object
+ * — the runtime would silently overwrite the optional's "absent"
+ * intent with a non-empty marker.
+ *
+ * `.default(x)` is left intact at every level so deriveDefault
+ * returns the explicit default value. Bounded iteration cap as a
+ * runaway guard for pathological wrappers.
  */
 function unwrapStructuralWrappers(schema: z.ZodType): z.ZodType {
   let current: z.ZodType = schema
   for (let i = 0; i < 64; i++) {
-    const k = kindOf(current)
-    if (k === 'optional' || k === 'nullable') {
-      const inner = unwrapInner(current)
-      if (inner === undefined) return current
-      current = inner
-      continue
-    }
-    break
+    const outerKind = kindOf(current)
+    if (outerKind !== 'optional' && outerKind !== 'nullable') break
+    const inner = unwrapInner(current)
+    if (inner === undefined) return current
+    if (!isStructuralKind(kindOf(inner))) break
+    current = inner
   }
   return current
+}
+
+/**
+ * Kinds for which mergeStructural can recurse to fill missing keys
+ * or pad missing positions. Primitive leaves (string / number / etc.)
+ * and opaque non-recursable wrappers fall outside this set, so
+ * peeling Optional / Nullable around them would lose information
+ * (the wrapper's "absent / null" semantic) without enabling any fill.
+ *
+ * Wrappers themselves count as structural — `unwrapStructuralWrappers`
+ * recurses to re-check their inner kind.
+ */
+const STRUCTURAL_KINDS: ReadonlySet<ReturnType<typeof kindOf>> = new Set([
+  'object',
+  'array',
+  'tuple',
+  'record',
+  'discriminated-union',
+  'union',
+  'intersection',
+  'optional',
+  'nullable',
+  'default',
+  'readonly',
+  'catch',
+  'pipe',
+  'lazy',
+])
+
+function isStructuralKind(kind: ReturnType<typeof kindOf>): boolean {
+  return STRUCTURAL_KINDS.has(kind)
 }
 
 export function zodV4Adapter<FormSchema extends z.ZodObject, Form extends z.infer<FormSchema>>(

--- a/src/runtime/adapters/zod-v4/adapter.ts
+++ b/src/runtime/adapters/zod-v4/adapter.ts
@@ -81,6 +81,22 @@ export function zodV4Adapter<FormSchema extends z.ZodObject, Form extends z.infe
         return { data, errors: undefined, success: true, formKey }
       },
 
+      getDefaultAtPath(path) {
+        // For empty path, the "default at root" is the schema's full
+        // default — return the deriveDefault of the root, not the slim-
+        // schema validate-then-fix loop (that's getDefaultValues' job).
+        if (path.length === 0) return deriveDefault(rootSchema, true)
+        const [first] = getNestedZodSchemasAtPath(rootSchema, path)
+        if (first === undefined) return undefined
+        // First candidate matches validateAtPath's first-success semantic
+        // and getDefaultValuesFromZodSchema's line-256 first-candidate
+        // behavior. For discriminated unions the candidate set is filtered
+        // by the path-walker; for plain unions the first option's default
+        // is the canonical "fresh" value (matches deriveDefault's union
+        // branch).
+        return deriveDefault(first, true)
+      },
+
       getSchemasAtPath(path) {
         const resolved = getNestedZodSchemasAtPath(rootSchema, path)
         return resolved.map(

--- a/src/runtime/composables/use-abstract-form.ts
+++ b/src/runtime/composables/use-abstract-form.ts
@@ -14,6 +14,8 @@ import type { FieldStateView } from '../core/field-state-api'
 import { getComputedSchema } from '../core/get-computed-schema'
 import { createHistoryModule, type HistoryModule } from '../core/history'
 import {
+  buildPersistedPayload,
+  cleanupOrphanKeys,
   createDebouncedWriter,
   filterErrorsByPaths,
   getStorageAdapter,
@@ -22,10 +24,9 @@ import {
   PERSISTENCE_MODULE_KEY,
   pluckPaths,
   readPersistedPayload,
-  resolveStorageKey,
-  sweepAllStandardStores,
-  sweepNonConfiguredStandardStores,
-  type PersistedPayload,
+  resolveStorageKeyBase,
+  sweepAllOrphansAcrossStandardStores,
+  sweepNonConfiguredStandardStoresForOrphans,
   type PersistenceModule,
 } from '../core/persistence'
 import { canonicalizePath, type Path, type PathKey } from '../core/paths'
@@ -136,32 +137,23 @@ export function useAbstractForm<
   if (existing === undefined && !registry.isSSR) {
     if (merged.persist !== undefined) {
       const resolvedPersist = normalizePersistConfig(merged.persist)
-      const persistenceKey = resolveStorageKey(resolvedPersist, state.formKey)
-      // Cross-store cleanup. The configured backend is the source of
-      // truth — any standard backend not matching the configured one
-      // gets a `removeItem(key)` so historic entries can't orphan
-      // sensitive data when the dev migrates between backends. Inlined
-      // per-backend (see `sweepNonConfiguredStandardStores`) so this
-      // doesn't drag in adapter chunks the consumer didn't ask for.
-      sweepNonConfiguredStandardStores(resolvedPersist.storage, persistenceKey)
+      const persistenceBase = resolveStorageKeyBase(resolvedPersist, state.formKey)
+      // Cross-store orphan cleanup: any standard backend not matching
+      // the configured one gets every cx-managed key under the base
+      // wiped (legacy pre-fingerprint AND stale fingerprints alike).
+      // Ensures stale drafts can't survive in stores the dev migrated
+      // AWAY from. Fire-and-forget; backend unavailability is silent.
+      void sweepNonConfiguredStandardStoresForOrphans(resolvedPersist.storage, persistenceBase)
       const persistenceModule = wirePersistence(state, resolvedPersist)
       state.modules.set(PERSISTENCE_MODULE_KEY, persistenceModule)
       state.registerCleanup(() => persistenceModule.dispose())
     } else {
       // No `persist:` configured. The form might have HAD persistence
-      // in a prior deployment that the dev has since removed
-      // (compliance pivot, simplification). Sweep the default-key
-      // entry from every standard backend so removing the option
-      // actually removes the on-disk artifact — without this, sensitive
-      // draft data from a "we used to persist this" past can linger
-      // indefinitely. We can only reach the default key
-      // (`chemical-x-forms:${formKey}`); a previous deployment that
-      // used a custom `persist.key` is on the consumer to clean up via
-      // an explicit migration. Anonymous forms (`__cx:anon:*`) don't
-      // have a stable key across sessions, so the sweep is mostly
-      // wasted for them — but the cost is bounded (3 fire-and-forget
-      // calls) and the security guarantee is consistent.
-      sweepAllStandardStores(`${PERSISTENCE_KEY_PREFIX}${state.formKey}`)
+      // in a prior deployment that the dev has since removed. Sweep
+      // every cx-managed key under the default base from every
+      // standard backend so removing the option actually removes the
+      // on-disk artifact across all fingerprints that ever ran.
+      void sweepAllOrphansAcrossStandardStores(`${PERSISTENCE_KEY_PREFIX}${state.formKey}`)
     }
   }
 
@@ -438,14 +430,17 @@ function wirePersistence<F extends GenericForm>(
   state: FormStore<F>,
   config: PersistConfigOptions
 ): PersistenceModule {
-  const key = resolveStorageKey(config, state.formKey)
+  // Fingerprint the schema once and bake it into the storage key. Any
+  // structural schema change (added/removed/renamed field, type swap)
+  // produces a different fingerprint, so the new mount looks up a fresh
+  // key — the old draft becomes an orphan, cleaned up in the same mount
+  // by `cleanupOrphanKeys` below. Replaces the manual `version: number`
+  // protocol that was previously the consumer's responsibility.
+  const fingerprint = state.schema.fingerprint()
+  const base = resolveStorageKeyBase(config, state.formKey)
+  const key = `${base}:${fingerprint}`
   const debounceMs = config.debounceMs ?? DEFAULT_PERSISTENCE_DEBOUNCE_MS
   const include = config.include ?? 'form'
-  // Default version bumped 1 → 2 in the 0.12 release: errors split into
-  // schemaErrors + userErrors at the payload level. Old v1 payloads
-  // (single flat `errors` field) get rejected by readPersistedPayload's
-  // version-mismatch check, falling back to schema defaults on next load.
-  const version = config.version ?? 2
   const clearOnSubmitSuccess = config.clearOnSubmitSuccess ?? true
 
   // Single shared adapter promise — both the hydration path and the
@@ -475,24 +470,18 @@ function wirePersistence<F extends GenericForm>(
     // proxy's own-enumerable keys anyway.
     const rawForm = toRaw(state.form.value)
     const filteredForm = pluckPaths(rawForm, optedInPaths) as F
-    if (include === 'form') {
-      await adapter.setItem(key, { v: version, data: { form: filteredForm } })
-      return
-    }
-    // include === 'form+errors': filter both error stores to the
-    // opted-in paths only. A persisted error without a persisted
-    // value would dangle on rehydration; dropping is the consistent
-    // contract.
+    // Build the envelope with the cx-internal envelope version baked
+    // in by `buildPersistedPayload`. Consumers no longer manage `v` —
+    // schema-content invalidation lives at the storage-key level via
+    // the fingerprint suffix.
     const filteredSchemaErrors = filterErrorsByPaths(state.schemaErrors, optedInPaths)
     const filteredUserErrors = filterErrorsByPaths(state.userErrors, optedInPaths)
-    const payload: PersistedPayload<F> = {
-      v: version,
-      data: {
-        form: filteredForm,
-        schemaErrors: [...filteredSchemaErrors.entries()].map(([k, v]) => [k, [...v]] as const),
-        userErrors: [...filteredUserErrors.entries()].map(([k, v]) => [k, [...v]] as const),
-      },
-    }
+    const payload = buildPersistedPayload<F>(
+      filteredForm,
+      include,
+      filteredSchemaErrors,
+      filteredUserErrors
+    )
     await adapter.setItem(key, payload)
   }, debounceMs)
 
@@ -531,18 +520,18 @@ function wirePersistence<F extends GenericForm>(
   void (async () => {
     const adapter = await adapterPromise
     if (disposed) return
+    // Orphan cleanup: delete any cx-managed key under the same base
+    // whose fingerprint suffix doesn't match the current schema. Runs
+    // once per mount, fire-and-forget. Bounded cost: typically 0-1
+    // orphans per form.
+    void cleanupOrphanKeys(adapter, base, key)
     try {
       const raw = await adapter.getItem(key)
-      const payload = readPersistedPayload<F>(raw, version)
+      const payload = readPersistedPayload<F>(raw)
       if (payload === null) {
-        // Truly-absent entries are a no-op; we'd churn the adapter for
-        // nothing. But a non-null raw that didn't parse is a stale
-        // payload — wrong version, malformed shape, corrupted JSON —
-        // and leaving it on disk is the same hysteresis problem the
-        // cross-store cleanup avoids. The dev bumped `version` (or the
-        // shape drifted) to signal "old data is invalid"; auto-wipe so
-        // the next mount reads cleanly and so sensitive fields from a
-        // pre-version-bump deployment can't linger indefinitely.
+        // Truly-absent entries are a no-op. A non-null raw that didn't
+        // parse is a stale payload — wrong cx envelope version, or
+        // malformed shape — wipe so the next mount reads cleanly.
         if (raw !== null && raw !== undefined) {
           await adapter.removeItem(key)
         }
@@ -619,12 +608,12 @@ function wirePersistence<F extends GenericForm>(
     const adapter = await adapterPromise
     if (disposed) return
     const raw = await adapter.getItem(key)
-    const existing = readPersistedPayload<F>(raw, version)
+    const existing = readPersistedPayload<F>(raw)
     const baseForm = existing?.data.form ?? ({} as F)
     const value = getAtPath(toRaw(state.form.value), path)
     const nextForm = setAtPath(baseForm, path, value) as F
     if (include === 'form') {
-      await adapter.setItem(key, { v: version, data: { form: nextForm } })
+      await adapter.setItem(key, buildPersistedPayload<F>(nextForm, 'form', new Map(), new Map()))
       return
     }
     // include === 'form+errors': preserve the rest of the persisted
@@ -644,15 +633,10 @@ function wirePersistence<F extends GenericForm>(
     } else {
       userMap.delete(pathKey)
     }
-    const payload: PersistedPayload<F> = {
-      v: version,
-      data: {
-        form: nextForm,
-        schemaErrors: [...schemaMap.entries()].map(([k, v]) => [k, [...v]] as const),
-        userErrors: [...userMap.entries()].map(([k, v]) => [k, [...v]] as const),
-      },
-    }
-    await adapter.setItem(key, payload)
+    await adapter.setItem(
+      key,
+      buildPersistedPayload<F>(nextForm, 'form+errors', schemaMap, userMap)
+    )
   }
 
   /**
@@ -672,7 +656,7 @@ function wirePersistence<F extends GenericForm>(
       return
     }
     const raw = await adapter.getItem(key)
-    const existing = readPersistedPayload<F>(raw, version)
+    const existing = readPersistedPayload<F>(raw)
     if (existing === null) return
     const nextForm = deleteAtPath(existing.data.form, path) as F
     if (isEmptyContainer(nextForm)) {
@@ -680,21 +664,18 @@ function wirePersistence<F extends GenericForm>(
       return
     }
     if (include === 'form') {
-      await adapter.setItem(key, { v: version, data: { form: nextForm } })
+      await adapter.setItem(key, buildPersistedPayload<F>(nextForm, 'form', new Map(), new Map()))
       return
     }
     const { key: pathKey } = canonicalizePath(path)
     const schemaErrors = (existing.data.schemaErrors ?? []).filter(([k]) => k !== pathKey)
     const userErrors = (existing.data.userErrors ?? []).filter(([k]) => k !== pathKey)
-    const payload: PersistedPayload<F> = {
-      v: version,
-      data: {
-        form: nextForm,
-        schemaErrors: schemaErrors.map(([k, v]) => [k, [...v]] as const),
-        userErrors: userErrors.map(([k, v]) => [k, [...v]] as const),
-      },
-    }
-    await adapter.setItem(key, payload)
+    const schemaMap = new Map<string, ValidationError[]>(schemaErrors.map(([k, v]) => [k, [...v]]))
+    const userMap = new Map<string, ValidationError[]>(userErrors.map(([k, v]) => [k, [...v]]))
+    await adapter.setItem(
+      key,
+      buildPersistedPayload<F>(nextForm, 'form+errors', schemaMap, userMap)
+    )
   }
 
   function dispose(): void {

--- a/src/runtime/core/build-form-api.ts
+++ b/src/runtime/core/build-form-api.ts
@@ -19,7 +19,7 @@ import type { FormStore } from './create-form-store'
 import { buildFieldArrayApi } from './field-arrays'
 import { buildFieldStateAccessor } from './field-state-api'
 import type { HistoryModule } from './history'
-import { getAtPath } from './path-walker'
+import { getAtPath, mergeStructural } from './path-walker'
 import { canonicalizePath, type Path, type Segment } from './paths'
 import { PERSISTENCE_MODULE_KEY, type PersistenceModule } from './persistence'
 import { enforceSensitiveCheck } from './persistence/sensitive-names'
@@ -95,18 +95,32 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
 
   function setValueImpl(pathOrValue: unknown, maybeValue?: unknown): boolean {
     if (arguments.length === 1) {
+      // Whole-form: prev is the live form (already structurally
+      // complete under the runtime invariant). The consumer's RETURN
+      // value passes through mergeStructural so any gaps the consumer
+      // introduced (partial replacement) are filled from defaults.
       const next =
         typeof pathOrValue === 'function'
           ? (pathOrValue as (prev: unknown) => unknown)(state.form.value)
           : pathOrValue
-      state.applyFormReplacement(next as Form)
+      const completed = mergeStructural(state.schema, [], next)
+      state.applyFormReplacement(completed as Form)
       return true
     }
     const segments = canonicalizePath(pathOrValue as string | Path).segments
-    const resolvedValue =
-      typeof maybeValue === 'function'
-        ? (maybeValue as (prev: unknown) => unknown)(state.getValueAtPath(segments))
-        : maybeValue
+    // Path-form callback: when the slot at `segments` is unpopulated,
+    // hand the consumer the schema's default at that path instead of
+    // `undefined` so `(prev) => prev.first.toUpperCase()` is safe.
+    // For populated slots, prev is the live value (consumer's intent
+    // is to update existing data, not reset to defaults).
+    let resolvedValue: unknown
+    if (typeof maybeValue === 'function') {
+      const current = state.getValueAtPath(segments)
+      const prev = current === undefined ? state.schema.getDefaultAtPath(segments) : current
+      resolvedValue = (maybeValue as (prev: unknown) => unknown)(prev)
+    } else {
+      resolvedValue = maybeValue
+    }
     state.setValueAtPath(segments, resolvedValue)
     return true
   }

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -13,7 +13,7 @@ import type { DeepPartial, GenericForm } from '../types/types-core'
 import { DEFAULT_FIELD_VALIDATION_DEBOUNCE_MS } from './defaults'
 import { diffAndApply } from './diff-apply'
 import { canonicalizePath, type Path, type PathKey, type Segment } from './paths'
-import { getAtPath, setAtPath } from './path-walker'
+import { getAtPath, mergeStructural, setAtPath, setAtPathWithSchemaFill } from './path-walker'
 import {
   createPersistOptInRegistry,
   type PersistOptInRegistry,
@@ -356,9 +356,19 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
   // Schema is ALWAYS consulted: we need the schema-derived originals even
   // when hydrating, so pristine/dirty computation survives SSR round-trip.
   // The form's actual starting value, though, prefers hydration data.
+  //
+  // Run consumer-supplied `defaultValues` through `mergeStructural` first
+  // so partial constraints against tuple shapes (e.g. `coords: [42]` for
+  // `z.tuple([_, _, _])`) get padded with position defaults BEFORE the
+  // adapter's validate-then-fix loop sees them. Without this, the
+  // adapter's wholesale-replace fix-up would lose the consumer's data.
+  const completedConstraints =
+    defaultValues === undefined
+      ? undefined
+      : (mergeStructural(schema, [], defaultValues) as DeepPartial<F>)
   const schemaResponse: DefaultValuesResponse<F> = schema.getDefaultValues({
     useDefaultSchemaValues: true,
-    constraints: defaultValues,
+    constraints: completedConstraints,
     validationMode,
   })
   const schemaInitialData = schemaResponse.data
@@ -508,7 +518,20 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
   }
 
   function setValueAtPath(path: Path, value: unknown, meta?: WriteMeta): void {
-    const nextForm = setAtPath(form.value, path, value) as F
+    // Structural-completeness invariant: every write must leave the
+    // form satisfying the slim schema. Two ingress points to fill:
+    //   1. The target value (consumer may have passed a partial; the
+    //      schema's element default fills missing keys / array
+    //      elements via mergeStructural).
+    //   2. Intermediate gaps along the path (missing object property,
+    //      array length below target index — setAtPathWithSchemaFill
+    //      asks the schema for defaults at each gap site).
+    // The common case (write to existing slot with a complete value)
+    // hits no schema lookups: mergeStructural short-circuits on
+    // ref-equal sub-trees, and the fill walker only queries the
+    // schema at gap sites.
+    const completedValue = mergeStructural(schema, path, value)
+    const nextForm = setAtPathWithSchemaFill(form.value, schema, path, completedValue) as F
     applyFormReplacement(nextForm, meta)
     if (fieldValidationMode === 'change') {
       scheduleFieldValidation(path, false /* debounced */)
@@ -810,9 +833,15 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
   // --- Reset ---
 
   function reset(nextDefaultValues?: DeepPartial<F>): void {
+    // Fall back to construction-time `defaultValues` when the caller
+    // doesn't provide a fresh override. Otherwise `reset()` produces
+    // schema-only defaults — losing the consumer's initial state from
+    // `useForm({ defaultValues: ... })`. The structural-completeness
+    // invariant covers post-write correctness; preserving construction
+    // defaults across reset is a separate semantic the consumer expects.
     const next = schema.getDefaultValues({
       useDefaultSchemaValues: true,
-      constraints: nextDefaultValues,
+      constraints: nextDefaultValues ?? defaultValues,
       validationMode,
     }).data
     // Replace form in one shot — applyFormReplacement will emit diffAndApply

--- a/src/runtime/core/path-walker.ts
+++ b/src/runtime/core/path-walker.ts
@@ -307,40 +307,45 @@ function setAtPathWithSchemaFillImpl(
 
   if (typeof head === 'number') {
     const arr = Array.isArray(root) ? [...root] : []
-    // Pad with element defaults if extending past length. For arrays
-    // every position resolves to the same element default; we cache
-    // the lookup (via `padDefault`) rather than re-asking the schema
-    // per pad index. For tuples per-position defaults differ — query
-    // the schema each iteration.
+    const prefix = fullPath.slice(0, startIdx)
+    // Pad with element defaults if extending past length. Tuple-vs-
+    // array detection mirrors mergeStructural: probe at a high index
+    // — tuples return `undefined` (out of range), unbounded arrays
+    // return the element default. The previous heuristic (compare two
+    // adjacent defaults via Object.is) gave wrong answers for arrays
+    // of objects (each call yields a fresh object, identity differs)
+    // AND for tuples of identical primitives (Object.is(0, 0) === true).
     if (arr.length < head) {
-      // Detect tuple vs array by probing two adjacent positions: if
-      // they yield distinct, both-present defaults the schema is a
-      // tuple-like; else cache once. The probe path uses the slot the
-      // pad would occupy, never the existing slots.
-      const padPath0: Segment[] = [...fullPath.slice(0, startIdx), arr.length]
-      const padDefault0 = schema.getDefaultAtPath(padPath0)
-      const padPath1: Segment[] = [...fullPath.slice(0, startIdx), arr.length + 1]
-      const padDefault1 = schema.getDefaultAtPath(padPath1)
-      const tupleLike =
-        padDefault0 !== undefined &&
-        padDefault1 !== undefined &&
-        !Object.is(padDefault0, padDefault1)
+      const TUPLE_PROBE_INDEX = 1_000_000
+      const probe = schema.getDefaultAtPath([...prefix, TUPLE_PROBE_INDEX])
+      const tupleLike = probe === undefined
+      // For unbounded arrays, every position resolves to the same
+      // element default — cache the lookup once. For tuples, query
+      // per-position so each slot's default lands at its own index.
+      const cachedArrayDefault = tupleLike ? undefined : schema.getDefaultAtPath([...prefix, 0])
       while (arr.length < head) {
         const idx = arr.length
-        if (tupleLike) {
-          arr.push(schema.getDefaultAtPath([...fullPath.slice(0, startIdx), idx]))
-        } else {
-          arr.push(padDefault0)
-        }
+        arr.push(tupleLike ? schema.getDefaultAtPath([...prefix, idx]) : cachedArrayDefault)
       }
     }
 
     if (isLeafStep) {
       arr[head] = value
-    } else {
-      const childRoot = arr[head]
-      arr[head] = setAtPathWithSchemaFillImpl(childRoot, schema, fullPath, value, startIdx + 1)
+      return arr
     }
+
+    // Intermediate step: ensure the slot at `head` is structurally
+    // complete BEFORE recursing into the rest of the path. Without
+    // this fill, recursion starts from `undefined` and the next level
+    // builds a fresh `{}` populated only by the keys the path
+    // actually touches — sibling fields (other Person keys, other
+    // Address keys) get silently dropped. Same intermediate-fill
+    // semantic the object branch applies a few lines below.
+    let childRoot = arr[head]
+    if (childRoot === undefined || (childRoot !== null && typeof childRoot !== 'object')) {
+      childRoot = schema.getDefaultAtPath([...prefix, head])
+    }
+    arr[head] = setAtPathWithSchemaFillImpl(childRoot, schema, fullPath, value, startIdx + 1)
     return arr
   }
 

--- a/src/runtime/core/path-walker.ts
+++ b/src/runtime/core/path-walker.ts
@@ -1,6 +1,17 @@
 import type { Path, Segment } from './paths'
 
 /**
+ * The minimal slice of `AbstractSchema` the structural-completeness
+ * helpers need. Declared inline (not imported from types-api) so this
+ * file stays free of cyclic imports — types-api imports types-core,
+ * types-core does not import types-api, and this file is consumed by
+ * core/create-form-store.ts which sits between the two.
+ */
+export type SchemaForFill = {
+  getDefaultAtPath(path: Path): unknown
+}
+
+/**
  * Structured-path get/set primitives. Replace `lodash-es/get` and
  * `lodash-es/set` for internal callers that speak `Path` rather than
  * dotted strings.
@@ -137,5 +148,220 @@ export function deleteAtPath(root: unknown, path: Path): unknown {
   if (!(head in root)) return root
   const rec: Record<string, unknown> = { ...root }
   rec[head] = deleteAtPath(rec[head], rest)
+  return rec
+}
+
+/**
+ * Recursive merge that fills consumer-supplied gaps with the schema's
+ * prescribed defaults. The runtime calls this on every `setValueAtPath`
+ * write (and on whole-form callback returns) so the form remains
+ * structurally complete after the write.
+ *
+ * Semantics:
+ * - Plain object: every schema-default key not present in `consumer`
+ *   is filled with the schema default's value at that key. Schema-only
+ *   keys recurse into structural completeness; consumer-only keys (not
+ *   in the schema) survive untouched (validation flags them).
+ * - Array: each consumer element is merged with the SCHEMA element
+ *   default (looked up via `schema.getDefaultAtPath([...path, i])`).
+ *   Length follows the consumer — padding past the consumer's length
+ *   is `setAtPathWithSchemaFill`'s job, not this function's.
+ * - `null` consumer wins (a deliberate "clear" signal — validation
+ *   catches misuse against non-nullable shapes).
+ * - `undefined` consumer falls back to the schema default (treats
+ *   undefined as "missing"). When the schema default is also
+ *   undefined the result is undefined — schema and consumer agree.
+ * - Primitives, Date, RegExp, Map, Set, class instances: consumer
+ *   wins; no recursion (these are leaves under `isPlainRecord`).
+ *
+ * Idempotent short-circuit: when consumer is structurally complete
+ * relative to defaults the function returns `consumer` by reference,
+ * so common-case writes (consumer already complete) allocate nothing.
+ */
+export function mergeStructural(
+  schema: SchemaForFill,
+  path: Path,
+  consumer: unknown,
+  defaultValue: unknown = schema.getDefaultAtPath(path)
+): unknown {
+  // Consumer is missing — fall back to the schema default. When the
+  // schema default itself is `undefined` (path doesn't exist in the
+  // schema), the result is `undefined` and we don't fight it.
+  if (consumer === undefined) return defaultValue
+
+  // Null wins: deliberate consumer signal. Schema-validation catches
+  // null-vs-non-nullable; runtime doesn't override consumer intent.
+  if (consumer === null) return null
+
+  // Array branch: distinguish tuple-like (fixed length) from array
+  // (unbounded). Probe at a high index — tuples return `undefined`,
+  // arrays return the element default. For tuple-like, pad consumer
+  // up to the structural length; for arrays, length tracks consumer.
+  if (Array.isArray(consumer)) {
+    const TUPLE_PROBE_INDEX = 1_000_000
+    const probe = schema.getDefaultAtPath([...path, TUPLE_PROBE_INDEX])
+    let targetLen = consumer.length
+    if (probe === undefined) {
+      // Tuple-like: find structural length via sequential probe. Cap
+      // protects against pathological recursive lazies.
+      let n = consumer.length
+      while (n < 1024 && schema.getDefaultAtPath([...path, n]) !== undefined) n++
+      targetLen = n
+    }
+    let mutated = targetLen > consumer.length
+    const out = consumer.slice() as unknown[]
+    while (out.length < targetLen) out.push(undefined)
+    for (let i = 0; i < targetLen; i++) {
+      const elemDefault = schema.getDefaultAtPath([...path, i])
+      const consumerElem = i < consumer.length ? consumer[i] : undefined
+      const merged = mergeStructural(schema, [...path, i], consumerElem, elemDefault)
+      if (merged !== consumerElem) {
+        out[i] = merged
+        mutated = true
+      }
+    }
+    return mutated ? out : consumer
+  }
+
+  // Plain object: fill missing keys from default, recurse on present
+  // keys. Consumer-only keys pass through.
+  if (isPlainRecord(consumer)) {
+    if (!isPlainRecord(defaultValue)) {
+      // Default is non-record (or undefined / leaf) — nothing to fill;
+      // consumer wins as-is. Recurse just in case consumer holds nested
+      // keys that the schema knows about at deeper paths (rare).
+      return consumer
+    }
+    let mutated = false
+    const out: Record<string, unknown> = { ...consumer }
+    // Fill schema-default keys missing from consumer.
+    for (const key of Object.keys(defaultValue)) {
+      if (!(key in consumer) || consumer[key] === undefined) {
+        const defAtKey = defaultValue[key]
+        // Recurse so that filling produces a structurally-complete
+        // sub-tree (covers nested-object defaults that themselves
+        // contain wrappers / unions).
+        const filled = mergeStructural(schema, [...path, key], undefined, defAtKey)
+        if (filled !== undefined) {
+          out[key] = filled
+          mutated = true
+        }
+      }
+    }
+    // Recurse into consumer-supplied keys to catch nested gaps.
+    for (const key of Object.keys(consumer)) {
+      const merged = mergeStructural(schema, [...path, key], consumer[key], defaultValue[key])
+      if (merged !== consumer[key]) {
+        out[key] = merged
+        mutated = true
+      }
+    }
+    return mutated ? out : consumer
+  }
+
+  // Leaf-ish (primitives, Date, RegExp, Map, Set, class instances) —
+  // consumer wins, no recursion.
+  return consumer
+}
+
+/**
+ * Schema-aware variant of `setAtPath`. When extending past array
+ * length, pads new positions with the schema's element default
+ * instead of `undefined`. When descending into an object whose
+ * intermediate property is missing, fills the intermediate with
+ * the schema's default at that sub-path.
+ *
+ * `value` is the already-mergeStructural'd target value — this
+ * function only handles INTERMEDIATE fill. The caller (typically
+ * `setValueAtPath` on the form store) is responsible for completing
+ * the leaf.
+ *
+ * Performance: schema lookups happen only at gap sites. The common
+ * case (write to existing slot) does a copy-on-write spread without
+ * touching the schema. Misuse (`setValue('posts.21', x)` against an
+ * empty array) costs `getDefaultAtPath` once for the array element
+ * default (cached via `lastArrayDefault`/`lastArrayPathPrefix` for
+ * the duration of the call) and N pad inserts.
+ */
+export function setAtPathWithSchemaFill(
+  root: unknown,
+  schema: SchemaForFill,
+  fullPath: Path,
+  value: unknown
+): unknown {
+  if (fullPath.length === 0) return value
+  return setAtPathWithSchemaFillImpl(root, schema, fullPath, value, 0)
+}
+
+function setAtPathWithSchemaFillImpl(
+  root: unknown,
+  schema: SchemaForFill,
+  fullPath: Path,
+  value: unknown,
+  startIdx: number
+): unknown {
+  if (startIdx >= fullPath.length) return value
+
+  const head = fullPath[startIdx] as Segment
+  const isLeafStep = startIdx === fullPath.length - 1
+
+  if (typeof head === 'number') {
+    const arr = Array.isArray(root) ? [...root] : []
+    // Pad with element defaults if extending past length. For arrays
+    // every position resolves to the same element default; we cache
+    // the lookup (via `padDefault`) rather than re-asking the schema
+    // per pad index. For tuples per-position defaults differ — query
+    // the schema each iteration.
+    if (arr.length < head) {
+      // Detect tuple vs array by probing two adjacent positions: if
+      // they yield distinct, both-present defaults the schema is a
+      // tuple-like; else cache once. The probe path uses the slot the
+      // pad would occupy, never the existing slots.
+      const padPath0: Segment[] = [...fullPath.slice(0, startIdx), arr.length]
+      const padDefault0 = schema.getDefaultAtPath(padPath0)
+      const padPath1: Segment[] = [...fullPath.slice(0, startIdx), arr.length + 1]
+      const padDefault1 = schema.getDefaultAtPath(padPath1)
+      const tupleLike =
+        padDefault0 !== undefined &&
+        padDefault1 !== undefined &&
+        !Object.is(padDefault0, padDefault1)
+      while (arr.length < head) {
+        const idx = arr.length
+        if (tupleLike) {
+          arr.push(schema.getDefaultAtPath([...fullPath.slice(0, startIdx), idx]))
+        } else {
+          arr.push(padDefault0)
+        }
+      }
+    }
+
+    if (isLeafStep) {
+      arr[head] = value
+    } else {
+      const childRoot = arr[head]
+      arr[head] = setAtPathWithSchemaFillImpl(childRoot, schema, fullPath, value, startIdx + 1)
+    }
+    return arr
+  }
+
+  // Object key.
+  const rec: Record<string, unknown> = isPlainRecord(root) ? { ...root } : {}
+  if (isLeafStep) {
+    rec[head] = value
+    return rec
+  }
+
+  // Intermediate: ensure the child exists, filling from the schema
+  // default if missing or non-descendable.
+  const existing = rec[head]
+  let childRoot: unknown
+  if (existing === undefined || (existing !== null && typeof existing !== 'object')) {
+    const intermPath: Segment[] = [...fullPath.slice(0, startIdx + 1)]
+    const intermDefault = schema.getDefaultAtPath(intermPath)
+    childRoot = intermDefault
+  } else {
+    childRoot = existing
+  }
+  rec[head] = setAtPathWithSchemaFillImpl(childRoot, schema, fullPath, value, startIdx + 1)
   return rec
 }

--- a/src/runtime/core/persistence/index.ts
+++ b/src/runtime/core/persistence/index.ts
@@ -72,20 +72,21 @@ export async function getStorageAdapter(
 }
 
 /**
- * Versioned payload shape. A consumer who bumps `persist.version`
- * invalidates every existing entry — the reader drops entries whose
- * `v` doesn't match. `data` mirrors the SSR `SerializedFormData`
- * shape so one deserialiser handles both.
+ * Persisted payload envelope.
+ *
+ * `v` is a CX-INTERNAL storage-format version — bumped only when the
+ * library's persisted payload schema itself changes (e.g. adding a new
+ * field, restructuring `data`). It is NOT consumer-controlled.
+ * Schema-driven invalidation uses the storage key's `:${fingerprint}`
+ * suffix instead, so consumers don't need to manage versioning at all.
+ *
+ * `data` mirrors the SSR `SerializedFormData` shape so one deserialiser
+ * handles both.
  *
  * Errors are stored source-segregated (matching FormStore's split):
  *   - `schemaErrors` is validation-owned; cleared by reset / submit-success.
  *   - `userErrors` is consumer-owned (written via setFieldErrors* APIs);
  *     persists across schema revalidation and successful submits.
- *
- * The two are surfaced separately on the persisted payload so the
- * lifecycle distinction round-trips through reload. Default
- * `PersistConfig.version` bumped to 2 for the 0.12 release — older v1
- * payloads (single flat `errors` field) are dropped silently on read.
  */
 export type PersistedPayload<Form> = {
   readonly v: number
@@ -97,17 +98,28 @@ export type PersistedPayload<Form> = {
 }
 
 /**
+ * Current CX-internal envelope version. Bumped only when the library
+ * changes the persisted payload's structural shape — readers reject
+ * envelopes with a different `v`. Schema-content invalidation is
+ * handled at the storage key level (the `:${fingerprint}` suffix), so
+ * consumers shouldn't see this number.
+ */
+export const PERSISTED_ENVELOPE_VERSION = 2
+
+/**
  * `value` is expected to be a raw `PersistedPayload` (parsed JSON or
  * structured-cloned object). Returns `null` if the shape doesn't match
  * — the caller falls back to schema defaults.
+ *
+ * The cx-internal envelope `v` must match `PERSISTED_ENVELOPE_VERSION`;
+ * mismatches (older library versions' payloads) are dropped. Schema
+ * change detection lives at the storage-key level via the fingerprint
+ * suffix.
  */
-export function readPersistedPayload<Form>(
-  value: unknown,
-  expectedVersion: number
-): PersistedPayload<Form> | null {
+export function readPersistedPayload<Form>(value: unknown): PersistedPayload<Form> | null {
   if (value === null || value === undefined || typeof value !== 'object') return null
   const envelope = value as Partial<PersistedPayload<Form>>
-  if (typeof envelope.v !== 'number' || envelope.v !== expectedVersion) return null
+  if (typeof envelope.v !== 'number' || envelope.v !== PERSISTED_ENVELOPE_VERSION) return null
   if (envelope.data === undefined || typeof envelope.data !== 'object') return null
   return envelope as PersistedPayload<Form>
 }
@@ -116,12 +128,11 @@ export function buildPersistedPayload<Form>(
   form: Form,
   include: 'form' | 'form+errors',
   schemaErrors: ReadonlyMap<string, ValidationError[]>,
-  userErrors: ReadonlyMap<string, ValidationError[]>,
-  version: number
+  userErrors: ReadonlyMap<string, ValidationError[]>
 ): PersistedPayload<Form> {
-  if (include === 'form') return { v: version, data: { form } }
+  if (include === 'form') return { v: PERSISTED_ENVELOPE_VERSION, data: { form } }
   return {
-    v: version,
+    v: PERSISTED_ENVELOPE_VERSION,
     data: {
       form,
       schemaErrors: [...schemaErrors.entries()].map(([k, v]) => [k, [...v]] as const),
@@ -180,12 +191,69 @@ export function createDebouncedWriter(
 }
 
 /**
- * Resolve the per-form storage key. Default is
+ * Resolve the per-form storage KEY BASE. Default is
  * `chemical-x-forms:${formKey}` — consumers who want a different
  * namespace (multi-tenant app, per-user prefix) pass `persist.key`.
+ *
+ * The full storage key is `${base}:${fingerprint}` (see
+ * `resolveStorageKey`). The base is exposed separately so the
+ * orphan-cleanup pass can `listKeys(base)` and prune any entry under
+ * an old fingerprint.
  */
-export function resolveStorageKey(config: PersistConfigOptions, formKey: string): string {
+export function resolveStorageKeyBase(config: PersistConfigOptions, formKey: string): string {
   return config.key ?? `${PERSISTENCE_KEY_PREFIX}${formKey}`
+}
+
+/**
+ * Resolve the full per-form storage key, composed of the base and the
+ * schema's structural fingerprint. The fingerprint suffix gives free
+ * automatic invalidation: any structural schema change produces a new
+ * fingerprint, so the new mount looks up a fresh key and the old
+ * draft becomes an orphan (cleaned up on the same mount via
+ * `cleanupOrphanKeys`).
+ */
+export function resolveStorageKey(
+  config: PersistConfigOptions,
+  formKey: string,
+  fingerprint: string
+): string {
+  return `${resolveStorageKeyBase(config, formKey)}:${fingerprint}`
+}
+
+/**
+ * Delete every cx-managed key under `base` that's not the current
+ * fingerprint key. Includes:
+ *   - Pre-fingerprint legacy keys (no `:` suffix at all) — left
+ *     behind by older library versions.
+ *   - New-format keys whose fingerprint suffix doesn't match the
+ *     current schema.
+ *
+ * Exact-or-`:`-prefix match prevents collision with sibling forms
+ * whose `config.key` shares a string prefix (e.g. `'my-form'` vs
+ * `'my-form-2'`).
+ *
+ * Fire-and-forget; never throws. SSR-guarded by the caller (cleanup
+ * runs inside `wirePersistence`, which is itself client-only).
+ */
+export async function cleanupOrphanKeys(
+  adapter: FormStorage,
+  base: string,
+  currentKey: string
+): Promise<void> {
+  let keys: string[]
+  try {
+    keys = await adapter.listKeys(base)
+  } catch {
+    return
+  }
+  for (const key of keys) {
+    if (key === currentKey) continue
+    // Match either the exact base (legacy pre-fingerprint key) or
+    // an explicit `:` continuation (new-format with stale fingerprint).
+    if (key === base || key.startsWith(`${base}:`)) {
+      void adapter.removeItem(key).catch(() => undefined)
+    }
+  }
 }
 
 /**
@@ -221,17 +289,28 @@ export function normalizePersistConfig(input: PersistConfig): PersistConfigOptio
 }
 
 /**
- * Calls `removeItem(key)` on every standard backend (`'local'` /
- * `'session'` / `'indexeddb'`) — fire-and-forget. Used when no
- * `persist:` is configured on the form: a previous deployment may
- * have written an entry under this key, and the dev removing
- * persistence should mean the on-disk artifact is gone too. Same
- * fire-and-forget posture as `sweepNonConfiguredStandardStores`;
- * errors are swallowed.
+ * Wipe every cx-managed key under `base` from every standard backend.
+ * Fire-and-forget. Used when no `persist:` is configured on the form:
+ * a previous deployment may have written entries under this base
+ * (any fingerprint), and the dev removing persistence should mean the
+ * on-disk artifact is gone too — for every fingerprint that ever ran.
+ *
+ * Includes pre-fingerprint legacy keys (no `:` suffix) and
+ * fingerprint-suffixed keys equally. Errors per backend are swallowed.
  */
-export function sweepAllStandardStores(key: string): void {
+export async function sweepAllOrphansAcrossStandardStores(base: string): Promise<void> {
   for (const kind of STANDARD_STORAGE_KINDS) {
-    void removeFromStandardBackend(kind, key).catch(() => undefined)
+    try {
+      const adapter = await getStorageAdapter(kind)
+      const keys = await adapter.listKeys(base)
+      for (const key of keys) {
+        if (key === base || key.startsWith(`${base}:`)) {
+          void adapter.removeItem(key).catch(() => undefined)
+        }
+      }
+    } catch {
+      // Backend unavailable (Node, Safari private mode, IDB blocked).
+    }
   }
 }
 
@@ -261,79 +340,39 @@ export function sweepAllStandardStores(key: string): void {
  * Errors are swallowed — cleanup is best-effort. Backend unavailable
  * (Node, Safari private mode, IDB blocked) is also a silent skip.
  */
-export function sweepNonConfiguredStandardStores(
+/**
+ * Cross-store orphan cleanup: wipe every cx-managed key under `base`
+ * from each standard backend that's NOT the configured one. Symmetric
+ * with `cleanupOrphanKeys` on the configured store: ensures stale
+ * drafts don't survive in stores the dev migrated AWAY from. Includes
+ * legacy pre-fingerprint keys and stale-fingerprint keys equally.
+ *
+ * If `configured` is a custom `FormStorage` adapter, all three
+ * standard backends are swept (we don't know which built-in the dev
+ * migrated away from, and we can't reach custom adapters by
+ * enumeration).
+ *
+ * Fire-and-forget. Per-backend errors swallowed.
+ */
+export async function sweepNonConfiguredStandardStoresForOrphans(
   configured: FormStorageKind | FormStorage,
-  key: string
-): void {
+  base: string
+): Promise<void> {
   const configuredKind = typeof configured === 'string' ? configured : null
   for (const kind of STANDARD_STORAGE_KINDS) {
     if (kind === configuredKind) continue
-    void removeFromStandardBackend(kind, key).catch(() => undefined)
-  }
-}
-
-async function removeFromStandardBackend(kind: FormStorageKind, key: string): Promise<void> {
-  if (kind === 'local') {
-    if (typeof localStorage === 'undefined') return
     try {
-      localStorage.removeItem(key)
-    } catch {
-      // Private-mode write guards / SecurityError — swallow.
-    }
-    return
-  }
-  if (kind === 'session') {
-    if (typeof sessionStorage === 'undefined') return
-    try {
-      sessionStorage.removeItem(key)
-    } catch {
-      // Same guards as localStorage.
-    }
-    return
-  }
-  // kind === 'indexeddb'
-  if (typeof indexedDB === 'undefined') return
-  await new Promise<void>((resolve) => {
-    let request: IDBOpenDBRequest
-    try {
-      // Same DB / store / version as the full IDB adapter
-      // (see `./indexeddb.ts`). Opening at the same version skips the
-      // upgrade path entirely; if the DB doesn't yet exist (no
-      // persistence ever wrote here), `onupgradeneeded` creates the
-      // store and the subsequent `delete(key)` is a no-op — cheap.
-      request = indexedDB.open('chemical-x-forms', 1)
-    } catch {
-      return resolve()
-    }
-    request.onupgradeneeded = () => {
-      const db = request.result
-      if (!db.objectStoreNames.contains('kv')) db.createObjectStore('kv')
-    }
-    request.onsuccess = () => {
-      const db = request.result
-      try {
-        const tx = db.transaction('kv', 'readwrite')
-        tx.objectStore('kv').delete(key)
-        tx.oncomplete = () => {
-          db.close()
-          resolve()
+      const adapter = await getStorageAdapter(kind)
+      const keys = await adapter.listKeys(base)
+      for (const key of keys) {
+        if (key === base || key.startsWith(`${base}:`)) {
+          void adapter.removeItem(key).catch(() => undefined)
         }
-        tx.onabort = () => {
-          db.close()
-          resolve()
-        }
-        tx.onerror = () => {
-          db.close()
-          resolve()
-        }
-      } catch {
-        db.close()
-        resolve()
       }
+    } catch {
+      // Backend unavailable.
     }
-    request.onerror = () => resolve()
-    request.onblocked = () => resolve()
-  })
+  }
 }
 
 /**

--- a/src/runtime/core/persistence/indexeddb.ts
+++ b/src/runtime/core/persistence/indexeddb.ts
@@ -114,6 +114,21 @@ export function createIndexedDbAdapter(): FormStorage {
     async removeItem(key) {
       await runWriteOp((store) => void store.delete(key))
     },
+    async listKeys(prefix) {
+      // `IDBKeyRange.bound(prefix, prefix + '￿')` would skip cx
+      // keys that contain the U+FFFF code unit; safer to fetch all
+      // keys and filter in-process. The cx-managed key namespace is
+      // tiny in practice, so the cost is negligible.
+      const all = await runReadOp<IDBValidKey[]>(
+        (store) => store.getAllKeys() as IDBRequest<IDBValidKey[]>
+      )
+      if (all === undefined) return []
+      const out: string[] = []
+      for (const k of all) {
+        if (typeof k === 'string' && k.startsWith(prefix)) out.push(k)
+      }
+      return out
+    },
   }
 }
 

--- a/src/runtime/core/persistence/local-storage.ts
+++ b/src/runtime/core/persistence/local-storage.ts
@@ -50,5 +50,18 @@ export function createLocalStorageAdapter(): FormStorage {
       }
       return Promise.resolve()
     },
+    listKeys(prefix) {
+      if (!available) return Promise.resolve([])
+      const out: string[] = []
+      try {
+        for (let i = 0; i < localStorage.length; i++) {
+          const k = localStorage.key(i)
+          if (k !== null && k.startsWith(prefix) === true) out.push(k)
+        }
+      } catch {
+        // SecurityError under private-mode locks.
+      }
+      return Promise.resolve(out)
+    },
   }
 }

--- a/src/runtime/core/persistence/session-storage.ts
+++ b/src/runtime/core/persistence/session-storage.ts
@@ -37,5 +37,18 @@ export function createSessionStorageAdapter(): FormStorage {
       }
       return Promise.resolve()
     },
+    listKeys(prefix) {
+      if (!available) return Promise.resolve([])
+      const out: string[] = []
+      try {
+        for (let i = 0; i < sessionStorage.length; i++) {
+          const k = sessionStorage.key(i)
+          if (k !== null && k.startsWith(prefix) === true) out.push(k)
+        }
+      } catch {
+        // SecurityError under private-mode locks.
+      }
+      return Promise.resolve(out)
+    },
   }
 }

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -218,11 +218,19 @@ export type FormStorageKind = 'local' | 'session' | 'indexeddb'
  * stores structured-cloned values. The local/session adapters
  * stringify on write and parse on read, so from the caller's
  * perspective the contract is "give me back whatever I put in".
+ *
+ * `listKeys(prefix)` returns every key whose name starts with `prefix`.
+ * Used by the orphan-cleanup pass at form mount: storage keys carry
+ * a fingerprint suffix (`${prefix}:${fingerprint}`) so schema changes
+ * auto-invalidate stale entries; cleanup walks all matching keys and
+ * deletes any whose suffix doesn't match the current fingerprint.
+ * Required across all backends; pre-1.0 break for custom adapters.
  */
 export type FormStorage = {
   getItem(key: string): Promise<unknown>
   setItem(key: string, value: unknown): Promise<void>
   removeItem(key: string): Promise<void>
+  listKeys(prefix: string): Promise<string[]>
 }
 
 export type PersistIncludeMode = 'form' | 'form+errors'
@@ -279,13 +287,6 @@ export type PersistConfigOptions = {
    * is expensive to reconstruct (complex cross-field refinements).
    */
   include?: PersistIncludeMode
-
-  /**
-   * Increment to invalidate all existing persisted payloads across
-   * every client. Readers check `v` and drop mismatched entries.
-   * Default `1`.
-   */
-  version?: number
 
   /** Clear the persisted entry when a submit handler resolves. Default `true`. */
   clearOnSubmitSuccess?: boolean

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -95,6 +95,31 @@ export type AbstractSchema<Form, GetValueFormType> = {
 
   getDefaultValues(config: GetDefaultValuesConfig<Form>): DefaultValuesResponse<Form>
   /**
+   * Return the schema-prescribed default value at the given path. The
+   * runtime uses this to fill structural gaps so every `setValue` write
+   * leaves the form satisfying the slim schema (objects/arrays/primitives
+   * without refines).
+   *
+   * Semantics:
+   * - **Object property path:** the property's schema default.
+   * - **Array element path:** the element default (paths past the
+   *   array's current length still resolve — every position resolves
+   *   to the same element type).
+   * - **Tuple position path:** the position-specific default. Out-of-
+   *   range positions return `undefined`.
+   * - **Optional/Default/Nullable/Readonly/Catch/Pipe wrappers:** the
+   *   inner default.
+   * - **Discriminated union:** the first variant's default (matches
+   *   `validateAtPath`'s first-success semantic).
+   * - **Leaf:** the primitive default (`''`, `0`, `false`, etc., or the
+   *   wrapper's `.default(x)` value when present).
+   * - **Path doesn't exist in schema:** `undefined`.
+   *
+   * Adapters may return `undefined` when the path can't be resolved;
+   * callers treat that as "don't fill" and fall back to existing data.
+   */
+  getDefaultAtPath(path: Path): unknown
+  /**
    * Return every sub-schema that could resolve at the given structured
    * path. Multiple results are only expected for discriminated / union
    * branches where the adapter can't decide a single winner until the

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -8,7 +8,9 @@ import type {
   FlatPath,
   GenericForm,
   IsObjectOrArray,
+  NestedReadType,
   NestedType,
+  WithIndexedUndefined,
 } from './types-core'
 
 export type FormKey = string
@@ -690,8 +692,35 @@ export type RegisterDirective =
   | RegisterRadioCustomDirective
   | RegisterModelDynamicCustomDirective
 
-export type SetValueCallback<Payload> = (value: DeepPartial<Payload>) => DeepPartial<Payload>
-export type SetValuePayload<Payload> = DeepPartial<Payload> | SetValueCallback<Payload>
+/**
+ * Callback form of `setValue`'s value argument. The callback receives
+ * `prev` as the consumer-facing READ shape (may differ from the write
+ * shape — see SetValuePayload below) and returns the same READ shape.
+ * The runtime mergeStructural's the return value back against the
+ * schema default, filling any structural gaps.
+ *
+ * Returning the read shape (rather than a stricter write shape) is
+ * deliberate: it lets consumers do `({ ...prev, foo: bar })` without
+ * fighting TypeScript over array element undefinedness on the spread.
+ * The runtime guarantees structural completeness AFTER the write
+ * regardless of what shape the consumer returns.
+ */
+export type SetValueCallback<Read> = (prev: Read) => Read
+
+/**
+ * Union of value-form and callback-form for `setValue`'s value
+ * argument. Strict on the value-form — `DeepPartial` was dropped in
+ * favour of the runtime mergeStructural completing partial writes
+ * against the schema default.
+ *
+ * `Write` is the shape required for the value form (typically strict
+ * `Form` or `NestedType<Form, Path>`). `Read` is the shape `prev`
+ * exposes to a callback and the shape the callback returns; defaults
+ * to `Write`. Whole-form `setValue` parameterises `Read` to
+ * `WithIndexedUndefined<Form>` so consumer reads of `prev.posts[5]`
+ * are honest about returning `Post | undefined`.
+ */
+export type SetValuePayload<Write, Read = Write> = Write | SetValueCallback<Read>
 
 type DeepFlatten<T> =
   // If it's not an object, just leave it as-is
@@ -852,24 +881,40 @@ export type UseAbstractFormReturnType<
 > = {
   getFieldState: (path: FlatPath<Form, keyof Form, true>) => Ref<FieldState>
   handleSubmit: HandleSubmit<Form>
+  // getValue READS the form. At array sub-paths the runtime can return
+  // undefined (out-of-bounds index), so the read shape uses
+  // `NestedReadType` — once the path crosses a numeric segment, every
+  // result is `T | undefined`. Strict (no taint) for paths that don't
+  // cross arrays.
   getValue: {
-    (): Readonly<Ref<GetValueFormType>>
-    <Path extends FlatPath<Form>>(path: Path): Readonly<Ref<NestedType<GetValueFormType, Path>>>
+    (): Readonly<Ref<WithIndexedUndefined<GetValueFormType>>>
+    <Path extends FlatPath<Form>>(path: Path): Readonly<Ref<NestedReadType<GetValueFormType, Path>>>
     <WithMeta extends boolean>(
       context: CurrentValueContext<WithMeta>
     ): WithMeta extends true
-      ? CurrentValueWithContext<GetValueFormType>
-      : Readonly<Ref<GetValueFormType>>
+      ? CurrentValueWithContext<WithIndexedUndefined<GetValueFormType>>
+      : Readonly<Ref<WithIndexedUndefined<GetValueFormType>>>
     <Path extends FlatPath<Form>, WithMeta extends boolean>(
       path: Path,
       context: CurrentValueContext<WithMeta>
     ): WithMeta extends true
-      ? CurrentValueWithContext<NestedType<GetValueFormType, Path>>
-      : Readonly<Ref<NestedType<GetValueFormType, Path>>>
+      ? CurrentValueWithContext<NestedReadType<GetValueFormType, Path>>
+      : Readonly<Ref<NestedReadType<GetValueFormType, Path>>>
   }
+  // setValue WRITES the form. Both forms drop `DeepPartial` — write
+  // shapes lead with the strict NestedType. The runtime mergeStructural
+  // completes any partial writes, so casts still work; types are honest
+  // about what consumers SHOULD pass.
+  //
+  // Whole-form: `prev` is undefined-tainted (read shape); return is
+  // strict (write shape). Path-form: both prev and return are strict
+  // (runtime auto-defaults prev when the slot is missing).
   setValue: {
-    <Value extends SetValuePayload<Form>>(value: Value): boolean
-    <Path extends FlatPath<Form>, Value extends SetValuePayload<NestedType<Form, Path>>>(
+    <Value extends SetValuePayload<Form, WithIndexedUndefined<Form>>>(value: Value): boolean
+    <
+      Path extends FlatPath<Form>,
+      Value extends SetValuePayload<NestedType<Form, Path>, NonNullable<NestedType<Form, Path>>>,
+    >(
       path: Path,
       value: Value
     ): boolean
@@ -907,7 +952,7 @@ export type UseAbstractFormReturnType<
   register: <Path extends RegisterFlatPath<Form, keyof Form>>(
     path: Path,
     options?: RegisterOptions
-  ) => RegisterValue<NestedType<Form, Path> | undefined>
+  ) => RegisterValue<NestedReadType<Form, Path>>
   key: FormKey
 
   // --- Reactive field-error API ---

--- a/src/runtime/types/types-core.ts
+++ b/src/runtime/types/types-core.ts
@@ -119,6 +119,103 @@ export type NestedType<
 type Primitive = string | number | boolean | symbol | bigint | null | undefined
 
 /**
+ * Distinguish a tuple from a regular array. Tuples have a literal
+ * `length` (`2`, `3`, ...); arrays have `length: number`.
+ *
+ *   IsTuple<[string, number]>  // true
+ *   IsTuple<string[]>          // false
+ *
+ * Used by `WithIndexedUndefined` to skip taint on tuple positions
+ * (which are guaranteed to be defined at runtime once the tuple is
+ * structurally complete) while still tainting unbounded array
+ * elements (where `arr[N]` can return `undefined` for out-of-bounds
+ * reads).
+ */
+export type IsTuple<T extends readonly unknown[]> = number extends T['length'] ? false : true
+
+/**
+ * "Honest read shape" for a form value. Tags every UNBOUNDED array's
+ * element type with `| undefined` so consumer code that touches
+ * `prev.posts[5]` or similar must narrow before using the result —
+ * matching the runtime reality that array index reads can fall off
+ * the end. Recurses into objects and tuple positions; leaves Date /
+ * RegExp / Map / Set / class instances untouched.
+ *
+ * Used for:
+ * - Whole-form callback `prev` in `setValue(cb)` (the live form is
+ *   read; the runtime structural-completeness invariant guarantees
+ *   the form is structurally complete after every write, but doesn't
+ *   guarantee any particular array LENGTH).
+ * - `getValue(path)` returns at array sub-paths.
+ *
+ * NOT applied to:
+ * - Path-form callback `prev` in `setValue(path, cb)` — the runtime
+ *   auto-defaults `prev` from `schema.getDefaultAtPath(path)` when
+ *   the slot is missing, so the strict `NestedType` is honest there.
+ * - `setValue` value form — write shapes stay strict so consumers
+ *   can't accidentally pass partial-array values that the type
+ *   system promises but the validation layer rejects.
+ */
+export type WithIndexedUndefined<T> = T extends
+  | Date
+  | RegExp
+  | Map<unknown, unknown>
+  | Set<unknown>
+  | ((...args: never) => unknown)
+  ? T
+  : T extends ReadonlyArray<infer Item>
+    ? IsTuple<T> extends true
+      ? { -readonly [K in keyof T]: WithIndexedUndefined<T[K]> }
+      : ReadonlyArray<WithIndexedUndefined<Item> | undefined>
+    : T extends object
+      ? { [K in keyof T]: WithIndexedUndefined<T[K]> }
+      : T
+
+/**
+ * Like `NestedType` but tracks whether a numerical-index segment was
+ * crossed during the walk. Once tainted, every subsequent result is
+ * `T | undefined`. Use for the READ side of path-walking APIs
+ * (`getValue`, `register`'s value ref) where the runtime can return
+ * `undefined` if the array index is out of bounds.
+ *
+ * The strict `NestedType` stays in place for write-side APIs and for
+ * path-form callback prev (which is auto-defaulted at runtime).
+ */
+export type NestedReadType<
+  RootValue,
+  FlattenedPath extends string,
+  _Tainted extends boolean = false,
+  _RootValue = NonNullable<RootValue>,
+> =
+  IsObjectOrArray<_RootValue> extends false
+    ? never
+    : FlattenedPath extends `${infer Key}.${infer Rest}`
+      ? Key extends `${number}`
+        ? Key extends keyof _RootValue
+          ? NestedReadType<_RootValue[Key], Rest, true>
+          : Key extends `${infer NumericKey extends number}`
+            ? NumericKey extends keyof _RootValue
+              ? NestedReadType<_RootValue[NumericKey], Rest, true>
+              : never
+            : never
+        : Key extends keyof _RootValue
+          ? NestedReadType<_RootValue[Key], Rest, _Tainted>
+          : never
+      : FlattenedPath extends `${number}`
+        ? FlattenedPath extends keyof _RootValue
+          ? _RootValue[FlattenedPath] | undefined
+          : FlattenedPath extends `${infer NumericKey extends number}`
+            ? NumericKey extends keyof _RootValue
+              ? _RootValue[NumericKey] | undefined
+              : never
+            : never
+        : FlattenedPath extends keyof _RootValue
+          ? _Tainted extends true
+            ? _RootValue[FlattenedPath] | undefined
+            : _RootValue[FlattenedPath]
+          : never
+
+/**
  * Filter FlatPath<Form> down to the subset of paths whose resolved leaf
  * is an array. Used by the typed field-array helpers (append / remove /
  * swap / ...) so those helpers only accept paths that actually address

--- a/test/adapters/zod-v3/get-default-at-path.test.ts
+++ b/test/adapters/zod-v3/get-default-at-path.test.ts
@@ -136,15 +136,19 @@ describe('zod v3: getDefaultAtPath', () => {
       expect(adapter.getDefaultAtPath(['validated', 'age'])).toBe(0)
     })
 
-    it('returns undefined at wrapper level when wrapper has no .default()', () => {
+    it('peels Optional at the LEAF and returns structural inner default', () => {
       const schema = z.object({
-        profile: z.object({ name: z.string() }).optional(),
+        profile: z.object({ name: z.string(), age: z.number() }).optional(),
       })
       const adapter = zodAdapter(schema)('f')
-      // Wrapper level: ZodOptional unwraps to undefined per generateValue.
-      expect(adapter.getDefaultAtPath(['profile'])).toBeUndefined()
-      // Sub-paths still resolve through the wrapper.
+      expect(adapter.getDefaultAtPath(['profile'])).toEqual({ name: '', age: 0 })
       expect(adapter.getDefaultAtPath(['profile', 'name'])).toBe('')
+    })
+
+    it('peels Nullable at the LEAF and returns structural inner default', () => {
+      const schema = z.object({ name: z.string().nullable() })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['name'])).toBe('')
     })
   })
 

--- a/test/adapters/zod-v3/get-default-at-path.test.ts
+++ b/test/adapters/zod-v3/get-default-at-path.test.ts
@@ -145,10 +145,30 @@ describe('zod v3: getDefaultAtPath', () => {
       expect(adapter.getDefaultAtPath(['profile', 'name'])).toBe('')
     })
 
-    it('peels Nullable at the LEAF and returns structural inner default', () => {
+    it('preserves Optional around a PRIMITIVE leaf — returns undefined, not the inner default', () => {
+      const schema = z.object({
+        notes: z.string().optional(),
+        score: z.number().optional(),
+        active: z.boolean().optional(),
+      })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['notes'])).toBeUndefined()
+      expect(adapter.getDefaultAtPath(['score'])).toBeUndefined()
+      expect(adapter.getDefaultAtPath(['active'])).toBeUndefined()
+    })
+
+    it('preserves Nullable around a PRIMITIVE leaf — returns null, not the inner default', () => {
       const schema = z.object({ name: z.string().nullable() })
       const adapter = zodAdapter(schema)('f')
-      expect(adapter.getDefaultAtPath(['name'])).toBe('')
+      expect(adapter.getDefaultAtPath(['name'])).toBeNull()
+    })
+
+    it('peels Nullable around a STRUCTURAL inner — returns the inner default', () => {
+      const schema = z.object({
+        user: z.object({ name: z.string(), age: z.number() }).nullable(),
+      })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['user'])).toEqual({ name: '', age: 0 })
     })
   })
 

--- a/test/adapters/zod-v3/get-default-at-path.test.ts
+++ b/test/adapters/zod-v3/get-default-at-path.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod-v3'
+import { zodAdapter } from '../../../src/runtime/adapters/zod-v3'
+
+/**
+ * Mirror of the v4 adapter's `get-default-at-path.test.ts`. Both adapters
+ * MUST resolve the same defaults at the same paths so the runtime's
+ * structural-completeness invariant holds identically across them. v3's
+ * native path-walker doesn't peel wrappers, so the adapter's
+ * `getDefaultAtPath` uses a separate wrapper-peeling walker
+ * (`walkV3ToLeafSchema`) — these tests pin parity with v4.
+ */
+
+describe('zod v3: getDefaultAtPath', () => {
+  describe('basic paths', () => {
+    it('returns the form root default for empty path', () => {
+      const schema = z.object({ email: z.string(), age: z.number() })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath([])).toEqual({ email: '', age: 0 })
+    })
+
+    it('returns property default for object property path', () => {
+      const schema = z.object({ email: z.string(), age: z.number() })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['email'])).toBe('')
+      expect(adapter.getDefaultAtPath(['age'])).toBe(0)
+    })
+
+    it('returns the .default(x) value when set', () => {
+      const schema = z.object({
+        role: z.string().default('user'),
+        count: z.number().default(5),
+      })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['role'])).toBe('user')
+      expect(adapter.getDefaultAtPath(['count'])).toBe(5)
+    })
+
+    it('returns undefined for paths that do not exist', () => {
+      const schema = z.object({ email: z.string() })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['nope'])).toBeUndefined()
+      expect(adapter.getDefaultAtPath(['email', 'nested'])).toBeUndefined()
+    })
+  })
+
+  describe('arrays', () => {
+    it('returns element default for any numeric index', () => {
+      const schema = z.object({
+        posts: z.array(z.object({ title: z.string(), views: z.number() })),
+      })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['posts', 0])).toEqual({ title: '', views: 0 })
+      expect(adapter.getDefaultAtPath(['posts', 21])).toEqual({ title: '', views: 0 })
+    })
+
+    it('returns scalar element default for primitive arrays', () => {
+      const schema = z.object({ tags: z.array(z.string()) })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['tags', 0])).toBe('')
+      expect(adapter.getDefaultAtPath(['tags', 99])).toBe('')
+    })
+
+    it('returns nested defaults through array → object → array', () => {
+      const schema = z.object({
+        people: z.array(
+          z.object({
+            name: z.string(),
+            addresses: z.array(z.object({ street: z.string(), zip: z.string() })),
+          })
+        ),
+      })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['people', 0, 'name'])).toBe('')
+      expect(adapter.getDefaultAtPath(['people', 0, 'addresses', 0])).toEqual({
+        street: '',
+        zip: '',
+      })
+      expect(adapter.getDefaultAtPath(['people', 5, 'addresses', 3, 'street'])).toBe('')
+    })
+  })
+
+  describe('tuples', () => {
+    it('returns position-specific defaults', () => {
+      const schema = z.object({
+        coords: z.tuple([z.string(), z.number(), z.boolean()]),
+      })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['coords', 0])).toBe('')
+      expect(adapter.getDefaultAtPath(['coords', 1])).toBe(0)
+      expect(adapter.getDefaultAtPath(['coords', 2])).toBe(false)
+    })
+
+    it('returns undefined for out-of-range tuple positions', () => {
+      const schema = z.object({ pair: z.tuple([z.string(), z.number()]) })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['pair', 5])).toBeUndefined()
+    })
+  })
+
+  describe('wrappers (parity with v4)', () => {
+    it('peels Optional and returns inner default at sub-paths', () => {
+      const schema = z.object({
+        profile: z.object({ name: z.string(), age: z.number() }).optional(),
+      })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['profile', 'name'])).toBe('')
+      expect(adapter.getDefaultAtPath(['profile', 'age'])).toBe(0)
+    })
+
+    it('peels Nullable and returns inner default at sub-paths', () => {
+      const schema = z.object({
+        meta: z.object({ note: z.string() }).nullable(),
+      })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['meta', 'note'])).toBe('')
+    })
+
+    it('peels Default and reaches inner properties', () => {
+      const schema = z.object({
+        prefs: z.object({ theme: z.string() }).default({ theme: 'dark' }),
+      })
+      const adapter = zodAdapter(schema)('f')
+      // Inner property: returns the primitive default ('').
+      expect(adapter.getDefaultAtPath(['prefs', 'theme'])).toBe('')
+      // Wrapper level: returns the .default() value.
+      expect(adapter.getDefaultAtPath(['prefs'])).toEqual({ theme: 'dark' })
+    })
+
+    it('peels ZodEffects (refinements / transforms) at sub-paths', () => {
+      const schema = z.object({
+        validated: z.object({ name: z.string(), age: z.number() }).refine((v) => v.age >= 0),
+      })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['validated', 'name'])).toBe('')
+      expect(adapter.getDefaultAtPath(['validated', 'age'])).toBe(0)
+    })
+
+    it('returns undefined at wrapper level when wrapper has no .default()', () => {
+      const schema = z.object({
+        profile: z.object({ name: z.string() }).optional(),
+      })
+      const adapter = zodAdapter(schema)('f')
+      // Wrapper level: ZodOptional unwraps to undefined per generateValue.
+      expect(adapter.getDefaultAtPath(['profile'])).toBeUndefined()
+      // Sub-paths still resolve through the wrapper.
+      expect(adapter.getDefaultAtPath(['profile', 'name'])).toBe('')
+    })
+  })
+
+  describe('discriminated unions', () => {
+    it('returns first variant default at the union root', () => {
+      const schema = z.object({
+        event: z.discriminatedUnion('kind', [
+          z.object({ kind: z.literal('a'), x: z.number() }),
+          z.object({ kind: z.literal('b'), y: z.string() }),
+        ]),
+      })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['event'])).toEqual({ kind: 'a', x: 0 })
+    })
+
+    it('descends into the matching variant for variant-specific keys', () => {
+      const schema = z.object({
+        event: z.discriminatedUnion('kind', [
+          z.object({ kind: z.literal('a'), x: z.number() }),
+          z.object({ kind: z.literal('b'), y: z.string() }),
+        ]),
+      })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['event', 'x'])).toBe(0)
+      expect(adapter.getDefaultAtPath(['event', 'y'])).toBe('')
+    })
+  })
+
+  describe('records', () => {
+    it('returns the value-type default for any record key', () => {
+      const schema = z.object({
+        users: z.record(z.string(), z.object({ name: z.string(), age: z.number() })),
+      })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['users', 'alice'])).toEqual({ name: '', age: 0 })
+      expect(adapter.getDefaultAtPath(['users', 'bob', 'name'])).toBe('')
+    })
+  })
+
+  describe('cross-cutting', () => {
+    it('treats non-existent paths through arrays as undefined', () => {
+      const schema = z.object({
+        posts: z.array(z.object({ title: z.string() })),
+      })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['posts', 0, 'nope'])).toBeUndefined()
+    })
+
+    it('returns the schema-prescribed default even for unpopulated array indices', () => {
+      const schema = z.object({
+        posts: z.array(z.object({ title: z.string().default('untitled') })),
+      })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['posts', 7])).toEqual({ title: 'untitled' })
+    })
+  })
+})

--- a/test/adapters/zod-v4/get-default-at-path.test.ts
+++ b/test/adapters/zod-v4/get-default-at-path.test.ts
@@ -127,15 +127,35 @@ describe('zod v4: getDefaultAtPath', () => {
       expect(adapter.getDefaultAtPath(['prefs'])).toEqual({ theme: 'dark' })
     })
 
-    it('returns the inner default when wrapper has no .default()', () => {
+    it('peels Optional at the LEAF and returns structural inner default', () => {
+      // The runtime uses this to fill partial writes through optional
+      // sub-schemas: `setValue('user.profile', { name: 'Carol' })` against
+      // `profile: z.object({...}).optional()` needs the inner default
+      // `{ name: '', age: 0 }` to fill missing keys.
       const schema = z.object({
-        profile: z.object({ name: z.string() }).optional(),
+        profile: z.object({ name: z.string(), age: z.number() }).optional(),
       })
       const adapter = zodAdapter(schema)('f')
-      // Wrapper level: ZodOptional → undefined (matches deriveDefault).
-      expect(adapter.getDefaultAtPath(['profile'])).toBeUndefined()
-      // But sub-paths still resolve through the wrapper.
+      // Structural default at the wrapper level: inner shape's default.
+      expect(adapter.getDefaultAtPath(['profile'])).toEqual({ name: '', age: 0 })
+      // Sub-paths also resolve through the wrapper.
       expect(adapter.getDefaultAtPath(['profile', 'name'])).toBe('')
+    })
+
+    it('peels Nullable at the LEAF and returns structural inner default', () => {
+      const schema = z.object({ name: z.string().nullable() })
+      const adapter = zodAdapter(schema)('f')
+      // Structural default: '' (slim view), not null.
+      expect(adapter.getDefaultAtPath(['name'])).toBe('')
+    })
+
+    it('preserves .default(x) at wrapper level — not peeled', () => {
+      // `.default(x)` is the explicit "fresh" value; it stays.
+      const schema = z.object({
+        prefs: z.object({ theme: z.string() }).default({ theme: 'dark' }),
+      })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['prefs'])).toEqual({ theme: 'dark' })
     })
   })
 

--- a/test/adapters/zod-v4/get-default-at-path.test.ts
+++ b/test/adapters/zod-v4/get-default-at-path.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { zodAdapter } from '../../../src/runtime/adapters/zod-v4'
+
+/**
+ * Adapter-level tests for `getDefaultAtPath`. The runtime structural-
+ * completeness invariant fills missing slots in the form via this method,
+ * so its semantics need to be uniform across adapters and stable across
+ * common Zod shapes (objects, arrays, tuples, wrappers, unions).
+ */
+
+describe('zod v4: getDefaultAtPath', () => {
+  describe('basic paths', () => {
+    it('returns the form root default for empty path', () => {
+      const schema = z.object({ email: z.string(), age: z.number() })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath([])).toEqual({ email: '', age: 0 })
+    })
+
+    it('returns property default for object property path', () => {
+      const schema = z.object({ email: z.string(), age: z.number() })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['email'])).toBe('')
+      expect(adapter.getDefaultAtPath(['age'])).toBe(0)
+    })
+
+    it('returns the .default(x) value when set', () => {
+      const schema = z.object({
+        role: z.string().default('user'),
+        count: z.number().default(5),
+      })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['role'])).toBe('user')
+      expect(adapter.getDefaultAtPath(['count'])).toBe(5)
+    })
+
+    it('returns undefined for paths that do not exist', () => {
+      const schema = z.object({ email: z.string() })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['nope'])).toBeUndefined()
+      expect(adapter.getDefaultAtPath(['email', 'nested'])).toBeUndefined()
+    })
+  })
+
+  describe('arrays', () => {
+    it('returns element default for any numeric index (the array is element-uniform)', () => {
+      const schema = z.object({
+        posts: z.array(z.object({ title: z.string(), views: z.number() })),
+      })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['posts', 0])).toEqual({ title: '', views: 0 })
+      expect(adapter.getDefaultAtPath(['posts', 21])).toEqual({ title: '', views: 0 })
+    })
+
+    it('returns scalar element default for primitive arrays', () => {
+      const schema = z.object({ tags: z.array(z.string()) })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['tags', 0])).toBe('')
+      expect(adapter.getDefaultAtPath(['tags', 99])).toBe('')
+    })
+
+    it('returns nested defaults through array → object → array', () => {
+      const schema = z.object({
+        people: z.array(
+          z.object({
+            name: z.string(),
+            addresses: z.array(z.object({ street: z.string(), zip: z.string() })),
+          })
+        ),
+      })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['people', 0, 'name'])).toBe('')
+      expect(adapter.getDefaultAtPath(['people', 0, 'addresses', 0])).toEqual({
+        street: '',
+        zip: '',
+      })
+      expect(adapter.getDefaultAtPath(['people', 5, 'addresses', 3, 'street'])).toBe('')
+    })
+  })
+
+  describe('tuples', () => {
+    it('returns position-specific defaults', () => {
+      const schema = z.object({
+        coords: z.tuple([z.string(), z.number(), z.boolean()]),
+      })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['coords', 0])).toBe('')
+      expect(adapter.getDefaultAtPath(['coords', 1])).toBe(0)
+      expect(adapter.getDefaultAtPath(['coords', 2])).toBe(false)
+    })
+
+    it('returns undefined for out-of-range tuple positions', () => {
+      const schema = z.object({ pair: z.tuple([z.string(), z.number()]) })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['pair', 5])).toBeUndefined()
+    })
+  })
+
+  describe('wrappers', () => {
+    it('peels Optional and returns inner default at sub-paths', () => {
+      const schema = z.object({
+        profile: z.object({ name: z.string(), age: z.number() }).optional(),
+      })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['profile', 'name'])).toBe('')
+      expect(adapter.getDefaultAtPath(['profile', 'age'])).toBe(0)
+    })
+
+    it('peels Nullable and returns inner default at sub-paths', () => {
+      const schema = z.object({
+        meta: z.object({ note: z.string() }).nullable(),
+      })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['meta', 'note'])).toBe('')
+    })
+
+    it('peels Default and returns inner default at sub-paths', () => {
+      const schema = z.object({
+        prefs: z.object({ theme: z.string() }).default({ theme: 'dark' }),
+      })
+      const adapter = zodAdapter(schema)('f')
+      // The leaf inside the .default is unwrapped; theme as a property
+      // returns its primitive default. The .default value applies at the
+      // wrapper level (path ['prefs']), not below it.
+      expect(adapter.getDefaultAtPath(['prefs', 'theme'])).toBe('')
+      // At the wrapper level itself, the .default value applies.
+      expect(adapter.getDefaultAtPath(['prefs'])).toEqual({ theme: 'dark' })
+    })
+
+    it('returns the inner default when wrapper has no .default()', () => {
+      const schema = z.object({
+        profile: z.object({ name: z.string() }).optional(),
+      })
+      const adapter = zodAdapter(schema)('f')
+      // Wrapper level: ZodOptional → undefined (matches deriveDefault).
+      expect(adapter.getDefaultAtPath(['profile'])).toBeUndefined()
+      // But sub-paths still resolve through the wrapper.
+      expect(adapter.getDefaultAtPath(['profile', 'name'])).toBe('')
+    })
+  })
+
+  describe('discriminated unions', () => {
+    it('returns first variant default at the union root', () => {
+      const schema = z.object({
+        event: z.discriminatedUnion('kind', [
+          z.object({ kind: z.literal('a'), x: z.number() }),
+          z.object({ kind: z.literal('b'), y: z.string() }),
+        ]),
+      })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['event'])).toEqual({ kind: 'a', x: 0 })
+    })
+
+    it('descends into the matching variant for variant-specific keys', () => {
+      const schema = z.object({
+        event: z.discriminatedUnion('kind', [
+          z.object({ kind: z.literal('a'), x: z.number() }),
+          z.object({ kind: z.literal('b'), y: z.string() }),
+        ]),
+      })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['event', 'x'])).toBe(0)
+      expect(adapter.getDefaultAtPath(['event', 'y'])).toBe('')
+    })
+  })
+
+  describe('records', () => {
+    it('returns the value-type default for any record key', () => {
+      const schema = z.object({
+        users: z.record(z.string(), z.object({ name: z.string(), age: z.number() })),
+      })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['users', 'alice'])).toEqual({ name: '', age: 0 })
+      expect(adapter.getDefaultAtPath(['users', 'bob', 'name'])).toBe('')
+    })
+  })
+
+  describe('cross-cutting', () => {
+    it('treats non-existent paths through arrays as undefined', () => {
+      const schema = z.object({
+        posts: z.array(z.object({ title: z.string() })),
+      })
+      const adapter = zodAdapter(schema)('f')
+      // 'nope' isn't in the post shape.
+      expect(adapter.getDefaultAtPath(['posts', 0, 'nope'])).toBeUndefined()
+    })
+
+    it('returns the schema-prescribed default even for unpopulated array indices', () => {
+      // The runtime needs this to fill posts[0..N-1] when consumer writes
+      // to posts[N] against an empty array — the schema must answer
+      // "what's the element default at index 0?" identically for any N.
+      const schema = z.object({
+        posts: z.array(z.object({ title: z.string().default('untitled') })),
+      })
+      const adapter = zodAdapter(schema)('f')
+      const def = adapter.getDefaultAtPath(['posts', 7])
+      expect(def).toEqual({ title: 'untitled' })
+    })
+  })
+})

--- a/test/adapters/zod-v4/get-default-at-path.test.ts
+++ b/test/adapters/zod-v4/get-default-at-path.test.ts
@@ -142,11 +142,43 @@ describe('zod v4: getDefaultAtPath', () => {
       expect(adapter.getDefaultAtPath(['profile', 'name'])).toBe('')
     })
 
-    it('peels Nullable at the LEAF and returns structural inner default', () => {
+    it('preserves Optional around a PRIMITIVE leaf — returns undefined, not the inner default', () => {
+      // Regression guard: peeling an optional primitive to its inner
+      // default `''` would silently overwrite the optional's "absent"
+      // semantic. mergeStructural would write `notes: ''` into a sibling
+      // fill instead of leaving notes undefined / unset, and downstream
+      // consumers reading `notes` would see an empty string they didn't
+      // ask for.
+      const schema = z.object({
+        notes: z.string().optional(),
+        score: z.number().optional(),
+        active: z.boolean().optional(),
+      })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['notes'])).toBeUndefined()
+      expect(adapter.getDefaultAtPath(['score'])).toBeUndefined()
+      expect(adapter.getDefaultAtPath(['active'])).toBeUndefined()
+    })
+
+    it('preserves Nullable around a PRIMITIVE leaf — returns null, not the inner default', () => {
+      // The wrapper IS the meaningful schema for primitive leaves:
+      // `.nullable()` means "null is allowed". Peeling to `''` would
+      // let mergeStructural overwrite an honest null with an empty
+      // string when filling sibling keys at a parent object.
       const schema = z.object({ name: z.string().nullable() })
       const adapter = zodAdapter(schema)('f')
-      // Structural default: '' (slim view), not null.
-      expect(adapter.getDefaultAtPath(['name'])).toBe('')
+      expect(adapter.getDefaultAtPath(['name'])).toBeNull()
+    })
+
+    it('peels Nullable around a STRUCTURAL inner — returns the inner default', () => {
+      // Nullable around an object: we DO peel so `setValue('user',
+      // { name: 'Alice' })` against `user: z.object({...}).nullable()`
+      // can fill the inner shape's missing keys.
+      const schema = z.object({
+        user: z.object({ name: z.string(), age: z.number() }).nullable(),
+      })
+      const adapter = zodAdapter(schema)('f')
+      expect(adapter.getDefaultAtPath(['user'])).toEqual({ name: '', age: 0 })
     })
 
     it('preserves .default(x) at wrapper level — not peeled', () => {

--- a/test/composables/custom-defaults-e2e.test.ts
+++ b/test/composables/custom-defaults-e2e.test.ts
@@ -1,0 +1,236 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, type App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { createChemicalXForms } from '../../src/runtime/core/plugin'
+
+/**
+ * End-to-end coverage for explicit `.default(customValue)` flowing
+ * through the consumer-facing surface. The adapter unit tests prove
+ * `getDefaultValues` / `getDefaultAtPath` / `deriveDefault` each honor
+ * `.default()` in isolation; these tests pin the consumer-visible
+ * behavior:
+ *
+ *   1. Form construction: `useForm({ schema })` with `.default('user')`
+ *      on a field produces `'user'` at `form.getValue('role').value`.
+ *   2. Path-form callback prev auto-default: when the slot is missing,
+ *      `setValue('field', cb)` hands the consumer the `.default(x)`
+ *      value (not the natural falsy primitive default).
+ *   3. Sparse-array fill: writing past length pads each slot with the
+ *      schema element default — including any `.default(x)` values
+ *      nested inside the element shape.
+ *
+ * Catches regressions where Phase-2 / Phase-3 plumbing accidentally
+ * stops calling deriveDefault with useDefault=true, or where the
+ * structural-completeness fill walker drops `.default()` wrappers
+ * during peeling.
+ */
+
+function harness<S extends z.ZodObject>(
+  schema: S
+): {
+  app: App
+  form: ReturnType<typeof useForm<S>>
+} {
+  let captured!: ReturnType<typeof useForm<S>>
+  const Probe = defineComponent({
+    setup() {
+      captured = useForm({
+        schema,
+        key: `custom-defaults-${Math.random().toString(36).slice(2)}`,
+      })
+      return () => h('div')
+    },
+  })
+  const app = createApp(Probe)
+  app.use(createChemicalXForms())
+  app.mount(document.createElement('div'))
+  return { app, form: captured }
+}
+
+describe('custom .default() values flow through the consumer surface', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  describe('form construction picks .default() over natural falsy', () => {
+    it('string with .default("user") produces "user" — not ""', () => {
+      const schema = z.object({ role: z.string().default('user') })
+      const { app, form } = harness(schema)
+      apps.push(app)
+      expect(form.getValue('role').value).toBe('user')
+    })
+
+    it('number with .default(5) produces 5 — not 0', () => {
+      const schema = z.object({ count: z.number().default(5) })
+      const { app, form } = harness(schema)
+      apps.push(app)
+      expect(form.getValue('count').value).toBe(5)
+    })
+
+    it('boolean with .default(true) produces true — not false', () => {
+      const schema = z.object({ active: z.boolean().default(true) })
+      const { app, form } = harness(schema)
+      apps.push(app)
+      expect(form.getValue('active').value).toBe(true)
+    })
+
+    it('object .default({...}) produces the literal default', () => {
+      const schema = z.object({
+        prefs: z.object({ theme: z.string(), density: z.string() }).default({
+          theme: 'dark',
+          density: 'comfortable',
+        }),
+      })
+      const { app, form } = harness(schema)
+      apps.push(app)
+      expect(form.getValue('prefs').value).toEqual({
+        theme: 'dark',
+        density: 'comfortable',
+      })
+    })
+
+    it('nested .default() inside an object field produces the nested default', () => {
+      const schema = z.object({
+        prefs: z.object({
+          theme: z.string().default('dark'),
+          // No .default — natural ''.
+          locale: z.string(),
+        }),
+      })
+      const { app, form } = harness(schema)
+      apps.push(app)
+      expect(form.getValue('prefs').value).toEqual({
+        theme: 'dark',
+        locale: '',
+      })
+    })
+
+    it('array element with nested .default() honours the nested default on construction', () => {
+      const schema = z.object({
+        // Array starts empty (no .default on the array itself); the
+        // element default is `{ title: 'untitled', views: 0 }` and is
+        // exposed via getDefaultAtPath when the array is grown.
+        posts: z.array(
+          z.object({
+            title: z.string().default('untitled'),
+            views: z.number(),
+          })
+        ),
+      })
+      const { app, form } = harness(schema)
+      apps.push(app)
+      // The array is empty at construction, but a synthetic write past
+      // length should pad with the element default — `.default('untitled')`
+      // for title.
+      form.setValue('posts.2', { title: 'real', views: 100 })
+      expect(form.getValue('posts').value).toEqual([
+        { title: 'untitled', views: 0 },
+        { title: 'untitled', views: 0 },
+        { title: 'real', views: 100 },
+      ])
+    })
+  })
+
+  describe('path-form callback prev auto-default uses .default(x)', () => {
+    it('callback prev for an unpopulated optional field is the .default value', () => {
+      const schema = z.object({
+        // Optional so the slot is genuinely missing at construction.
+        prefs: z
+          .object({
+            theme: z.string().default('dark'),
+            density: z.string().default('comfortable'),
+          })
+          .optional(),
+      })
+      const { app, form } = harness(schema)
+      apps.push(app)
+
+      let receivedPrev: unknown
+      form.setValue('prefs', (prev) => {
+        receivedPrev = prev
+        return { ...prev, theme: 'light' }
+      })
+
+      // prev was auto-defaulted from getDefaultAtPath(['prefs']),
+      // which peels the .optional() and returns the inner shape's
+      // structural default — including the `.default('dark')` /
+      // `.default('comfortable')` values rather than `''`.
+      expect(receivedPrev).toEqual({ theme: 'dark', density: 'comfortable' })
+      // Final value carries the consumer's override, defaults survive.
+      expect(form.getValue('prefs').value).toEqual({
+        theme: 'light',
+        density: 'comfortable',
+      })
+    })
+
+    it('callback prev for a missing array element honours nested .default()', () => {
+      const schema = z.object({
+        posts: z.array(
+          z.object({
+            title: z.string().default('untitled'),
+            views: z.number().default(0),
+          })
+        ),
+      })
+      const { app, form } = harness(schema)
+      apps.push(app)
+
+      let receivedPrev: unknown
+      form.setValue('posts.0', (prev) => {
+        receivedPrev = prev
+        return { ...prev, title: 'first' }
+      })
+
+      // The element default is `{ title: 'untitled', views: 0 }` —
+      // verifies the .default('untitled') survives the path-form
+      // auto-default path (vs. natural empty string '').
+      expect(receivedPrev).toEqual({ title: 'untitled', views: 0 })
+    })
+  })
+
+  describe('sparse-array fill picks nested .default(x)', () => {
+    it('writing posts.3 against empty posts populates 0..2 with .default-aware elements', () => {
+      const schema = z.object({
+        posts: z.array(
+          z.object({
+            title: z.string().default('untitled'),
+            views: z.number().default(10),
+          })
+        ),
+      })
+      const { app, form } = harness(schema)
+      apps.push(app)
+
+      form.setValue('posts.3', { title: 'real', views: 100 })
+
+      // Indices 0..2: element default with both .default() values
+      // present. Index 3: the consumer's value.
+      expect(form.getValue('posts').value).toEqual([
+        { title: 'untitled', views: 10 },
+        { title: 'untitled', views: 10 },
+        { title: 'untitled', views: 10 },
+        { title: 'real', views: 100 },
+      ])
+    })
+
+    it('tuple positions pick their own .default(x) when fill kicks in', () => {
+      const schema = z.object({
+        coords: z.tuple([z.number().default(7), z.number().default(13), z.number().default(99)]),
+      })
+      const { app, form } = harness(schema)
+      apps.push(app)
+
+      // Form construction already produces [7, 13, 99] from positional
+      // defaults. Verify it directly first.
+      expect(form.getValue('coords').value).toEqual([7, 13, 99])
+
+      // Now mutate: setValue at position 2 should leave 0,1 as their
+      // existing defaults (no fill needed — they're already populated).
+      form.setValue('coords.2', 42)
+      expect(form.getValue('coords').value).toEqual([7, 13, 42])
+    })
+  })
+})

--- a/test/composables/persistence.test.ts
+++ b/test/composables/persistence.test.ts
@@ -7,6 +7,7 @@ import { useForm } from '../../src/zod'
 import { vRegister } from '../../src/runtime/core/directive'
 import { __resetIndexedDbForTests } from '../../src/runtime/core/persistence/indexeddb'
 import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { fingerprintZodSchema } from '../../src/runtime/adapters/zod-v4/fingerprint'
 
 /**
  * Node 25's native `localStorage` (behind `--experimental-webstorage`)
@@ -57,6 +58,16 @@ const schema = z.object({
   email: z.string(),
   password: z.string(),
 })
+
+/**
+ * Fingerprint suffix appended to every storage key by the runtime.
+ * Tests that pre-seed storage at a specific key need to seed at the
+ * fingerprint-suffixed key the live form will read; otherwise the
+ * pre-seeded entry is treated as an orphan (stale-fingerprint) and
+ * cleaned up on mount instead of rehydrating.
+ */
+const FP = fingerprintZodSchema(schema)
+const fpKey = (base: string): string => `${base}:${FP}`
 
 type ApiReturn = ReturnType<typeof useForm<typeof schema>>
 type Field = 'email' | 'password'
@@ -176,7 +187,7 @@ describe('persistence — localStorage backend', () => {
     apps.push(app)
     await drain()
     type('email', 'alice@example.com')
-    const raw = await waitUntil(() => localStorage.getItem('test-local'))
+    const raw = await waitUntil(() => localStorage.getItem(fpKey('test-local')))
     expect(raw).not.toBeNull()
     const payload = JSON.parse(raw as string) as { v: number; data: { form: { email: string } } }
     expect(payload.v).toBe(2)
@@ -185,7 +196,7 @@ describe('persistence — localStorage backend', () => {
 
   it('hydrates from a persisted payload on mount', async () => {
     localStorage.setItem(
-      'test-hydrate',
+      fpKey('test-hydrate'),
       JSON.stringify({ v: 2, data: { form: { email: 'seed@example.com', password: 'pw' } } })
     )
     const { app, api } = mountForm({ storage: 'local', key: 'test-hydrate', debounceMs: 20 })
@@ -201,20 +212,19 @@ describe('persistence — localStorage backend', () => {
 
   it('drops AND wipes a version-mismatched payload', async () => {
     localStorage.setItem(
-      'test-vmismatch',
+      fpKey('test-vmismatch'),
       JSON.stringify({ v: 99, data: { form: { email: 'stale@x.com', password: 'stale' } } })
     )
     const { app, api } = mountForm({
       storage: 'local',
       key: 'test-vmismatch',
       debounceMs: 20,
-      version: 1,
     })
     apps.push(app)
     // Schema defaults (empty strings) — the stale payload was rejected.
     // Hydration is async, so wait for the wipe to land before asserting.
-    await waitUntil(() => (localStorage.getItem('test-vmismatch') === null ? true : null))
-    expect(localStorage.getItem('test-vmismatch')).toBeNull()
+    await waitUntil(() => (localStorage.getItem(fpKey('test-vmismatch')) === null ? true : null))
+    expect(localStorage.getItem(fpKey('test-vmismatch'))).toBeNull()
     expect(api.getValue('email').value).toBe('')
   })
 
@@ -223,7 +233,7 @@ describe('persistence — localStorage backend', () => {
     // wrong type, etc.) is treated like a stale entry — auto-wiped so
     // sensitive fields from a previous shape can't linger.
     localStorage.setItem(
-      'test-malformed',
+      fpKey('test-malformed'),
       JSON.stringify({ totally: 'not the right shape', email: 'leak@x.com' })
     )
     const { app, api } = mountForm({
@@ -232,14 +242,14 @@ describe('persistence — localStorage backend', () => {
       debounceMs: 20,
     })
     apps.push(app)
-    await waitUntil(() => (localStorage.getItem('test-malformed') === null ? true : null))
-    expect(localStorage.getItem('test-malformed')).toBeNull()
+    await waitUntil(() => (localStorage.getItem(fpKey('test-malformed')) === null ? true : null))
+    expect(localStorage.getItem(fpKey('test-malformed'))).toBeNull()
     expect(api.getValue('email').value).toBe('')
   })
 
   it('clears the persisted entry on submit success', async () => {
     localStorage.setItem(
-      'test-clear',
+      fpKey('test-clear'),
       JSON.stringify({ v: 2, data: { form: { email: 'pre@x.com', password: 'pw' } } })
     )
     const { app, api } = mountForm({ storage: 'local', key: 'test-clear', debounceMs: 20 })
@@ -254,8 +264,8 @@ describe('persistence — localStorage backend', () => {
     // The onSubmitSuccess listener fires a fire-and-forget
     // flush()→removeItem() chain; poll for the entry to disappear
     // rather than wagering a fixed sleep.
-    await waitUntil(() => (localStorage.getItem('test-clear') === null ? true : null))
-    expect(localStorage.getItem('test-clear')).toBeNull()
+    await waitUntil(() => (localStorage.getItem(fpKey('test-clear')) === null ? true : null))
+    expect(localStorage.getItem(fpKey('test-clear'))).toBeNull()
   })
 
   it('honours clearOnSubmitSuccess: false', async () => {
@@ -268,8 +278,8 @@ describe('persistence — localStorage backend', () => {
     apps.push(app)
     await drain()
     type('email', 'user@x.com')
-    await waitUntil(() => localStorage.getItem('test-noclear'))
-    expect(localStorage.getItem('test-noclear')).not.toBeNull()
+    await waitUntil(() => localStorage.getItem(fpKey('test-noclear')))
+    expect(localStorage.getItem(fpKey('test-noclear'))).not.toBeNull()
     const handler = api.handleSubmit(async () => {})
     await handler()
     await drain()
@@ -278,7 +288,7 @@ describe('persistence — localStorage backend', () => {
     // (otherwise a delayed removeItem would fail this after the
     // assertion settles).
     await wait(40)
-    expect(localStorage.getItem('test-noclear')).not.toBeNull()
+    expect(localStorage.getItem(fpKey('test-noclear'))).not.toBeNull()
   })
 })
 
@@ -295,7 +305,7 @@ describe('persistence — sessionStorage backend', () => {
     apps.push(app)
     await drain()
     type('email', 'sess@example.com')
-    const raw = await waitUntil(() => sessionStorage.getItem('test-session'))
+    const raw = await waitUntil(() => sessionStorage.getItem(fpKey('test-session')))
     expect(raw).not.toBeNull()
     const payload = JSON.parse(raw as string) as { data: { form: { email: string } } }
     expect(payload.data.form.email).toBe('sess@example.com')
@@ -354,7 +364,7 @@ describe('persistence — include=form+errors', () => {
     // error for persistence — programmatic api.setValue would bypass the
     // per-element gate.
     type('password', 'trigger')
-    const raw = await waitUntil(() => localStorage.getItem('test-form-errors'))
+    const raw = await waitUntil(() => localStorage.getItem(fpKey('test-form-errors')))
     expect(raw).not.toBeNull()
     const payload = JSON.parse(raw as string) as {
       data: {
@@ -421,7 +431,7 @@ describe('persistence — per-element opt-in', () => {
     // Generous wait — debounce is 20 ms, so 80 ms covers timer + drain.
     await wait(80)
     await drain()
-    expect(localStorage.getItem('test-noop')).toBeNull()
+    expect(localStorage.getItem(fpKey('test-noop'))).toBeNull()
   })
 
   it('directive write WITHOUT register({ persist: true }) does NOT persist', async () => {
@@ -463,7 +473,7 @@ describe('persistence — per-element opt-in', () => {
     input.dispatchEvent(new Event('input', { bubbles: true }))
     await wait(80)
     await drain()
-    expect(localStorage.getItem('test-no-flag')).toBeNull()
+    expect(localStorage.getItem(fpKey('test-no-flag'))).toBeNull()
     // Sanity: the value still landed in the form ref (writes work, just
     // no persistence).
     expect(handle.api?.getValue('email').value).toBe('no-opt-in@example.com')
@@ -518,13 +528,13 @@ describe('persistence — per-element opt-in', () => {
     b.dispatchEvent(new Event('input', { bubbles: true }))
     await wait(80)
     await drain()
-    expect(localStorage.getItem('test-mixed')).toBeNull()
+    expect(localStorage.getItem(fpKey('test-mixed'))).toBeNull()
 
     // Input A fires — should persist.
     const a = handle.a as HTMLInputElement
     a.value = 'from-a@example.com'
     a.dispatchEvent(new Event('input', { bubbles: true }))
-    const raw = await waitUntil(() => localStorage.getItem('test-mixed'))
+    const raw = await waitUntil(() => localStorage.getItem(fpKey('test-mixed')))
     expect(raw).not.toBeNull()
     const payload = JSON.parse(raw as string) as { data: { form: { email: string } } }
     expect(payload.data.form.email).toBe('from-a@example.com')
@@ -656,7 +666,7 @@ describe('persistence — sensitive-name heuristic', () => {
     await expect(
       handle.api?.persist('password', { acknowledgeSensitive: true })
     ).resolves.toBeUndefined()
-    const raw = localStorage.getItem('test-sensitive-imp-ack')
+    const raw = localStorage.getItem(fpKey('test-sensitive-imp-ack'))
     expect(raw).not.toBeNull()
     const payload = JSON.parse(raw as string) as { data: { form: { password?: string } } }
     expect(payload.data.form.password).toBe('unsafe-but-acknowledged')
@@ -699,7 +709,7 @@ describe('persistence — form.persist / form.clearPersistedDraft', () => {
 
     handle.api?.setValue('email', 'checkpoint@example.com')
     await handle.api?.persist('email')
-    const raw = localStorage.getItem('test-imp-persist')
+    const raw = localStorage.getItem(fpKey('test-imp-persist'))
     expect(raw).not.toBeNull()
     const payload = JSON.parse(raw as string) as { data: { form: { email: string } } }
     expect(payload.data.form.email).toBe('checkpoint@example.com')
@@ -709,7 +719,7 @@ describe('persistence — form.persist / form.clearPersistedDraft', () => {
     // Seed an entry with both fields populated, then persist only one
     // path's update — the other field's persisted value must survive.
     localStorage.setItem(
-      'test-imp-merge',
+      fpKey('test-imp-merge'),
       JSON.stringify({ v: 2, data: { form: { email: 'prev@x.com', password: 'prev-pw' } } })
     )
     const handle: { api?: ApiReturn } = {}
@@ -733,7 +743,7 @@ describe('persistence — form.persist / form.clearPersistedDraft', () => {
 
     handle.api?.setValue('email', 'updated@example.com')
     await handle.api?.persist('email')
-    const raw = localStorage.getItem('test-imp-merge')
+    const raw = localStorage.getItem(fpKey('test-imp-merge'))
     const payload = JSON.parse(raw as string) as {
       data: { form: { email: string; password: string } }
     }
@@ -744,7 +754,7 @@ describe('persistence — form.persist / form.clearPersistedDraft', () => {
 
   it('form.clearPersistedDraft() wipes the entry; form.clearPersistedDraft(path) wipes only that subpath', async () => {
     localStorage.setItem(
-      'test-clear-api',
+      fpKey('test-clear-api'),
       JSON.stringify({ v: 2, data: { form: { email: 'a@x.com', password: 'pw' } } })
     )
     const handle: { api?: ApiReturn } = {}
@@ -767,7 +777,7 @@ describe('persistence — form.persist / form.clearPersistedDraft', () => {
 
     // Subpath wipe — email gone, password remains.
     await handle.api?.clearPersistedDraft('email')
-    const after1 = JSON.parse(localStorage.getItem('test-clear-api') as string) as {
+    const after1 = JSON.parse(localStorage.getItem(fpKey('test-clear-api')) as string) as {
       data: { form: Record<string, string> }
     }
     expect(after1.data.form['email']).toBeUndefined()
@@ -775,7 +785,7 @@ describe('persistence — form.persist / form.clearPersistedDraft', () => {
 
     // Whole-entry wipe.
     await handle.api?.clearPersistedDraft()
-    expect(localStorage.getItem('test-clear-api')).toBeNull()
+    expect(localStorage.getItem(fpKey('test-clear-api'))).toBeNull()
   })
 
   it('form.persist / form.clearPersistedDraft are silent no-ops when persist: not configured', async () => {
@@ -816,13 +826,13 @@ describe('persistence — reset wipes the persisted draft', () => {
     apps.push(app)
     await drain()
     type('email', 'before-reset@example.com')
-    await waitUntil(() => localStorage.getItem('test-reset'))
-    expect(localStorage.getItem('test-reset')).not.toBeNull()
+    await waitUntil(() => localStorage.getItem(fpKey('test-reset')))
+    expect(localStorage.getItem(fpKey('test-reset'))).not.toBeNull()
 
     api.reset()
     // Storage wipe is fire-and-forget — poll for the entry to disappear.
-    await waitUntil(() => (localStorage.getItem('test-reset') === null ? true : null))
-    expect(localStorage.getItem('test-reset')).toBeNull()
+    await waitUntil(() => (localStorage.getItem(fpKey('test-reset')) === null ? true : null))
+    expect(localStorage.getItem(fpKey('test-reset'))).toBeNull()
     expect(api.getValue('email').value).toBe('')
   })
 
@@ -879,7 +889,7 @@ describe('persistence — reset wipes the persisted draft', () => {
     const passwordEl = handle.passwordEl as HTMLInputElement
     passwordEl.value = 'never-persisted'
     passwordEl.dispatchEvent(new Event('input', { bubbles: true }))
-    const raw = await waitUntil(() => localStorage.getItem('test-sparse'))
+    const raw = await waitUntil(() => localStorage.getItem(fpKey('test-sparse')))
     expect(raw).not.toBeNull()
     const payload = JSON.parse(raw as string) as { data: { form: Record<string, unknown> } }
     expect(payload.data.form['email']).toBe('opted-in@example.com')
@@ -893,7 +903,7 @@ describe('persistence — reset wipes the persisted draft', () => {
     // Seed a sparse payload (only email present). On mount, email
     // hydrates from the seed, password falls back to schema default.
     localStorage.setItem(
-      'test-sparse-hydrate',
+      fpKey('test-sparse-hydrate'),
       JSON.stringify({ v: 2, data: { form: { email: 'sparse-seed@x.com' } } })
     )
     const { app, api } = mountForm({
@@ -1053,7 +1063,7 @@ describe('persistence — reset wipes the persisted draft', () => {
     // Seed both fields, mount with both opted in, then resetField just
     // 'email'. Storage should drop email but keep password.
     localStorage.setItem(
-      'test-reset-field',
+      fpKey('test-reset-field'),
       JSON.stringify({ v: 2, data: { form: { email: 'seed@x.com', password: 'seed-pw' } } })
     )
     const { app, api } = mountForm({
@@ -1067,12 +1077,12 @@ describe('persistence — reset wipes the persisted draft', () => {
     api.resetField('email')
     // Wait for the fire-and-forget clearPersistedDraft to land.
     await waitUntil(() => {
-      const raw = localStorage.getItem('test-reset-field')
+      const raw = localStorage.getItem(fpKey('test-reset-field'))
       if (raw === null) return null
       const parsed = JSON.parse(raw) as { data: { form: Record<string, unknown> } }
       return parsed.data.form['email'] === undefined ? true : null
     })
-    const final = JSON.parse(localStorage.getItem('test-reset-field') as string) as {
+    const final = JSON.parse(localStorage.getItem(fpKey('test-reset-field')) as string) as {
       data: { form: Record<string, string> }
     }
     expect(final.data.form['email']).toBeUndefined()
@@ -1134,7 +1144,7 @@ describe('persistence — shorthand config', () => {
     el.value = 'shorthand@example.com'
     el.dispatchEvent(new Event('input', { bubbles: true }))
     // Default debounceMs is 300 — allow 600 ms for the timer + adapter chain.
-    const expectedKey = `chemical-x-forms:${formKey}`
+    const expectedKey = `chemical-x-forms:${formKey}:${FP}`
     const raw = await waitUntil(() => localStorage.getItem(expectedKey), 1000)
     expect(raw).not.toBeNull()
     const payload = JSON.parse(raw as string) as { v: number; data: { form: { email: string } } }
@@ -1153,6 +1163,7 @@ describe('persistence — shorthand config', () => {
         return Promise.resolve()
       },
       removeItem: (): Promise<void> => Promise.resolve(),
+      listKeys: (): Promise<string[]> => Promise.resolve([]),
     }
     const handle: { el?: HTMLInputElement } = {}
     const formKey = `custom-${Math.random().toString(36).slice(2)}`
@@ -1185,7 +1196,7 @@ describe('persistence — shorthand config', () => {
     await waitUntil(() => (writes.length > 0 ? true : null), 1000)
     expect(writes.length).toBeGreaterThan(0)
     const [writtenKey, writtenValue] = writes[writes.length - 1]!
-    expect(writtenKey).toBe(`chemical-x-forms:${formKey}`)
+    expect(writtenKey).toBe(`chemical-x-forms:${formKey}:${FP}`)
     const payload = writtenValue as { data: { form: { email: string } } }
     expect(payload.data.form.email).toBe('custom@example.com')
   })
@@ -1234,30 +1245,33 @@ describe('persistence — cross-store cleanup at mount', () => {
     return app
   }
 
-  it("configured 'local' wipes the same-key entry from sessionStorage", async () => {
+  it("configured 'local' wipes orphan entries from sessionStorage (legacy + stale-fingerprint)", async () => {
     const key = 'cleanup-shared-key'
+    // Legacy pre-fingerprint key in non-configured store.
     sessionStorage.setItem(key, JSON.stringify({ stale: 'data' }))
-    localStorage.setItem(key, JSON.stringify({ v: 2, data: { form: { email: 'keep' } } }))
+    // Current-fingerprint key in configured store stays (cleanup only
+    // touches non-current-fingerprint orphans).
+    localStorage.setItem(fpKey(key), JSON.stringify({ v: 2, data: { form: { email: 'keep' } } }))
     expect(sessionStorage.getItem(key)).not.toBeNull()
     mountMinimal({ storage: 'local', key })
     // Cleanup is fire-and-forget; poll for the session entry to vanish.
     await waitUntil(() => (sessionStorage.getItem(key) === null ? true : null), 500)
     expect(sessionStorage.getItem(key)).toBeNull()
-    // The configured backend's entry must NOT be touched by the sweep.
-    expect(localStorage.getItem(key)).not.toBeNull()
+    // The configured backend's CURRENT entry must NOT be touched.
+    expect(localStorage.getItem(fpKey(key))).not.toBeNull()
   })
 
-  it("configured 'session' wipes the same-key entry from localStorage", async () => {
+  it("configured 'session' wipes orphan entries from localStorage", async () => {
     const key = 'cleanup-shared-key-2'
     localStorage.setItem(key, JSON.stringify({ stale: 'data' }))
-    sessionStorage.setItem(key, JSON.stringify({ v: 2, data: { form: { email: 'keep' } } }))
+    sessionStorage.setItem(fpKey(key), JSON.stringify({ v: 2, data: { form: { email: 'keep' } } }))
     mountMinimal({ storage: 'session', key })
     await waitUntil(() => (localStorage.getItem(key) === null ? true : null), 500)
     expect(localStorage.getItem(key)).toBeNull()
-    expect(sessionStorage.getItem(key)).not.toBeNull()
+    expect(sessionStorage.getItem(fpKey(key))).not.toBeNull()
   })
 
-  it('configured custom adapter wipes both localStorage and sessionStorage', async () => {
+  it('configured custom adapter wipes orphans from both localStorage and sessionStorage', async () => {
     // Custom adapters can't be reached by enumeration, so the cleanup
     // sweeps ALL three standard backends — the dev might have migrated
     // away from any of them.
@@ -1268,6 +1282,7 @@ describe('persistence — cross-store cleanup at mount', () => {
       getItem: (): Promise<unknown> => Promise.resolve(undefined),
       setItem: (): Promise<void> => Promise.resolve(),
       removeItem: (): Promise<void> => Promise.resolve(),
+      listKeys: (): Promise<string[]> => Promise.resolve([]),
     }
     mountMinimal({ storage: customAdapter, key })
     await waitUntil(
@@ -1366,5 +1381,139 @@ describe('persistence — cross-store cleanup at mount', () => {
     )
     expect(localStorage.getItem(expectedStorageKey)).toBeNull()
     expect(sessionStorage.getItem(expectedStorageKey)).toBeNull()
+  })
+})
+
+/**
+ * Fingerprint-keyed storage key + active orphan cleanup. Schema content
+ * changes produce a different fingerprint, so the new mount looks up a
+ * fresh storage key — old drafts become orphans, cleaned up by the
+ * same mount via `listKeys + removeItem`. Replaces the old manual
+ * `version: number` invalidation protocol.
+ */
+describe('persistence — fingerprint-keyed storage + orphan cleanup', () => {
+  const apps: App[] = []
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+
+  it('storage key includes the schema fingerprint suffix', async () => {
+    const { app, type } = mountForm({ storage: 'local', key: 'fp-write', debounceMs: 20 })
+    apps.push(app)
+    await drain()
+    type('email', 'fp@example.com')
+    const expected = fpKey('fp-write')
+    const raw = await waitUntil(() => localStorage.getItem(expected))
+    expect(raw).not.toBeNull()
+  })
+
+  it('schema-A → schema-B: fingerprint differs → no rehydration', async () => {
+    const stalePayload = JSON.stringify({
+      v: 2,
+      data: { form: { email: 'stale@x.com', password: 'stale' } },
+    })
+    localStorage.setItem('fp-mismatch:OLD-FINGERPRINT', stalePayload)
+    const { app, api } = mountForm({ storage: 'local', key: 'fp-mismatch', debounceMs: 20 })
+    apps.push(app)
+    await drain()
+    expect(api.getValue('email').value).toBe('')
+  })
+
+  it('orphan cleanup: stale-fingerprint entries wiped on mount of the same form', async () => {
+    const stalePayload = JSON.stringify({
+      v: 2,
+      data: { form: { email: 'stale@x.com', password: 'stale' } },
+    })
+    localStorage.setItem('fp-orphan:OLD-FP-1', stalePayload)
+    localStorage.setItem('fp-orphan:OLD-FP-2', stalePayload)
+    localStorage.setItem(
+      fpKey('fp-orphan'),
+      JSON.stringify({ v: 2, data: { form: { email: 'live@x.com', password: 'live' } } })
+    )
+    const { app, api } = mountForm({ storage: 'local', key: 'fp-orphan', debounceMs: 20 })
+    apps.push(app)
+    await waitUntil(() => (api.getValue('email').value === 'live@x.com' ? true : null))
+    await waitUntil(() =>
+      localStorage.getItem('fp-orphan:OLD-FP-1') === null &&
+      localStorage.getItem('fp-orphan:OLD-FP-2') === null
+        ? true
+        : null
+    )
+    expect(localStorage.getItem('fp-orphan:OLD-FP-1')).toBeNull()
+    expect(localStorage.getItem('fp-orphan:OLD-FP-2')).toBeNull()
+    expect(localStorage.getItem(fpKey('fp-orphan'))).not.toBeNull()
+  })
+
+  it('orphan cleanup: pre-fingerprint legacy keys (no `:` suffix) are wiped', async () => {
+    localStorage.setItem(
+      'fp-legacy',
+      JSON.stringify({ v: 2, data: { form: { email: 'legacy@x.com', password: 'pw' } } })
+    )
+    const { app } = mountForm({ storage: 'local', key: 'fp-legacy', debounceMs: 20 })
+    apps.push(app)
+    await waitUntil(() => (localStorage.getItem('fp-legacy') === null ? true : null))
+    expect(localStorage.getItem('fp-legacy')).toBeNull()
+  })
+
+  it('orphan cleanup uses exact-or-`:`-prefix match (no sibling-form collision)', async () => {
+    localStorage.setItem(
+      fpKey('my-form-2'),
+      JSON.stringify({ v: 2, data: { form: { email: 'sibling@x.com', password: 'pw' } } })
+    )
+    const { app } = mountForm({ storage: 'local', key: 'my-form', debounceMs: 20 })
+    apps.push(app)
+    await drain()
+    expect(localStorage.getItem(fpKey('my-form-2'))).not.toBeNull()
+  })
+})
+
+/**
+ * `FormStorage.listKeys(prefix)` per-backend smoke tests. Each adapter
+ * must enumerate keys whose name starts with the given prefix; the
+ * orphan-cleanup pass relies on this contract.
+ */
+describe('FormStorage.listKeys — per-backend', () => {
+  it('localStorage adapter returns matching keys', async () => {
+    const { createLocalStorageAdapter } =
+      await import('../../src/runtime/core/persistence/local-storage')
+    const adapter = createLocalStorageAdapter()
+    localStorage.clear()
+    localStorage.setItem('cx-test:a', 'va')
+    localStorage.setItem('cx-test:b:fp', 'vb')
+    localStorage.setItem('other:x', 'vx')
+    const keys = await adapter.listKeys('cx-test:')
+    expect(keys.sort()).toEqual(['cx-test:a', 'cx-test:b:fp'])
+    localStorage.clear()
+  })
+
+  it('sessionStorage adapter returns matching keys', async () => {
+    const { createSessionStorageAdapter } =
+      await import('../../src/runtime/core/persistence/session-storage')
+    const adapter = createSessionStorageAdapter()
+    sessionStorage.clear()
+    sessionStorage.setItem('s-test:a', 'va')
+    sessionStorage.setItem('s-test:b:fp', 'vb')
+    sessionStorage.setItem('other:x', 'vx')
+    const keys = await adapter.listKeys('s-test:')
+    expect(keys.sort()).toEqual(['s-test:a', 's-test:b:fp'])
+    sessionStorage.clear()
+  })
+
+  it('IndexedDB adapter returns matching keys', async () => {
+    __resetIndexedDbForTests()
+    const { createIndexedDbAdapter } = await import('../../src/runtime/core/persistence/indexeddb')
+    const adapter = createIndexedDbAdapter()
+    await adapter.setItem('idb-test:a', { v: 2, data: { form: { x: 1 } } })
+    await adapter.setItem('idb-test:b:fp', { v: 2, data: { form: { x: 2 } } })
+    await adapter.setItem('other:x', { v: 2, data: { form: {} } })
+    const keys = await adapter.listKeys('idb-test:')
+    expect(keys.sort()).toEqual(['idb-test:a', 'idb-test:b:fp'])
+    __resetIndexedDbForTests()
   })
 })

--- a/test/composables/set-value-schema-fill-regression.test.ts
+++ b/test/composables/set-value-schema-fill-regression.test.ts
@@ -1,0 +1,495 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, type App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { createChemicalXForms } from '../../src/runtime/core/plugin'
+
+/**
+ * Regression spec: every write through setValue must leave the form
+ * **structurally complete** — every slot, intermediate and leaf, is the
+ * shape the slim schema (objects/arrays/primitives without refines)
+ * requires. Refine-level violations remain a validation concern and
+ * surface through fieldErrors; structural correctness is a runtime
+ * invariant that the lib owns.
+ *
+ * Today's gaps surfaced by these tests:
+ *
+ * 1. Sparse array writes leave intermediate slots `undefined` (lib
+ *    fills, but with the wrong content — `null` / `undefined` rather
+ *    than the schema element default).
+ * 2. Path-form callback `prev` is `undefined` when the slot doesn't
+ *    exist yet — should be the schema element default.
+ * 3. Object writes through a missing intermediate object create that
+ *    object as the minimum needed to land the write (`{ name: 'X' }`
+ *    only) instead of populating the full default and overriding.
+ *
+ * The lib already owns initial-state generation via
+ * `schema.getDefaultValues({...})`. The same machinery should be
+ * exposed at path level (`schema.getDefaultAtPath(path)`) and consumed
+ * everywhere a write would otherwise leave a schema-incompatible gap.
+ *
+ * Mindset (per design discussion): consumers using the API correctly
+ * write to existing slots or use `append` for ordered insert. The
+ * "write to people.21 against an empty array" path is a misuse, but the
+ * lib still produces schema-complete data when it happens — that's the
+ * structural-correctness invariant.
+ */
+
+const personSchema = z.object({
+  name: z.string().default(''),
+  age: z.number().default(0),
+})
+
+const formSchema = z.object({
+  people: z.array(personSchema),
+})
+
+type Form = z.output<typeof formSchema>
+
+function harness(initialPeople: Form['people']) {
+  let captured!: ReturnType<typeof useForm<typeof formSchema>>
+  const Probe = defineComponent({
+    setup() {
+      captured = useForm({
+        schema: formSchema,
+        key: `schema-fill-${Math.random().toString(36).slice(2)}`,
+        defaultValues: { people: initialPeople },
+      })
+      return () => h('div')
+    },
+  })
+  const app = createApp(Probe)
+  app.use(createChemicalXForms())
+  app.mount(document.createElement('div'))
+  return { app, form: captured }
+}
+
+describe('setValue — intermediate array slots fill with schema element defaults', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('value-form: writing to people.5 against empty people fills 0..4 with element defaults', () => {
+    const { app, form } = harness([])
+    apps.push(app)
+
+    form.setValue('people.5', { name: 'Carol', age: 30 })
+
+    // Indices 0..4 should be schema element defaults — { name: '', age: 0 } —
+    // NOT null. Index 5 is the consumer's write.
+    expect(form.getValue('people').value).toEqual([
+      { name: '', age: 0 },
+      { name: '', age: 0 },
+      { name: '', age: 0 },
+      { name: '', age: 0 },
+      { name: '', age: 0 },
+      { name: 'Carol', age: 30 },
+    ])
+  })
+
+  it('value-form: writing to people.5 against length-2 fills 2..4 with element defaults', () => {
+    const { app, form } = harness([
+      { name: 'Alice', age: 25 },
+      { name: 'Bob', age: 28 },
+    ])
+    apps.push(app)
+
+    form.setValue('people.5', { name: 'Eve', age: 22 })
+
+    // Existing 0,1 preserved. 2..4 are schema element defaults. 5 is the new value.
+    expect(form.getValue('people').value).toEqual([
+      { name: 'Alice', age: 25 },
+      { name: 'Bob', age: 28 },
+      { name: '', age: 0 },
+      { name: '', age: 0 },
+      { name: '', age: 0 },
+      { name: 'Eve', age: 22 },
+    ])
+  })
+
+  it('callback-form: writing to people.5 also fills 0..4 with schema element defaults', () => {
+    const { app, form } = harness([])
+    apps.push(app)
+
+    form.setValue('people.5', () => ({ name: 'Dave', age: 40 }))
+
+    expect(form.getValue('people').value).toEqual([
+      { name: '', age: 0 },
+      { name: '', age: 0 },
+      { name: '', age: 0 },
+      { name: '', age: 0 },
+      { name: '', age: 0 },
+      { name: 'Dave', age: 40 },
+    ])
+  })
+})
+
+describe('setValue — path-form callback `prev` is the schema element default when the slot is missing', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('callback prev is the element default for an empty array', () => {
+    const { app, form } = harness([])
+    apps.push(app)
+
+    let receivedPrev: unknown
+    form.setValue('people.0', (prev) => {
+      receivedPrev = prev
+      return { ...prev, name: 'Alice' }
+    })
+
+    // prev arrived populated by the schema, not as undefined.
+    expect(receivedPrev).toEqual({ name: '', age: 0 })
+
+    // The consumer's spread + override produces a complete Person.
+    expect(form.getValue('people').value[0]).toEqual({ name: 'Alice', age: 0 })
+  })
+
+  it('callback prev for an existing slot is the existing value, not a fresh default', () => {
+    const { app, form } = harness([{ name: 'Existing', age: 99 }])
+    apps.push(app)
+
+    let receivedPrev: unknown
+    form.setValue('people.0', (prev) => {
+      receivedPrev = prev
+      return { ...prev, age: prev.age + 1 }
+    })
+
+    expect(receivedPrev).toEqual({ name: 'Existing', age: 99 })
+    expect(form.getValue('people').value[0]).toEqual({ name: 'Existing', age: 100 })
+  })
+
+  it('callback prev for a missing high index also gets the element default', () => {
+    const { app, form } = harness([])
+    apps.push(app)
+
+    let receivedPrev: unknown
+    form.setValue('people.5', (prev) => {
+      receivedPrev = prev
+      return { ...prev, name: 'Carol' }
+    })
+
+    // Same default-prev guarantee at index 5 as at index 0.
+    expect(receivedPrev).toEqual({ name: '', age: 0 })
+    // Intermediates 0..4 also defaulted (the structural fill from the
+    // first describe block); index 5 is the consumer's spread + override.
+    expect(form.getValue('people').value).toEqual([
+      { name: '', age: 0 },
+      { name: '', age: 0 },
+      { name: '', age: 0 },
+      { name: '', age: 0 },
+      { name: '', age: 0 },
+      { name: 'Carol', age: 0 },
+    ])
+  })
+})
+
+/**
+ * Object-intermediate gaps. Same theme: when a deep write traverses
+ * through a missing object, the lib must populate that object with the
+ * schema default — not just create the minimum sub-tree needed to land
+ * the leaf.
+ */
+
+const profileSchema = z.object({
+  user: z.object({
+    // `.optional()` prevents construction-time `getDefaultValues` from
+    // pre-populating profile — the gap genuinely exists at runtime, so
+    // setValue's intermediate-fill behaviour is what's under test here.
+    profile: z
+      .object({
+        name: z.string().default(''),
+        age: z.number().default(0),
+        bio: z.string().default(''),
+      })
+      .optional(),
+  }),
+})
+
+type ProfileForm = z.output<typeof profileSchema>
+
+function profileHarness(initial: Partial<ProfileForm['user']>) {
+  let captured!: ReturnType<typeof useForm<typeof profileSchema>>
+  const Probe = defineComponent({
+    setup() {
+      captured = useForm({
+        schema: profileSchema,
+        key: `profile-fill-${Math.random().toString(36).slice(2)}`,
+        defaultValues: { user: initial as ProfileForm['user'] },
+      })
+      return () => h('div')
+    },
+  })
+  const app = createApp(Probe)
+  app.use(createChemicalXForms())
+  app.mount(document.createElement('div'))
+  return { app, form: captured }
+}
+
+describe('setValue — intermediate object gaps fill with schema defaults', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('writing to user.profile.name through a missing user.profile populates the whole profile default', () => {
+    // Setup: user exists but profile is undefined.
+    const { app, form } = profileHarness({})
+    apps.push(app)
+
+    form.setValue('user.profile.name', 'Alice')
+
+    // Consumer wrote `name`. The lib must fill the rest of `profile`
+    // with the schema default, not leave `age`/`bio` as undefined.
+    expect(form.getValue('user.profile').value).toEqual({
+      name: 'Alice',
+      age: 0,
+      bio: '',
+    })
+  })
+
+  it('callback prev for a missing intermediate object slot is the full default', () => {
+    const { app, form } = profileHarness({})
+    apps.push(app)
+
+    let receivedPrev: unknown
+    form.setValue('user.profile', (prev) => {
+      receivedPrev = prev
+      return { ...prev, name: 'Bob' }
+    })
+
+    // prev is the whole profile default — every required field present.
+    expect(receivedPrev).toEqual({ name: '', age: 0, bio: '' })
+    // Result is a structurally-complete profile.
+    expect(form.getValue('user.profile').value).toEqual({
+      name: 'Bob',
+      age: 0,
+      bio: '',
+    })
+  })
+})
+
+/**
+ * Partial value-form writes. The consumer passes a value at the path
+ * that's structurally incomplete (e.g. `[{ name: 'A' }]` against
+ * `Person[]` requiring `age` too). Per the theme, the lib should fill
+ * missing required fields with schema defaults rather than write the
+ * partial as-is.
+ *
+ * This is the most opinionated of the three areas — the consumer
+ * explicitly typed a value with a missing field, and we're saying the
+ * lib auto-completes it. Worth landing if structural-completeness is a
+ * non-negotiable invariant; revisit if the surprise factor outweighs
+ * the consistency win.
+ */
+/**
+ * Combined: deep nested path that crosses an object boundary AND an
+ * array boundary, with a callback that spreads `prev` and overrides one
+ * field. Probably the cleanest single-shot expression of the
+ * structural-completeness invariant.
+ */
+
+const addressSchema = z.object({
+  address: z.object({
+    street: z.string().default(''),
+    people: z.array(
+      z.object({
+        name: z.string().default(''),
+        age: z.number().default(0),
+      })
+    ),
+  }),
+})
+
+type AddressForm = z.output<typeof addressSchema>
+
+function addressHarness(initialPeople: AddressForm['address']['people']) {
+  let captured!: ReturnType<typeof useForm<typeof addressSchema>>
+  const Probe = defineComponent({
+    setup() {
+      captured = useForm({
+        schema: addressSchema,
+        key: `address-fill-${Math.random().toString(36).slice(2)}`,
+        defaultValues: { address: { street: '123 Main St', people: initialPeople } },
+      })
+      return () => h('div')
+    },
+  })
+  const app = createApp(Probe)
+  app.use(createChemicalXForms())
+  app.mount(document.createElement('div'))
+  return { app, form: captured }
+}
+
+describe('setValue — combined: object + array intermediate fill via callback', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('setValue("address.people.4", (person) => ({ ...person, name: "ed" })) against empty people produces structurally correct output', () => {
+    const { app, form } = addressHarness([])
+    apps.push(app)
+
+    let receivedPrev: unknown
+    form.setValue('address.people.4', (person) => {
+      receivedPrev = person
+      return { ...person, name: 'ed' }
+    })
+
+    // The callback received the schema element default — populated, not undefined.
+    expect(receivedPrev).toEqual({ name: '', age: 0 })
+
+    // The whole address subtree is structurally correct: street preserved
+    // from defaultValues, people populated through index 4, intermediates
+    // 0..3 are schema element defaults, index 4 is the callback's result.
+    expect(form.getValue('address').value).toEqual({
+      street: '123 Main St',
+      people: [
+        { name: '', age: 0 },
+        { name: '', age: 0 },
+        { name: '', age: 0 },
+        { name: '', age: 0 },
+        { name: 'ed', age: 0 },
+      ],
+    })
+  })
+})
+
+/**
+ * Tuples (positional arrays). Same structural-completeness invariant
+ * as regular arrays: writing past the current length must fill the
+ * intermediate positions with the schema-prescribed defaults for those
+ * positions — and tuples have *position-specific* defaults (each slot
+ * is its own type), so the fill is per-position, not a single element
+ * default reused.
+ */
+
+const tupleSchema = z.object({
+  coords: z.tuple([z.number().default(0), z.number().default(0), z.number().default(0)]),
+})
+
+type TupleForm = z.output<typeof tupleSchema>
+
+function tupleHarness(initial: TupleForm['coords']) {
+  let captured!: ReturnType<typeof useForm<typeof tupleSchema>>
+  const Probe = defineComponent({
+    setup() {
+      captured = useForm({
+        schema: tupleSchema,
+        key: `tuple-fill-${Math.random().toString(36).slice(2)}`,
+        defaultValues: { coords: initial },
+      })
+      return () => h('div')
+    },
+  })
+  const app = createApp(Probe)
+  app.use(createChemicalXForms())
+  app.mount(document.createElement('div'))
+  return { app, form: captured }
+}
+
+describe('setValue — tuple intermediate positions fill with schema position defaults', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('writing to coords.2 with only coords.0 set fills coords.1 with the position default', () => {
+    // Force a structural gap: tuple starts with only index 0.
+    const { app, form } = tupleHarness([42] as unknown as TupleForm['coords'])
+    apps.push(app)
+
+    form.setValue('coords.2', 99)
+
+    // Index 1 should be the schema's position-1 default (0), not undefined.
+    expect(form.getValue('coords').value).toEqual([42, 0, 99])
+  })
+})
+
+/**
+ * Reset confirmation. `reset()` should produce a structurally-complete
+ * state per the schema — the same invariant. Probably already works
+ * today (reset rebuilds via `getDefaultValues`), but worth pinning so
+ * any future churn that bypasses the schema-default pipeline regresses
+ * a test rather than slipping through.
+ */
+describe('reset / resetField — structural completeness preserved', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('reset() returns the form to a structurally-complete state', () => {
+    const { app, form } = harness([
+      { name: 'Alice', age: 25 },
+      { name: 'Bob', age: 28 },
+    ])
+    apps.push(app)
+
+    // Mutate into a state that may be schema-incomplete (depending on
+    // how the regression fix above lands — currently this leaves
+    // intermediate undefineds).
+    form.setValue('people.5', { name: 'Carol', age: 30 })
+
+    // Reset should wipe back to the original defaults — no leftover
+    // schema-incomplete shape from the prior write.
+    form.reset()
+
+    expect(form.getValue('people').value).toEqual([
+      { name: 'Alice', age: 25 },
+      { name: 'Bob', age: 28 },
+    ])
+  })
+
+  it('resetField on an array path returns to the schema-default for that path', () => {
+    const { app, form } = harness([
+      { name: 'Alice', age: 25 },
+      { name: 'Bob', age: 28 },
+    ])
+    apps.push(app)
+
+    form.setValue('people.0.name', 'Mutated')
+    form.resetField('people')
+
+    expect(form.getValue('people').value).toEqual([
+      { name: 'Alice', age: 25 },
+      { name: 'Bob', age: 28 },
+    ])
+  })
+})
+
+describe('setValue — partial value writes are filled with schema defaults', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('writing a partial array element via the value form fills missing fields', () => {
+    const { app, form } = harness([])
+    apps.push(app)
+
+    // The cast forces the type checker to allow the partial; at runtime
+    // the lib should fill `age` from the schema default.
+    form.setValue('people', [{ name: 'Alice' } as Form['people'][number]])
+
+    expect(form.getValue('people').value).toEqual([{ name: 'Alice', age: 0 }])
+  })
+
+  it('writing a partial object via the value form fills missing fields', () => {
+    const { app, form } = profileHarness({})
+    apps.push(app)
+
+    form.setValue('user.profile', { name: 'Carol' } as ProfileForm['user']['profile'])
+
+    expect(form.getValue('user.profile').value).toEqual({
+      name: 'Carol',
+      age: 0,
+      bio: '',
+    })
+  })
+})

--- a/test/composables/set-value-schema-fill-regression.test.ts
+++ b/test/composables/set-value-schema-fill-regression.test.ts
@@ -361,6 +361,146 @@ describe('setValue — combined: object + array intermediate fill via callback',
 })
 
 /**
+ * Deep cascade — three levels of intermediate fill in one write:
+ * `object → array → object → array → object → leaf`. The original
+ * implementation got the OUTERMOST array fill right (people[0..1])
+ * but lost sibling fields on the slot at the cascading boundary —
+ * people[2] was emitted as `{ addresses: [...] }` (no name / age)
+ * because the array branch failed to fill arr[head] before recursing
+ * past the existing length, and the next level built a fresh `{}`
+ * populated only by the keys the path actually touched.
+ *
+ * Same bug at the inner array boundary: addresses[3] landed as
+ * `{ street: 'X' }` only — `city` dropped.
+ *
+ * Regression: every slot the path traverses is structurally complete,
+ * end-to-end, regardless of cascade depth.
+ */
+
+const cascadeSchema = z.object({
+  people: z.array(
+    z.object({
+      name: z.string(),
+      age: z.number(),
+      addresses: z.array(
+        z.object({
+          street: z.string(),
+          city: z.string(),
+          notes: z.string().optional(),
+        })
+      ),
+    })
+  ),
+})
+
+type CascadeForm = z.output<typeof cascadeSchema>
+
+function cascadeHarness() {
+  let captured!: ReturnType<typeof useForm<typeof cascadeSchema>>
+  const Probe = defineComponent({
+    setup() {
+      captured = useForm({
+        schema: cascadeSchema,
+        key: `cascade-fill-${Math.random().toString(36).slice(2)}`,
+        defaultValues: { people: [] as CascadeForm['people'] },
+      })
+      return () => h('div')
+    },
+  })
+  const app = createApp(Probe)
+  app.use(createChemicalXForms())
+  app.mount(document.createElement('div'))
+  return { app, form: captured }
+}
+
+describe('setValue — deep cascade fills every traversed slot completely', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('setValue("people.2.addresses.3.street", x) against empty people produces a structurally complete tree', () => {
+    const { app, form } = cascadeHarness()
+    apps.push(app)
+
+    form.setValue('people.2.addresses.3.street', 'Diagonal Drive')
+
+    // people[0..1] are full Person defaults (each with empty addresses
+    // — the inner array's natural default).
+    // people[2] is a Person populated through addresses[3]: the array
+    // branch pre-fills the slot with the schema element default before
+    // recursing, so name/age survive even though the path only writes
+    // through addresses.
+    // addresses[0..2] are full Address defaults.
+    // addresses[3] is a structurally complete Address with the
+    // consumer's `street` overlaid — `city` was filled from the schema
+    // element default, NOT dropped just because the path didn't name
+    // it.
+    expect(form.getValue('people').value).toEqual([
+      { name: '', age: 0, addresses: [] },
+      { name: '', age: 0, addresses: [] },
+      {
+        name: '',
+        age: 0,
+        addresses: [
+          { street: '', city: '' },
+          { street: '', city: '' },
+          { street: '', city: '' },
+          { street: 'Diagonal Drive', city: '' },
+        ],
+      },
+    ])
+  })
+
+  it('callback form: setValue("people.2.addresses.3", (a) => ({...a, street: x})) preserves siblings at every cascade level', () => {
+    const { app, form } = cascadeHarness()
+    apps.push(app)
+
+    let receivedPrev: unknown
+    form.setValue('people.2.addresses.3', (prev) => {
+      receivedPrev = prev
+      return { ...prev, street: 'Callback Street' }
+    })
+
+    // Path-form callback prev is auto-defaulted from
+    // schema.getDefaultAtPath(['people', 2, 'addresses', 3]) — the
+    // inner Address default. notes is optional → omitted.
+    expect(receivedPrev).toEqual({ street: '', city: '' })
+
+    // Same shape guarantee as the value-form variant above.
+    expect(form.getValue('people').value).toEqual([
+      { name: '', age: 0, addresses: [] },
+      { name: '', age: 0, addresses: [] },
+      {
+        name: '',
+        age: 0,
+        addresses: [
+          { street: '', city: '' },
+          { street: '', city: '' },
+          { street: '', city: '' },
+          { street: 'Callback Street', city: '' },
+        ],
+      },
+    ])
+  })
+
+  it('writing the SAME deep path twice is idempotent (no double-fill / no overwrite)', () => {
+    const { app, form } = cascadeHarness()
+    apps.push(app)
+
+    form.setValue('people.2.addresses.3.street', 'First')
+    form.setValue('people.2.addresses.3.street', 'Second')
+
+    // Second write should only touch the leaf — every intermediate
+    // already exists, no fill triggers, and the value lands cleanly.
+    const people = form.getValue('people').value
+    expect(people).toHaveLength(3)
+    const target = (people as CascadeForm['people'])[2]?.addresses[3]
+    expect(target).toEqual({ street: 'Second', city: '' })
+  })
+})
+
+/**
  * Tuples (positional arrays). Same structural-completeness invariant
  * as regular arrays: writing past the current length must fill the
  * intermediate positions with the schema-prescribed defaults for those

--- a/test/composables/type-inference.test.ts
+++ b/test/composables/type-inference.test.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import type { Ref } from 'vue'
 import type { FormState } from '../../src'
 import type { useForm } from '../../src/zod'
+import type { WithIndexedUndefined } from '../../src/runtime/types/types-core'
 
 /**
  * Type-inference tests for `useForm` via the Zod v4 adapter.
@@ -96,9 +97,12 @@ describe('useForm type inference — factory signature', () => {
     void missingSchemaConfig
   })
 
-  it('returns the inferred Form shape at the top-level getValue()', () => {
+  it('returns the inferred Form shape at the top-level getValue() (with array taint)', () => {
+    // After the Phase-4 read-type honesty pass, `getValue()` returns the
+    // form wrapped in `WithIndexedUndefined` — `value.tags[N]` etc. is
+    // `string | undefined` since arrays can be out-of-bounds at runtime.
     const whole = form.getValue()
-    expectTypeOf(whole.value).toEqualTypeOf<ExpectedForm>()
+    expectTypeOf(whole.value).toEqualTypeOf<WithIndexedUndefined<ExpectedForm>>()
   })
 })
 
@@ -117,13 +121,16 @@ describe('useForm type inference — getValue', () => {
     expectTypeOf(form.getValue('profile.bio')).toEqualTypeOf<Readonly<Ref<string | undefined>>>()
   })
 
-  it('array index path', () => {
-    expectTypeOf(form.getValue('tags.0')).toEqualTypeOf<Readonly<Ref<string>>>()
+  it('array index path is undefined-tainted (out-of-bounds is honest)', () => {
+    // After Phase 4, paths through a numeric segment yield `T | undefined`
+    // — `tags[5]` against a length-2 array returns `undefined` at runtime,
+    // and the type now reflects that.
+    expectTypeOf(form.getValue('tags.0')).toEqualTypeOf<Readonly<Ref<string | undefined>>>()
   })
 
-  it('array-of-object nested path (posts.N.field)', () => {
-    expectTypeOf(form.getValue('posts.0.title')).toEqualTypeOf<Readonly<Ref<string>>>()
-    expectTypeOf(form.getValue('posts.0.views')).toEqualTypeOf<Readonly<Ref<number>>>()
+  it('array-of-object nested path (posts.N.field) is tainted past the array boundary', () => {
+    expectTypeOf(form.getValue('posts.0.title')).toEqualTypeOf<Readonly<Ref<string | undefined>>>()
+    expectTypeOf(form.getValue('posts.0.views')).toEqualTypeOf<Readonly<Ref<number | undefined>>>()
   })
 
   it('rejects paths not present in the schema', () => {
@@ -184,19 +191,70 @@ describe('useForm type inference — setValue', () => {
 })
 
 describe('useForm type inference — register', () => {
-  it('innerRef is typed as `| undefined` of the path leaf', () => {
+  it('non-array paths are STRICT — register returns the leaf type without taint', () => {
+    // Phase 4: register read shape is now `NestedReadType<Form, Path>`.
+    // Paths that don't cross a numeric segment stay strict — runtime
+    // structural-completeness guarantees the slot is populated.
     const r = form.register('email')
-    expectTypeOf(r.innerRef.value).toEqualTypeOf<string | undefined>()
+    expectTypeOf(r.innerRef.value).toEqualTypeOf<string>()
   })
 
-  it('nested object path', () => {
+  it('nested object path stays strict (no array crossing)', () => {
     const r = form.register('profile.name')
-    expectTypeOf(r.innerRef.value).toEqualTypeOf<string | undefined>()
+    expectTypeOf(r.innerRef.value).toEqualTypeOf<string>()
   })
 
-  it('array-index nested path', () => {
+  it('array-index nested path is undefined-tainted (out-of-bounds at runtime)', () => {
     const r = form.register('posts.0.title')
     expectTypeOf(r.innerRef.value).toEqualTypeOf<string | undefined>()
+  })
+})
+
+describe('Phase 4: WithIndexedUndefined + strict SetValuePayload', () => {
+  it('whole-form callback prev sees array elements as `T | undefined`', () => {
+    form.setValue((prev) => {
+      // Array index reads are honestly tainted. `prev.posts[5]` could
+      // be out-of-bounds at runtime, so the type must include undefined.
+      expectTypeOf(prev.posts[5]).toEqualTypeOf<{ title: string; views: number } | undefined>()
+      expectTypeOf(prev.tags[0]).toEqualTypeOf<string | undefined>()
+      // Non-array properties remain strict.
+      expectTypeOf(prev.email).toEqualTypeOf<string>()
+      // Spread is fine — the return type matches the read shape and
+      // mergeStructural fills any structural gaps at the runtime layer.
+      return { ...prev, email: 'updated@example.com' }
+    })
+  })
+
+  it('path-form callback prev is STRICT (runtime auto-defaults)', () => {
+    // The runtime hands the consumer the schema default at the path
+    // when the slot is unpopulated, so prev is genuinely populated —
+    // strict NestedType (not undefined-tainted) is honest.
+    form.setValue('posts.0', (prev) => {
+      expectTypeOf(prev).toEqualTypeOf<{ title: string; views: number }>()
+      // No `?.` or fallback needed — `prev.title` is `string`, not
+      // `string | undefined`.
+      return { ...prev, title: prev.title.toUpperCase() }
+    })
+  })
+
+  it('value form is STRICT — drops DeepPartial', () => {
+    // Phase 4 dropped `DeepPartial<Payload>` from `SetValuePayload`. A
+    // partial object at a strict path is now a TYPE ERROR; consumers
+    // either provide the complete shape or use the callback form. The
+    // runtime mergeStructural still fills any gaps that slip through
+    // via casts.
+    form.setValue('profile.name', 'alice')
+    // @ts-expect-error - profile requires { name, bio? }; partial wrong-shape rejected.
+    form.setValue('profile', { unknown: 'field' })
+  })
+
+  it('register read shape uses NestedReadType — taint after numeric segment', () => {
+    // Path doesn't cross a numeric segment.
+    expectTypeOf(form.register('email').innerRef.value).toEqualTypeOf<string>()
+    // Path crosses a numeric segment ('0').
+    expectTypeOf(form.register('posts.0.title').innerRef.value).toEqualTypeOf<string | undefined>()
+    // Bare array element path.
+    expectTypeOf(form.register('tags.0').innerRef.value).toEqualTypeOf<string | undefined>()
   })
 })
 

--- a/test/composables/use-form-v3-forwarding.test.ts
+++ b/test/composables/use-form-v3-forwarding.test.ts
@@ -6,6 +6,7 @@ import type { FormStorage, UseAbstractFormReturnType } from '../../src/runtime/t
 import { vRegister } from '../../src/runtime/core/directive'
 import { createChemicalXForms } from '../../src/runtime/core/plugin'
 import { useForm } from '../../src/zod-v3'
+import { fingerprintZodSchema } from '../../src/runtime/adapters/zod-v3/fingerprint'
 
 /**
  * Regression pin: the zod v3 `useForm` wrapper used to hand-pick the
@@ -85,6 +86,7 @@ describe('v3 useForm forwards opt-in options to useAbstractForm', () => {
       getItem: () => Promise.resolve(undefined),
       setItem,
       removeItem: () => Promise.resolve(),
+      listKeys: () => Promise.resolve([]),
     }
 
     // Persistence is per-element opt-in, so the test must drive its
@@ -132,7 +134,8 @@ describe('v3 useForm forwards opt-in options to useAbstractForm', () => {
 
     expect(setItem).toHaveBeenCalled()
     const [key, payload] = setItem.mock.calls[0] ?? []
-    expect(key).toBe('chemical-x-forms:v3-persist')
+    const fp = fingerprintZodSchema(schema)
+    expect(key).toBe(`chemical-x-forms:v3-persist:${fp}`)
     expect(payload).toMatchObject({
       v: 2,
       data: { form: { email: 'alice@example.com' } },

--- a/test/core/merge-structural.test.ts
+++ b/test/core/merge-structural.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from 'vitest'
+import {
+  mergeStructural,
+  setAtPathWithSchemaFill,
+  type SchemaForFill,
+} from '../../src/runtime/core/path-walker'
+import type { Path } from '../../src/runtime/core/paths'
+
+/**
+ * Unit tests for the structural-completeness helpers in path-walker.ts.
+ * The full integration with `setValueAtPath` is covered by
+ * `test/composables/set-value-schema-fill-regression.test.ts`; this
+ * file pins the helpers' lower-level contracts.
+ */
+
+/**
+ * Schema-stub builder. Defines a literal "default at path" map; any
+ * other path returns undefined. For arrays, returning element defaults
+ * at indices 0..big simulates a Zod array; returning per-position
+ * values at exactly N indices simulates a Zod tuple of length N.
+ */
+function buildSchema(
+  defaults: Record<string, unknown>,
+  options?: { arrayElementDefault?: unknown; tupleAt?: Record<string, readonly unknown[]> }
+): SchemaForFill {
+  return {
+    getDefaultAtPath(path: Path): unknown {
+      if (path.length === 0) {
+        // Combine top-level keys into a single defaults object.
+        const root: Record<string, unknown> = {}
+        for (const key of Object.keys(defaults)) {
+          root[key] = defaults[key]
+        }
+        if (options?.tupleAt) {
+          for (const tupleKey of Object.keys(options.tupleAt)) {
+            root[tupleKey] = options.tupleAt[tupleKey]
+          }
+        }
+        return root
+      }
+      // Tuple lookup: tuple[index] for paths of form [tupleKey, idx].
+      if (options?.tupleAt && path.length === 2) {
+        const [tupleKey, idx] = path
+        if (typeof tupleKey === 'string' && typeof idx === 'number') {
+          const tuple = options.tupleAt[tupleKey]
+          if (tuple !== undefined) {
+            return idx < tuple.length ? tuple[idx] : undefined
+          }
+        }
+      }
+      // Array element default: any path through an array key returns
+      // the configured element default.
+      if (options?.arrayElementDefault !== undefined) {
+        const [first] = path
+        if (typeof first === 'string' && first === 'arr') {
+          return options.arrayElementDefault
+        }
+      }
+      // Object lookup.
+      const head = path[0]
+      if (typeof head !== 'string') return undefined
+      const next = defaults[head]
+      if (path.length === 1) return next
+      if (next === null || typeof next !== 'object' || Array.isArray(next)) return undefined
+      let current: unknown = next
+      for (let i = 1; i < path.length; i++) {
+        if (current === null || typeof current !== 'object' || Array.isArray(current)) {
+          return undefined
+        }
+        const seg = path[i]
+        const key = typeof seg === 'number' ? String(seg) : seg
+        current = (current as Record<string, unknown>)[key as string]
+      }
+      return current
+    },
+  }
+}
+
+describe('mergeStructural', () => {
+  describe('primitives', () => {
+    it('passes through consumer primitives unchanged', () => {
+      const schema = buildSchema({ name: '' })
+      expect(mergeStructural(schema, ['name'], 'alice')).toBe('alice')
+      expect(mergeStructural(schema, ['name'], 0)).toBe(0)
+      expect(mergeStructural(schema, ['name'], false)).toBe(false)
+    })
+
+    it('treats undefined consumer as missing — falls back to default', () => {
+      const schema = buildSchema({ name: 'fallback' })
+      expect(mergeStructural(schema, ['name'], undefined)).toBe('fallback')
+    })
+
+    it('treats null consumer as a deliberate value — null wins', () => {
+      const schema = buildSchema({ name: '' })
+      expect(mergeStructural(schema, ['name'], null)).toBeNull()
+    })
+  })
+
+  describe('plain objects', () => {
+    it('fills missing keys from default', () => {
+      const schema = buildSchema({ user: { name: '', age: 0 } })
+      const result = mergeStructural(schema, [], { user: { name: 'alice' } })
+      expect(result).toEqual({ user: { name: 'alice', age: 0 } })
+    })
+
+    it('preserves consumer-only keys (validation flags them)', () => {
+      const schema = buildSchema({ user: { name: '' } })
+      const result = mergeStructural(schema, [], {
+        user: { name: 'alice', extra: 'foo' },
+      })
+      expect(result).toEqual({ user: { name: 'alice', extra: 'foo' } })
+    })
+
+    it('idempotent short-circuit — returns input ref when no fills needed', () => {
+      const schema = buildSchema({ user: { name: '' } })
+      const consumer = { user: { name: 'alice' } }
+      const result = mergeStructural(schema, [], consumer)
+      expect(result).toBe(consumer)
+    })
+
+    it('handles deeply nested partial objects', () => {
+      const schema = buildSchema({
+        user: { profile: { name: '', age: 0, bio: '' } },
+      })
+      const result = mergeStructural(schema, [], {
+        user: { profile: { name: 'carol' } },
+      })
+      expect(result).toEqual({
+        user: { profile: { name: 'carol', age: 0, bio: '' } },
+      })
+    })
+  })
+
+  describe('arrays — unbounded (array-like)', () => {
+    it('uses consumer length, fills nothing when probe returns element default', () => {
+      const schema = buildSchema({ arr: [] }, { arrayElementDefault: 'def' })
+      const result = mergeStructural(schema, ['arr'], ['a', 'b'])
+      expect(result).toEqual(['a', 'b'])
+    })
+
+    it('passes through empty consumer arrays as-is', () => {
+      const schema = buildSchema({ arr: [] }, { arrayElementDefault: 'def' })
+      const consumer: unknown[] = []
+      const result = mergeStructural(schema, ['arr'], consumer)
+      expect(result).toBe(consumer)
+    })
+  })
+
+  describe('arrays — tuple-like (fixed length)', () => {
+    it('pads consumer up to tuple length with position defaults', () => {
+      const schema = buildSchema({}, { tupleAt: { coords: [0, 0, 0] } })
+      const result = mergeStructural(schema, ['coords'], [42])
+      expect(result).toEqual([42, 0, 0])
+    })
+
+    it('preserves consumer values at provided positions', () => {
+      const schema = buildSchema({}, { tupleAt: { coords: ['', 0, false] } })
+      const result = mergeStructural(schema, ['coords'], ['x'])
+      expect(result).toEqual(['x', 0, false])
+    })
+  })
+
+  describe('non-plain-objects (Date, Map, Set)', () => {
+    it('Date passes through (not recursed into)', () => {
+      const schema = buildSchema({ when: new Date(0) })
+      const date = new Date(2024, 5, 1)
+      const result = mergeStructural(schema, ['when'], date)
+      expect(result).toBe(date)
+    })
+
+    it('Map passes through', () => {
+      const schema = buildSchema({ m: new Map() })
+      const m = new Map([['k', 'v']])
+      const result = mergeStructural(schema, ['m'], m)
+      expect(result).toBe(m)
+    })
+
+    it('Set passes through', () => {
+      const schema = buildSchema({ s: new Set() })
+      const s = new Set([1, 2, 3])
+      const result = mergeStructural(schema, ['s'], s)
+      expect(result).toBe(s)
+    })
+  })
+})
+
+describe('setAtPathWithSchemaFill', () => {
+  it('writes to an existing slot without schema lookups', () => {
+    const schema = buildSchema({ user: { name: '' } })
+    const root = { user: { name: 'alice' } }
+    const next = setAtPathWithSchemaFill(root, schema, ['user', 'name'], 'bob')
+    expect(next).toEqual({ user: { name: 'bob' } })
+  })
+
+  it('fills missing intermediate object with schema default', () => {
+    const schema = buildSchema({
+      user: { profile: { name: '', age: 0 } },
+    })
+    const root = { user: {} }
+    const next = setAtPathWithSchemaFill(root, schema, ['user', 'profile', 'name'], 'carol')
+    expect(next).toEqual({ user: { profile: { name: 'carol', age: 0 } } })
+  })
+
+  it('pads array past length with element defaults (array case)', () => {
+    const schema = buildSchema({ arr: [] }, { arrayElementDefault: 'def' })
+    const root = { arr: ['a'] }
+    const next = setAtPathWithSchemaFill(root, schema, ['arr', 3], 'x')
+    expect(next).toEqual({ arr: ['a', 'def', 'def', 'x'] })
+  })
+
+  it('pads tuple past length with per-position defaults', () => {
+    const schema = buildSchema({}, { tupleAt: { coords: [0, 0, 0] } })
+    const root = { coords: [42] }
+    const next = setAtPathWithSchemaFill(root, schema, ['coords', 2], 99)
+    expect(next).toEqual({ coords: [42, 0, 99] })
+  })
+
+  it('returns the value unchanged when path is empty', () => {
+    const schema = buildSchema({})
+    const next = setAtPathWithSchemaFill({ a: 1 }, schema, [], { b: 2 })
+    expect(next).toEqual({ b: 2 })
+  })
+})

--- a/test/core/persist-config-normalize.test.ts
+++ b/test/core/persist-config-normalize.test.ts
@@ -29,6 +29,7 @@ describe('normalizePersistConfig', () => {
       getItem: () => Promise.resolve(undefined),
       setItem: () => Promise.resolve(),
       removeItem: () => Promise.resolve(),
+      listKeys: () => Promise.resolve([]),
     }
     const normalized = normalizePersistConfig(adapter)
     expect(normalized.storage).toBe(adapter)

--- a/test/utils/fake-schema.ts
+++ b/test/utils/fake-schema.ts
@@ -1,4 +1,3 @@
-import { getAtPath } from '../../src/runtime/core/path-walker'
 import type { Path } from '../../src/runtime/core/paths'
 import type {
   AbstractSchema,
@@ -55,11 +54,25 @@ export function fakeSchema<F extends GenericForm>(
       }
     },
     getDefaultAtPath(path) {
-      // Tests that don't care just inherit a "lookup-in-defaults" semantic
-      // — for any path that exists in the provided defaults tree, return
-      // the value there; otherwise undefined. Tests that DO care can
-      // overwrite this on the returned object before passing to consumers.
-      return getAtPath(defaults, path)
+      // fakeSchema is data-keyed, not schema-keyed — it can't distinguish
+      // tuple from unbounded array. To keep the structural-completeness
+      // machinery honest in tests:
+      //   - Object paths: return the value at the path (lookup).
+      //   - Once any intermediate is an array, return undefined: the test
+      //     util doesn't model element schemas.
+      //   - Empty path: return the whole defaults tree.
+      // Tests that need array element defaults (e.g. element-fill on
+      // sparse writes) should use a Zod adapter instead, or override
+      // this method on the returned object.
+      if (path.length === 0) return defaults
+      let current: unknown = defaults
+      for (const seg of path) {
+        if (Array.isArray(current)) return undefined
+        if (current === null || typeof current !== 'object') return undefined
+        const key = typeof seg === 'number' ? String(seg) : seg
+        current = (current as Record<string, unknown>)[key]
+      }
+      return current
     },
     getSchemasAtPath(path) {
       void path

--- a/test/utils/fake-schema.ts
+++ b/test/utils/fake-schema.ts
@@ -1,3 +1,4 @@
+import { getAtPath } from '../../src/runtime/core/path-walker'
 import type { Path } from '../../src/runtime/core/paths'
 import type {
   AbstractSchema,
@@ -52,6 +53,13 @@ export function fakeSchema<F extends GenericForm>(
         success: true,
         formKey: '',
       }
+    },
+    getDefaultAtPath(path) {
+      // Tests that don't care just inherit a "lookup-in-defaults" semantic
+      // — for any path that exists in the provided defaults tree, return
+      // the value there; otherwise undefined. Tests that DO care can
+      // overwrite this on the returned object before passing to consumers.
+      return getAtPath(defaults, path)
     },
     getSchemasAtPath(path) {
       void path


### PR DESCRIPTION
## Summary

Three intertwined gaps closed before customers consume cx — every change pulls toward the same invariant: *"the form is always structurally satisfying the slim schema, regardless of how the consumer arrives."*

1. **Structural-completeness invariant.** Every `setValue` write leaves the form satisfying the slim schema (objects/arrays/primitives without refines). Sparse-array writes pad missing positions with element defaults; partial-object writes fill missing keys; path-form callback `prev` is auto-defaulted from the schema; whole-form callback returns are mergeStructural'd against the schema default. Consumer code can rely on `prev.first.toUpperCase()` instead of `prev?.first?.toUpperCase() ?? ''`.

2. **Persistence auto-invalidation.** Storage keys carry a `:${schema.fingerprint()}` suffix; schema changes auto-orphan stale data. `version: number` consumer config is gone. New `FormStorage.listKeys(prefix)` powers active orphan cleanup at mount (cleans current-store stale-fingerprint AND legacy pre-fingerprint keys, plus mirror-cleans non-configured stores so a `'local' → 'session'` migration doesn't leave PII behind).

3. **Type honesty after array indices.** `getValue('posts.5')` returns `Post | undefined` (out-of-bounds is a real runtime case); whole-form callback `prev.posts[5]` is similarly tainted via `WithIndexedUndefined`. `register('email')` returns the strict `string` (no array crossing) — the previous blanket `| undefined` was dishonest about the runtime guarantee. Path-form callback `prev` stays strict — the runtime auto-defaults it. `setValue` value-form drops `DeepPartial<P>`; types lead with the strict shape, runtime mergeStructural is the safety net.

This is a coherent two-layer contract:
- **Types educate** (TS errors guide the dev to the canonical pattern at compile time).
- **Runtime ensures correctness** (mergeStructural / setAtPathWithSchemaFill maintain the invariant regardless of whether the consumer cooperates — survives casts, dynamic data, refactors that miss a key).

## Phases (commits)

- Phase 1: `getDefaultAtPath(path)` on `AbstractSchema`. v4 reuses `getNestedZodSchemasAtPath` + `deriveDefault`. v3 brings its path-walker to wrapper-peeling parity (latent bug — `{ profile: z.object(...).optional() }` paths used to return the wrapper, now descend through it). 37 adapter parity tests.
- Phase 2: `mergeStructural` + `setAtPathWithSchemaFill` in path-walker.ts. `setValueAtPath` consumes both. Path-form callback `prev` auto-defaults; whole-form callback merges return value. Construction-time `defaultValues` route through mergeStructural so partial-tuple constraints survive validate-then-fix. `reset()` falls back to construction-time defaults. The 12 regression tests at `set-value-schema-fill-regression.test.ts` flip to passing. 19 new `merge-structural` unit cases.
- Phase 3: Fingerprint-keyed storage + active orphan cleanup. `FormStorage.listKeys` added across local/session/IDB backends. Drops `version` from `PersistConfig`; envelope `v` becomes cx-internal. 8 new persistence tests.
- Phase 4: `WithIndexedUndefined`, `NestedReadType`, `IsTuple`, parameterized `SetValuePayload<Write, Read = Write>`. `getValue` / `register` swap to `NestedReadType`. Drops `DeepPartial` from `SetValuePayload`. Pure type change, zero runtime weight. Type-inference tests updated; 4 new Phase-4 type tests.
- E2E coverage for custom `.default(x)` flowing through the consumer surface (caught no bugs but pins the chain end-to-end against future refactors).
- Fix: deep-cascade fill drops sibling keys at intermediate boundaries (caught via the spike during validation). Three nested issues — array-branch missing intermediate fill, broken tuple-vs-array detection (`!Object.is` was wrong in both directions), and `unwrapStructuralWrappers` over-peeling primitive Optional/Nullable wrappers. 3 new regression tests.
- Docs: CHANGELOG + migration guide + API reference + persistence/custom-adapter/dynamic-field-arrays/troubleshooting recipes all updated to reflect the new contract.

## Breaking changes

- **`PersistConfig.version` removed.** Schema-content invalidation is automatic via the fingerprint suffix in the storage key. Consumers passing `version: N` get a typecheck error → delete the field. Drafts persisted by the previous version of cx are orphan-cleaned on first mount of the new code (silent, no error).
- **`FormStorage.listKeys(prefix)` is required.** Custom storage adapters must implement it. Each built-in backend (local/session/IDB) ships with one.
- **`AbstractSchema.getDefaultAtPath(path)` is required.** Custom-adapter authors implement a fifth method.
- **`SetValuePayload` drops `DeepPartial<P>`.** `setValue('user.profile', { name: 'Carol' })` against a strict profile schema is now a TS error. Use the callback form for partial writes (`setValue('user.profile', prev => ({ ...prev, name: 'Carol' }))`), or provide the complete shape. The runtime mergeStructural still backfills any partials that slip through casts.
- **`getValue` / `register` read types now use `NestedReadType`.** Array-crossing paths return `T | undefined`. Non-array paths stay strict. Existing consumers with explicit annotations of the old shapes may need updating.
- **v3 path-walker peels wrappers.** Previously broken behavior — paths through `z.optional(z.object(...))` returned the wrapper. Now descends correctly. Pre-1.0; documented in changelog.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 882 tests pass (was ~800)
- [x] `pnpm lint` — clean
- [x] `pnpm check:size` — under cap (16.63 KB / 16.17 KB / 16.03 KB; ceiling raised 16 → 17 KB to absorb the runtime additions: mergeStructural, setAtPathWithSchemaFill, listKeys, orphan cleanup, fingerprint plumbing)
- [x] **Spike validation:** cubic-forms' `spike-cx.vue` exercised end-to-end. Section 14 ("Structural-completeness invariant") demonstrates sparse-array fill, path-form callback auto-default, and deep-cascade structural completeness through `object → array → object → array → object → leaf`.

## Stack history

Originally stacked on #146; recreated against main after the parent merged. Identical diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed manual `persist.version` configuration; persistence now auto-invalidates on schema changes via fingerprint-based storage keys.
  * Updated `setValue` and `getValue` type signatures for stricter read/write semantics and array boundary handling.
  * Custom adapter requirements expanded: `AbstractSchema.getDefaultAtPath()` and `FormStorage.listKeys()` now required.

* **New Features**
  * Automatic orphan cleanup on mount removes stale persisted drafts across schema changes.
  * Enhanced structural completeness: forms auto-fill missing schema-defined fields on writes.

* **Documentation**
  * Comprehensive migration guide and API reference updates for v0.12 changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->