### PR TITLE
fix(slim-gate): reject unknown-path writes + property tests + KISS warn copy

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -49,6 +49,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      # Generate playground/.nuxt/imports.d.ts so the eslint config can
+      # parse Nuxt's auto-imports (`computed`, `useState`, etc.) and
+      # `no-undef` doesn't false-fail on auto-imported names. The full
+      # `test` job below also runs this before `pnpm check`; mirroring
+      # the same step here keeps the dedicated lint job self-contained.
+      - name: Prepare Nuxt auto-imports
+        run: pnpm dev:prepare
+
       - name: ESLint
         run: pnpm lint
 

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ coverage
 .nyc_output
 /.husky/_
 
+# Claude Code (auto-memory + plan files; per-developer, not committed)
+.claude
+
 # VSCode
 .vscode/*
 !.vscode/settings.json

--- a/docs/api.md
+++ b/docs/api.md
@@ -339,17 +339,17 @@ Three places accept the sentinel:
 
 - **`defaultValues`** — every primitive leaf can be `unset`. The
   library walks the payload at construction and adds the leaf's path
-  to the form's transient-empty set.
+  to the form's blank set.
 - **`setValue(path, unset)`** — translated at the API boundary;
-  storage gets the slim default with `transientEmpty: true` meta.
+  storage gets the slim default with `blank: true` meta.
 - **`reset({ … })`** — same translation; the post-reset state
   becomes the new dirty=false baseline.
 
 **Auto-mark on construction.** A freshly opened form has no user
 input yet, so every primitive leaf the consumer didn't supply in
-`defaultValues` is auto-marked `pendingEmpty`. This means
+`defaultValues` is auto-marked `blank`. This means
 `useForm({ schema: z.object({ email: z.string() }) })` (no
-`defaultValues`) starts with `email` in the transient-empty set —
+`defaultValues`) starts with `email` in the blank set —
 its `displayValue` is `''`, and `handleSubmit` raises `"No value supplied"`
 until the user types something. To opt a leaf out of auto-mark,
 supply a non-`unset` value for it: `defaultValues: { email: '' }`
@@ -359,10 +359,10 @@ defaults (`{ user: { name: 'a' } }` against `user.{name, age}`
 auto-marks `user.age`). It does NOT recurse into arrays — array
 elements are runtime-added; opt them in per-element via `unset`.
 Hydration overrides: when the form is rehydrated from a persisted
-draft or SSR payload, the hydrated `transientEmptyPaths` list is
+draft or SSR payload, the hydrated `blankPaths` list is
 authoritative and auto-mark does not fire.
 
-**Submit / validate honor the sentinel.** A transient-empty path
+**Submit / validate honor the sentinel.** A blank path
 bound to a _required_ schema (no `.optional()` / `.nullable()` /
 `.default(N)` / `.catch(N)`) raises a synthesized `"No value supplied"`
 error during `handleSubmit` / `validate` / `validateAsync`. Use
@@ -375,8 +375,8 @@ DOM (`<input type="number">` or `<input v-register.number>`); for
 strings and booleans the dev opts in via `unset` because the DOM
 state alone doesn't carry "user-cleared" intent.
 
-Per-path introspection: `form.getFieldState(path).value.pendingEmpty`.
-Bulk introspection: `form.transientEmptyPaths.value` returns a
+Per-path introspection: `form.getFieldState(path).value.blank`.
+Bulk introspection: `form.blankPaths.value` returns a
 frozen `ReadonlySet<PathKey>` of every marked leaf, suitable for
 "unanswered fields" logging or conditional UI.
 
@@ -634,12 +634,12 @@ operation is a no-op (out-of-range index on `remove` / `swap` /
 See [dynamic-field-arrays recipe](./recipes/dynamic-field-arrays.md)
 for the `v-for` pattern.
 
-### Transient-empty introspection
+### Blank introspection
 
-| Member                                   | Type                  | What it does                                                                                                                                                                                                                                                                                                                               |
-| ---------------------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `transientEmptyPaths.value`              | `ReadonlySet<string>` | Frozen snapshot of every path-key currently in the form's transient-empty set. Reactive — Vue tracks `.has()` / `.size` / iteration. Mutating the snapshot is a no-op (writes go through `setValue(_, unset)`, the directive's input listener, or `markTransientEmpty()` on a register binding). See `unset` exported from the core entry. |
-| `getFieldState(path).value.pendingEmpty` | `boolean`             | Per-path equivalent: `true` while `path` is in the transient-empty set.                                                                                                                                                                                                                                                                    |
+| Member                            | Type                  | What it does                                                                                                                                                                                                                                                                                                            |
+| --------------------------------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `blankPaths.value`                | `ReadonlySet<string>` | Frozen snapshot of every path-key currently in the form's blank set. Reactive — Vue tracks `.has()` / `.size` / iteration. Mutating the snapshot is a no-op (writes go through `setValue(_, unset)`, the directive's input listener, or `markBlank()` on a register binding). See `unset` exported from the core entry. |
+| `getFieldState(path).value.blank` | `boolean`             | Per-path equivalent: `true` while `path` is in the blank set.                                                                                                                                                                                                                                                           |
 
 ### Identity
 

--- a/docs/migration/0.11-to-0.12.md
+++ b/docs/migration/0.11-to-0.12.md
@@ -69,7 +69,7 @@ Eighteen breaking changes:
     slim-primitive write contract (item 14). `isRequiredAtPath(path)`
     returns `true` when the leaf has no `.optional()` / `.nullable()`
     / `.default()` / `.catch()` wrapper; the runtime calls it from
-    the transient-empty validation augmentation to raise
+    the blank validation augmentation to raise
     `cx:no-value-supplied` for unfilled required fields. Custom-
     adapter authors must implement all three.
 11. **`FormStorage.listKeys(prefix)` is now required.** Custom
@@ -1092,7 +1092,7 @@ The caps (`maxEntries`, `maxPathDepth`) and security guidance
 unchanged — see the [server-errors recipe](../recipes/server-errors.md)
 for the full pattern.
 
-## New: `unset` sentinel + transient-empty mechanism
+## New: `unset` sentinel + blank mechanism
 
 Numeric inputs in 0.11 had two failure modes when cleared:
 
@@ -1104,31 +1104,31 @@ Numeric inputs in 0.11 had two failure modes when cleared:
   content emitted a slim-primitive-gate dev-warn for what was
   actually a transient mid-edit state.
 
-  0.12 fixes both via the `unset` sentinel + transient-empty mechanism:
+  0.12 fixes both via the `unset` sentinel + blank mechanism:
 
 - Storage stays well-typed (`number`, never `''`). Calculations
   and reads continue to work without narrowing.
 - The "displayed empty" state lives in a per-form `Set<PathKey>` —
-  the **transient-empty set**. Surfaced via
-  `meta.pendingEmpty` / `getFieldState(path).value.pendingEmpty`
-  for per-path access and `form.transientEmptyPaths.value` for
+  the **blank set**. Surfaced via
+  `meta.blank` / `getFieldState(path).value.blank`
+  for per-path access and `form.blankPaths.value` for
   bulk introspection.
 - The directive's input listener auto-marks numeric inputs on
   empty / non-castable DOM. For strings and booleans, the dev
   opts in declaratively (`defaultValues: { name: unset }`) or
   imperatively (`setValue('name', unset)`).
 - **Construction-time auto-mark.** Every primitive leaf the consumer
-  did not supply in `defaultValues` is auto-marked `pendingEmpty` at
+  did not supply in `defaultValues` is auto-marked `blank` at
   construction. Rationale: a freshly opened form has no user input
   yet, so `useForm({ schema: z.object({ email: z.string() }) })`
-  starts with `email` as transient-empty (display = `''`, submit
+  starts with `email` as blank (display = `''`, submit
   raises "No value supplied"). To opt a leaf out, supply a non-`unset` value
   for it (`defaultValues: { email: '' }` is the explicit "empty
   string is intentional" signal). Hydration overrides — when the
   form rehydrates from a persisted draft or SSR payload, the
   hydrated set is authoritative.
 - **Submit / validate honor the mark for required schemas.** A
-  transient-empty path bound to a strict `z.number()` /
+  blank path bound to a strict `z.number()` /
   `z.string()` / `z.boolean()` raises a synthesized `"No value supplied"`
   error during `handleSubmit` / `validate` / `validateAsync` —
   the public-housing footgun fix (a user who didn't answer "what
@@ -1141,11 +1141,11 @@ The `defaultValues`, `setValue`, and `reset` types widened from
 `DefaultValuesShape<T>` is `WriteShape<T>` plus `Unset` admitted at
 every primitive leaf. Existing code that passes plain values
 type-checks unchanged (widening is additive). `MetaTrackerValue`
-gained a `pendingEmpty: boolean` field; `FieldState` gained the same
-field at top level. `WriteMeta` gained `transientEmpty?: boolean`.
+gained a `blank: boolean` field; `FieldState` gained the same
+field at top level. `WriteMeta` gained `blank?: boolean`.
 
 Persistence envelope bumped `v: 2` → `v: 3` to round-trip the
-transient-empty list. v=2 payloads are dropped on read with a one-
+blank list. v=2 payloads are dropped on read with a one-
 time dev-warn — drafts saved against 0.11 won't restore on 0.12.
 
 ## Breaking: `ValidationError.code` is now required

--- a/docs/recipes/app-defaults.md
+++ b/docs/recipes/app-defaults.md
@@ -119,11 +119,11 @@ Three patterns:
 import { unset } from '@chemical-x/forms/zod'
 
 // 1. Plain values — explicit defaults flow into storage and the form
-//    is not transient-empty for those leaves.
+//    is not blank for those leaves.
 useForm({ schema, defaultValues: { email: 'me@example.com', count: 10 } })
 
 // 2. Omit defaultValues entirely — every primitive leaf (string,
-//    number, boolean, bigint) is auto-marked transient-empty at
+//    number, boolean, bigint) is auto-marked blank at
 //    construction. Storage holds the schema's slim defaults; the
 //    form displays empty; submit raises 'No value supplied' for
 //    required schemas.
@@ -132,7 +132,7 @@ useForm({ schema })
 // 3. Mark specific leaves as `unset` — those leaves are transient-
 //    empty; siblings without an explicit value are auto-marked too.
 useForm({ schema, defaultValues: { email: unset, count: 10 } })
-//                                  ^^^^^^^^^^^^^ transient-empty
+//                                  ^^^^^^^^^^^^^ blank
 //                                                  ^^^^^^^^^ explicit value
 ```
 
@@ -140,9 +140,9 @@ useForm({ schema, defaultValues: { email: unset, count: 10 } })
 identically — same semantic everywhere.
 
 The auto-mark and the explicit `unset` paths converge on the same
-state: the path lives in the form's transient-empty set, surfaced
-via `getFieldState(path).value.pendingEmpty` and
-`form.transientEmptyPaths.value` for bulk introspection. Submit /
+state: the path lives in the form's blank set, surfaced
+via `getFieldState(path).value.blank` and
+`form.blankPaths.value` for bulk introspection. Submit /
 validate / validateAsync raise `'No value supplied'` (`code:
 'cx:no-value-supplied'`) for required schemas; `.optional()` /
 `.nullable()` / `.default(N)` / `.catch(N)` schemas accept the
@@ -151,7 +151,7 @@ empty case.
 To opt a leaf OUT of auto-mark, supply a non-`unset` value for it
 (`defaultValues: { email: '' }` is the explicit "empty string is
 intentional" signal — storage holds `''` and the path is NOT
-transient-empty).
+blank).
 
 ## Alternative: userland wrapper
 

--- a/docs/recipes/custom-adapter.md
+++ b/docs/recipes/custom-adapter.md
@@ -46,7 +46,7 @@ type AbstractSchema<Form, GetValueFormType = Form> = {
   dynamic writes don't get rejected.
 - **`isRequiredAtPath(path)`** — returns `true` when the leaf is
   required (no `.optional()` / `.nullable()` / `.default()` /
-  `.catch()` wrapper). Used by the transient-empty validation
+  `.catch()` wrapper). Used by the blank validation
   augmentation to raise `'No value supplied'` for unfilled required
   fields. Return `false` for any wrapper that admits the empty
   case.

--- a/docs/recipes/persistence.md
+++ b/docs/recipes/persistence.md
@@ -248,7 +248,7 @@ serialised shape. Consumers don't (and now can't) set it. Drafts
 saved against a stale envelope version are dropped with a one-time
 dev-warn on read.
 
-The envelope also round-trips the form's transient-empty set when
+The envelope also round-trips the form's blank set when
 populated, so a numeric field cleared by the user stays visually
 empty after reload (storage holds the slim default; the displayed-
 empty state survives).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -153,7 +153,7 @@ escape hatch).
 
 ## "Submit fails with 'No value supplied' on a field the user can leave blank"
 
-The path is in the form's transient-empty set and bound to a
+The path is in the form's blank set and bound to a
 required schema. Three resolutions, depending on intent:
 
 - **The field is genuinely optional.** Wrap the schema:
@@ -265,7 +265,7 @@ return {
 
 See the [custom-adapter recipe](./recipes/custom-adapter.md) for
 the full contract including `isRequiredAtPath` (used by the
-transient-empty validation augmentation) and
+blank validation augmentation) and
 `getSlimPrimitiveTypesAtPath` (used by the slim-primitive write
 gate).
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -118,6 +118,15 @@ export default [
     },
   },
 
+  // Playground components mirror the user-facing test app structure;
+  // the multi-word rule isn't useful for these throwaway repros.
+  {
+    files: ['playground/components/**/*.vue'],
+    rules: {
+      'vue/multi-word-component-names': 'off',
+    },
+  },
+
   // File structure rules
   {
     files: ['**/*.{js,ts,vue}'],

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -22,7 +22,15 @@
 
   const { register, getFieldState, handleSubmit, getValue } = useForm({
     schema: login,
+    // Explicit key required for `persist:` to round-trip reliably —
+    // anon keys drift across mounts (HMR / refresh / SSR↔CSR) and the
+    // persistence layer would orphan entries on every reload.
+    key: 'login',
     persist: 'session',
+    defaultValues: {
+      email: 'mango',
+      favoriteFruits: ['banana'],
+    },
   })
   const field = getFieldState('salary')
 
@@ -50,7 +58,7 @@
     <form @submit="onSubmit">
       <div>
         <label for="email">Email</label>
-        <input id="email" v-register="register('email', { persist: true })" />
+        <input id="email" v-register.trim.lazy="register('email', { persist: true })" />
         <div>{{ displayError }}</div>
       </div>
       <br />
@@ -62,7 +70,7 @@
 
       <div>
         <label for="salary">Salary</label>
-        <input id="salary" v-register="register('salary')" />
+        <input id="salary" v-register.number="register('salary')" />
       </div>
 
       <hr />

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -62,7 +62,6 @@
       <div>
         <label for="email">Email</label>
         <input id="email" v-register.trim="register('email', { persist: true })" />
-        <div>{{ displayError }}</div>
       </div>
       <br />
 
@@ -74,6 +73,7 @@
       <div>
         <label for="salary">Salary</label>
         <input id="salary" v-register.number="register('salary')" />
+        <div>{{ displayError }}</div>
       </div>
 
       <hr />

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -10,6 +10,14 @@
       city: z.string(),
     }),
     salary: z.number(),
+    // Checkbox demos:
+    //   - boolean → single checkbox (true/false)
+    //   - array → checkbox group (membership add/remove)
+    //   - enum + :true-value/:false-value → single checkbox mapped
+    //     to one of two strings
+    agreedToTerms: z.boolean(),
+    favoriteFruits: z.array(z.string()),
+    newsletter: z.enum(['subscribe', 'unsubscribe']),
   })
 
   const { register, getFieldState, handleSubmit, getValue } = useForm({
@@ -54,8 +62,47 @@
 
       <div>
         <label for="salary">Salary</label>
-        <input id="salary" v-register="register('address.salary')" />
+        <input id="salary" v-register="register('salary')" />
       </div>
+
+      <hr />
+      <h3>Checkboxes</h3>
+
+      <div>
+        <label>
+          <input v-register="register('agreedToTerms')" type="checkbox" />
+          I agree to the terms (single boolean)
+        </label>
+      </div>
+
+      <fieldset>
+        <legend>Favorite fruits (array group — share one register binding)</legend>
+        <label>
+          <input v-register="register('favoriteFruits')" type="checkbox" value="apple" />
+          Apple
+        </label>
+        <label>
+          <input v-register="register('favoriteFruits')" type="checkbox" value="banana" />
+          Banana
+        </label>
+        <label>
+          <input v-register="register('favoriteFruits')" type="checkbox" value="cherry" />
+          Cherry
+        </label>
+      </fieldset>
+
+      <div>
+        <label>
+          <input
+            v-register="register('newsletter')"
+            type="checkbox"
+            :true-value="'subscribe'"
+            :false-value="'unsubscribe'"
+          />
+          Newsletter (single checkbox mapped to a string via :true-value / :false-value)
+        </label>
+      </div>
+
       <button>Log in</button>
     </form>
 

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,91 +1,65 @@
 <script setup lang="ts">
-  // Explicit zod-v4 import: Phase 7.1 dropped the `useZod` Nuxt option, so
-  // the Nuxt-auto-imported `useForm` is now the schema-agnostic abstract
-  // composable. Use the /zod subpath (v4) or /zod-v3 for zod-typed forms.
   import { useForm } from '@chemical-x/forms/zod'
-  import { parseApiErrors } from '@chemical-x/forms'
-  import { z } from 'zod'
+  import z from 'zod'
+  import Child from './components/Child.vue'
 
-  // -- Original demo: register + getValue across multiple inputs --
-  const schema = z.object({ fruit: z.string() })
-  const { register, getValue } = useForm({ schema, key: 'example-form' })
-  const registerValue = register('fruit')
-
-  // -- New error API demo --
-  const signupSchema = z.object({
-    email: z.string().email('Enter a valid email'),
-    password: z.string().min(8, 'At least 8 characters'),
-  })
-  const signupForm = useForm({ schema: signupSchema, key: 'signup' })
-  const {
-    register: registerSignup,
-    fieldErrors: signupErrors,
-    handleSubmit: handleSignupSubmit,
-    setFieldErrors,
-    clearFieldErrors,
-    getFieldState,
-  } = signupForm
-
-  const emailReg = registerSignup('email')
-  const passwordReg = registerSignup('password')
-
-  // handleSubmit wraps the user callback: validation failure auto-populates
-  // signupErrors, success clears it. The user's onSubmit can then parse
-  // a server response via parseApiErrors() and write the result with
-  // setFieldErrors(...) to layer server-side errors on top.
-  const onSubmit = handleSignupSubmit(async (values) => {
-    // simulate server returning a 422
-    const apiResult = parseApiErrors(
-      { error: { details: { email: ['Already taken'] } } },
-      { formKey: signupForm.key }
-    )
-    if (apiResult.ok) setFieldErrors(apiResult.errors)
-    // eslint-disable-next-line no-console
-    console.log('client-validated values:', values)
+  const login = z.object({
+    email: z.email(),
+    password: z.string(),
+    address: z.object({
+      city: z.string(),
+    }),
+    salary: z.number(),
   })
 
-  const emailFieldState = getFieldState('email')
+  const { register, getFieldState, handleSubmit, getValue } = useForm({
+    schema: login,
+    persist: 'session',
+  })
+  const field = getFieldState('salary')
+
+  const displayError = computed(() => {
+    if (!field.value.touched) return ''
+    const msg = field.value.errors?.[0]?.message ?? ''
+    return msg
+  })
+
+  const onSubmit = handleSubmit(
+    (values) => {
+      // eslint-disable-next-line no-console
+      console.log('Success!', values)
+    },
+    (errors) => {
+      // eslint-disable-next-line no-console
+      console.log('Nope!', errors)
+    }
+  )
 </script>
 
 <template>
-  <div style="font-family: system-ui; max-width: 640px; margin: 2rem auto; padding: 0 1rem">
-    <h1>chemical-x-forms playground</h1>
-
-    <h2>Original API</h2>
-    <p>current fruit: '{{ getValue('fruit').value }}'</p>
-    <input v-register="registerValue" />
-    <hr />
-    <input v-register="registerValue" />
-    <hr />
-    <RootInput :fruit="registerValue" />
-
-    <h2 style="margin-top: 2rem">Error API (new in 0.6)</h2>
-    <form style="display: flex; flex-direction: column; gap: 1rem" @submit.prevent="onSubmit">
-      <label style="display: flex; flex-direction: column; gap: 0.25rem">
-        <span>Email</span>
-        <input v-register="emailReg" type="email" />
-        <small v-if="signupErrors.email?.[0]" style="color: #dc2626">
-          {{ signupErrors.email[0].message }}
-        </small>
-      </label>
-
-      <label style="display: flex; flex-direction: column; gap: 0.25rem">
-        <span>Password</span>
-        <input v-register="passwordReg" type="password" />
-        <small v-if="signupErrors.password?.[0]" style="color: #dc2626">
-          {{ signupErrors.password[0].message }}
-        </small>
-      </label>
-
-      <div style="display: flex; gap: 0.5rem">
-        <button type="submit">Submit</button>
-        <button type="button" @click="clearFieldErrors()">Clear errors</button>
+  <div>
+    <NuxtRouteAnnouncer />
+    <form @submit="onSubmit">
+      <div>
+        <label for="email">Email</label>
+        <input id="email" v-register="register('email', { persist: true })" />
+        <div>{{ displayError }}</div>
       </div>
+      <br />
+
+      <div>
+        <label for="password">Password</label>
+        <Child id="password" />
+      </div>
+
+      <div>
+        <label for="salary">Salary</label>
+        <input id="salary" v-register="register('address.salary')" />
+      </div>
+      <button>Log in</button>
     </form>
 
-    <h3 style="margin-top: 1.5rem">Same data via getFieldState (FieldState.errors)</h3>
-    <pre style="background: #f8fafc; padding: 0.75rem; border-radius: 6px">{{
-      JSON.stringify(emailFieldState.errors, null, 2)
-    }}</pre>
+    <pre>{{ getValue().value }}</pre>
+    <pre>{{ JSON.stringify(field, null, 2) }}</pre>
   </div>
 </template>

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -18,6 +18,10 @@
     agreedToTerms: z.boolean(),
     favoriteFruits: z.array(z.string()),
     newsletter: z.enum(['subscribe', 'unsubscribe']),
+    // Radio group — one register binding shared across multiple
+    // <input type="radio">, each with a distinct value=. Model is
+    // the option-value of the currently-checked radio.
+    subscriptionTier: z.enum(['free', 'pro', 'enterprise']),
   })
 
   const { register, getFieldState, handleSubmit, getValue } = useForm({
@@ -28,7 +32,6 @@
     key: 'login',
     persist: 'session',
     defaultValues: {
-      email: 'mango',
       favoriteFruits: ['banana'],
     },
   })
@@ -58,7 +61,7 @@
     <form @submit="onSubmit">
       <div>
         <label for="email">Email</label>
-        <input id="email" v-register.trim.lazy="register('email', { persist: true })" />
+        <input id="email" v-register.trim="register('email', { persist: true })" />
         <div>{{ displayError }}</div>
       </div>
       <br />
@@ -110,6 +113,24 @@
           Newsletter (single checkbox mapped to a string via :true-value / :false-value)
         </label>
       </div>
+
+      <hr />
+      <h3>Radio group</h3>
+      <fieldset>
+        <legend>Subscription tier (one register binding, distinct value= per radio)</legend>
+        <label>
+          <input v-register="register('subscriptionTier')" type="radio" value="free" />
+          Free
+        </label>
+        <label>
+          <input v-register="register('subscriptionTier')" type="radio" value="pro" />
+          Pro
+        </label>
+        <label>
+          <input v-register="register('subscriptionTier')" type="radio" value="enterprise" />
+          Enterprise
+        </label>
+      </fieldset>
 
       <button>Log in</button>
     </form>

--- a/playground/components/Child.vue
+++ b/playground/components/Child.vue
@@ -1,0 +1,6 @@
+<template>
+  <div style="background-color: darkorange; padding: 4rem">
+    Hi, I'm the child
+    <Grandchild></Grandchild>
+  </div>
+</template>

--- a/playground/components/Grandchild.vue
+++ b/playground/components/Grandchild.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+  import { useFormContext } from '@chemical-x/forms'
+
+  const ctx = useFormContext()
+  const value = ctx?.getValue()
+</script>
+
+<template>
+  <div style="background-color: cadetblue">
+    Some Surrounding UI
+    <input
+      v-register="ctx?.register('address.city')"
+      type="text"
+      style="background-color: yellow"
+    />
+
+    Child Component has access to the form:
+    <pre>{{ JSON.stringify(value, null, 2) }}</pre>
+  </div>
+</template>

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -9,6 +9,11 @@ export default defineNuxtConfig({
     // composable picks up the zod-v4 schema types rather than the Nuxt
     // auto-imported abstract useForm.
     '@chemical-x/forms/zod': '../src/zod.ts',
+    // Bare-path import for the schema-agnostic surface (parseApiErrors,
+    // useFormContext, etc). Without this, vite-node fails to resolve
+    // `@chemical-x/forms` and the SSR worker crashes with
+    // "IPC connection closed".
+    '@chemical-x/forms': '../src/index.ts',
   },
   compatibilityDate: '2025-01-28',
 }) as DefineNuxtConfig

--- a/src/runtime/adapters/zod-v3/index.ts
+++ b/src/runtime/adapters/zod-v3/index.ts
@@ -996,7 +996,7 @@ function isLeafRequiredV3(schema: z.ZodTypeAny, depth = 0): boolean {
     return next === undefined ? true : isLeafRequiredV3(next, depth + 1)
   }
   if (isZodSchemaType(schema, 'ZodPipeline')) {
-    // Use the input side: transient-empty is a write-time concern.
+    // Use the input side: blank is a write-time concern.
     const inner = (schema._def as { in?: z.ZodTypeAny }).in
     return inner === undefined ? true : isLeafRequiredV3(inner, depth + 1)
   }

--- a/src/runtime/adapters/zod-v3/index.ts
+++ b/src/runtime/adapters/zod-v3/index.ts
@@ -373,7 +373,10 @@ export function zodAdapter<
           stripConfig: { stripDefaultValues: true, stripZodEffects: true },
         })
         const resolved = getNestedZodSchemasAtPath(slimSchema, path)
-        if (resolved.length === 0) return new Set(PERMISSIVE_V3)
+        // Path doesn't resolve in the schema → no kinds accepted.
+        // The gate's membership check rejects every kind against an
+        // empty set, blocking writes to typo / unknown paths.
+        if (resolved.length === 0) return new Set()
         const out = new Set<SlimPrimitiveKind>()
         for (const candidate of resolved) {
           for (const k of slimPrimitivesV3(candidate as z.ZodTypeAny)) out.add(k)
@@ -736,6 +739,14 @@ function getNestedZodSchemasAtPath<Schema extends z.ZodSchema>(
       }
 
       return foundSchemas
+    } else {
+      // Hit a non-container (leaf primitive, wrapper, union — anything
+      // we don't recognise as descendable) but more segments remain.
+      // The path goes deeper than the schema admits; return empty
+      // so callers (slim-gate, validateAtPath, getDefaultAtPath)
+      // treat it as unresolvable rather than falsely binding to the
+      // last container's leaf. Mirrors v4's path-walker leaf branches.
+      return []
     }
   }
 

--- a/src/runtime/adapters/zod-v3/index.ts
+++ b/src/runtime/adapters/zod-v3/index.ts
@@ -179,7 +179,9 @@ export function zodAdapter<
             const path = coercePathSegments(issue.path)
             if (!schemasAtPath.length) {
               console.error(
-                `No schemas at path '${path.join(PATH_SEPARATOR)}' for key '${_formKey}'`
+                `[@chemical-x/forms] zod-v3 adapter: no schema at path ` +
+                  `'${path.join(PATH_SEPARATOR)}' for key '${_formKey}'. ` +
+                  `Skipping the issue. (This is a library-internal invariant — please file a bug.)`
               )
               continue
             }
@@ -1358,7 +1360,11 @@ function getDefaultValuesFromZodSchema<
       if (inner) return generateValue(inner)
     }
 
-    console.warn(`Unsupported schema: ${schema.constructor.name} (key '${formKey}')`)
+    console.warn(
+      `[@chemical-x/forms] zod-v3 adapter: unsupported schema kind ` +
+        `'${schema.constructor.name}' on form '${formKey}'. Defaulting the field to null. ` +
+        `Use a supported zod kind (object/array/record/string/number/etc.) at this path.`
+    )
     return null
   }
 

--- a/src/runtime/adapters/zod-v4/adapter.ts
+++ b/src/runtime/adapters/zod-v4/adapter.ts
@@ -23,7 +23,7 @@ import {
   unwrapPipe,
 } from './introspect'
 import { getNestedZodSchemasAtPath } from './path-walker'
-import { PERMISSIVE, slimPrimitivesOf } from './slim-primitives'
+import { slimPrimitivesOf } from './slim-primitives'
 
 /**
  * Zod v4 adapter — implements `AbstractSchema` against Zod v4's public
@@ -301,7 +301,10 @@ export function zodV4Adapter<FormSchema extends z.ZodObject, Form extends z.infe
         // is the root form: always an object.
         if (path.length === 0) return new Set(['object'])
         const resolved = getNestedZodSchemasAtPath(rootSchema, path)
-        if (resolved.length === 0) return new Set(PERMISSIVE)
+        // Path doesn't resolve in the schema → no kinds accepted.
+        // The gate's membership check rejects every kind against an
+        // empty set, blocking writes to typo / unknown paths.
+        if (resolved.length === 0) return new Set()
         const out = new Set<SlimPrimitiveKind>()
         for (const candidate of resolved) {
           for (const k of slimPrimitivesOf(candidate)) out.add(k)

--- a/src/runtime/adapters/zod-v4/adapter.ts
+++ b/src/runtime/adapters/zod-v4/adapter.ts
@@ -143,7 +143,7 @@ function isLeafRequired(schema: z.ZodType, depth = 0): boolean {
     return inner === undefined ? true : isLeafRequired(inner, depth + 1)
   }
   if (kind === 'pipe') {
-    // Use the input side: transient-empty is a write-time concern.
+    // Use the input side: blank is a write-time concern.
     const inner = unwrapPipe(schema)
     return inner === undefined ? true : isLeafRequired(inner, depth + 1)
   }
@@ -315,7 +315,7 @@ export function zodV4Adapter<FormSchema extends z.ZodObject, Form extends z.infe
       isRequiredAtPath(path): boolean {
         // Root form is always "required" in the structural sense — it's
         // the object we're parsing. Submit/validate's required-empty
-        // check never sees the root path in `transientEmptyPaths`
+        // check never sees the root path in `blankPaths`
         // (the set tracks primitive leaves), so the value is academic.
         if (path.length === 0) return true
         const resolved = getNestedZodSchemasAtPath(rootSchema, path)

--- a/src/runtime/composables/use-abstract-form.ts
+++ b/src/runtime/composables/use-abstract-form.ts
@@ -672,10 +672,10 @@ function wirePersistence<F extends GenericForm>(
         if (disposed) return
         if (state.persistOptIns.isEmpty()) {
           console.warn(
-            `[@chemical-x/forms] Persistence is configured for form ` +
-              `"${state.formKey}" but no fields opted in. Each persisted ` +
-              `field needs \`register('foo', { persist: true })\`, or call ` +
-              `\`form.persist('foo')\` for an explicit checkpoint. ` +
+            `[@chemical-x/forms] useForm({ persist: ... }) is configured on form ` +
+              `"${state.formKey}" but no fields opted in — nothing will be saved. ` +
+              `Fix: add \`{ persist: true }\` to register() calls, ` +
+              `e.g. register('email', { persist: true }). ` +
               `See ./docs/recipes/persistence.md.`
           )
         }

--- a/src/runtime/composables/use-abstract-form.ts
+++ b/src/runtime/composables/use-abstract-form.ts
@@ -621,16 +621,23 @@ function wirePersistence<F extends GenericForm>(
       const merged = mergeSparseHydration(toRaw(state.form.value) as F, payload.data.form)
       state.applyFormReplacement(merged)
       // Restore the transient-empty UI state from the persisted
-      // payload. This rebaselines BOTH the live set AND the originals
-      // snapshot — the persisted UI state is the new "construction-
-      // time" reference for `reset()` semantics, so a subsequent
-      // reset() restores the empty fields the user had on the
-      // previous mount, not the freshly-constructed empty set. Form
-      // values rebaseline implicitly through `originals` (which the
-      // existing applyFormReplacement updates via diff-apply), so
-      // mirroring that behaviour here keeps the two domains aligned.
-      state.transientEmptyPaths.clear()
-      state.originalsTransientEmpty.clear()
+      // payload. Persistence is per-element opt-in, so the persisted
+      // payload only covers paths within the opt-in scope (the leaf
+      // paths populated in `payload.data.form`). Construction-time
+      // auto-marks for paths OUTSIDE that scope must survive — without
+      // this, a non-opted-in `z.number()` field's slim default (0)
+      // would lose its transient-empty mark on hydrate and surface
+      // as `'0'` in its <input> instead of empty.
+      //
+      // Within the opt-in scope, the persisted state IS the truth: a
+      // persisted path that's no longer transient-empty (the user
+      // typed) clears the construction-time mark, and a persisted
+      // path that IS transient-empty (still slim default) re-asserts.
+      const persistedLeafPaths = collectPersistedLeafPaths(payload.data.form)
+      for (const k of persistedLeafPaths) {
+        state.transientEmptyPaths.delete(k)
+        state.originalsTransientEmpty.delete(k)
+      }
       for (const k of payload.data.transientEmptyPaths ?? []) {
         state.transientEmptyPaths.add(k as PathKey)
         state.originalsTransientEmpty.add(k as PathKey)
@@ -849,6 +856,37 @@ function isEmptyContainer(value: unknown): boolean {
   if (Array.isArray(value)) return value.length === 0
   if (isPlainRecord(value)) return Object.keys(value).length === 0
   return false
+}
+
+/**
+ * Walk a sparse persisted form and collect the canonical PathKey of
+ * every leaf. "Leaf" = anything that isn't a plain object or array
+ * (so primitives, null, deserialized Dates / strings all count). The
+ * persisted form's leaves correspond 1:1 with the per-element opt-in
+ * scope at the time persistence wrote, which the hydration path uses
+ * to bound which transient-empty entries to overwrite.
+ */
+function collectPersistedLeafPaths(form: unknown): PathKey[] {
+  const out: PathKey[] = []
+  walk(form, [])
+  return out
+
+  function walk(node: unknown, prefix: Path): void {
+    if (Array.isArray(node)) {
+      for (let i = 0; i < node.length; i++) {
+        walk(node[i], [...prefix, i])
+      }
+      return
+    }
+    if (isPlainRecord(node)) {
+      for (const key of Object.keys(node)) {
+        walk((node as Record<string, unknown>)[key], [...prefix, key])
+      }
+      return
+    }
+    if (prefix.length === 0) return // root scalar — no path to canonicalize
+    out.push(canonicalizePath(prefix).key)
+  }
 }
 
 /**

--- a/src/runtime/composables/use-abstract-form.ts
+++ b/src/runtime/composables/use-abstract-form.ts
@@ -293,13 +293,13 @@ function buildFreshState<F extends GenericForm, G extends GenericForm = F>(
     schema as unknown as AbstractSchema<GenericForm, GenericForm>
   )
   // Hydration precedence: when a hydration payload is present its
-  // `transientEmptyPaths` field is the authoritative truth. We still
+  // `blankPaths` field is the authoritative truth. We still
   // run the walker to scrub `unset` symbols out of `defaultValues` (so
   // they never reach storage), but discard the discovered paths in
   // favour of the hydrated set. Without this, a server-rendered form
-  // with no transient-empty paths would gain ones the client's
+  // with no blank paths would gain ones the client's
   // construction-time defaults invented.
-  const initialTransientEmpty: ReadonlyArray<string> | undefined =
+  const initialBlankPaths: ReadonlyArray<string> | undefined =
     pending === undefined ? walked.paths : undefined
   const createOptions: Parameters<typeof createFormStore<F, G>>[0] = {
     formKey: key,
@@ -309,7 +309,7 @@ function buildFreshState<F extends GenericForm, G extends GenericForm = F>(
     hydration: pending,
     fieldValidation: configuration.fieldValidation,
     isSSR: registry.isSSR,
-    ...(initialTransientEmpty !== undefined ? { initialTransientEmpty } : {}),
+    ...(initialBlankPaths !== undefined ? { initialBlankPaths } : {}),
   }
   const state = createFormStore<F, G>(createOptions)
   // Storage type is FormStore<GenericForm>; the lookup above narrows
@@ -556,11 +556,11 @@ function wirePersistence<F extends GenericForm>(
     // the fingerprint suffix.
     const filteredSchemaErrors = filterErrorsByPaths(state.schemaErrors, optedInPaths)
     const filteredUserErrors = filterErrorsByPaths(state.userErrors, optedInPaths)
-    // Transient-empty paths are part of the restorable UI state, so
+    // Blank paths are part of the restorable UI state, so
     // they ride the same opt-in gate as form values: only persist
     // the entries whose paths are also opted in for persistence.
     const filteredTransientEmpty = new Set<string>()
-    for (const tk of state.transientEmptyPaths) {
+    for (const tk of state.blankPaths) {
       if (optedInPaths.has(tk as PathKey)) filteredTransientEmpty.add(tk)
     }
     const payload = buildPersistedPayload<F>(
@@ -640,27 +640,27 @@ function wirePersistence<F extends GenericForm>(
       // keep their schema defaults.
       const merged = mergeSparseHydration(toRaw(state.form.value) as F, payload.data.form)
       state.applyFormReplacement(merged)
-      // Restore the transient-empty UI state from the persisted
+      // Restore the blank UI state from the persisted
       // payload. Persistence is per-element opt-in, so the persisted
       // payload only covers paths within the opt-in scope (the leaf
       // paths populated in `payload.data.form`). Construction-time
       // auto-marks for paths OUTSIDE that scope must survive — without
       // this, a non-opted-in `z.number()` field's slim default (0)
-      // would lose its transient-empty mark on hydrate and surface
+      // would lose its blank mark on hydrate and surface
       // as `'0'` in its <input> instead of empty.
       //
       // Within the opt-in scope, the persisted state IS the truth: a
-      // persisted path that's no longer transient-empty (the user
+      // persisted path that's no longer blank (the user
       // typed) clears the construction-time mark, and a persisted
-      // path that IS transient-empty (still slim default) re-asserts.
+      // path that IS blank (still slim default) re-asserts.
       const persistedLeafPaths = collectPersistedLeafPaths(payload.data.form)
       for (const k of persistedLeafPaths) {
-        state.transientEmptyPaths.delete(k)
-        state.originalsTransientEmpty.delete(k)
+        state.blankPaths.delete(k)
+        state.originalBlankPaths.delete(k)
       }
-      for (const k of payload.data.transientEmptyPaths ?? []) {
-        state.transientEmptyPaths.add(k as PathKey)
-        state.originalsTransientEmpty.add(k as PathKey)
+      for (const k of payload.data.blankPaths ?? []) {
+        state.blankPaths.add(k as PathKey)
+        state.originalBlankPaths.add(k as PathKey)
       }
       if (include === 'form+errors') {
         // Each store rebuilds independently from its persisted entries.
@@ -728,7 +728,7 @@ function wirePersistence<F extends GenericForm>(
     const baseForm = existing?.data.form ?? ({} as F)
     const value = getAtPath(toRaw(state.form.value), path)
     const nextForm = setAtPath(baseForm, path, value) as F
-    // Refresh this path's transient-empty entry — and any descendants
+    // Refresh this path's blank entry — and any descendants
     // — while preserving entries for OTHER paths the previous mount
     // persisted. Non-leaf writes (`writePathImmediately('user')`)
     // overwrite the entire subtree, so any disk entries below the
@@ -736,11 +736,11 @@ function wirePersistence<F extends GenericForm>(
     // contributes whatever marks are still active under that subtree.
     const { key: pathKey } = canonicalizePath(path)
     const transientSet = new Set<string>(
-      (existing?.data.transientEmptyPaths ?? []).filter(
+      (existing?.data.blankPaths ?? []).filter(
         (k) => k !== pathKey && !isDescendantPathKey(k, pathKey)
       )
     )
-    for (const liveKey of state.transientEmptyPaths) {
+    for (const liveKey of state.blankPaths) {
       if (liveKey === pathKey || isDescendantPathKey(liveKey, pathKey)) {
         transientSet.add(liveKey)
       }
@@ -800,12 +800,12 @@ function wirePersistence<F extends GenericForm>(
     }
     const { key: pathKey } = canonicalizePath(path)
     // Drop the cleared path AND every descendant from the persisted
-    // transient-empty list so a later mount doesn't restore an
+    // blank list so a later mount doesn't restore an
     // "empty" UI state for a path that no longer has any value
     // behind it. Non-leaf clears (`clearPersistedDraft('user')`)
     // wipe the whole user.* subtree.
     const transientSet = new Set(
-      (existing.data.transientEmptyPaths ?? []).filter(
+      (existing.data.blankPaths ?? []).filter(
         (k) => k !== pathKey && !isDescendantPathKey(k, pathKey)
       )
     )
@@ -931,7 +931,7 @@ function enforceAnonPersistRule(formKey: string, isSSR: boolean): boolean {
  * (so primitives, null, deserialized Dates / strings all count). The
  * persisted form's leaves correspond 1:1 with the per-element opt-in
  * scope at the time persistence wrote, which the hydration path uses
- * to bound which transient-empty entries to overwrite.
+ * to bound which blank entries to overwrite.
  */
 function collectPersistedLeafPaths(form: unknown): PathKey[] {
   const out: PathKey[] = []

--- a/src/runtime/composables/use-abstract-form.ts
+++ b/src/runtime/composables/use-abstract-form.ts
@@ -9,7 +9,7 @@ import {
 } from '../core/defaults'
 import { __DEV__ } from '../core/dev'
 import { captureUserCallSite } from '../core/dev-stack-trace'
-import { ReservedFormKeyError } from '../core/errors'
+import { AnonPersistError, ReservedFormKeyError } from '../core/errors'
 import type { FieldStateView } from '../core/field-state-api'
 import { getComputedSchema } from '../core/get-computed-schema'
 import { createHistoryModule, type HistoryModule } from '../core/history'
@@ -29,6 +29,7 @@ import {
   sweepNonConfiguredStandardStoresForOrphans,
   type PersistenceModule,
 } from '../core/persistence'
+import { hashStableString } from '../core/hash'
 import { canonicalizePath, type Path, type PathKey } from '../core/paths'
 import { deleteAtPath, getAtPath, setAtPath, isPlainRecord } from '../core/path-walker'
 import { kFormContext, useRegistry } from '../core/registry'
@@ -137,9 +138,21 @@ export function useAbstractForm<
   //
   // The shorthand input (`persist: 'local'`, `persist: customAdapter`)
   // is normalised to the resolved options bag once at this boundary —
+  // Anonymous + persist enforcement. Dev throws (catches the bug at
+  // the offending useForm() call); prod returns `true` so the wiring
+  // block below skips entirely AND cleans up any prior persisted
+  // entries — we'd rather pretend persist wasn't configured than
+  // silently mis-route data between forms that happened to share an
+  // anon id. Runs regardless of SSR / first-mount-vs-rehook so the
+  // dev-mode throw fires on the SSR pass too (without a server-side
+  // throw, the SSR pass would succeed silently and the client would
+  // throw on hydration — that surfaces as a confusing hydration
+  // mismatch instead of pointing at the actual config bug).
+  const persistDisabledByAnonRule =
+    merged.persist !== undefined && enforceAnonPersistRule(state.formKey, registry.isSSR)
   // everything below operates on the resolved shape.
   if (existing === undefined && !registry.isSSR) {
-    if (merged.persist !== undefined) {
+    if (merged.persist !== undefined && !persistDisabledByAnonRule) {
       const resolvedPersist = normalizePersistConfig(merged.persist)
       const persistenceBase = resolveStorageKeyBase(resolvedPersist, state.formKey)
       // Cross-store orphan cleanup: any standard backend not matching
@@ -157,11 +170,11 @@ export function useAbstractForm<
       state.registerDrain(() => persistenceModule.awaitPendingWrites())
       state.registerCleanup(() => persistenceModule.dispose())
     } else {
-      // No `persist:` configured. The form might have HAD persistence
-      // in a prior deployment that the dev has since removed. Sweep
-      // every cx-managed key under the default base from every
-      // standard backend so removing the option actually removes the
-      // on-disk artifact across all fingerprints that ever ran.
+      // Either the dev didn't configure `persist:` OR we just disabled
+      // it via the anon-persist rule. Either way, sweep every
+      // cx-managed key under this form's base across all standard
+      // backends so dropping (or refusing to wire) persistence
+      // actually leaves storage clean.
       void sweepAllOrphansAcrossStandardStores(`${PERSISTENCE_KEY_PREFIX}${state.formKey}`)
     }
   }
@@ -473,7 +486,14 @@ function wirePersistence<F extends GenericForm>(
   // produces a different fingerprint, so the new mount looks up a fresh
   // key — the old draft becomes an orphan, cleaned up in the same mount
   // by `cleanupOrphanKeys` below. No manual version protocol required.
-  const fingerprint = state.schema.fingerprint()
+  // Hash the long structural fingerprint into a fixed-size token before
+  // baking it into the storage key. The raw fingerprint is the
+  // schema's full shape stringified (`object{"address":object{...}}`),
+  // which works correctly for invalidation but produces 200+ char
+  // storage keys for non-trivial schemas AND leaks the schema's
+  // structure into client-side storage. The hash preserves
+  // determinism (same schema → same hash) without either downside.
+  const fingerprint = hashStableString(state.schema.fingerprint())
   const base = resolveStorageKeyBase(config, state.formKey)
   const key = `${base}:${fingerprint}`
   const debounceMs = config.debounceMs ?? DEFAULT_PERSISTENCE_DEBOUNCE_MS
@@ -856,6 +876,53 @@ function isEmptyContainer(value: unknown): boolean {
   if (Array.isArray(value)) return value.length === 0
   if (isPlainRecord(value)) return Object.keys(value).length === 0
   return false
+}
+
+/**
+ * Tracks the FormStore identities the anon-persist warn already
+ * fired for in production. Dev-mode throws (via AnonPersistError)
+ * don't need a dedupe set — the throw aborts the call before
+ * subsequent identical calls can land.
+ */
+const warnedAnonPersistKeys: Set<string> = new Set<string>()
+
+/**
+ * Anonymous + `persist:` is unsafe by construction: the synthetic
+ * `__cx:anon:<id>` identity drifts on every remount (Vue's `useId()`
+ * allocator is per-app and per-tree-position; HMR rebuilds the
+ * instance) AND can collide between two unrelated anon forms that
+ * happen to land on the same id. With matching schemas + backend,
+ * the second form would read the first's draft and write back over
+ * it — actual cross-form data leakage, not just stale entries.
+ *
+ * Two-tier handling:
+ *   - **Dev** (`__DEV__` true): throw `AnonPersistError`. Hard-fails
+ *     the call at the offending useForm() site.
+ *   - **Prod**: one-shot `console.warn` + return `true` so the
+ *     caller skips persistence wiring entirely. A deployed app
+ *     shipping the anti-pattern shouldn't hard-crash, but it also
+ *     shouldn't silently mis-route data — disabling the mechanism
+ *     is the safe failure.
+ *
+ * Returns `true` when persistence MUST be skipped (anon + persist).
+ */
+function enforceAnonPersistRule(formKey: string, isSSR: boolean): boolean {
+  if (!formKey.startsWith(ANONYMOUS_FORM_KEY_PREFIX)) return false
+  if (__DEV__) throw new AnonPersistError()
+  // Production: warn + tell the caller to skip wiring. Client-only
+  // warn (skip server logs to avoid spamming SSR per-request output).
+  // Persist is still skipped on the SSR pass — same disabling
+  // outcome — just without the log noise.
+  if (!isSSR && !warnedAnonPersistKeys.has(formKey)) {
+    warnedAnonPersistKeys.add(formKey)
+    console.warn(
+      "[@chemical-x/forms] persist: ignored — anonymous useForm() can't safely persist " +
+        '(key drift + cross-form collision risk).\n' +
+        '  Persistence is disabled for this form; the app keeps working.\n' +
+        "  Fix: useForm({ schema, key: 'login', persist: '...' })"
+    )
+  }
+  return true
 }
 
 /**

--- a/src/runtime/composables/use-register.ts
+++ b/src/runtime/composables/use-register.ts
@@ -130,7 +130,9 @@ function warnOutsideSetup(): void {
   warnedOutsideSetup = true
   const frame = captureUserCallSite()
   console.warn(
-    `[@chemical-x/forms] useRegister called outside of a component setup; returning ComputedRef<undefined>.` +
+    `[@chemical-x/forms] useRegister() called outside a component setup; returning ComputedRef<undefined>. ` +
+      `Fix: call it inside <script setup> or a setup() function — not from an event handler ` +
+      `or async callback.` +
       (frame !== undefined ? ` ${frame}` : '')
   )
 }

--- a/src/runtime/core/build-form-api.ts
+++ b/src/runtime/core/build-form-api.ts
@@ -134,7 +134,7 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
       // or returned `unset` for some leaf in a function form) flow
       // through the walker — every leaf gets translated, the cleaned
       // value lands in storage, and the discovered paths are added to
-      // `transientEmptyPaths` via direct setValueAtPath calls (the
+      // `blankPaths` via direct setValueAtPath calls (the
       // gate hook handles the bookkeeping).
       const walked = walkUnsetSentinels(
         next,
@@ -142,26 +142,26 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
       )
       const ok = state.setValueAtPath([], walked.cleanedValues)
       if (!ok) return false
-      // Mark each transient-empty path. `setValueAtPath` was just called
+      // Mark each blank path. `setValueAtPath` was just called
       // with cleaned values, so the gate hook's implicit-unmark would
-      // have removed any prior transient-empty entries for the paths
+      // have removed any prior blank entries for the paths
       // we just touched — re-add them now.
       for (const pathKey of walked.paths) {
         const segments = JSON.parse(pathKey) as Path
         state.setValueAtPath(segments, state.schema.getDefaultAtPath(segments), {
-          transientEmpty: true,
+          blank: true,
         })
       }
       return true
     }
     const segments = canonicalizePath(pathOrValue as string | Path).segments
     // `unset` at a specific path: resolve the slim default and route
-    // through `setValueAtPath` with `transientEmpty: true`. Storage
+    // through `setValueAtPath` with `blank: true`. Storage
     // gets the well-typed default; the path is marked for the
     // displayValue / required-empty machinery.
     if (isUnset(maybeValue)) {
       return state.setValueAtPath(segments, state.schema.getDefaultAtPath(segments), {
-        transientEmpty: true,
+        blank: true,
       })
     }
     // Path-form callback: when the slot at `segments` is unpopulated,
@@ -178,7 +178,7 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
       // direct case above.
       if (isUnset(resolvedValue)) {
         return state.setValueAtPath(segments, state.schema.getDefaultAtPath(segments), {
-          transientEmpty: true,
+          blank: true,
         })
       }
     } else {
@@ -250,13 +250,13 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
     for (const [, { segments, value: original }] of state.originals) {
       if (!Object.is(getAtPath(state.form.value, segments), original)) return true
     }
-    // Storage matches but transient-empty membership might have
+    // Storage matches but blank membership might have
     // changed (user cleared a field whose default was non-empty, or
     // typed into a field that was construction-time-empty). Compare
     // the live reactive set against the construction-time snapshot.
-    if (state.transientEmptyPaths.size !== state.originalsTransientEmpty.size) return true
-    for (const key of state.transientEmptyPaths) {
-      if (!state.originalsTransientEmpty.has(key)) return true
+    if (state.blankPaths.size !== state.originalBlankPaths.size) return true
+    for (const key of state.blankPaths) {
+      if (!state.originalBlankPaths.has(key)) return true
     }
     return false
   })
@@ -329,7 +329,7 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
       // paths. The cleaned values land in form storage via state.reset;
       // the marked paths get added back via direct setValueAtPath
       // calls AFTER the reset so the FormStore's own reset (which
-      // clears the transient-empty set in the args branch) doesn't
+      // clears the blank set in the args branch) doesn't
       // wipe them.
       const walked = walkUnsetSentinels(
         nextDefaultValues,
@@ -343,11 +343,11 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
       for (const pathKey of walked.paths) {
         const segments = JSON.parse(pathKey) as Path
         state.setValueAtPath(segments, state.schema.getDefaultAtPath(segments), {
-          transientEmpty: true,
+          blank: true,
         })
-        // Mirror the new baseline into originalsTransientEmpty so the
+        // Mirror the new baseline into originalBlankPaths so the
         // post-reset state is the dirty=false reference.
-        state.originalsTransientEmpty.add(pathKey as PathKey)
+        state.originalBlankPaths.add(pathKey as PathKey)
       }
     }
     if (persistence !== undefined) {
@@ -406,17 +406,17 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
   // --- Field arrays ---
   const fieldArrays = buildFieldArrayApi(state)
 
-  // --- Bulk transient-empty introspection ---
-  // Read-only view of the form's transient-empty path set. Vue 3.5
+  // --- Bulk blank introspection ---
+  // Read-only view of the form's blank path set. Vue 3.5
   // tracks `.has()` / `for..of` / size accesses on a reactive Set,
   // so the computed below is a lazy, dependency-tracked passthrough.
   // Wrapped in a Proxy that traps mutating methods so consumers can't
   // pollute the snapshot they receive (`Object.freeze` does NOT make
   // a Set readonly — `add` / `delete` / `clear` still work on frozen
   // Sets). Writes still go through `setValue(_, unset)` /
-  // `markTransientEmpty()` / the directive's input listener.
-  const transientEmptyPathsView = computed<ReadonlySet<string>>(() => {
-    return readonlySetSnapshot(state.transientEmptyPaths)
+  // `markBlank()` / the directive's input listener.
+  const blankPathsView = computed<ReadonlySet<string>>(() => {
+    return readonlySetSnapshot(state.blankPaths)
   })
 
   return {
@@ -457,7 +457,7 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
     swap: fieldArrays.swap as UseAbstractFormReturnType<Form, GetValueFormType>['swap'],
     move: fieldArrays.move as UseAbstractFormReturnType<Form, GetValueFormType>['move'],
     replace: fieldArrays.replace as UseAbstractFormReturnType<Form, GetValueFormType>['replace'],
-    transientEmptyPaths: transientEmptyPathsView,
+    blankPaths: blankPathsView,
   }
 }
 

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -84,9 +84,9 @@ export type FormStore<F extends GenericForm, G extends GenericForm = F> = {
    * default). The directive's input listener marks numeric clears
    * here; the declarative `unset` symbol routes through the same set.
    *
-   * Reads (`displayValue` computed, `getFieldState(...).meta.pendingEmpty`)
+   * Reads (`displayValue` computed, `getFieldState(...).meta.blank`)
    * track via Vue 3.5's reactive Set handlers. Writes happen inside
-   * `setValueAtPath` (gate-hook bookkeeping: `transientEmpty: true`
+   * `setValueAtPath` (gate-hook bookkeeping: `blank: true`
    * meta adds the path; any other write removes it) and `reset`.
    *
    * Storage NEVER reflects this set — calculations and reads against
@@ -94,15 +94,15 @@ export type FormStore<F extends GenericForm, G extends GenericForm = F> = {
    * channel that submit/validate consult to raise "No value supplied" errors
    * for required schemas.
    */
-  readonly transientEmptyPaths: Set<PathKey>
+  readonly blankPaths: Set<PathKey>
   /**
-   * Snapshot of `transientEmptyPaths` captured at construction (and
+   * Snapshot of `blankPaths` captured at construction (and
    * re-captured on `reset(args)`). Used by dirty calculation: a path
    * whose membership differs from the snapshot is dirty even if
    * storage matches the original. Eagerly populated to avoid a "dirty
    * on first read" race after construction.
    */
-  readonly originalsTransientEmpty: Set<PathKey>
+  readonly originalBlankPaths: Set<PathKey>
   readonly schema: AbstractSchema<F, G>
 
   /**
@@ -353,13 +353,13 @@ export type FormStoreHydration = {
   readonly userErrors: ReadonlyArray<readonly [string, unknown]>
   readonly fields: ReadonlyArray<readonly [string, unknown]>
   /**
-   * Path keys that were in the form's `transientEmptyPaths` set at
+   * Path keys that were in the form's `blankPaths` set at
    * SSR time. Replayed into the reactive Set on the client so the
    * "displayed empty" state survives the round-trip. Optional —
    * pre-v3 envelopes don't carry it; missing means "no transient-
    * empty paths".
    */
-  readonly transientEmptyPaths?: ReadonlyArray<string>
+  readonly blankPaths?: ReadonlyArray<string>
 }
 
 export type CreateFormStoreOptions<F extends GenericForm, G extends GenericForm = F> = {
@@ -371,14 +371,14 @@ export type CreateFormStoreOptions<F extends GenericForm, G extends GenericForm 
   readonly fieldValidation?: FieldValidationConfig | undefined
   readonly isSSR?: boolean | undefined
   /**
-   * Path keys to seed the `transientEmptyPaths` set with at construction.
+   * Path keys to seed the `blankPaths` set with at construction.
    * Only consulted when `hydration` is undefined — hydration data is
-   * authoritative when present (its own `transientEmptyPaths` field
+   * authoritative when present (its own `blankPaths` field
    * takes precedence). Used by `useAbstractForm`'s `unset`-symbol pre-
    * pass (commit 7 wires the producer); commit 2 plumbs the channel
    * through with no callers yet.
    */
-  readonly initialTransientEmpty?: ReadonlyArray<string> | undefined
+  readonly initialBlankPaths?: ReadonlyArray<string> | undefined
 }
 
 export function createFormStore<F extends GenericForm, G extends GenericForm = F>(
@@ -464,20 +464,20 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
   // to recover the canonical Path.
   const originals = new Map<PathKey, OriginalsRecord>()
 
-  // Transient-empty bookkeeping. The reactive Set tracks paths whose
+  // Blank bookkeeping. The reactive Set tracks paths whose
   // displayed state should be EMPTY even though storage holds a real
   // slim default; the originals snapshot mirrors construction-time
   // membership so dirty calculation can detect the user's clear /
-  // un-clear actions. Hydration takes precedence over `initialTransientEmpty`
+  // un-clear actions. Hydration takes precedence over `initialBlankPaths`
   // (the SSR snapshot wins when present), matching how the hydrated
   // `form` value overrides the schema's getDefaultValues result.
   const initialTransientList: ReadonlyArray<string> =
-    hydration?.transientEmptyPaths ?? options.initialTransientEmpty ?? []
-  const transientEmptyPaths = reactive(new Set<PathKey>()) as Set<PathKey>
-  const originalsTransientEmpty = new Set<PathKey>()
+    hydration?.blankPaths ?? options.initialBlankPaths ?? []
+  const blankPaths = reactive(new Set<PathKey>()) as Set<PathKey>
+  const originalBlankPaths = new Set<PathKey>()
   for (const raw of initialTransientList) {
-    transientEmptyPaths.add(raw as PathKey)
-    originalsTransientEmpty.add(raw as PathKey)
+    blankPaths.add(raw as PathKey)
+    originalBlankPaths.add(raw as PathKey)
   }
 
   // Submission lifecycle refs. Initial values encode "no submission has
@@ -604,18 +604,18 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
       return false
     }
 
-    // Transient-empty bookkeeping. `transientEmpty: true` adds the path
+    // Blank bookkeeping. `blank: true` adds the path
     // to the set (the call site declares "this write represents an
     // empty intent"); any other write removes it (the user typed a
     // real value or programmatically reassigned). The mark/unmark sit
     // BEFORE the identity short-circuit so transitions that don't
     // change storage value (e.g. typing 0 over slim-default 0) still
-    // update the visual / pendingEmpty state correctly.
+    // update the visual / blank state correctly.
     const pathKey = canonicalizePath(path).key
-    if (meta?.transientEmpty === true) {
-      transientEmptyPaths.add(pathKey)
-    } else if (transientEmptyPaths.has(pathKey)) {
-      transientEmptyPaths.delete(pathKey)
+    if (meta?.blank === true) {
+      blankPaths.add(pathKey)
+    } else if (blankPaths.has(pathKey)) {
+      blankPaths.delete(pathKey)
     }
 
     // Structural-completeness invariant: every write must leave the
@@ -986,21 +986,21 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
       const { key } = canonicalizePath(patch.path)
       originals.set(key, { segments: patch.path, value: patch.newValue })
     })
-    // Transient-empty: with `nextDefaultValues` provided, both sets
+    // Blank: with `nextDefaultValues` provided, both sets
     // adopt the new baseline (commit 7 plugs the `unset`-symbol walker
     // into this branch — for now the new defaults can't carry unset
     // symbols at the type level, so the post-reset baseline is empty).
-    // With no args, restore `transientEmptyPaths` from the snapshot so
-    // construction-time membership returns; originalsTransientEmpty is
+    // With no args, restore `blankPaths` from the snapshot so
+    // construction-time membership returns; originalBlankPaths is
     // preserved (the snapshot encodes the consumer's last declared
     // baseline, which `reset()` should honour).
     if (nextDefaultValues !== undefined) {
-      transientEmptyPaths.clear()
-      originalsTransientEmpty.clear()
+      blankPaths.clear()
+      originalBlankPaths.clear()
     } else {
-      transientEmptyPaths.clear()
-      for (const key of originalsTransientEmpty) {
-        transientEmptyPaths.add(key)
+      blankPaths.clear()
+      for (const key of originalBlankPaths) {
+        blankPaths.add(key)
       }
     }
     // Drop every recorded error — the form is a fresh surface again.
@@ -1169,12 +1169,12 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
   function isPristineAtPath(path: Path): boolean {
     const { key, segments } = canonicalizePath(path)
     // Storage match is necessary but not sufficient: a primitive leaf
-    // toggled between "displayed empty" (transient-empty + slim default)
+    // toggled between "displayed empty" (blank + slim default)
     // and "explicitly the slim default" carries the same storage value
     // but differs visually. Compare both surfaces against the originals
-    // snapshot so the transient-empty contract dirties when membership
+    // snapshot so the blank contract dirties when membership
     // diverges.
-    if (transientEmptyPaths.has(key) !== originalsTransientEmpty.has(key)) return false
+    if (blankPaths.has(key) !== originalBlankPaths.has(key)) return false
     const entry = originals.get(key)
     if (entry === undefined) return true
     return Object.is(getAtPath(form.value, segments), entry.value)
@@ -1275,8 +1275,8 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     awaitPendingWrites,
     modules,
     persistOptIns,
-    transientEmptyPaths,
-    originalsTransientEmpty,
+    blankPaths,
+    originalBlankPaths,
     dispose,
   }
 }

--- a/src/runtime/core/directive.ts
+++ b/src/runtime/core/directive.ts
@@ -369,7 +369,8 @@ function setAssignFunction(
   }
   if (!isRegisterValue(value)) {
     warn(
-      `v-register expected value of type RegisterValue, got value of type ${typeof value} instead. Please check your v-register value.`
+      `v-register expected a RegisterValue, got '${typeof value}'. ` +
+        `Bind to form.register('field') — not the field's ref, value, or path string.`
     )
     el[assignKey] = makeNoopAssigner()
     return
@@ -656,7 +657,9 @@ const vRegisterCheckbox: RegisterCheckboxCustomDirective = {
       if (isArray(modelValue)) {
         if (elementValue === undefined) {
           warn(
-            'checkbox bound to a v-registerer array or set does not have an explicit value, state not updated.'
+            'Checkbox bound to an array model is missing a `value` attribute — ' +
+              'cannot determine which item to add or remove. ' +
+              'Add value="..." to each <input type="checkbox">.'
           )
           return
         }
@@ -672,7 +675,9 @@ const vRegisterCheckbox: RegisterCheckboxCustomDirective = {
       } else if (isSet(modelValue)) {
         if (elementValue === undefined) {
           warn(
-            'Please add `value` prop to checkbox or pass RegisterValue of primitive value to register.'
+            'Checkbox bound to a Set model is missing a `value` attribute — ' +
+              'cannot determine which item to add or remove. ' +
+              'Add value="..." to each <input type="checkbox">.'
           )
           return
         }
@@ -813,8 +818,9 @@ function setSelected(el: HTMLSelectElement, value: unknown) {
   if (isMultiple && !isArrayValue && !isSet(externalValue)) {
     if (__DEV__) {
       warn(
-        `<select multiple v-register> expected an Array or Set value for its binding, ` +
-          `but got ${Object.prototype.toString.call(externalValue).slice(8, -1)} instead.`
+        `<select multiple v-register> expected an Array or Set, got ` +
+          `${Object.prototype.toString.call(externalValue).slice(8, -1)}. ` +
+          `Bind to a list-typed schema (e.g. z.array(z.string()) or z.set(z.string())).`
       )
     }
     return

--- a/src/runtime/core/directive.ts
+++ b/src/runtime/core/directive.ts
@@ -742,17 +742,26 @@ const vRegisterRadio: RegisterRadioCustomDirective = {
     if (!isRegisterValue(value)) return
 
     value.registerElement(el)
-    // Read the option-value via `getValue(el)` rather than
-    // `vnode.props?.['value']` for the same reason as setChecked:
-    // hydrated static `value="..."` attributes don't surface in
-    // vnode.props (Vue's static-attr fast path), so the prop-only
-    // read returned undefined and the radio mounted unchecked.
-    el.checked = looseEqual(value.innerRef.value, getValue(el))
     setAssignFunction(el, vnode, value)
     addEventListener(el, 'change', () => {
       if (shouldBailListener(el)) return
       el[assignKey]?.(getValue(el))
     })
+  },
+  // Initial checked-state sync runs in `mounted`, NOT `created` —
+  // Vue's directive lifecycle fires `created` BEFORE the element's
+  // attributes are patched (`type`, `value`, `_value` etc. aren't on
+  // the element yet), so `getValue(el)` would return `undefined` and
+  // every radio in a group would mount unchecked regardless of the
+  // model. Checkbox already uses `mounted: setChecked` for the same
+  // reason.
+  mounted(el, { value }) {
+    if (!isRegisterValue(value)) return
+    // Read the option-value via `getValue(el)` rather than
+    // `vnode.props?.['value']` so SSR-hydrated static `value="..."`
+    // attributes (which don't surface in vnode.props because Vue's
+    // static-attr fast path skips patchProp) still resolve correctly.
+    el.checked = looseEqual(value.innerRef.value, getValue(el))
   },
   beforeUpdate(el, { value, oldValue }, vnode) {
     if (!isRegisterValue(value)) return

--- a/src/runtime/core/directive.ts
+++ b/src/runtime/core/directive.ts
@@ -893,8 +893,24 @@ function setSelected(el: HTMLSelectElement, value: unknown) {
 }
 
 // retrieve raw value set via :value bindings
+//
+// `explicitRequired` is the checkbox-array / checkbox-Set caller's way
+// of saying "the user must have provided an option-value via either a
+// dynamic `:value` binding (Vue sets `el._value`) OR a static `value`
+// attribute (DOM has `value` attribute set). If neither is present,
+// the default `el.value` of 'on' would silently add the bogus literal
+// 'on' to the array on every toggle — surface as undefined so the
+// caller can warn instead."
+//
+// Without the `hasAttribute('value')` fallback, the SSR + static-attr
+// hydration path fails: Vue's hydration skips patchProp for hoisted
+// static attributes, `el._value` is never set, but the DOM still
+// reflects the rendered `value="apple"` attribute. We need to honor
+// either signal.
 function getValue(el: HTMLOptionElement | HTMLInputElement, explicitRequired = false) {
-  return '_value' in el ? (el._value ?? undefined) : explicitRequired ? undefined : el.value
+  if ('_value' in el) return el._value
+  if (explicitRequired && !el.hasAttribute('value')) return undefined
+  return el.value
 }
 
 // retrieve raw value for true-value and false-value set via :true-value or :false-value bindings

--- a/src/runtime/core/directive.ts
+++ b/src/runtime/core/directive.ts
@@ -701,7 +701,7 @@ const vRegisterCheckbox: RegisterCheckboxCustomDirective = {
   },
 }
 
-function setChecked(el: HTMLInputElement, { value, oldValue }: DirectiveBinding, vnode: VNode) {
+function setChecked(el: HTMLInputElement, { value, oldValue }: DirectiveBinding, _vnode: VNode) {
   // store the v-registerer value on the element so it can be accessed by the
   // change listener.
   if (!isRegisterValue(value)) return
@@ -709,10 +709,19 @@ function setChecked(el: HTMLInputElement, { value, oldValue }: DirectiveBinding,
   const originalValue = value.innerRef.value
   let checked: boolean
 
+  // Read the option-value via `getValue(el)` rather than
+  // `vnode.props?.['value']`. On SSR + hydration, Vue skips
+  // `patchProp` for hoisted static `value="..."` attributes — vnode
+  // props don't carry the value AND `el._value` is never set, so the
+  // old code returned undefined and unchecked the box even when the
+  // DOM `value` attribute matched the model. `getValue` (post the
+  // static-attr fix) checks `_value` first, then the DOM property,
+  // so all three paths (Vue dynamic, Vue hydrated static, manual
+  // setAttribute) resolve identically.
   if (isArray(originalValue)) {
-    checked = looseIndexOf(originalValue, vnode.props?.['value']) > -1
+    checked = looseIndexOf(originalValue, getValue(el)) > -1
   } else if (isSet(originalValue)) {
-    checked = originalValue.has(vnode.props?.['value'])
+    checked = originalValue.has(getValue(el))
   } else {
     if (originalValue === oldValue) {
       return
@@ -733,8 +742,12 @@ const vRegisterRadio: RegisterRadioCustomDirective = {
     if (!isRegisterValue(value)) return
 
     value.registerElement(el)
-    // setAssignFunction(el, vnode, value)
-    el.checked = looseEqual(value.innerRef.value, vnode.props?.['value'])
+    // Read the option-value via `getValue(el)` rather than
+    // `vnode.props?.['value']` for the same reason as setChecked:
+    // hydrated static `value="..."` attributes don't surface in
+    // vnode.props (Vue's static-attr fast path), so the prop-only
+    // read returned undefined and the radio mounted unchecked.
+    el.checked = looseEqual(value.innerRef.value, getValue(el))
     setAssignFunction(el, vnode, value)
     addEventListener(el, 'change', () => {
       if (shouldBailListener(el)) return
@@ -746,7 +759,7 @@ const vRegisterRadio: RegisterRadioCustomDirective = {
 
     setAssignFunction(el, vnode, value)
     if (value.innerRef.value !== oldValue) {
-      el.checked = looseEqual(value.innerRef.value, vnode.props?.['value'])
+      el.checked = looseEqual(value.innerRef.value, getValue(el))
     }
   },
 }

--- a/src/runtime/core/directive.ts
+++ b/src/runtime/core/directive.ts
@@ -414,7 +414,7 @@ const vRegisterText: RegisterTextCustomDirective = {
       if (castToNumber) {
         // Empty after the (deferred) trim — most commonly a backspace-
         // clear on `<input type="number">` or a `.number` text input.
-        // Mark the path transient-empty rather than skipping silently:
+        // Mark the path blank rather than skipping silently:
         // storage gets the slim default (0), the UI shows blank via
         // `displayValue.value === ''`, and submit-time validation
         // raises "No value supplied" if the schema demands a number (the
@@ -429,7 +429,7 @@ const vRegisterText: RegisterTextCustomDirective = {
         // a genuine empty field — we use it to distinguish a real
         // user-clear (mark) from a transient mid-edit (skip). Without
         // this guard, typing `1e` into a `type="number"` field fires
-        // `markTransientEmpty`, `displayValue` recomputes to `''`,
+        // `markBlank`, `displayValue` recomputes to `''`,
         // Vue patches the DOM and yanks the user's `1e` away.
         if (domValue === '') {
           // Guard against non-input elements with custom assigners
@@ -444,7 +444,7 @@ const vRegisterText: RegisterTextCustomDirective = {
           }
           if (isRegisterValue(value)) {
             value.lastTypedForm.value = null
-            value.markTransientEmpty()
+            value.markBlank()
           }
           return
         }
@@ -459,7 +459,7 @@ const vRegisterText: RegisterTextCustomDirective = {
           // state.
           if (isRegisterValue(value)) {
             value.lastTypedForm.value = null
-            value.markTransientEmpty()
+            value.markBlank()
           }
           return
         }
@@ -518,13 +518,13 @@ const vRegisterText: RegisterTextCustomDirective = {
             // overflow (`1e309` parses to Infinity). Native
             // `<input type="number">` blur behaviour clears in both
             // cases; we match that. The keystroke listener has
-            // already markTransientEmpty'd uncastable input under
+            // already markBlank'd uncastable input under
             // non-lazy, but under `.lazy.number` (or for an overflow
             // pasted directly via the change event) this is the first
             // chance, so re-mark defensively.
             if (isRegisterValue(value)) {
               value.lastTypedForm.value = null
-              value.markTransientEmpty()
+              value.markBlank()
             }
             el.value = ''
           }

--- a/src/runtime/core/error-codes.ts
+++ b/src/runtime/core/error-codes.ts
@@ -22,7 +22,7 @@
  * ```
  */
 export const CxErrorCode = {
-  /** A required field is in the transient-empty set — user hasn't supplied a value. */
+  /** A required field is in the blank set — user hasn't supplied a value. */
   NoValueSupplied: 'cx:no-value-supplied',
   /** The schema adapter's `validateAtPath` threw synchronously. */
   AdapterThrew: 'cx:adapter-threw',

--- a/src/runtime/core/errors.ts
+++ b/src/runtime/core/errors.ts
@@ -80,6 +80,33 @@ export class ReservedFormKeyError extends Error {
 }
 
 /**
+ * Thrown (in dev) when `useForm({ persist: ... })` is configured on
+ * an anonymous form (no `key:` provided). The synthetic `__cx:anon:`
+ * identity isn't stable across remounts (Vue's `useId()` allocator
+ * drifts under HMR, and any sibling `useId()` call shifts subsequent
+ * IDs), so the persistence layer can't reliably find the previous
+ * mount's draft. Result: stale entries pile up in storage and the
+ * user's most recent edit doesn't always come back.
+ *
+ * Fix: pass an explicit `key` to `useForm()`.
+ *
+ * In production builds the runtime downgrades this to a one-shot
+ * `console.warn` so a deployed third-party app shipping the
+ * anti-pattern doesn't hard-crash.
+ */
+export class AnonPersistError extends Error {
+  override readonly name = 'AnonPersistError'
+  constructor() {
+    super(
+      '[@chemical-x/forms] persist: requires an explicit key on useForm().\n' +
+        '  Why: anonymous keys drift on remount AND can collide between forms — your data could leak across unrelated forms.\n' +
+        "  Fix: useForm({ schema, key: 'login', persist: '...' })\n" +
+        '  In prod: no throw — persistence is silently disabled and a one-time warn is logged.'
+    )
+  }
+}
+
+/**
  * Thrown when `register(path, { persist: true })` or `form.persist(path)`
  * targets a path whose name matches a sensitive-data heuristic
  * (password, cvv, ssn, token, etc.) without an explicit

--- a/src/runtime/core/errors.ts
+++ b/src/runtime/core/errors.ts
@@ -72,9 +72,9 @@ export class ReservedFormKeyError extends Error {
   override readonly name = 'ReservedFormKeyError'
   constructor(key: string) {
     super(
-      `[@chemical-x/forms] The form key "${key}" uses the reserved "__cx:" namespace. ` +
-        `This prefix is reserved for the library's internal synthetic keys (anonymous useForm calls). ` +
-        `Pick a different prefix for your form.`
+      `[@chemical-x/forms] Form key "${key}" uses the reserved "__cx:" namespace. ` +
+        `Use a different prefix — "__cx:" is for library-internal synthetic keys ` +
+        `(anonymous useForm() calls without an explicit key).`
     )
   }
 }
@@ -97,12 +97,11 @@ export class SensitivePersistFieldError extends Error {
   constructor(path: ReadonlyArray<string | number> | string) {
     const display = Array.isArray(path) ? path.join('.') : String(path)
     super(
-      `[@chemical-x/forms] The path "${display}" matches a sensitive-name ` +
-        `pattern (password / cvv / ssn / token / etc.). Persisting sensitive ` +
-        `data to client-side storage (localStorage / sessionStorage / IndexedDB) ` +
-        `is a compliance risk (HIPAA / PII / PCI-DSS / SOC2). If you genuinely ` +
-        `intend to persist this path, pass \`acknowledgeSensitive: true\` to ` +
-        `register() (or to form.persist()) to opt out of this check.`
+      `[@chemical-x/forms] Refusing to persist "${display}" — this path matches a ` +
+        `sensitive-name pattern (password / cvv / ssn / token / etc.). Storing sensitive ` +
+        `data in client-side storage is a compliance risk (HIPAA / PII / PCI-DSS / SOC2). ` +
+        `Fix: persist this server-side, OR pass \`acknowledgeSensitive: true\` to register() ` +
+        `(or form.persist()) if the client-side persistence is intentional.`
     )
   }
 }

--- a/src/runtime/core/field-state-api.ts
+++ b/src/runtime/core/field-state-api.ts
@@ -17,23 +17,42 @@ import { canonicalizePath, type Path } from './paths'
  */
 
 export type FieldStateView = {
+  /** The current value at this path. */
   readonly value: unknown
+  /** The value the field was initialised with. */
   readonly original: unknown
+  /** `true` when `value` matches `original`. */
   readonly pristine: boolean
+  /** `true` when `value` differs from `original`. */
   readonly dirty: boolean
+  /** `true` while the input has DOM focus; `null` until the first focus event. */
   readonly focused: boolean | null
+  /** Flips to `true` on the first blur and stays there; `null` until then. */
   readonly blurred: boolean | null
+  /** Flips to `true` on the first blur AFTER a focus and stays there; `null` until then. */
   readonly touched: boolean | null
+  /** `true` while at least one DOM input is registered to this path. */
   readonly isConnected: boolean
+  /** ISO timestamp of the most recent write; `null` until the first write. */
   readonly updatedAt: string | null
+  /** Validation errors at this path (schema + user errors merged). Empty when valid. */
   readonly errors: ValidationError[]
+  /** Canonical path segments — same shape as the input to `getFieldState`. */
   readonly path: Path
   /**
-   * `true` when this path is in the form's transient-empty set —
-   * storage holds the slim default but the UI displays empty.
-   * See `MetaTrackerValue.pendingEmpty` for the full contract.
+   * `true` when the user hasn't supplied a value yet — the input
+   * renders as empty even though storage holds a slim default
+   * (e.g. `0` for `z.number()`, `''` for `z.string()`). Answers
+   * the question: "Is this field empty because the user left it
+   * blank, or because the slim default happens to be `0` / `''`?"
+   *
+   * Becomes `false` on the first keystroke / programmatic write;
+   * toggles back via `setValue(path, unset)` / `markBlank()`
+   * / clearing a `<input type="number">`. Submit-time validation
+   * surfaces "No value supplied" for required fields that are still
+   * `blank`.
    */
-  readonly pendingEmpty: boolean
+  readonly blank: boolean
 }
 
 export function buildFieldStateAccessor<F extends GenericForm>(state: FormStore<F>) {
@@ -71,7 +90,7 @@ export function buildFieldStateAccessor<F extends GenericForm>(state: FormStore<
         updatedAt: record?.updatedAt ?? null,
         errors,
         path: segments,
-        pendingEmpty: state.transientEmptyPaths.has(key),
+        blank: state.blankPaths.has(key),
       }
     })
   }

--- a/src/runtime/core/hash.ts
+++ b/src/runtime/core/hash.ts
@@ -1,0 +1,40 @@
+/**
+ * Deterministic non-cryptographic string hash. Used to compact long
+ * structural-fingerprint strings into bounded-size storage-key tokens
+ * (`chemical-x-forms:formKey:<hash>` instead of
+ * `chemical-x-forms:formKey:object{"a":string,"b":number,...}`).
+ *
+ * Output: 11-char base36 string with leading zeros padded —
+ * stable size regardless of input. ~53 bits of entropy (base of the
+ * cyrb53 algorithm); collision space is 2^53. For the storage-key
+ * disambiguation use case (a single app's worth of form schemas, all
+ * fingerprinted at runtime) this is overkill.
+ *
+ * Properties:
+ *   - **Deterministic**: same input always produces the same output.
+ *   - **Sync, no allocations beyond the result**: hot-path-friendly;
+ *     no `crypto.subtle` (async) or `node:crypto` (server-only).
+ *   - **Browser + Node compatible**: only `Math.imul` and `String`
+ *     methods.
+ *
+ * NOT suitable for security-sensitive uses (auth tokens, integrity
+ * checks). cyrb53 is non-cryptographic by design.
+ *
+ * Reference: bryc's collection of small JS hash functions
+ * (https://github.com/bryc/code/blob/master/jshash/PRNGs.md).
+ */
+export function hashStableString(input: string, seed = 0): string {
+  let h1 = 0xdeadbeef ^ seed
+  let h2 = 0x41c6ce57 ^ seed
+  for (let i = 0; i < input.length; i++) {
+    const ch = input.charCodeAt(i)
+    h1 = Math.imul(h1 ^ ch, 2654435761)
+    h2 = Math.imul(h2 ^ ch, 1597334677)
+  }
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909)
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909)
+  // Combine the two 32-bit halves into a 53-bit value, base36-encode.
+  // `padStart(11, '0')` keeps the output a fixed length so storage
+  // keys are visually aligned and easy to grep.
+  return (4294967296 * (2097151 & h2) + (h1 >>> 0)).toString(36).padStart(11, '0')
+}

--- a/src/runtime/core/persistence/index.ts
+++ b/src/runtime/core/persistence/index.ts
@@ -105,14 +105,14 @@ export type PersistedPayload<Form> = {
     readonly schemaErrors?: ReadonlyArray<readonly [string, ValidationError[]]>
     readonly userErrors?: ReadonlyArray<readonly [string, ValidationError[]]>
     /**
-     * Path keys that were in the form's `transientEmptyPaths` set at
+     * Path keys that were in the form's `blankPaths` set at
      * serialisation time. Optional — older v=2 envelopes don't carry it,
-     * and forms with no transient-empty paths skip the field too.
+     * and forms with no blank paths skip the field too.
      * Replayed into the reactive Set on the next mount so an accidental
      * refresh preserves the user's "displayed empty" state across
      * sessions. Introduced in envelope v=3.
      */
-    readonly transientEmptyPaths?: ReadonlyArray<string>
+    readonly blankPaths?: ReadonlyArray<string>
   }
 }
 
@@ -123,8 +123,8 @@ export type PersistedPayload<Form> = {
  * handled at the storage key level (the `:${fingerprint}` suffix), so
  * consumers shouldn't see this number.
  *
- * v=3: adds `data.transientEmptyPaths` for round-tripping the
- * transient-empty UI state across persistence + SSR. v=2 envelopes
+ * v=3: adds `data.blankPaths` for round-tripping the
+ * blank UI state across persistence + SSR. v=2 envelopes
  * are dropped with a one-time dev-warn (commit 6 of the unset feature).
  *
  * v=4: `ValidationError` gained a required `code` field. Persisted
@@ -184,23 +184,21 @@ export function buildPersistedPayload<Form>(
   include: 'form' | 'form+errors',
   schemaErrors: ReadonlyMap<string, ValidationError[]>,
   userErrors: ReadonlyMap<string, ValidationError[]>,
-  transientEmptyPaths?: ReadonlySet<string>
+  blankPaths?: ReadonlySet<string>
 ): PersistedPayload<Form> {
-  // The transient-empty list is part of the form's restorable UI
+  // The blank list is part of the form's restorable UI
   // state — its visibility doesn't depend on the `include` mode
   // (which only governs whether errors come along for the ride).
   // Skip the field when the set is empty so v=3 round-trips with
   // unchanged minimal payload size for forms that never go empty.
   const transientList: ReadonlyArray<string> | undefined =
-    transientEmptyPaths !== undefined && transientEmptyPaths.size > 0
-      ? [...transientEmptyPaths]
-      : undefined
+    blankPaths !== undefined && blankPaths.size > 0 ? [...blankPaths] : undefined
 
   if (include === 'form') {
     if (transientList === undefined) return { v: PERSISTED_ENVELOPE_VERSION, data: { form } }
     return {
       v: PERSISTED_ENVELOPE_VERSION,
-      data: { form, transientEmptyPaths: transientList },
+      data: { form, blankPaths: transientList },
     }
   }
   return {
@@ -209,7 +207,7 @@ export function buildPersistedPayload<Form>(
       form,
       schemaErrors: [...schemaErrors.entries()].map(([k, v]) => [k, [...v]] as const),
       userErrors: [...userErrors.entries()].map(([k, v]) => [k, [...v]] as const),
-      ...(transientList !== undefined ? { transientEmptyPaths: transientList } : {}),
+      ...(transientList !== undefined ? { blankPaths: transientList } : {}),
     },
   }
 }

--- a/src/runtime/core/persistence/index.ts
+++ b/src/runtime/core/persistence/index.ts
@@ -172,12 +172,10 @@ function warnVersionMismatch(observedVersion: number): void {
   if (warnedVersions.has(observedVersion)) return
   warnedVersions.add(observedVersion)
   console.warn(
-    `[@chemical-x/forms] dropping persisted draft (envelope v=${observedVersion}, ` +
-      `expected v=${PERSISTED_ENVELOPE_VERSION}). The library upgraded its ` +
-      `internal payload shape — drafts saved against an older version are not ` +
-      `restored. New drafts written from this session will use the current ` +
-      `envelope and round-trip cleanly. This warning is dev-only and fires once ` +
-      `per observed version per session.`
+    `[@chemical-x/forms] Dropping persisted draft — envelope v=${observedVersion}, ` +
+      `but this version of the library expects v=${PERSISTED_ENVELOPE_VERSION}. ` +
+      `The persisted shape changed across releases; older drafts can't be restored. ` +
+      `New drafts saved this session will use the current envelope.`
   )
 }
 

--- a/src/runtime/core/plugin.ts
+++ b/src/runtime/core/plugin.ts
@@ -67,9 +67,9 @@ export function createChemicalXForms(options: ChemicalXFormsPluginOptions = {}):
       if (app._chemicalX !== undefined) {
         if (__DEV__) {
           console.warn(
-            '[@chemical-x/forms] createChemicalXForms() install was called more than once on the same app. ' +
-              'The second install is a no-op; the existing registry is preserved. ' +
-              'Likely cause: registering the plugin twice (vite + nuxt module + manual `app.use`).'
+            '[@chemical-x/forms] createChemicalXForms() install was called twice on the same app; ' +
+              'the second call is a no-op. ' +
+              'Likely cause: registering the plugin via both the Nuxt module AND a manual `app.use(...)`.'
           )
         }
         return

--- a/src/runtime/core/process-form.ts
+++ b/src/runtime/core/process-form.ts
@@ -178,7 +178,7 @@ export function buildProcessForm<F extends GenericForm>(
     // Required-empty augmentation. The schema can't tell the difference
     // between "user typed 0" and "user didn't answer" because storage
     // holds the slim default (`0` for `z.number()`) in both cases. We
-    // close the gap by consulting the form's `transientEmptyPaths` set:
+    // close the gap by consulting the form's `blankPaths` set:
     // every path in there + a required leaf in the schema becomes a
     // synthesised "No value supplied" error. Empty set or no required leaves →
     // no-op, return the base result unchanged.
@@ -366,7 +366,7 @@ function adapterThrowMessage(err: unknown): string {
 
 /**
  * Synthesise a "No value supplied" `ValidationError` for every path in the
- * form's `transientEmptyPaths` whose schema requires the leaf — i.e.
+ * form's `blankPaths` whose schema requires the leaf — i.e.
  * the schema is NOT `.optional()` / `.nullable()` / `.default(N)` /
  * `.catch(N)` at that leaf. When a `scope` is provided (per-path
  * `validate(path)` / `validateAsync(path)`), only paths inside the
@@ -380,9 +380,9 @@ function collectRequiredEmptyErrors<F extends GenericForm>(
   state: FormStore<F>,
   scope: Path | undefined
 ): ValidationError[] {
-  if (state.transientEmptyPaths.size === 0) return []
+  if (state.blankPaths.size === 0) return []
   const errors: ValidationError[] = []
-  for (const pathKey of state.transientEmptyPaths) {
+  for (const pathKey of state.blankPaths) {
     // PathKey is `JSON.stringify(segments)` per `canonicalizePath`, so
     // recovering the structured segments is `JSON.parse(...)`. Don't
     // round-trip through `canonicalizePath(pathKey)` — that would treat
@@ -392,7 +392,7 @@ function collectRequiredEmptyErrors<F extends GenericForm>(
     if (scope !== undefined && !pathStartsWith(segments, scope)) continue
     if (!state.schema.isRequiredAtPath(segments)) continue
     errors.push({
-      // The path is in `transientEmptyPaths` — the user hasn't
+      // The path is in `blankPaths` — the user hasn't
       // committed a value yet (or explicitly cleared via `unset` /
       // a numeric DOM clear). The schema requires a value here.
       // Message wording differentiates from a generic schema failure
@@ -411,7 +411,7 @@ function collectRequiredEmptyErrors<F extends GenericForm>(
 /**
  * `true` if `target`'s segments start with `prefix`. Used by
  * `collectRequiredEmptyErrors` to honour the per-path scope of
- * `validate(path)` — only transient-empty paths inside the validated
+ * `validate(path)` — only blank paths inside the validated
  * subtree raise required errors. An empty prefix matches every path.
  */
 function pathStartsWith(target: Path, prefix: Path): boolean {

--- a/src/runtime/core/process-form.ts
+++ b/src/runtime/core/process-form.ts
@@ -138,10 +138,10 @@ export function buildProcessForm<F extends GenericForm>(
     ) {
       warnedNoScopeStores.add(state as FormStore<GenericForm>)
       console.warn(
-        '[@chemical-x/forms] validate() called outside a Vue effect scope. ' +
-          'The reactive watcher will not be released until the JS engine garbage-collects the form ' +
-          '— move the call into setup() / a child component, or wrap in `effectScope().run(...)`. ' +
-          'Tests can suppress this warning by mocking console.warn for the run.'
+        '[@chemical-x/forms] validate() called outside a Vue effect scope; ' +
+          'its reactive watcher will leak until the form is garbage-collected. ' +
+          'Fix: call validate() inside setup() / a child component, ' +
+          'or wrap the call in `effectScope().run(...)`.'
       )
     }
     return result as Readonly<Ref<ReactiveValidationStatus<F>>>

--- a/src/runtime/core/register-api.ts
+++ b/src/runtime/core/register-api.ts
@@ -107,8 +107,8 @@ export function buildRegister<F extends GenericForm>(state: FormStore<F>) {
     }
 
     // String-form view of the path's storage value, with `''` returned
-    // for transient-empty membership and for null/undefined storage.
-    // The transient-empty branch is what lets a user clear a numeric
+    // for blank membership and for null/undefined storage.
+    // The blank branch is what lets a user clear a numeric
     // field: even though storage holds 0, the `:value` binding reads
     // displayValue and writes `''` to el.value, so Vue's next render
     // doesn't undo the user's clear.
@@ -123,7 +123,7 @@ export function buildRegister<F extends GenericForm>(state: FormStore<F>) {
     // setValue / hydration / reset (different storage value → fall
     // back to `String(...)`).
     const displayValue = computed(() => {
-      if (state.transientEmptyPaths.has(pathKey)) return ''
+      if (state.blankPaths.has(pathKey)) return ''
       const raw = state.getValueAtPath(segments)
       if (raw === null || raw === undefined) return ''
       const typed = lastTypedForm.value
@@ -135,7 +135,7 @@ export function buildRegister<F extends GenericForm>(state: FormStore<F>) {
 
     // Slim default precomputed at register-time. The schema is fixed
     // for the form's lifetime, so this is safe to cache; downstream
-    // `markTransientEmpty` calls reuse it without re-walking the
+    // `markBlank` calls reuse it without re-walking the
     // schema tree.
     const slimDefault = state.schema.getDefaultAtPath(segments)
 
@@ -192,15 +192,15 @@ export function buildRegister<F extends GenericForm>(state: FormStore<F>) {
       displayValue,
       lastTypedForm,
 
-      markTransientEmpty: (): boolean => {
-        // Mirror the binding's persist meta so the transient-empty
+      markBlank: (): boolean => {
+        // Mirror the binding's persist meta so the blank
         // mark rides the same persistence channel as user-typed
         // writes — without this, refresh after a clear silently loses
         // the empty state. The slim default keeps storage well-typed
         // (the schema's getDefaultAtPath returns 0 for z.number(), ''
         // for z.string(), false for z.boolean(), etc.).
         return state.setValueAtPath(segments, slimDefault, {
-          transientEmpty: true,
+          blank: true,
           persist,
         })
       },

--- a/src/runtime/core/register-api.ts
+++ b/src/runtime/core/register-api.ts
@@ -178,12 +178,11 @@ export function buildRegister<F extends GenericForm>(state: FormStore<F>) {
         // The console auto-renders its own clickable stack below the
         // message anyway.
         console.warn(
-          `[@chemical-x/forms] register('${display}', { persist: true }) was used on form ` +
-            `"${state.formKey}", but no \`persist:\` option is configured on useForm(). The ` +
-            `opt-in is recorded, but no writes will land in any storage backend. Add ` +
-            `\`persist: 'local'\` (or another backend) to your useForm() options. To find the ` +
-            `offending call, search your codebase for \`register('${display}'\`. See ` +
-            `./docs/recipes/persistence.md.`
+          `[@chemical-x/forms] register('${display}', { persist: true }) is set on form ` +
+            `"${state.formKey}", but useForm() has no \`persist\` option configured — ` +
+            `nothing will be saved to storage. ` +
+            `Fix: add \`persist: 'local'\` (or 'session' / 'indexeddb') to your useForm() options. ` +
+            `See ./docs/recipes/persistence.md.`
         )
       }
     }

--- a/src/runtime/core/registry.ts
+++ b/src/runtime/core/registry.ts
@@ -44,14 +44,14 @@ export type SerializedFormData = {
   /** Per-field metadata (timestamps, raw values, connection flags) captured at snapshot time. */
   readonly fields: ReadonlyArray<readonly [string, unknown]>
   /**
-   * Path keys that were in the form's `transientEmptyPaths` set at
+   * Path keys that were in the form's `blankPaths` set at
    * snapshot time. Round-trips the "displayed empty" UI state across
    * the SSR boundary — without it, the client briefly renders
    * `String(slim-default)` (e.g. `'0'`) for fields the server
    * rendered as blank. Optional in the wire format so older payload
    * shapes deserialise cleanly.
    */
-  readonly transientEmptyPaths?: ReadonlyArray<string>
+  readonly blankPaths?: ReadonlyArray<string>
 }
 
 export type PendingHydration = Map<FormKey, SerializedFormData>

--- a/src/runtime/core/serialize.ts
+++ b/src/runtime/core/serialize.ts
@@ -40,11 +40,11 @@ export function renderChemicalXState(app: App): SerializedChemicalXState {
   const registry = getRegistryFromApp(app)
   const forms: Array<readonly [FormKey, SerializedFormData]> = []
   for (const [key, state] of registry.forms) {
-    // Skip the transient-empty field when the set is empty so the
+    // Skip the blank field when the set is empty so the
     // wire payload stays minimal for forms that don't use it. The
     // optional shape on the consuming side handles the absence
-    // cleanly (defaults to "no transient-empty paths").
-    const transientList = Array.from(state.transientEmptyPaths)
+    // cleanly (defaults to "no blank paths").
+    const transientList = Array.from(state.blankPaths)
     forms.push([
       key,
       {
@@ -52,7 +52,7 @@ export function renderChemicalXState(app: App): SerializedChemicalXState {
         schemaErrors: Array.from(state.schemaErrors.entries()),
         userErrors: Array.from(state.userErrors.entries()),
         fields: Array.from(state.fields.entries()),
-        ...(transientList.length > 0 ? { transientEmptyPaths: transientList } : {}),
+        ...(transientList.length > 0 ? { blankPaths: transientList } : {}),
       },
     ])
   }

--- a/src/runtime/core/slim-primitive-gate.ts
+++ b/src/runtime/core/slim-primitive-gate.ts
@@ -120,13 +120,18 @@ function walk(
   // schema's slim kinds at this path? Recurse into containers
   // afterwards — the recursion checks the elements' kinds at
   // the sub-paths.
+  //
+  // An empty accept set means the schema rejects every kind at this
+  // path: either the path doesn't resolve (typo / unknown leaf) or
+  // the path resolves to `z.never()`. Either way, the membership
+  // check below rejects, blocking the write. `z.any()` / `z.unknown()`
+  // / `z.void()` and the lazy-peel-failure case return the full
+  // permissive set — those still accept any kind.
   const accepted = schema.getSlimPrimitiveTypesAtPath(path)
-  if (accepted.size > 0) {
-    const kind = isLeafValue(value) ? slimKindOf(value) : Array.isArray(value) ? 'array' : 'object'
-    if (!accepted.has(kind)) {
-      reportRejection(store, path, kind, accepted)
-      return false
-    }
+  const kind = isLeafValue(value) ? slimKindOf(value) : Array.isArray(value) ? 'array' : 'object'
+  if (!accepted.has(kind)) {
+    reportRejection(store, path, kind, accepted)
+    return false
   }
 
   if (Array.isArray(value)) {
@@ -158,8 +163,22 @@ function reportRejection(
   const dotted = path.map((s: Segment) => String(s)).join('.') || '(root)'
   const key = `${dotted}::${kind}`
   if (!shouldWarnOnce(store, key)) return
-  const acceptedList = [...accepted].sort().join(', ')
 
+  // An empty accept set means the path either doesn't resolve in the
+  // schema (typo / unknown leaf) or resolves to `z.never()`. The two
+  // surface differently in the message so the dev knows whether to
+  // fix the path or relax the schema.
+  if (accepted.size === 0) {
+    console.warn(
+      `[@chemical-x/forms] write rejected: path '${dotted}' is not defined in the schema, ` +
+        `or resolves to a type (z.never) that admits no values. The write was a no-op. ` +
+        `Check for typos in your register('${dotted}') call, or relax the schema if the path ` +
+        `is intentional.`
+    )
+    return
+  }
+
+  const acceptedList = [...accepted].sort().join(', ')
   console.warn(
     `[@chemical-x/forms] write rejected: value of kind '${kind}' is not assignable to ` +
       `path '${dotted}' (slim primitive set: { ${acceptedList} }). ` +

--- a/src/runtime/core/slim-primitive-gate.ts
+++ b/src/runtime/core/slim-primitive-gate.ts
@@ -164,25 +164,49 @@ function reportRejection(
   const key = `${dotted}::${kind}`
   if (!shouldWarnOnce(store, key)) return
 
-  // An empty accept set means the path either doesn't resolve in the
-  // schema (typo / unknown leaf) or resolves to `z.never()`. The two
-  // surface differently in the message so the dev knows whether to
-  // fix the path or relax the schema.
+  // KISS rule: state the problem in one sentence, then list the fix.
+  // Devs scan the first line; everything after is the recipe.
+
+  // Path doesn't resolve (or resolves to z.never). The headline names
+  // the actual cause; z.never is rare enough that it doesn't deserve
+  // top billing.
   if (accepted.size === 0) {
     console.warn(
-      `[@chemical-x/forms] write rejected: path '${dotted}' is not defined in the schema, ` +
-        `or resolves to a type (z.never) that admits no values. The write was a no-op. ` +
-        `Check for typos in your register('${dotted}') call, or relax the schema if the path ` +
-        `is intentional.`
+      `[@chemical-x/forms] Cannot write to '${dotted}' — this path is not in your schema.\n` +
+        `  Fix: check for a typo in register('${dotted}'); it should match a leaf key in your schema.\n` +
+        `  (If the path resolves to z.never, the schema explicitly admits no values — relax the schema if intentional.)\n` +
+        `  The write was a no-op.`
     )
     return
   }
 
-  const acceptedList = [...accepted].sort().join(', ')
+  const expected = formatExpectedKinds(accepted)
+
+  // String-to-number is the most common gate rejection in real apps:
+  // a plain `<input v-register>` against a `z.number()` field reads
+  // `el.value` as a string. Show both v-register fix paths verbatim
+  // so the dev can copy-paste rather than parse "slim primitive set".
+  if (kind === 'string' && accepted.has('number')) {
+    console.warn(
+      `[@chemical-x/forms] Cannot write a string to '${dotted}' — the schema expects ${expected}.\n` +
+        `  Fix: add type="number" to the input, OR use the .number modifier on v-register:\n` +
+        `    <input type="number" v-register="register('${dotted}')" />\n` +
+        `    <input v-register.number="register('${dotted}')" />\n` +
+        `  The write was a no-op.`
+    )
+    return
+  }
+
+  // Generic kind mismatch — no built-in DOM coercion path to suggest.
   console.warn(
-    `[@chemical-x/forms] write rejected: value of kind '${kind}' is not assignable to ` +
-      `path '${dotted}' (slim primitive set: { ${acceptedList} }). ` +
-      `Refinement-level constraints (.email(), .min(N), enum membership, etc.) are NOT ` +
-      `enforced at write time — only the primitive shape. The write was a no-op.`
+    `[@chemical-x/forms] Cannot write a ${kind} to '${dotted}' — the schema expects ${expected}.\n` +
+      `  The write was a no-op.`
   )
+}
+
+function formatExpectedKinds(accepted: Set<SlimPrimitiveKind>): string {
+  const list = [...accepted].sort()
+  if (list.length === 1) return list[0] as string
+  if (list.length === 2) return `${list[0]} or ${list[1]}`
+  return `one of: ${list.join(', ')}`
 }

--- a/src/runtime/core/slim-primitive-gate.ts
+++ b/src/runtime/core/slim-primitive-gate.ts
@@ -93,8 +93,14 @@ function isLeafValue(value: unknown): boolean {
  * dev-warn naming the bad path + offending kind + accepted kinds).
  *
  * Conventions:
- * - Empty accept set → permissive (matches `z.any()` / `z.unknown()`
- *   and the unresolvable-path case). Allow the write.
+ * - Empty accept set → REJECT every kind. This covers `z.never()`
+ *   (intentionally accepts nothing) AND unresolvable paths (typo
+ *   in `register('addr.zipp')` against a schema that doesn't have
+ *   that field — silently accepting the write would create a phantom
+ *   slot in storage). `z.any()` / `z.unknown()` / `z.void()` and the
+ *   lazy-peel-failure case return the FULL permissive set, so they
+ *   accept anything via the membership check below — they don't go
+ *   through this branch.
  * - The value AT the write path is also checked: writing `'oops'`
  *   to a path expecting `'object'` is rejected at the top-level.
  * - For wrappers like `.optional()` / `.nullable()`, the adapter's

--- a/src/runtime/core/unset-walker.ts
+++ b/src/runtime/core/unset-walker.ts
@@ -7,7 +7,7 @@ import { isUnset } from './unset'
 /**
  * Walk a defaults / setValue / reset payload depth-first and produce
  * the cleaned-up storage tree plus the set of paths to mark as
- * transient-empty (`pendingEmpty`). Used at three boundaries:
+ * blank (`blank`). Used at three boundaries:
  *
  *   - `useAbstractForm` construction (defaultValues pre-pass)
  *   - `setValue(path, unset)` translation
@@ -178,7 +178,7 @@ function warnNonPrimitiveLeaf(segments: Segment[], slim: unknown): void {
     `[@chemical-x/forms] \`unset\` at "${dotted || '<root>'}" is a no-op — ` +
       `unset only works at primitive leaves (string / number / boolean / bigint, ` +
       `plus their optional / nullable variants), got "${slimType}". ` +
-      `The slim default was written but the path is NOT marked transient-empty. ` +
+      `The slim default was written but the path is NOT marked blank. ` +
       `(TypeScript catches this at compile time; this warn covers plain-JS callers.)`
   )
 }

--- a/src/runtime/core/unset-walker.ts
+++ b/src/runtime/core/unset-walker.ts
@@ -175,12 +175,10 @@ function warnNonPrimitiveLeaf(segments: Segment[], slim: unknown): void {
   warnedNonPrimitivePaths.add(dotted)
   const slimType = slim === null ? 'null' : slim instanceof Date ? 'Date' : typeof slim
   console.warn(
-    `[@chemical-x/forms] \`unset\` is only supported at primitive leaves ` +
-      `(string / number / boolean / bigint, plus their optional / nullable ` +
-      `variants); got "${slimType}" at "${dotted || '<root>'}". The slim ` +
-      `default is written to storage but the path is NOT marked transient-` +
-      `empty. The TypeScript \`DefaultValuesShape<T>\` widening prevents ` +
-      `this at compile time — this dev-warn fires once per offending path ` +
-      `to catch plain-JS consumers and dynamic plumbing that bypasses TS.`
+    `[@chemical-x/forms] \`unset\` at "${dotted || '<root>'}" is a no-op — ` +
+      `unset only works at primitive leaves (string / number / boolean / bigint, ` +
+      `plus their optional / nullable variants), got "${slimType}". ` +
+      `The slim default was written but the path is NOT marked transient-empty. ` +
+      `(TypeScript catches this at compile time; this warn covers plain-JS callers.)`
   )
 }

--- a/src/runtime/lib/core/transforms/input-text-area-transform.ts
+++ b/src/runtime/lib/core/transforms/input-text-area-transform.ts
@@ -293,11 +293,11 @@ export const inputTextAreaNodeTransform: NodeTransform = (node) => {
         ? registerSummarizedProp.value
         : [registerSummarizedProp.value]
       // Read `displayValue.value` rather than `innerRef.value` so the
-      // `:value` binding renders the transient-empty `''` when the
+      // `:value` binding renders the blank `''` when the
       // user clears a numeric field. `displayValue` returns
       // `String(storage)` for non-empty storage and `''` for both
       // null/undefined storage and paths in the form's
-      // `transientEmptyPaths` set — a single read surface for the
+      // `blankPaths` set — a single read surface for the
       // injected expression. For checkbox / radio (the ternary's
       // truthy branch above), this leg is unreached, so behaviour
       // there is unchanged.

--- a/src/runtime/lib/core/transforms/input-text-area-transform.ts
+++ b/src/runtime/lib/core/transforms/input-text-area-transform.ts
@@ -236,15 +236,26 @@ export const inputTextAreaNodeTransform: NodeTransform = (node) => {
 
     // this gets paired with `value` to get the [selectionLabel]=[label] prop for the given input
     // checkbox and radio are marked as selected via `checked`, others typically use `value`
+    //
+    // The HTML spec matches `type` ASCII case-insensitively, so
+    // `<input type="CHECKBOX">` and `<input type="Radio">` produce the
+    // same runtime element as their lowercase counterparts. The
+    // injected expression normalizes via `String(t).toLowerCase()`
+    // before comparing — the compile-time `isStaticTypeOneOf` already
+    // uses case-insensitive matching, so without the runtime
+    // normalization a `type="CHECKBOX"` input would have its static
+    // `value` preserved (per `keepStaticValue`) but still emit
+    // `:value="..."` instead of `:checked="..."`, breaking SSR initial
+    // checked state.
     const elementSelectionLabelExpression = createCompoundExpression([
       '(',
-      '(',
+      'String((',
       ...inputTypeExpressionArray,
-      ')',
+      ')).toLowerCase()',
       " === 'checkbox' || ",
-      '(',
+      'String((',
       ...inputTypeExpressionArray,
-      ") === 'radio'",
+      ")).toLowerCase() === 'radio'",
       ") ? 'checked' : 'value'",
     ])
 

--- a/src/runtime/lib/core/transforms/input-text-area-transform.ts
+++ b/src/runtime/lib/core/transforms/input-text-area-transform.ts
@@ -115,6 +115,27 @@ function isExactKey(summarizedKey: string, name: string): boolean {
 }
 
 /**
+ * Returns true iff the type prop's value is the static-attribute literal
+ * matching one of `names` (case-insensitive). Used to detect static
+ * `type="checkbox"` / `type="radio"` shapes where the `value` attribute
+ * is the option-value (a discriminator within the group), not display
+ * state — so the transform must NOT strip it.
+ *
+ * Conservative on dynamic shapes — `:type="x"` returns false, falling
+ * through to the text-input branch which strips `value`. Authors using
+ * dynamic types between checkbox/radio and text are rare; if they hit
+ * this they can add a static `type=` to lock the shape.
+ */
+function isStaticTypeOneOf(value: SummarizedProp['value'], names: readonly string[]): boolean {
+  if (Array.isArray(value)) return false
+  const trimmed = value.trim()
+  const literalMatch = /^(["'`])(.*)\1$/.exec(trimmed)
+  if (literalMatch === null) return false
+  const inner = (literalMatch[2] as string).toLowerCase()
+  return names.includes(inner)
+}
+
+/**
  * Returns true if the type prop's value MIGHT resolve to "file" at runtime.
  * Conservative — anything not provably non-"file" returns true so the caller
  * skips the transform.
@@ -227,7 +248,19 @@ export const inputTextAreaNodeTransform: NodeTransform = (node) => {
       const injectedLoc: SourceLocation = _node.loc
 
       const props = _node.props
-      removePropsByName(props, ['checked', 'value']) // (re)create the `value` prop further down
+      // For statically-typed checkbox / radio inputs, the `value=`
+      // attribute is the OPTION-value (the discriminator the directive
+      // matches against the model), not display state. The synthesized
+      // binding below resolves to `:checked="..."` for those types, a
+      // different attribute key — so the static `value` survives
+      // alongside it without conflict. Stripping it (as we still do
+      // for text/textarea, where the synthesized binding resolves to
+      // `:value`) leaves the SSR HTML without the attribute, and on
+      // hydration the directive can't tell which option this checkbox
+      // represents.
+      const keepStaticValue =
+        typeProp !== undefined && isStaticTypeOneOf(typeProp.value, ['checkbox', 'radio'])
+      removePropsByName(props, keepStaticValue ? ['checked'] : ['checked', 'value'])
       const registerValueArr = Array.isArray(registerSummarizedProp.value)
         ? registerSummarizedProp.value
         : [registerSummarizedProp.value]

--- a/src/runtime/lib/core/transforms/input-text-area-transform.ts
+++ b/src/runtime/lib/core/transforms/input-text-area-transform.ts
@@ -54,12 +54,27 @@ function getSummarizedPropValue(exp: ExpressionNode): SummarizedProp['value'] {
 
 function generateEqualityExpression(
   registerValue: SummarizedProp['value'],
-  elementValue: SummarizedProp['value']
+  optionValue: SummarizedProp['value'],
+  scalarTarget: SummarizedProp['value']
 ): CompoundExpressionNode['children'] {
   const registerValueArr = Array.isArray(registerValue) ? registerValue : [registerValue]
-  const elementValueArr = Array.isArray(elementValue) ? elementValue : [elementValue]
+  const optionValueArr = Array.isArray(optionValue) ? optionValue : [optionValue]
+  const scalarTargetArr = Array.isArray(scalarTarget) ? scalarTarget : [scalarTarget]
 
-  // account for register value being an array, set, or some other value
+  // Discriminator selection:
+  //   - Array model     → membership of the option-value (e.g. value="apple")
+  //   - Set model       → membership of the option-value
+  //   - Scalar model    → equality with the scalar-equality target
+  //
+  // The scalar target differs from the option-value for two checkbox
+  // shapes that the directive's runtime `setChecked` already handles
+  // via `getCheckboxValue(el, true)`:
+  //
+  //   - boolean model + no `value=` → target is `true`
+  //   - string model + `:true-value="'X'"` → target is `'X'`
+  //
+  // For radio inputs the model is always scalar and the discriminator
+  // IS the option-value, so `optionValue === scalarTarget` there.
   return [
     'Array.isArray((',
     ...registerValueArr,
@@ -67,19 +82,19 @@ function generateEqualityExpression(
     '(',
     ...registerValueArr,
     ')?.innerRef?.value?.includes(',
-    ...elementValueArr,
+    ...optionValueArr,
     ') : ',
     '(',
     ...registerValueArr,
     ')?.innerRef?.value instanceof Set ? (',
     ...registerValueArr,
     ')?.innerRef?.value?.has(',
-    ...elementValueArr,
+    ...optionValueArr,
     ') : ',
     '((',
     ...registerValueArr,
     ')?.innerRef?.value === (',
-    ...elementValueArr,
+    ...scalarTargetArr,
     '))',
   ]
 }
@@ -258,8 +273,10 @@ export const inputTextAreaNodeTransform: NodeTransform = (node) => {
       // `:value`) leaves the SSR HTML without the attribute, and on
       // hydration the directive can't tell which option this checkbox
       // represents.
-      const keepStaticValue =
-        typeProp !== undefined && isStaticTypeOneOf(typeProp.value, ['checkbox', 'radio'])
+      const isStaticCheckbox =
+        typeProp !== undefined && isStaticTypeOneOf(typeProp.value, ['checkbox'])
+      const isStaticRadio = typeProp !== undefined && isStaticTypeOneOf(typeProp.value, ['radio'])
+      const keepStaticValue = isStaticCheckbox || isStaticRadio
       removePropsByName(props, keepStaticValue ? ['checked'] : ['checked', 'value'])
       const registerValueArr = Array.isArray(registerSummarizedProp.value)
         ? registerSummarizedProp.value
@@ -278,6 +295,26 @@ export const inputTextAreaNodeTransform: NodeTransform = (node) => {
         ...registerValueArr,
         ')?.displayValue?.value',
       ])
+
+      // Scalar-equality target. Three cases (see the long-form comment
+      // on `generateEqualityExpression`):
+      //   - static checkbox + `:true-value="X"` → X (the explicit
+      //     mapped string the model takes when checked)
+      //   - static checkbox without `:true-value` → boolean `true`
+      //     (matches the runtime's `getCheckboxValue(el, true)` default)
+      //   - static radio → the option-value (since radio model is
+      //     always scalar and the `value=` IS the discriminator)
+      //   - dynamic type → fall back to the option-value (current
+      //     behaviour); a dynamic-type element can't be statically
+      //     classified into checkbox vs radio vs text.
+      const trueValueIndex = elementProps.findIndex((p) => isExactKey(p.key, 'true-value'))
+      const trueValueProp = elementProps[trueValueIndex]
+      const scalarTarget: SummarizedProp['value'] = isStaticCheckbox
+        ? trueValueProp !== undefined
+          ? trueValueProp.value
+          : 'true'
+        : elementValueSummarizedProp.value
+
       const valueOrCheckedProp: DirectiveNode = {
         // reconstruct the `value` attribute based on the provided v-registerer, now that the computation is complete
         arg: elementSelectionLabelExpression,
@@ -288,7 +325,8 @@ export const inputTextAreaNodeTransform: NodeTransform = (node) => {
           // resolves to a boolean
           ...generateEqualityExpression(
             registerSummarizedProp.value,
-            elementValueSummarizedProp.value
+            elementValueSummarizedProp.value,
+            scalarTarget
           ),
           ') : (',
           // resolves to the provided register value

--- a/src/runtime/lib/core/transforms/select-transform.ts
+++ b/src/runtime/lib/core/transforms/select-transform.ts
@@ -441,12 +441,12 @@ export const selectNodeTransform: NodeTransform = (node, context) => {
       : [registerSummarizedProp?.value ?? 'undefined']
     // Read `displayValue.value` rather than `innerRef.value` so
     // selects share the same single read surface as text inputs.
-    // The directive never marks select paths transient-empty (no
+    // The directive never marks select paths blank (no
     // DOM "empty" state), so in normal flow `displayValue` is just
     // `String(storage)` — identical to today. The edge case where a
     // consumer programmatically calls `setValue(numericPath, unset)`
     // bound to a `<select>` is documented in the docs (browser falls
-    // back to first option; meta.pendingEmpty surfaces the intent).
+    // back to first option; meta.blank surfaces the intent).
     const initExpression = createCompoundExpression([
       '(',
       ...valuePropExpArray,

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -262,7 +262,7 @@ export type AbstractSchema<Form, GetValueFormType> = {
    * `.default(N)`, or `.catch(N)` at the leaf or any wrapper.
    *
    * Used by the submit / validate path to surface a "No value supplied" error
-   * when a field is in the form's `transientEmptyPaths` set (the user
+   * when a field is in the form's `blankPaths` set (the user
    * cleared it or never answered) AND the schema treats the field as
    * required. Without this, a strict `z.number()` would silently
    * accept the slim default (`0`) for an unanswered field — the
@@ -459,15 +459,15 @@ export type WriteMeta = {
   readonly persist?: boolean
   /**
    * When `true`, the path being written is added to the FormStore's
-   * `transientEmptyPaths` set — meaning storage holds a real, schema-
+   * `blankPaths` set — meaning storage holds a real, schema-
    * conformant value (the slim default) but the UI should display the
    * field as empty. The next write to that path WITHOUT this flag
    * implicitly removes the path from the set (the user typed something
-   * real). Internal — set by `markTransientEmpty()` on the register
+   * real). Internal — set by `markBlank()` on the register
    * binding and by the `unset` translation in `setValue` / `reset` /
    * `useAbstractForm` construction. Don't set from consumer code.
    */
-  readonly transientEmpty?: boolean
+  readonly blank?: boolean
 }
 
 /**
@@ -816,21 +816,24 @@ export type MetaTrackerValue = {
   /** Dotted-string path to this leaf. */
   path: string | null
   /**
-   * `true` when the path is in the form's transient-empty set —
-   * storage holds the slim default but the UI displays empty.
-   * Either the user cleared the field (numeric inputs auto-mark on
-   * empty DOM via the directive) or the consumer marked it
-   * declaratively via `defaultValues: { x: unset }` /
-   * imperatively via `setValue('x', unset)`.
+   * `true` when this field is **blank** — the user hasn't supplied
+   * a value yet, even though storage holds a slim default. Answers:
+   * "Is this field empty because the user left it blank, or because
+   * the slim default happens to be `0` / `''`?"
    *
-   * Submit-time validation raises "No value supplied" for transient-empty
-   * paths whose schema is required (no `.optional()` / `.nullable()`
-   * / `.default()`), so most consumers can ignore this field — it's
-   * the safety net's input. Read it directly when you want to drive
+   * Set by the directive on numeric clear, by `setValue(path, unset)`,
+   * by `register({ persist: true })` calls reading hydrated state,
+   * and at construction for any leaf the consumer didn't explicitly
+   * supply. Cleared on the first non-`unset` write.
+   *
+   * Submit-time validation raises "No value supplied" for required
+   * paths (no `.optional()` / `.nullable()` / `.default()`) that are
+   * still `blank`, so most consumers can ignore this flag — it's the
+   * safety net's input. Read it directly when you want to drive
    * conditional UI ("undecided checkbox" indicator, "review
    * unanswered fields" hint, etc.) BEFORE submission triggers.
    */
-  pendingEmpty: boolean
+  blank: boolean
 }
 export type MetaTracker = Record<string, MetaTrackerValue>
 export type MetaTrackerStore = Map<FormKey, MetaTracker>
@@ -1003,15 +1006,15 @@ export type RegisterValue<Value = unknown> = {
    * the compile-time `:value` injection reads on every input /
    * textarea / select bound by `v-register`.
    *
-   * Returns `''` when the path is in the form's `transientEmptyPaths`
+   * Returns `''` when the path is in the form's `blankPaths`
    * set OR storage is `null` / `undefined`; otherwise stringifies
-   * the storage value via `String(...)`. The transient-empty branch
+   * the storage value via `String(...)`. The blank branch
    * lets the user clear a numeric field without the next Vue render
    * patching `el.value` back to `'0'` (the slim default).
    */
   displayValue: Readonly<Ref<string>>
   /**
-   * Add this field's path to the form's `transientEmptyPaths` set,
+   * Add this field's path to the form's `blankPaths` set,
    * writing the slim default to storage. Returns the `setValueAtPath`
    * boolean (`true` accepted, `false` rejected by the slim-primitive
    * gate). Inherits the binding's `persist` meta so the mark rides
@@ -1022,7 +1025,7 @@ export type RegisterValue<Value = unknown> = {
    * (commit 7). Don't call from consumer code.
    * @internal
    */
-  markTransientEmpty: () => boolean
+  markBlank: () => boolean
   /**
    * The user's most recently typed string form for this field while
    * mid-typing, or `null` once the field has been blurred / cleared.
@@ -1301,13 +1304,14 @@ export type FieldState<Value = unknown> = DeepFlatten<
     /** `true` when `currentValue` differs from `originalValue`. */
     dirty: boolean
     /**
-     * `true` when this path is in the form's transient-empty set —
-     * storage holds the slim default but the UI displays empty.
-     * Surfaces both as a top-level field here AND via `meta.pendingEmpty`
+     * `true` when this field is blank — no user value supplied yet,
+     * even though storage holds a slim default. Answers: "Was this
+     * field blank originally, or was `0` / `''` already there?"
+     * Surfaces both as a top-level field here AND via `meta.blank`
      * (the meta projection mirrors the same value). Read whichever
      * matches your access pattern.
      */
-    pendingEmpty: boolean
+    blank: boolean
   }
 >
 export type DOMFieldStateStore = Map<string, DOMFieldState | undefined>
@@ -1660,7 +1664,7 @@ export type UseAbstractFormReturnType<
      * value didn't match the slot's expected primitive type.
      * Refinement-level mismatches succeed and surface as field
      * errors. Pass the `unset` symbol at any primitive leaf to mark
-     * it transient-empty (storage holds the slim default; UI displays
+     * it blank (storage holds the slim default; UI displays
      * empty; submit raises "No value supplied" for required schemas).
      */
     <
@@ -1951,7 +1955,7 @@ export type UseAbstractFormReturnType<
     value: ArrayItem<Form, Path>
   ) => void
   /**
-   * Read-only view of the form's transient-empty path set. Each entry
+   * Read-only view of the form's blank path set. Each entry
    * is a canonical `PathKey` (the `JSON.stringify(segments)` form
    * `canonicalizePath` produces). The set is reactive — Vue 3.5
    * tracks `.has()` / `for..of` / size accesses, so consumers can
@@ -1959,17 +1963,17 @@ export type UseAbstractFormReturnType<
    *
    * ```ts
    * watchEffect(() => {
-   *   if (form.transientEmptyPaths.value.size > 0) {
-   *     console.warn('unanswered fields:', [...form.transientEmptyPaths.value])
+   *   if (form.blankPaths.value.size > 0) {
+   *     console.warn('unanswered fields:', [...form.blankPaths.value])
    *   }
    * })
    * ```
    *
-   * For per-path access, use `getFieldState(path).meta.pendingEmpty`.
+   * For per-path access, use `getFieldState(path).meta.blank`.
    * Writes happen through `setValue(path, unset)`,
-   * `markTransientEmpty()` on a register binding, and the directive's
+   * `markBlank()` on a register binding, and the directive's
    * input listener on numeric clear. Mutating the snapshot returned
    * here does nothing — it's `Object.freeze`-d.
    */
-  transientEmptyPaths: ComputedRef<ReadonlySet<string>>
+  blankPaths: ComputedRef<ReadonlySet<string>>
 }

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -240,9 +240,13 @@ export type AbstractSchema<Form, GetValueFormType> = {
    * sides.
    *
    * Conventions:
-   * - Empty set → permissive ("unknown / unconstrained"). The runtime
-   *   gate treats this as "accept anything." Surfaces for `z.any()` /
-   *   `z.unknown()` / `z.never()` and the lazy-peel-failure case.
+   * - Empty set → no kind admitted. The runtime gate rejects every
+   *   write to the path. Surfaces for `z.never()` AND for paths that
+   *   don't resolve in the schema (typo / unknown leaf).
+   * - Permissive set (every kind) → "unknown / unconstrained." The
+   *   gate accepts any value. Surfaces for `z.any()` / `z.unknown()`
+   *   / `z.void()` and the lazy-peel-failure case where the adapter
+   *   can't introspect the schema.
    * - For `z.enum(['a','b'])` (string entries): returns `{'string'}`.
    *   For numeric enums: `{'number'}`.
    * - For `z.literal(x)`: returns `{primitiveKindOf(x)}`.

--- a/test/adapters/zod-v4/is-required-at-path.test.ts
+++ b/test/adapters/zod-v4/is-required-at-path.test.ts
@@ -5,7 +5,7 @@ import { zodAdapter } from '../../../src/runtime/adapters/zod-v4'
 /**
  * Adapter-level tests for `isRequiredAtPath`. The submit / validate
  * required-empty augmentation calls this to decide whether a path in
- * the form's `transientEmptyPaths` set should raise a "Required"
+ * the form's `blankPaths` set should raise a "Required"
  * error. Semantics: required = no `.optional()` / `.nullable()` /
  * `.default()` / `.catch()` wrapper at any layer of the leaf.
  */

--- a/test/composables/checkbox.test.ts
+++ b/test/composables/checkbox.test.ts
@@ -300,7 +300,7 @@ describe('<input type="checkbox" v-register> — array group', () => {
       const matched = warnSpy.mock.calls
         .map((args) => args.join(' '))
         .filter((m) => /missing a `value` attribute/.test(m))
-      expect(matched.length).toBeGreaterThan(0)
+      expect(matched).toHaveLength(1)
     } finally {
       warnSpy.mockRestore()
     }

--- a/test/composables/checkbox.test.ts
+++ b/test/composables/checkbox.test.ts
@@ -1,0 +1,454 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, withDirectives, type App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { vRegister } from '../../src/runtime/core/directive'
+import { createChemicalXForms } from '../../src/runtime/core/plugin'
+
+/**
+ * `<input type="checkbox" v-register>` end-to-end coverage.
+ *
+ * The directive variant `vRegisterCheckbox` mirrors Vue's
+ * `vModelCheckbox` and supports three shapes:
+ *
+ *   1. **Single boolean** — `z.boolean()`. Checked → `true`, unchecked
+ *      → `false`. No `value=""` attribute needed.
+ *   2. **Array group** — `z.array(<primitive>)`. Each checkbox shares
+ *      the same register binding and has a unique `value="..."`. The
+ *      directive adds/removes that value from the array on toggle.
+ *   3. **Set group** — `z.set(<primitive>)`. Same as array but the
+ *      state is a `Set`. The directive add/deletes via Set semantics.
+ *
+ * The `:true-value` / `:false-value` props let a single checkbox bind
+ * to a non-boolean state (e.g. `'subscribe'` / `'unsubscribe'`) — Vue
+ * sets `el._trueValue` / `el._falseValue` from those bindings, and
+ * the directive's `getCheckboxValue` reads them through.
+ */
+
+async function flush(): Promise<void> {
+  for (let i = 0; i < 4; i++) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+function dispatchChange(el: HTMLInputElement): void {
+  el.dispatchEvent(new Event('change', { bubbles: true }))
+}
+
+describe('<input type="checkbox" v-register> — single boolean', () => {
+  let app: App | undefined
+
+  afterEach(() => {
+    app?.unmount()
+    app = undefined
+    document.body.innerHTML = ''
+  })
+
+  it('checking the box writes true; unchecking writes false', async () => {
+    const schema = z.object({ agreed: z.boolean() })
+    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+
+    const Parent = defineComponent({
+      setup() {
+        const form = useForm({ schema, key: 'cb-bool', validationMode: 'lax' })
+        captured.api = form
+        return () =>
+          withDirectives(h('input', { type: 'checkbox', class: 'agreed' }), [
+            [vRegister, form.register('agreed')],
+          ])
+      },
+    })
+
+    app = createApp(Parent).use(createChemicalXForms())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await flush()
+
+    if (captured.api === undefined) throw new Error('unreachable')
+    const cb = root.querySelector('input.agreed') as HTMLInputElement
+    expect(cb.checked).toBe(false)
+    expect(captured.api.getValue('agreed').value).toBe(false)
+
+    cb.checked = true
+    dispatchChange(cb)
+    await flush()
+    expect(captured.api.getValue('agreed').value).toBe(true)
+
+    cb.checked = false
+    dispatchChange(cb)
+    await flush()
+    expect(captured.api.getValue('agreed').value).toBe(false)
+  })
+
+  it('mounts with el.checked synced to the form value', async () => {
+    const schema = z.object({ agreed: z.boolean() })
+    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+
+    const Parent = defineComponent({
+      setup() {
+        const form = useForm({
+          schema,
+          key: 'cb-bool-init',
+          defaultValues: { agreed: true },
+          validationMode: 'lax',
+        })
+        captured.api = form
+        return () =>
+          withDirectives(h('input', { type: 'checkbox', class: 'agreed' }), [
+            [vRegister, form.register('agreed')],
+          ])
+      },
+    })
+
+    app = createApp(Parent).use(createChemicalXForms())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await flush()
+
+    const cb = root.querySelector('input.agreed') as HTMLInputElement
+    expect(cb.checked).toBe(true)
+  })
+})
+
+describe('<input type="checkbox" v-register> — array group', () => {
+  let app: App | undefined
+
+  afterEach(() => {
+    app?.unmount()
+    app = undefined
+    document.body.innerHTML = ''
+  })
+
+  it('toggles add/remove the option value from the array', async () => {
+    const schema = z.object({ fruits: z.array(z.string()) })
+    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+
+    const Parent = defineComponent({
+      setup() {
+        const form = useForm({ schema, key: 'cb-array', validationMode: 'lax' })
+        captured.api = form
+        return () =>
+          h('div', [
+            withDirectives(h('input', { type: 'checkbox', value: 'apple', class: 'apple' }), [
+              [vRegister, form.register('fruits')],
+            ]),
+            withDirectives(h('input', { type: 'checkbox', value: 'banana', class: 'banana' }), [
+              [vRegister, form.register('fruits')],
+            ]),
+            withDirectives(h('input', { type: 'checkbox', value: 'cherry', class: 'cherry' }), [
+              [vRegister, form.register('fruits')],
+            ]),
+          ])
+      },
+    })
+
+    app = createApp(Parent).use(createChemicalXForms())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await flush()
+
+    if (captured.api === undefined) throw new Error('unreachable')
+    expect(captured.api.getValue('fruits').value).toEqual([])
+
+    const apple = root.querySelector('input.apple') as HTMLInputElement
+    const banana = root.querySelector('input.banana') as HTMLInputElement
+    const cherry = root.querySelector('input.cherry') as HTMLInputElement
+
+    apple.checked = true
+    dispatchChange(apple)
+    await flush()
+    expect(captured.api.getValue('fruits').value).toEqual(['apple'])
+
+    banana.checked = true
+    dispatchChange(banana)
+    await flush()
+    expect(captured.api.getValue('fruits').value).toEqual(['apple', 'banana'])
+
+    apple.checked = false
+    dispatchChange(apple)
+    await flush()
+    expect(captured.api.getValue('fruits').value).toEqual(['banana'])
+
+    cherry.checked = true
+    dispatchChange(cherry)
+    await flush()
+    expect(captured.api.getValue('fruits').value).toEqual(['banana', 'cherry'])
+  })
+
+  it('mounts with each checkbox checked iff its value is in the array', async () => {
+    const schema = z.object({ fruits: z.array(z.string()) })
+    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+
+    const Parent = defineComponent({
+      setup() {
+        const form = useForm({
+          schema,
+          key: 'cb-array-init',
+          defaultValues: { fruits: ['apple', 'cherry'] },
+          validationMode: 'lax',
+        })
+        captured.api = form
+        return () =>
+          h('div', [
+            withDirectives(h('input', { type: 'checkbox', value: 'apple', class: 'apple' }), [
+              [vRegister, form.register('fruits')],
+            ]),
+            withDirectives(h('input', { type: 'checkbox', value: 'banana', class: 'banana' }), [
+              [vRegister, form.register('fruits')],
+            ]),
+            withDirectives(h('input', { type: 'checkbox', value: 'cherry', class: 'cherry' }), [
+              [vRegister, form.register('fruits')],
+            ]),
+          ])
+      },
+    })
+
+    app = createApp(Parent).use(createChemicalXForms())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await flush()
+
+    expect((root.querySelector('input.apple') as HTMLInputElement).checked).toBe(true)
+    expect((root.querySelector('input.banana') as HTMLInputElement).checked).toBe(false)
+    expect((root.querySelector('input.cherry') as HTMLInputElement).checked).toBe(true)
+  })
+
+  it('warns once when an array-bound checkbox is missing a value attribute', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const schema = z.object({ fruits: z.array(z.string()) })
+      const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+
+      const Parent = defineComponent({
+        setup() {
+          const form = useForm({ schema, key: 'cb-array-missing-value', validationMode: 'lax' })
+          captured.api = form
+          // Intentionally NO `value` prop on the checkbox.
+          return () =>
+            withDirectives(h('input', { type: 'checkbox', class: 'no-value' }), [
+              [vRegister, form.register('fruits')],
+            ])
+        },
+      })
+
+      app = createApp(Parent).use(createChemicalXForms())
+      const root = document.createElement('div')
+      document.body.appendChild(root)
+      app.mount(root)
+      await flush()
+
+      const cb = root.querySelector('input.no-value') as HTMLInputElement
+      cb.checked = true
+      dispatchChange(cb)
+      await flush()
+
+      if (captured.api === undefined) throw new Error('unreachable')
+      // No state change — directive bailed at the missing-value check.
+      expect(captured.api.getValue('fruits').value).toEqual([])
+
+      const matched = warnSpy.mock.calls
+        .map((args) => args.join(' '))
+        .filter((m) => /missing a `value` attribute/.test(m))
+      expect(matched.length).toBeGreaterThan(0)
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+})
+
+describe('<input type="checkbox" v-register> — Set group', () => {
+  let app: App | undefined
+
+  afterEach(() => {
+    app?.unmount()
+    app = undefined
+    document.body.innerHTML = ''
+  })
+
+  it('toggles add/delete the option value through Set semantics', async () => {
+    const schema = z.object({ tags: z.set(z.string()) })
+    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+
+    const Parent = defineComponent({
+      setup() {
+        const form = useForm({
+          schema,
+          key: 'cb-set',
+          defaultValues: { tags: new Set<string>() },
+          validationMode: 'lax',
+        })
+        captured.api = form
+        return () =>
+          h('div', [
+            withDirectives(h('input', { type: 'checkbox', value: 'red', class: 'red' }), [
+              [vRegister, form.register('tags')],
+            ]),
+            withDirectives(h('input', { type: 'checkbox', value: 'green', class: 'green' }), [
+              [vRegister, form.register('tags')],
+            ]),
+          ])
+      },
+    })
+
+    app = createApp(Parent).use(createChemicalXForms())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await flush()
+
+    if (captured.api === undefined) throw new Error('unreachable')
+    expect((captured.api.getValue('tags').value as Set<string>).size).toBe(0)
+
+    const red = root.querySelector('input.red') as HTMLInputElement
+    const green = root.querySelector('input.green') as HTMLInputElement
+
+    red.checked = true
+    dispatchChange(red)
+    await flush()
+    expect([...(captured.api.getValue('tags').value as Set<string>)]).toEqual(['red'])
+
+    green.checked = true
+    dispatchChange(green)
+    await flush()
+    expect([...(captured.api.getValue('tags').value as Set<string>)].sort()).toEqual([
+      'green',
+      'red',
+    ])
+
+    red.checked = false
+    dispatchChange(red)
+    await flush()
+    expect([...(captured.api.getValue('tags').value as Set<string>)]).toEqual(['green'])
+  })
+})
+
+describe('<input type="checkbox" v-register> — :true-value / :false-value', () => {
+  let app: App | undefined
+
+  afterEach(() => {
+    app?.unmount()
+    app = undefined
+    document.body.innerHTML = ''
+  })
+
+  it('binds a single checkbox to one of two strings', async () => {
+    const schema = z.object({ newsletter: z.enum(['subscribe', 'unsubscribe']) })
+    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+
+    const Parent = defineComponent({
+      setup() {
+        const form = useForm({
+          schema,
+          key: 'cb-true-false-value',
+          // Explicit default: enum's first member is 'subscribe', which
+          // would mount the checkbox already-checked. Setting
+          // 'unsubscribe' isolates the toggle behavior.
+          defaultValues: { newsletter: 'unsubscribe' },
+          validationMode: 'lax',
+        })
+        captured.api = form
+        return () =>
+          withDirectives(
+            h('input', {
+              type: 'checkbox',
+              class: 'newsletter',
+              // Vue propagates these as `el._trueValue` / `el._falseValue`,
+              // which the directive's `getCheckboxValue` reads through.
+              'true-value': 'subscribe',
+              'false-value': 'unsubscribe',
+            }),
+            [[vRegister, form.register('newsletter')]]
+          )
+      },
+    })
+
+    app = createApp(Parent).use(createChemicalXForms())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await flush()
+
+    if (captured.api === undefined) throw new Error('unreachable')
+    const cb = root.querySelector('input.newsletter') as HTMLInputElement
+    expect(cb.checked).toBe(false)
+    expect(captured.api.getValue('newsletter').value).toBe('unsubscribe')
+
+    cb.checked = true
+    dispatchChange(cb)
+    await flush()
+    expect(captured.api.getValue('newsletter').value).toBe('subscribe')
+
+    cb.checked = false
+    dispatchChange(cb)
+    await flush()
+    expect(captured.api.getValue('newsletter').value).toBe('unsubscribe')
+  })
+})
+
+describe('checkbox slim-primitive gate interactions', () => {
+  let app: App | undefined
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    app?.unmount()
+    app = undefined
+    warnSpy.mockRestore()
+    document.body.innerHTML = ''
+  })
+
+  it('rejects a string write to a boolean checkbox path', async () => {
+    const schema = z.object({ agreed: z.boolean() })
+    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+
+    const Parent = defineComponent({
+      setup() {
+        captured.api = useForm({ schema, key: 'cb-gate-bool', validationMode: 'lax' })
+        return () => h('div')
+      },
+    })
+
+    app = createApp(Parent).use(createChemicalXForms())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await flush()
+
+    if (captured.api === undefined) throw new Error('unreachable')
+    const setVal = captured.api.setValue as (path: 'agreed', value: unknown) => boolean
+    expect(setVal('agreed', 'yes')).toBe(false)
+    expect(captured.api.getValue('agreed').value).toBe(false)
+  })
+
+  it('rejects a string write to an array checkbox path', async () => {
+    const schema = z.object({ fruits: z.array(z.string()) })
+    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+
+    const Parent = defineComponent({
+      setup() {
+        captured.api = useForm({ schema, key: 'cb-gate-array', validationMode: 'lax' })
+        return () => h('div')
+      },
+    })
+
+    app = createApp(Parent).use(createChemicalXForms())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await flush()
+
+    if (captured.api === undefined) throw new Error('unreachable')
+    const setVal = captured.api.setValue as (path: 'fruits', value: unknown) => boolean
+    // Wrong slim primitive: 'apple' is a string, but the path expects 'array'.
+    expect(setVal('fruits', 'apple')).toBe(false)
+    expect(captured.api.getValue('fruits').value).toEqual([])
+  })
+})

--- a/test/composables/checkbox.test.ts
+++ b/test/composables/checkbox.test.ts
@@ -219,6 +219,51 @@ describe('<input type="checkbox" v-register> — array group', () => {
     expect((root.querySelector('input.cherry') as HTMLInputElement).checked).toBe(true)
   })
 
+  it('falls back to el.value when Vue did not set _value (hydration with static value="...")', async () => {
+    // Repro for the playground bug: SSR renders <input value="apple">
+    // as a static attribute, then on hydration Vue's static-attr fast
+    // path skips patchProp, so `el._value` is never set. The directive's
+    // change handler must still resolve the option-value from the DOM
+    // attribute (el.value) rather than warn "missing value attribute".
+    //
+    // We simulate this by mounting the checkbox via h() (which DOES set
+    // _value) and then deleting `_value` before dispatching change —
+    // the post-hydration state in a real Nuxt app.
+    const schema = z.object({ fruits: z.array(z.string()) })
+    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+
+    const Parent = defineComponent({
+      setup() {
+        const form = useForm({ schema, key: 'cb-array-static-value', validationMode: 'lax' })
+        captured.api = form
+        return () =>
+          withDirectives(h('input', { type: 'checkbox', value: 'apple', class: 'apple' }), [
+            [vRegister, form.register('fruits')],
+          ])
+      },
+    })
+
+    app = createApp(Parent).use(createChemicalXForms())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await flush()
+
+    if (captured.api === undefined) throw new Error('unreachable')
+
+    const apple = root.querySelector('input.apple') as HTMLInputElement
+    // Strip the Vue-patched _value to mimic the hydrated-from-static-attr
+    // shape the directive sees in production. el.value (the DOM property)
+    // stays at 'apple' since that's set from the HTML value attribute.
+    delete (apple as unknown as { _value?: unknown })._value
+
+    apple.checked = true
+    dispatchChange(apple)
+    await flush()
+
+    expect(captured.api.getValue('fruits').value).toEqual(['apple'])
+  })
+
   it('warns once when an array-bound checkbox is missing a value attribute', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     try {

--- a/test/composables/form-aggregates.test.ts
+++ b/test/composables/form-aggregates.test.ts
@@ -34,9 +34,9 @@ function harness(initial?: Partial<SignupForm>) {
         schema: fakeSchema<SignupForm>(merged),
         key: `agg-${Math.random().toString(36).slice(2)}`,
         // Explicit defaultValues opt out of construction-time auto-mark
-        // (every primitive leaf would otherwise be `pendingEmpty`); this
+        // (every primitive leaf would otherwise be `blank`); this
         // suite pins the dirty/valid round-trip semantics independent of
-        // the transient-empty layer.
+        // the blank layer.
         defaultValues: merged,
       })
       return () => h('div')

--- a/test/composables/persistence.test.ts
+++ b/test/composables/persistence.test.ts
@@ -322,14 +322,14 @@ describe('persistence — localStorage backend', () => {
  * opt-in) showed `0` in its <input> on every page load instead of
  * displaying as empty until the user typed.
  *
- * Cause: persistence's hydrate path called `transientEmptyPaths.clear()`
+ * Cause: persistence's hydrate path called `blankPaths.clear()`
  * and replaced the live set with the persisted array. The persisted
  * array only ever contains paths the persistence layer has been writing
  * for — i.e., paths within the per-element opt-in scope. Non-opted-in
  * paths' construction-time auto-marks (number → 0 displayed as empty)
  * got wiped on first hydrate, surfacing as `0` in the field.
  */
-describe('persistence — non-opted-in transient-empty paths survive hydration', () => {
+describe('persistence — non-opted-in blank paths survive hydration', () => {
   const apps: App[] = []
   beforeEach(() => sessionStorage.clear())
   afterEach(() => {
@@ -337,7 +337,7 @@ describe('persistence — non-opted-in transient-empty paths survive hydration',
     sessionStorage.clear()
   })
 
-  it('keeps a non-opted-in number field auto-marked transient-empty on hydration', async () => {
+  it('keeps a non-opted-in number field auto-marked blank on hydration', async () => {
     const customSchema = z.object({
       email: z.string(),
       salary: z.number(),
@@ -350,15 +350,15 @@ describe('persistence — non-opted-in transient-empty paths survive hydration',
 
     // Pre-seed sessionStorage with a payload representing the state
     // after a user typed into the opted-in email field.
-    // `transientEmptyPaths: []` matches what the persistence-write
+    // `blankPaths: []` matches what the persistence-write
     // path actually saves under those conditions: only paths within
     // the write's path-scope are tracked, and email itself is no
-    // longer transient-empty post-typing.
+    // longer blank post-typing.
     sessionStorage.setItem(
       customKey,
       JSON.stringify({
         v: 4,
-        data: { form: { email: 'seed@example.com' }, transientEmptyPaths: [] },
+        data: { form: { email: 'seed@example.com' }, blankPaths: [] },
       })
     )
 
@@ -407,13 +407,13 @@ describe('persistence — non-opted-in transient-empty paths survive hydration',
     expect(captured.api.getValue('email').value).toBe('seed@example.com')
 
     // Critical assertion: the salary path is STILL in the
-    // transient-empty set after hydration. Pre-fix the persistence
+    // blank set after hydration. Pre-fix the persistence
     // hydrate cleared the set and replaced it with the persisted
     // (empty) array, dropping 'salary' from the set.
-    expect(captured.api.transientEmptyPaths.value.has('["salary"]')).toBe(true)
+    expect(captured.api.blankPaths.value.has('["salary"]')).toBe(true)
 
     // The user-visible consequence: the registered displayValue is
-    // `''` (transient-empty bypass), not `'0'`. The compile-time
+    // `''` (blank bypass), not `'0'`. The compile-time
     // input-text-area transform binds `:value="...displayValue.value"`
     // on the rendered <input>, so this assertion is the runtime
     // contract that drives the user-visible empty field. Storage

--- a/test/composables/persistence.test.ts
+++ b/test/composables/persistence.test.ts
@@ -312,6 +312,103 @@ describe('persistence — localStorage backend', () => {
   })
 })
 
+/**
+ * Repro for the playground bug: salary (z.number(), no `register()`
+ * opt-in) showed `0` in its <input> on every page load instead of
+ * displaying as empty until the user typed.
+ *
+ * Cause: persistence's hydrate path called `transientEmptyPaths.clear()`
+ * and replaced the live set with the persisted array. The persisted
+ * array only ever contains paths the persistence layer has been writing
+ * for — i.e., paths within the per-element opt-in scope. Non-opted-in
+ * paths' construction-time auto-marks (number → 0 displayed as empty)
+ * got wiped on first hydrate, surfacing as `0` in the field.
+ */
+describe('persistence — non-opted-in transient-empty paths survive hydration', () => {
+  const apps: App[] = []
+  beforeEach(() => sessionStorage.clear())
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+    sessionStorage.clear()
+  })
+
+  it('keeps a non-opted-in number field auto-marked transient-empty on hydration', async () => {
+    const customSchema = z.object({
+      email: z.string(),
+      salary: z.number(),
+    })
+    const customFp = fingerprintZodSchema(customSchema)
+    // Default `resolveStorageKeyBase`: `${PERSISTENCE_KEY_PREFIX}${formKey}`,
+    // and PERSISTENCE_KEY_PREFIX is 'chemical-x-forms:'. Then the full
+    // storage key appends `:${fingerprint}`.
+    const customKey = `chemical-x-forms:test-non-optin-tep:${customFp}`
+
+    // Pre-seed sessionStorage with a payload representing the state
+    // after a user typed into the opted-in email field.
+    // `transientEmptyPaths: []` matches what the persistence-write
+    // path actually saves under those conditions: only paths within
+    // the write's path-scope are tracked, and email itself is no
+    // longer transient-empty post-typing.
+    sessionStorage.setItem(
+      customKey,
+      JSON.stringify({
+        v: 4,
+        data: { form: { email: 'seed@example.com' }, transientEmptyPaths: [] },
+      })
+    )
+
+    const captured: { api?: ReturnType<typeof useForm<typeof customSchema>> } = {}
+    const App = defineComponent({
+      setup() {
+        const api = useForm({
+          schema: customSchema,
+          key: 'test-non-optin-tep',
+          persist: { storage: 'session', debounceMs: 20 },
+        })
+        captured.api = api
+        return () =>
+          h('div', [
+            withDirectives(h('input', { type: 'text', class: 'email' }), [
+              [vRegister, api.register('email', { persist: true })],
+            ]),
+            // `salary` is NOT opted in for persistence.
+            withDirectives(h('input', { type: 'text', class: 'salary' }), [
+              [vRegister, api.register('salary')],
+            ]),
+          ])
+      },
+    })
+    const app = createApp(App).use(createChemicalXForms())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    apps.push(app)
+    await drain()
+
+    // Wait for the persistence hydrate to land (it's async — dynamic
+    // import + adapter.getItem + apply).
+    if (captured.api === undefined) throw new Error('unreachable')
+    await waitUntil(() =>
+      captured.api?.getValue('email').value === 'seed@example.com' ? true : null
+    )
+
+    // Sanity: email did hydrate (otherwise the test below isn't
+    // exercising the post-hydrate state at all).
+    expect(captured.api.getValue('email').value).toBe('seed@example.com')
+
+    // Critical assertion: the salary path is STILL in the
+    // transient-empty set after hydration. Pre-fix the persistence
+    // hydrate cleared the set and replaced it with the persisted
+    // (empty) array, dropping 'salary' from the set.
+    expect(captured.api.transientEmptyPaths.value.has('["salary"]')).toBe(true)
+
+    // The user-visible consequence: salary displays as '' (transient-
+    // empty bypass), not '0'. Storage still holds the slim default.
+    expect(captured.api.register('salary').displayValue.value).toBe('')
+    expect(captured.api.getValue('salary').value).toBe(0)
+  })
+})
+
 describe('persistence — sessionStorage backend', () => {
   const apps: App[] = []
   beforeEach(() => sessionStorage.clear())

--- a/test/composables/persistence.test.ts
+++ b/test/composables/persistence.test.ts
@@ -963,9 +963,7 @@ describe('persistence — reset wipes the persisted draft', () => {
       // Drain the microtasks so the deferred warning fires.
       await drain()
       const warnCalls = warnSpy.mock.calls.map((args) => args.join(' '))
-      const matched = warnCalls.find((msg) =>
-        /Persistence is configured.*no fields opted in/.test(msg)
-      )
+      const matched = warnCalls.find((msg) => /persist:.*configured.*no fields opted in/.test(msg))
       expect(matched).toBeDefined()
     } finally {
       warnSpy.mockRestore()
@@ -979,9 +977,7 @@ describe('persistence — reset wipes the persisted draft', () => {
       apps.push(app)
       await drain()
       const warnCalls = warnSpy.mock.calls.map((args) => args.join(' '))
-      const matched = warnCalls.find((msg) =>
-        /Persistence is configured.*no fields opted in/.test(msg)
-      )
+      const matched = warnCalls.find((msg) => /persist:.*configured.*no fields opted in/.test(msg))
       expect(matched).toBeUndefined()
     } finally {
       warnSpy.mockRestore()
@@ -1016,7 +1012,7 @@ describe('persistence — reset wipes the persisted draft', () => {
       await drain()
       const warnCalls = warnSpy.mock.calls.map((args) => args.join(' '))
       const matched = warnCalls.find((msg) =>
-        /register\('email', \{ persist: true \}\).*no `persist:` option is configured/.test(msg)
+        /register\('email', \{ persist: true \}\).*no `persist` option configured/.test(msg)
       )
       expect(matched).toBeDefined()
     } finally {
@@ -1037,7 +1033,7 @@ describe('persistence — reset wipes the persisted draft', () => {
       apps.push(app)
       await drain()
       const warnCalls = warnSpy.mock.calls.map((args) => args.join(' '))
-      const matched = warnCalls.find((msg) => /no `persist:` option is configured/.test(msg))
+      const matched = warnCalls.find((msg) => /no `persist` option configured/.test(msg))
       expect(matched).toBeUndefined()
     } finally {
       warnSpy.mockRestore()
@@ -1074,7 +1070,7 @@ describe('persistence — reset wipes the persisted draft', () => {
       await drain()
       const matchCount = warnSpy.mock.calls
         .map((args) => args.join(' '))
-        .filter((msg) => /no `persist:` option is configured/.test(msg)).length
+        .filter((msg) => /no `persist` option configured/.test(msg)).length
       expect(matchCount).toBe(1)
     } finally {
       warnSpy.mockRestore()

--- a/test/composables/persistence.test.ts
+++ b/test/composables/persistence.test.ts
@@ -376,8 +376,13 @@ describe('persistence — non-opted-in transient-empty paths survive hydration',
             withDirectives(h('input', { type: 'text', class: 'email' }), [
               [vRegister, api.register('email', { persist: true })],
             ]),
-            // `salary` is NOT opted in for persistence.
-            withDirectives(h('input', { type: 'text', class: 'salary' }), [
+            // `salary` is NOT opted in for persistence. Use
+            // `type="number"` so this test exercises the exact
+            // browser-DOM path the playground bug reproduces (the
+            // user-visible regression was that the numeric input
+            // displayed `0` after hydration when it should have
+            // displayed empty).
+            withDirectives(h('input', { type: 'number', class: 'salary' }), [
               [vRegister, api.register('salary')],
             ]),
           ])
@@ -407,8 +412,17 @@ describe('persistence — non-opted-in transient-empty paths survive hydration',
     // (empty) array, dropping 'salary' from the set.
     expect(captured.api.transientEmptyPaths.value.has('["salary"]')).toBe(true)
 
-    // The user-visible consequence: salary displays as '' (transient-
-    // empty bypass), not '0'. Storage still holds the slim default.
+    // The user-visible consequence: the registered displayValue is
+    // `''` (transient-empty bypass), not `'0'`. The compile-time
+    // input-text-area transform binds `:value="...displayValue.value"`
+    // on the rendered <input>, so this assertion is the runtime
+    // contract that drives the user-visible empty field. Storage
+    // still holds the slim default.
+    //
+    // (The DOM <input>.value would also be `''` in production via
+    // that synthesized binding; raw-`h()` tests skip the transform,
+    // so the DOM-side check would only pass if we compiled the
+    // template — overkill for this regression.)
     expect(captured.api.register('salary').displayValue.value).toBe('')
     expect(captured.api.getValue('salary').value).toBe(0)
   })

--- a/test/composables/persistence.test.ts
+++ b/test/composables/persistence.test.ts
@@ -8,6 +8,7 @@ import { vRegister } from '../../src/runtime/core/directive'
 import { __resetIndexedDbForTests } from '../../src/runtime/core/persistence/indexeddb'
 import { createChemicalXForms } from '../../src/runtime/core/plugin'
 import { fingerprintZodSchema } from '../../src/runtime/adapters/zod-v4/fingerprint'
+import { hashStableString } from '../../src/runtime/core/hash'
 
 /**
  * Node 25's native `localStorage` (behind `--experimental-webstorage`)
@@ -86,7 +87,11 @@ const schema = z.object({
  * pre-seeded entry is treated as an orphan (stale-fingerprint) and
  * cleaned up on mount instead of rehydrating.
  */
-const FP = fingerprintZodSchema(schema)
+// Storage keys hash the structural fingerprint via cyrb53 to avoid
+// embedding the schema's full shape in localStorage entries. Mirror
+// the runtime's transformation here so tests that pre-seed or read
+// keys directly use the same suffix the form looks up.
+const FP = hashStableString(fingerprintZodSchema(schema))
 const fpKey = (base: string): string => `${base}:${FP}`
 
 type ApiReturn = ReturnType<typeof useForm<typeof schema>>
@@ -337,10 +342,10 @@ describe('persistence — non-opted-in transient-empty paths survive hydration',
       email: z.string(),
       salary: z.number(),
     })
-    const customFp = fingerprintZodSchema(customSchema)
+    const customFp = hashStableString(fingerprintZodSchema(customSchema))
     // Default `resolveStorageKeyBase`: `${PERSISTENCE_KEY_PREFIX}${formKey}`,
     // and PERSISTENCE_KEY_PREFIX is 'chemical-x-forms:'. Then the full
-    // storage key appends `:${fingerprint}`.
+    // storage key appends `:${hashedFingerprint}`.
     const customKey = `chemical-x-forms:test-non-optin-tep:${customFp}`
 
     // Pre-seed sessionStorage with a payload representing the state
@@ -426,6 +431,134 @@ describe('persistence — sessionStorage backend', () => {
     expect(raw).not.toBeNull()
     const payload = JSON.parse(raw as string) as { data: { form: { email: string } } }
     expect(payload.data.form.email).toBe('sess@example.com')
+  })
+})
+
+/**
+ * Repro for the playground bug: a developer wires `persist: 'local'`,
+ * the form writes to localStorage, then they switch to
+ * `persist: 'session'`. The sessionStorage entry appears (correctly)
+ * but the localStorage entry is left orphaned.
+ *
+ * The sweep at use-abstract-form.ts:150 (sweepNonConfiguredStandard
+ * StoresForOrphans) is supposed to handle this — it walks every
+ * non-configured standard backend and removes keys under the form's
+ * persistence base. The test below pins the contract for stable form
+ * keys; the anonymous-form variant is harder because the anon counter
+ * drifts under HMR (see the "stable across remounts" test).
+ */
+/**
+ * Anonymous + persist is unsafe by construction (synthetic key drifts
+ * on remount, can collide between unrelated forms with the same
+ * schema → cross-form data leakage). Dev throws AnonPersistError;
+ * prod warns and disables persistence for that form.
+ *
+ * Tests run with `__DEV__` true (Vitest default), so the throw path
+ * is exercised. The prod-warn-and-disable path is verified by
+ * stubbing `__DEV__` to false in a separate test.
+ */
+describe('persistence — anonymous useForm() rejects persist (dev throw)', () => {
+  const apps: App[] = []
+  beforeEach(() => {
+    sessionStorage.clear()
+    localStorage.clear()
+  })
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+    sessionStorage.clear()
+    localStorage.clear()
+  })
+
+  it('throws AnonPersistError when useForm has no key + persist is configured', () => {
+    const customSchema = z.object({ email: z.string() })
+    const App = defineComponent({
+      setup() {
+        // No `key:` → anonymous identity → throws.
+        useForm({ schema: customSchema, persist: 'session' })
+        return () => h('div')
+      },
+    })
+    const app = createApp(App).use(createChemicalXForms())
+    apps.push(app)
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+
+    // Vue's app.mount surfaces setup-time throws — capture and assert.
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      let caught: unknown = null
+      try {
+        app.mount(root)
+      } catch (err) {
+        caught = err
+      }
+      // Vue may swallow the setup throw and route it through its
+      // app-level handler; either way the message must reach the
+      // console.error stream.
+      const seenViaErrSpy = errSpy.mock.calls
+        .flat()
+        .some(
+          (arg) =>
+            (arg instanceof Error && /persist:.*requires an explicit key/.test(arg.message)) ||
+            (typeof arg === 'string' && /persist:.*requires an explicit key/.test(arg))
+        )
+      const seenViaCatch =
+        caught instanceof Error && /persist:.*requires an explicit key/.test(caught.message)
+      expect(seenViaErrSpy || seenViaCatch).toBe(true)
+    } finally {
+      errSpy.mockRestore()
+    }
+  })
+
+  it('does NOT throw when useForm has an explicit key + persist', async () => {
+    const { app, type } = mountForm({ storage: 'session', key: 'test-explicit', debounceMs: 20 })
+    apps.push(app)
+    await drain()
+    type('email', 'works@example.com')
+    const raw = await waitUntil(() => sessionStorage.getItem(fpKey('test-explicit')))
+    expect(raw).not.toBeNull()
+  })
+})
+
+describe('persistence — backend swap cleans up the prior backend', () => {
+  const apps: App[] = []
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+
+  it('switching local → session removes the old localStorage entry', async () => {
+    // Mount 1: persist to localStorage.
+    const first = mountForm({ storage: 'local', key: 'swap-test', debounceMs: 20 })
+    apps.push(first.app)
+    await drain()
+    first.type('email', 'mango')
+    await waitUntil(() => localStorage.getItem(fpKey('swap-test')))
+    expect(localStorage.getItem(fpKey('swap-test'))).not.toBeNull()
+    expect(sessionStorage.getItem(fpKey('swap-test'))).toBeNull()
+
+    // Tear down (mirrors the developer's edit-config-and-refresh flow).
+    first.app.unmount()
+    apps.length = 0
+
+    // Mount 2: SAME persist key, different storage backend.
+    const second = mountForm({ storage: 'session', key: 'swap-test', debounceMs: 20 })
+    apps.push(second.app)
+    // Drain microtasks for the cross-store sweep to land. The sweep
+    // is fire-and-forget; we wait via the negative-condition predicate.
+    await waitUntil(() => (localStorage.getItem(fpKey('swap-test')) === null ? true : null))
+
+    expect(localStorage.getItem(fpKey('swap-test'))).toBeNull()
+
+    // Sanity: writing into the new mount lands in sessionStorage.
+    second.type('email', 'mang')
+    await waitUntil(() => sessionStorage.getItem(fpKey('swap-test')))
+    expect(sessionStorage.getItem(fpKey('swap-test'))).not.toBeNull()
   })
 })
 

--- a/test/composables/radio.test.ts
+++ b/test/composables/radio.test.ts
@@ -1,0 +1,389 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, withDirectives, type App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { vRegister } from '../../src/runtime/core/directive'
+import { createChemicalXForms } from '../../src/runtime/core/plugin'
+
+/**
+ * `<input type="radio" v-register>` end-to-end coverage.
+ *
+ * Radio model is always SCALAR — the option-value of the currently
+ * checked radio. Every radio in a group shares one register binding
+ * and carries a distinct `value="..."`. The directive reflects model
+ * changes onto `el.checked` and writes the selected option-value back
+ * on change events.
+ *
+ * Mirror of `checkbox.test.ts` for symmetry; coverage targets the
+ * same regression classes (initial-state hydration, static-attr
+ * hydration, slim-gate interactions).
+ */
+
+async function flush(): Promise<void> {
+  for (let i = 0; i < 4; i++) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+function dispatchChange(el: HTMLInputElement): void {
+  el.dispatchEvent(new Event('change', { bubbles: true }))
+}
+
+describe('<input type="radio" v-register> — single-group selection', () => {
+  let app: App | undefined
+
+  afterEach(() => {
+    app?.unmount()
+    app = undefined
+    document.body.innerHTML = ''
+  })
+
+  it('selecting a radio writes its option-value to the model', async () => {
+    const schema = z.object({ tier: z.enum(['free', 'pro', 'enterprise']) })
+    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+
+    const Parent = defineComponent({
+      setup() {
+        const form = useForm({
+          schema,
+          key: 'radio-select',
+          // z.enum's slim default is the first member ('free') — opt
+          // into 'pro' as the construction-time selection so the test
+          // exercises a real user choice rather than the implicit default.
+          defaultValues: { tier: 'pro' },
+          validationMode: 'lax',
+        })
+        captured.api = form
+        return () =>
+          h('div', [
+            withDirectives(h('input', { type: 'radio', value: 'free', class: 'free' }), [
+              [vRegister, form.register('tier')],
+            ]),
+            withDirectives(h('input', { type: 'radio', value: 'pro', class: 'pro' }), [
+              [vRegister, form.register('tier')],
+            ]),
+            withDirectives(h('input', { type: 'radio', value: 'enterprise', class: 'ent' }), [
+              [vRegister, form.register('tier')],
+            ]),
+          ])
+      },
+    })
+
+    app = createApp(Parent).use(createChemicalXForms())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await flush()
+
+    if (captured.api === undefined) throw new Error('unreachable')
+    const free = root.querySelector('input.free') as HTMLInputElement
+    const pro = root.querySelector('input.pro') as HTMLInputElement
+    const ent = root.querySelector('input.ent') as HTMLInputElement
+
+    // Mount: only `pro` checked (the default).
+    expect(free.checked).toBe(false)
+    expect(pro.checked).toBe(true)
+    expect(ent.checked).toBe(false)
+    expect(captured.api.getValue('tier').value).toBe('pro')
+
+    // User selects `enterprise` — fire the change handler. (Setting
+    // .checked = true on a radio doesn't auto-uncheck siblings in
+    // jsdom; we do that manually to mirror real browser behavior.)
+    free.checked = false
+    pro.checked = false
+    ent.checked = true
+    dispatchChange(ent)
+    await flush()
+    expect(captured.api.getValue('tier').value).toBe('enterprise')
+
+    // User selects `free`.
+    free.checked = true
+    pro.checked = false
+    ent.checked = false
+    dispatchChange(free)
+    await flush()
+    expect(captured.api.getValue('tier').value).toBe('free')
+  })
+
+  it('mounts with el.checked synced to the model', async () => {
+    const schema = z.object({ tier: z.enum(['free', 'pro', 'enterprise']) })
+    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+
+    const Parent = defineComponent({
+      setup() {
+        const form = useForm({
+          schema,
+          key: 'radio-mount',
+          defaultValues: { tier: 'enterprise' },
+          validationMode: 'lax',
+        })
+        captured.api = form
+        return () =>
+          h('div', [
+            withDirectives(h('input', { type: 'radio', value: 'free', class: 'free' }), [
+              [vRegister, form.register('tier')],
+            ]),
+            withDirectives(h('input', { type: 'radio', value: 'pro', class: 'pro' }), [
+              [vRegister, form.register('tier')],
+            ]),
+            withDirectives(h('input', { type: 'radio', value: 'enterprise', class: 'ent' }), [
+              [vRegister, form.register('tier')],
+            ]),
+          ])
+      },
+    })
+
+    app = createApp(Parent).use(createChemicalXForms())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await flush()
+
+    expect((root.querySelector('input.free') as HTMLInputElement).checked).toBe(false)
+    expect((root.querySelector('input.pro') as HTMLInputElement).checked).toBe(false)
+    expect((root.querySelector('input.ent') as HTMLInputElement).checked).toBe(true)
+  })
+
+  it('reflects programmatic setValue on the radio elements (re-render path)', async () => {
+    // The model→DOM direction requires either the compile-time
+    // input-text-area-transform's synthesized `:checked` binding
+    // (production path — Vue tracks the binding and patches `el.checked`
+    // on every reactive update) OR a parent re-render that fires the
+    // directive's `beforeUpdate` hook. This raw-`h()` test covers the
+    // latter: include the form's value in the render function so a
+    // setValue call triggers a re-render → `beforeUpdate` → setChecked.
+    const schema = z.object({ tier: z.enum(['free', 'pro', 'enterprise']) })
+    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+
+    const Parent = defineComponent({
+      setup() {
+        const form = useForm({
+          schema,
+          key: 'radio-setvalue',
+          defaultValues: { tier: 'free' },
+          validationMode: 'lax',
+        })
+        captured.api = form
+        const tierRef = form.getValue('tier')
+        return () =>
+          h('div', [
+            // Read tierRef so the parent re-renders on form-state
+            // change — mirrors what a real template does when it
+            // renders any reactive form-derived value.
+            h('span', { class: 'tier-label' }, String(tierRef.value)),
+            withDirectives(h('input', { type: 'radio', value: 'free', class: 'free' }), [
+              [vRegister, form.register('tier')],
+            ]),
+            withDirectives(h('input', { type: 'radio', value: 'pro', class: 'pro' }), [
+              [vRegister, form.register('tier')],
+            ]),
+          ])
+      },
+    })
+
+    app = createApp(Parent).use(createChemicalXForms())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await flush()
+
+    if (captured.api === undefined) throw new Error('unreachable')
+    const free = root.querySelector('input.free') as HTMLInputElement
+    const pro = root.querySelector('input.pro') as HTMLInputElement
+
+    expect(free.checked).toBe(true)
+    expect(pro.checked).toBe(false)
+    ;(captured.api.setValue as (path: 'tier', value: 'pro') => boolean)('tier', 'pro')
+    await flush()
+    expect(free.checked).toBe(false)
+    expect(pro.checked).toBe(true)
+  })
+
+  it('mounts with NO radio checked when the model matches no option-value', async () => {
+    // Out-of-enum default — slim-gate-incompatible with strict zod
+    // parsing but the slim primitive (string) accepts it. The radio
+    // group should leave every option unchecked rather than picking
+    // an arbitrary one.
+    const schema = z.object({ tier: z.enum(['free', 'pro', 'enterprise']) })
+    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+
+    const Parent = defineComponent({
+      setup() {
+        const form = useForm({
+          schema,
+          key: 'radio-no-match',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          defaultValues: { tier: 'unknown' as any },
+          validationMode: 'lax',
+        })
+        captured.api = form
+        return () =>
+          h('div', [
+            withDirectives(h('input', { type: 'radio', value: 'free', class: 'free' }), [
+              [vRegister, form.register('tier')],
+            ]),
+            withDirectives(h('input', { type: 'radio', value: 'pro', class: 'pro' }), [
+              [vRegister, form.register('tier')],
+            ]),
+          ])
+      },
+    })
+
+    app = createApp(Parent).use(createChemicalXForms())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await flush()
+
+    expect((root.querySelector('input.free') as HTMLInputElement).checked).toBe(false)
+    expect((root.querySelector('input.pro') as HTMLInputElement).checked).toBe(false)
+  })
+})
+
+describe('<input type="radio" v-register> — hydration with static value attribute', () => {
+  let app: App | undefined
+
+  afterEach(() => {
+    app?.unmount()
+    app = undefined
+    document.body.innerHTML = ''
+  })
+
+  it('honors the DOM value attribute when Vue has not patched _value (post-hydrate shape)', async () => {
+    // Mirror of the checkbox hydration test: SSR renders <input
+    // type="radio" value="pro"> as a static attribute; Vue's
+    // hydration fast path skips patchProp, so el._value isn't set.
+    // The directive must still resolve the option-value via the DOM
+    // attribute (el.value) so el.checked reflects the model.
+    const schema = z.object({ tier: z.enum(['free', 'pro', 'enterprise']) })
+    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+
+    const Parent = defineComponent({
+      setup() {
+        const form = useForm({
+          schema,
+          key: 'radio-static-value',
+          defaultValues: { tier: 'pro' },
+          validationMode: 'lax',
+        })
+        captured.api = form
+        // Read the form value so a setValue() triggers a parent
+        // re-render → directive's `beforeUpdate` → setChecked. Without
+        // this read, the raw-`h()` parent doesn't subscribe to form
+        // state and the directive's beforeUpdate never fires.
+        // (The compile-time input-text-area transform's synthesized
+        // `:checked` binding makes this implicit in real templates.)
+        const tierRef = form.getValue('tier')
+        return () =>
+          h('div', [
+            h('span', { class: 'tier-label' }, String(tierRef.value)),
+            withDirectives(h('input', { type: 'radio', value: 'free', class: 'free' }), [
+              [vRegister, form.register('tier')],
+            ]),
+            withDirectives(h('input', { type: 'radio', value: 'pro', class: 'pro' }), [
+              [vRegister, form.register('tier')],
+            ]),
+          ])
+      },
+    })
+
+    app = createApp(Parent).use(createChemicalXForms())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await flush()
+
+    if (captured.api === undefined) throw new Error('unreachable')
+    const free = root.querySelector('input.free') as HTMLInputElement
+    const pro = root.querySelector('input.pro') as HTMLInputElement
+
+    // Strip the Vue-patched _value to mimic post-hydration shape.
+    delete (free as unknown as { _value?: unknown })._value
+    delete (pro as unknown as { _value?: unknown })._value
+
+    // Trigger a model change so beforeUpdate fires setChecked, which
+    // is the path that reads vnode.props?.['value'] (post-fix:
+    // getValue(el) with the DOM-attribute fallback).
+    ;(captured.api.setValue as (path: 'tier', value: 'free') => boolean)('tier', 'free')
+    await flush()
+
+    expect(free.checked).toBe(true)
+    expect(pro.checked).toBe(false)
+  })
+})
+
+describe('<input type="radio" v-register> — slim-gate interactions', () => {
+  let app: App | undefined
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  afterEach(() => {
+    app?.unmount()
+    app = undefined
+    warnSpy?.mockRestore()
+    document.body.innerHTML = ''
+  })
+
+  it('rejects a non-string write to a string-enum-bound radio path', async () => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const schema = z.object({ tier: z.enum(['free', 'pro']) })
+    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+
+    const Parent = defineComponent({
+      setup() {
+        captured.api = useForm({
+          schema,
+          key: 'radio-gate',
+          defaultValues: { tier: 'free' },
+          validationMode: 'lax',
+        })
+        return () => h('div')
+      },
+    })
+
+    app = createApp(Parent).use(createChemicalXForms())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await flush()
+
+    if (captured.api === undefined) throw new Error('unreachable')
+    // z.enum(['free','pro']) slim = string. Writing a number is rejected
+    // by the slim-primitive gate (kind mismatch).
+    const setVal = captured.api.setValue as (path: 'tier', value: unknown) => boolean
+    expect(setVal('tier', 1)).toBe(false)
+    expect(captured.api.getValue('tier').value).toBe('free')
+  })
+
+  it('accepts an out-of-enum string (refinement check, not a write-time gate)', async () => {
+    const schema = z.object({ tier: z.enum(['free', 'pro']) })
+    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+
+    const Parent = defineComponent({
+      setup() {
+        captured.api = useForm({
+          schema,
+          key: 'radio-out-of-enum',
+          defaultValues: { tier: 'free' },
+          validationMode: 'lax',
+        })
+        return () => h('div')
+      },
+    })
+
+    app = createApp(Parent).use(createChemicalXForms())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await flush()
+
+    if (captured.api === undefined) throw new Error('unreachable')
+    // The slim primitive for z.enum(string) is just 'string'; the
+    // enum-membership constraint is a refinement that surfaces via
+    // field-level validation, not the slim-gate.
+    const setVal = captured.api.setValue as (path: 'tier', value: unknown) => boolean
+    expect(setVal('tier', 'unknown-tier')).toBe(true)
+    expect(captured.api.getValue('tier').value).toBe('unknown-tier')
+  })
+})

--- a/test/composables/register-display-value.test.ts
+++ b/test/composables/register-display-value.test.ts
@@ -8,7 +8,7 @@ import { attachRegistryToApp, createRegistry } from '../../src/runtime/core/regi
 import type { UseAbstractFormReturnType } from '../../src/runtime/types/types-api'
 
 /**
- * Coverage for `displayValue` and `markTransientEmpty` on
+ * Coverage for `displayValue` and `markBlank` on
  * `RegisterValue` (commit 3). The transforms (`commit 4`) and
  * directive (commit 5) plug these into the UI flow; here we test the
  * contract directly through the register binding.
@@ -72,17 +72,17 @@ describe('displayValue', () => {
     expect(form.register('note').displayValue.value).toBe('')
   })
 
-  it('returns "" when the path is in transientEmptyPaths', () => {
+  it('returns "" when the path is in blankPaths', () => {
     const schema = z.object({ count: z.number() })
     // Pass explicit defaults to opt out of construction-time auto-mark
-    // — this test isolates the markTransientEmpty() flip path.
+    // — this test isolates the markBlank() flip path.
     const { app, form } = setupForm(schema, { count: 0 })
     apps.push(app)
     const binding = form.register('count')
     expect(binding.displayValue.value).toBe('0')
-    // Mark transient-empty — storage stays at slim default but
+    // Mark blank — storage stays at slim default but
     // displayValue switches to ''.
-    binding.markTransientEmpty()
+    binding.markBlank()
     expect(binding.displayValue.value).toBe('')
   })
 
@@ -97,7 +97,7 @@ describe('displayValue', () => {
   it('reactively updates when storage changes', () => {
     const schema = z.object({ count: z.number() })
     // Explicit defaults so the binding starts un-marked (auto-mark
-    // would prepopulate transientEmptyPaths and force '').
+    // would prepopulate blankPaths and force '').
     const { app, form } = setupForm(schema, { count: 0 })
     apps.push(app)
     const binding = form.register('count')
@@ -106,12 +106,12 @@ describe('displayValue', () => {
     expect(binding.displayValue.value).toBe('7')
   })
 
-  it('reactively switches when transient-empty membership changes', () => {
+  it('reactively switches when blank membership changes', () => {
     const schema = z.object({ count: z.number() })
     const { app, form } = setupForm(schema)
     apps.push(app)
     const binding = form.register('count')
-    binding.markTransientEmpty()
+    binding.markBlank()
     expect(binding.displayValue.value).toBe('')
     form.setValue('count', 5)
     expect(binding.displayValue.value).toBe('5')
@@ -174,7 +174,7 @@ describe('displayValue', () => {
   })
 })
 
-describe('markTransientEmpty', () => {
+describe('markBlank', () => {
   const apps: App[] = []
   afterEach(() => {
     while (apps.length > 0) apps.pop()?.unmount()
@@ -187,11 +187,11 @@ describe('markTransientEmpty', () => {
     form.setValue('count', 99)
 
     const binding = form.register('count')
-    const ok = binding.markTransientEmpty()
+    const ok = binding.markBlank()
     expect(ok).toBe(true)
     // Slim default for z.number() is 0.
     expect(form.getValue('count').value).toBe(0)
-    // pendingEmpty surfaces through the form's transientEmptyPaths
+    // blank surfaces through the form's blankPaths
     // (commit 7 wires the public meta accessor; for now we read the
     // FormStore set indirectly via getValue still showing 0 with
     // displayValue '').
@@ -202,7 +202,7 @@ describe('markTransientEmpty', () => {
     const schema = z.object({ count: z.number() })
     const { app, form } = setupForm(schema)
     apps.push(app)
-    expect(form.register('count').markTransientEmpty()).toBe(true)
+    expect(form.register('count').markBlank()).toBe(true)
   })
 
   it('uses the canonical path key when adding to the reactive set', () => {
@@ -210,8 +210,8 @@ describe('markTransientEmpty', () => {
     const { app, form } = setupForm(schema)
     apps.push(app)
     const binding = form.register('user.income')
-    binding.markTransientEmpty()
-    // displayValue branch hits via state.transientEmptyPaths.has(pathKey).
+    binding.markBlank()
+    // displayValue branch hits via state.blankPaths.has(pathKey).
     expect(binding.displayValue.value).toBe('')
     void canonicalizePath('user.income')
   })
@@ -221,7 +221,7 @@ describe('markTransientEmpty', () => {
     const { app, form } = setupForm(schema)
     apps.push(app)
     const binding = form.register('count')
-    binding.markTransientEmpty()
+    binding.markBlank()
     expect(binding.displayValue.value).toBe('')
     form.setValue('count', 5)
     expect(binding.displayValue.value).toBe('5')

--- a/test/composables/slim-primitive-write-gate-v3.property.test.ts
+++ b/test/composables/slim-primitive-write-gate-v3.property.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+import { fc, test } from '@fast-check/vitest'
+import { afterEach, beforeEach, describe, expect, vi } from 'vitest'
+import type { App } from 'vue'
+import { z } from 'zod-v3'
+import { useForm } from '../../src/zod-v3'
+import { zodAdapter } from '../../src/runtime/adapters/zod-v3'
+import { getAtPath } from '../../src/runtime/core/path-walker'
+import type { SlimPrimitiveKind } from '../../src/runtime/types/types-api'
+import { flush, makeMounter } from '../utils/form-harness'
+import {
+  arbitraryValueOfKind,
+  buildSchemaWithManifest,
+  COMPARABLE_KINDS,
+  type ComparableKind,
+} from '../utils/schema-manifest'
+
+/**
+ * Mirror of `slim-primitive-write-gate.property.test.ts`, targeting
+ * the zod v3 adapter. The generator and harness are shared; this file
+ * differs only in its imports (`zod-v3`, the v3 useForm/zodAdapter).
+ *
+ * The v3 adapter shipped the same unknown-path bug as v4 (returning
+ * `PERMISSIVE` instead of an empty set) and got the same fix; this
+ * test confirms the fix holds at the v3 boundary too.
+ */
+
+const arbSchema = buildSchemaWithManifest(z, 3)
+
+type SetValueFn = (path: string, value: unknown) => boolean
+
+describe('slim-primitive write gate — property: manifest sanity (v3)', () => {
+  test.prop([arbSchema])(
+    'manifest leaf accept-sets equal adapter.getSlimPrimitiveTypesAtPath',
+    ({ schema, leaves }) => {
+      const adapter = zodAdapter(schema as z.ZodObject<z.ZodRawShape>)('manifest-sanity')
+      for (const leaf of leaves) {
+        const adapterSet = adapter.getSlimPrimitiveTypesAtPath(leaf.path)
+        expect([...adapterSet].sort()).toEqual([...leaf.acceptSet].sort())
+      }
+    }
+  )
+})
+
+describe('slim-primitive write gate — property: known leaf paths (v3)', () => {
+  const apps: App[] = []
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+  afterEach(async () => {
+    while (apps.length > 0) apps.pop()?.unmount()
+    warnSpy.mockRestore()
+    await flush()
+  })
+
+  test.prop([
+    arbSchema.chain((sm) =>
+      fc
+        .record({
+          leafIdx: fc.nat({ max: sm.leaves.length - 1 }),
+          kind: fc.constantFrom<ComparableKind>(...COMPARABLE_KINDS),
+        })
+        .chain(({ leafIdx, kind }) =>
+          arbitraryValueOfKind(kind).map((value) => ({ sm, leafIdx, kind, value }))
+        )
+    ),
+  ])(
+    'setValue accepts iff value-kind ∈ leaf.acceptSet; leaf reflects the write',
+    async ({ sm, leafIdx, kind, value }) => {
+      const leaf = sm.leaves[leafIdx]
+      if (leaf === undefined) return
+      const expected = leaf.acceptSet.has(kind as SlimPrimitiveKind)
+
+      const { api, app } = makeMounter(useForm, sm.schema)()
+      apps.push(app)
+
+      const beforeForm = api.getValue().value
+      const ok = (api.setValue as SetValueFn)(leaf.path.join('.'), value)
+      await flush()
+
+      expect(ok).toBe(expected)
+
+      if (expected) {
+        expect(getAtPath(api.getValue().value, leaf.path)).toEqual(value)
+      } else {
+        expect(api.getValue().value).toBe(beforeForm)
+      }
+    }
+  )
+})
+
+describe('slim-primitive write gate — property: unknown paths (v3)', () => {
+  const apps: App[] = []
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+  afterEach(async () => {
+    while (apps.length > 0) apps.pop()?.unmount()
+    warnSpy.mockRestore()
+    await flush()
+  })
+
+  test.prop([
+    arbSchema.chain((sm) =>
+      fc
+        .record({
+          leafIdx: fc.nat({ max: sm.leaves.length - 1 }),
+          kind: fc.constantFrom<ComparableKind>(...COMPARABLE_KINDS),
+        })
+        .chain(({ leafIdx, kind }) =>
+          arbitraryValueOfKind(kind).map((value) => ({ sm, leafIdx, value }))
+        )
+    ),
+  ])(
+    'setValue to a path not defined in the schema rejects; form unchanged',
+    async ({ sm, leafIdx, value }) => {
+      const realLeaf = sm.leaves[leafIdx]
+      if (realLeaf === undefined) return
+
+      const unknownPath = [...realLeaf.path, '__unknown_xx'].join('.')
+
+      const { api, app } = makeMounter(useForm, sm.schema)()
+      apps.push(app)
+
+      const beforeForm = api.getValue().value
+      const ok = (api.setValue as SetValueFn)(unknownPath, value)
+      await flush()
+
+      expect(ok).toBe(false)
+      expect(api.getValue().value).toBe(beforeForm)
+    }
+  )
+})

--- a/test/composables/slim-primitive-write-gate.property.test.ts
+++ b/test/composables/slim-primitive-write-gate.property.test.ts
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+import { fc, test } from '@fast-check/vitest'
+import { afterEach, beforeEach, describe, expect, vi } from 'vitest'
+import type { App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { zodAdapter } from '../../src/runtime/adapters/zod-v4'
+import { getAtPath } from '../../src/runtime/core/path-walker'
+import type { SlimPrimitiveKind } from '../../src/runtime/types/types-api'
+import { flush, makeMounter } from '../utils/form-harness'
+import {
+  arbitraryValueOfKind,
+  buildSchemaWithManifest,
+  COMPARABLE_KINDS,
+  type ComparableKind,
+} from '../utils/schema-manifest'
+
+/**
+ * Property tests for the slim-primitive write gate (zod v4 adapter).
+ *
+ * Three properties cover the gate's contract end-to-end. The "manifest
+ * sanity" property must run first conceptually — if it fails, the
+ * generator (and therefore the other two properties) is testing the
+ * wrong thing.
+ *
+ * Mirror file: `slim-primitive-write-gate-v3.property.test.ts` runs
+ * the same three properties against the v3 adapter; the generator is
+ * shared via `test/utils/schema-manifest.ts`.
+ */
+
+const arbSchema = buildSchemaWithManifest(z, 3)
+
+// `setValue`'s typed signature on `useForm<S>` is `(path: string, value: any)
+// => boolean` for non-callback writes; cast through `unknown` once at
+// the helper boundary so each call site stays terse.
+type SetValueFn = (path: string, value: unknown) => boolean
+
+describe('slim-primitive write gate — property: manifest sanity (v4)', () => {
+  // No setValue here — directly reconciles the generator's recorded
+  // accept-set against the adapter's `getSlimPrimitiveTypesAtPath`.
+  // Failure means the generator (the test's oracle) is wrong.
+  test.prop([arbSchema])(
+    'manifest leaf accept-sets equal adapter.getSlimPrimitiveTypesAtPath',
+    ({ schema, leaves }) => {
+      const adapter = zodAdapter(schema as z.ZodObject)('manifest-sanity')
+      for (const leaf of leaves) {
+        const adapterSet = adapter.getSlimPrimitiveTypesAtPath(leaf.path)
+        expect([...adapterSet].sort()).toEqual([...leaf.acceptSet].sort())
+      }
+    }
+  )
+})
+
+describe('slim-primitive write gate — property: known leaf paths (v4)', () => {
+  const apps: App[] = []
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+  afterEach(async () => {
+    while (apps.length > 0) apps.pop()?.unmount()
+    warnSpy.mockRestore()
+    await flush()
+  })
+
+  test.prop([
+    // Two-stage chain: first generate the schema (so we know its
+    // leaves), then pick a leaf index and a kind, then sample a value
+    // of that kind. Using `chain` keeps everything correlated within
+    // a single arbitrary so fast-check's shrinker can collapse the
+    // whole tuple toward a minimal failing case.
+    arbSchema.chain((sm) =>
+      fc
+        .record({
+          leafIdx: fc.nat({ max: sm.leaves.length - 1 }),
+          kind: fc.constantFrom<ComparableKind>(...COMPARABLE_KINDS),
+        })
+        .chain(({ leafIdx, kind }) =>
+          arbitraryValueOfKind(kind).map((value) => ({ sm, leafIdx, kind, value }))
+        )
+    ),
+  ])(
+    'setValue accepts iff value-kind ∈ leaf.acceptSet; leaf reflects the write',
+    async ({ sm, leafIdx, kind, value }) => {
+      const leaf = sm.leaves[leafIdx]
+      if (leaf === undefined) return // generator invariant; never reached
+      const expected = leaf.acceptSet.has(kind as SlimPrimitiveKind)
+
+      const { api, app } = makeMounter(useForm, sm.schema)()
+      apps.push(app)
+
+      // Capture the form ref's pre-write value identity. Accepted writes
+      // that produce a real change replace `form.value` via
+      // `applyFormReplacement` (create-form-store.ts:649); rejected
+      // writes return early at the slim-gate (line 603) and don't
+      // touch the ref. Identity equality is therefore a tight
+      // "no mutation happened" check that sidesteps cloning Vue's
+      // reactive proxy (structuredClone refuses it).
+      const beforeForm = api.getValue().value
+
+      const ok = (api.setValue as SetValueFn)(leaf.path.join('.'), value)
+      await flush()
+
+      expect(ok).toBe(expected)
+
+      if (expected) {
+        // Leaf at the written path must equal the written value.
+        // `toEqual` handles Date/BigInt/null/undefined/primitives uniformly.
+        expect(getAtPath(api.getValue().value, leaf.path)).toEqual(value)
+      } else {
+        // Rejected: form ref must hold the same identity. A "rejected
+        // but partially applied" bug would replace the ref and fail this.
+        expect(api.getValue().value).toBe(beforeForm)
+      }
+    }
+  )
+})
+
+describe('slim-primitive write gate — property: unknown paths (v4)', () => {
+  const apps: App[] = []
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+  afterEach(async () => {
+    while (apps.length > 0) apps.pop()?.unmount()
+    warnSpy.mockRestore()
+    await flush()
+  })
+
+  test.prop([
+    arbSchema.chain((sm) =>
+      fc
+        .record({
+          leafIdx: fc.nat({ max: sm.leaves.length - 1 }),
+          kind: fc.constantFrom<ComparableKind>(...COMPARABLE_KINDS),
+        })
+        .chain(({ leafIdx, kind }) =>
+          arbitraryValueOfKind(kind).map((value) => ({ sm, leafIdx, value }))
+        )
+    ),
+  ])(
+    'setValue to a path not defined in the schema rejects; form unchanged',
+    async ({ sm, leafIdx, value }) => {
+      const realLeaf = sm.leaves[leafIdx]
+      if (realLeaf === undefined) return
+
+      // Append a sentinel segment that the schema generator can never
+      // emit. The object-key arbitrary requires
+      // `^[a-zA-Z_][a-zA-Z0-9_]*$` with maxLength 4 — `__unknown_xx`
+      // is 12 chars, so it cannot match a generated key regardless of
+      // schema shape. Tacking it onto a real path produces "real
+      // parent + unknown tail" coverage; the schema variation across
+      // runs gives us the missing-root-segment case naturally too.
+      const unknownPath = [...realLeaf.path, '__unknown_xx'].join('.')
+
+      const { api, app } = makeMounter(useForm, sm.schema)()
+      apps.push(app)
+
+      const beforeForm = api.getValue().value
+      const ok = (api.setValue as SetValueFn)(unknownPath, value)
+      await flush()
+
+      expect(ok).toBe(false)
+      expect(api.getValue().value).toBe(beforeForm)
+    }
+  )
+})

--- a/test/composables/slim-primitive-write-gate.test.ts
+++ b/test/composables/slim-primitive-write-gate.test.ts
@@ -1,9 +1,9 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createApp, defineComponent, h, nextTick, type App } from 'vue'
+import { type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { flush, makeMounter as makeMounterShared } from '../utils/form-harness'
 
 /**
  * The slim-primitive write contract.
@@ -27,31 +27,13 @@ import { createChemicalXForms } from '../../src/runtime/core/plugin'
  * `false`; the form value at the path is unchanged.
  */
 
-async function flush(): Promise<void> {
-  for (let i = 0; i < 4; i++) {
-    await Promise.resolve()
-    await nextTick()
-  }
-}
-
+// Local typed wrapper around the shared harness — this file's tests
+// access useForm<S>'s typed return (e.g. `api.setValue`'s typed
+// `path` parameter) so we narrow back from the harness's `any` here.
 function makeMounter<S extends z.ZodObject>(schema: S) {
-  return function mount(): { api: ReturnType<typeof useForm<S>>; app: App } {
-    const captured: { api?: ReturnType<typeof useForm<S>> } = {}
-    const App = defineComponent({
-      setup() {
-        captured.api = useForm({
-          schema,
-          key: `slim-${Math.random().toString(36).slice(2)}`,
-          validationMode: 'lax',
-        })
-        return () => h('div')
-      },
-    })
-    const app = createApp(App).use(createChemicalXForms())
-    const root = document.createElement('div')
-    document.body.appendChild(root)
-    app.mount(root)
-    return { api: captured.api as ReturnType<typeof useForm<S>>, app }
+  return makeMounterShared(useForm, schema) as () => {
+    api: ReturnType<typeof useForm<S>>
+    app: App
   }
 }
 
@@ -321,5 +303,86 @@ describe('slim-primitive write gate — non-form-key permissive shapes', () => {
     const setVal = api.setValue as (path: 'payload', value: unknown) => boolean
     expect(setVal('payload', 1)).toBe(true)
     expect(setVal('payload', 'x')).toBe(true)
+  })
+})
+
+/**
+ * Writes against paths the schema doesn't define MUST be rejected.
+ * The slim-primitive gate's previous "empty accept set → permissive"
+ * rule conflated three semantically distinct cases: `z.any()`,
+ * `z.never()`, and unknown-path. Only `z.any()` should be permissive.
+ *
+ * Without this, registering an input at a typo path
+ * (`register('address.salary')` against `address: { city }`) silently
+ * creates a bogus `address.salary` slot in the form on first
+ * keystroke, breaking the structural-completeness invariant.
+ */
+describe('slim-primitive write gate — unknown schema paths', () => {
+  const apps: App[] = []
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+  afterEach(async () => {
+    while (apps.length > 0) apps.pop()?.unmount()
+    warnSpy.mockRestore()
+    await flush()
+  })
+
+  it('rejects writes to a leaf path the schema does not define', async () => {
+    const schema = z.object({
+      address: z.object({ city: z.string() }),
+    })
+    const { api, app } = makeMounter(schema)()
+    apps.push(app)
+    const before = JSON.parse(JSON.stringify(api.getValue().value))
+    const ok = (api.setValue as (path: string, value: unknown) => boolean)('address.salary', 'abc')
+    await flush()
+    expect(ok).toBe(false)
+    // Form value unchanged — no `address.salary` slot created.
+    expect(api.getValue().value).toEqual(before)
+  })
+
+  it('rejects writes to an unknown root-level path', async () => {
+    const schema = z.object({ name: z.string() })
+    const { api, app } = makeMounter(schema)()
+    apps.push(app)
+    const before = JSON.parse(JSON.stringify(api.getValue().value))
+    const ok = (api.setValue as (path: string, value: unknown) => boolean)('phantom', 'x')
+    await flush()
+    expect(ok).toBe(false)
+    expect(api.getValue().value).toEqual(before)
+  })
+
+  it('rejects writes that would create a deeply-nested unknown path', async () => {
+    const schema = z.object({
+      profile: z.object({
+        details: z.object({ name: z.string() }),
+      }),
+    })
+    const { api, app } = makeMounter(schema)()
+    apps.push(app)
+    const before = JSON.parse(JSON.stringify(api.getValue().value))
+    const ok = (api.setValue as (path: string, value: unknown) => boolean)(
+      'profile.details.unknown',
+      'x'
+    )
+    await flush()
+    expect(ok).toBe(false)
+    expect(api.getValue().value).toEqual(before)
+  })
+
+  it('rejection emits a dev-warn naming the unknown path', async () => {
+    const schema = z.object({
+      address: z.object({ city: z.string() }),
+    })
+    const { api, app } = makeMounter(schema)()
+    apps.push(app)
+    ;(api.setValue as (path: string, value: unknown) => boolean)('address.salary', 'abc')
+    await flush()
+    expect(warnSpy).toHaveBeenCalled()
+    const message = warnSpy.mock.calls.flat().join(' ')
+    expect(message).toMatch(/address\.salary/)
   })
 })

--- a/test/composables/slim-primitive-write-gate.test.ts
+++ b/test/composables/slim-primitive-write-gate.test.ts
@@ -196,6 +196,22 @@ describe('slim-primitive write gate — rejected writes (wrong primitive)', () =
     expect(message).toMatch(/string|number/)
   })
 
+  it('string-to-number rejection points at the v-register fix paths (type="number" or .number)', async () => {
+    // KISS rule for warns: tell the dev what to do, not just what's
+    // wrong. The string-to-number case is the most common slim-gate
+    // rejection in real apps (a plain `<input v-register>` against a
+    // `z.number()` field types as a string), so the warn must show
+    // both fixes verbatim.
+    const schema = z.object({ salary: z.number() })
+    const { api, app } = makeMounter(schema)()
+    apps.push(app)
+    ;(api.setValue as (path: 'salary', value: unknown) => boolean)('salary', '123')
+    await flush()
+    const message = warnSpy.mock.calls.flat().join(' ')
+    expect(message).toContain('type="number"')
+    expect(message).toContain('.number')
+  })
+
   it('repeated rejection at the same path emits ONE warn (one-shot dedupe)', async () => {
     const schema = z.object({ age: z.number() })
     const { api, app } = makeMounter(schema)()
@@ -384,5 +400,20 @@ describe('slim-primitive write gate — unknown schema paths', () => {
     expect(warnSpy).toHaveBeenCalled()
     const message = warnSpy.mock.calls.flat().join(' ')
     expect(message).toMatch(/address\.salary/)
+  })
+
+  it('unknown-path rejection tells the dev the path is not in the schema', async () => {
+    // KISS rule: name the actual problem ("not in your schema") so the
+    // dev can act on it without a domain lesson on slim primitives.
+    const schema = z.object({
+      address: z.object({ city: z.string() }),
+    })
+    const { api, app } = makeMounter(schema)()
+    apps.push(app)
+    ;(api.setValue as (path: string, value: unknown) => boolean)('address.salary', 'abc')
+    await flush()
+    const message = warnSpy.mock.calls.flat().join(' ')
+    expect(message).toContain('not in your schema')
+    expect(message).toContain('typo')
   })
 })

--- a/test/composables/transient-empty-persistence.test.ts
+++ b/test/composables/transient-empty-persistence.test.ts
@@ -11,7 +11,7 @@ import { hashStableString } from '../../src/runtime/core/hash'
 import { createChemicalXForms } from '../../src/runtime/core/plugin'
 
 /**
- * Round-trip coverage for transient-empty across `localStorage`
+ * Round-trip coverage for blank across `localStorage`
  * persistence + the v=2→v=3 envelope bump.
  */
 
@@ -119,7 +119,7 @@ describe('persistence — v=2 envelope rejection emits a one-time dev-warn', () 
   })
 })
 
-describe('persistence — transient-empty round-trips across mount', () => {
+describe('persistence — blank round-trips across mount', () => {
   const apps: App[] = []
 
   beforeEach(() => {
@@ -131,17 +131,17 @@ describe('persistence — transient-empty round-trips across mount', () => {
     document.body.innerHTML = ''
   })
 
-  it('a v=3 payload with transientEmptyPaths restores the empty UI state on next mount', async () => {
+  it('a v=3 payload with blankPaths restores the empty UI state on next mount', async () => {
     const incomeKey = canonicalizePath('income').key
     // Pre-seed a v=3 payload that mirrors what the lib would have
     // written on a previous session: storage holds the slim default
-    // (0) but the path is in `transientEmptyPaths` so the UI
+    // (0) but the path is in `blankPaths` so the UI
     // re-renders blank.
     localStorage.setItem(
       fpKey('te-rt'),
       JSON.stringify({
         v: 4,
-        data: { form: { income: 0 }, transientEmptyPaths: [incomeKey] },
+        data: { form: { income: 0 }, blankPaths: [incomeKey] },
       })
     )
 
@@ -185,7 +185,7 @@ describe('persistence — transient-empty round-trips across mount', () => {
     expect(errs?.some((e) => e.code === CxErrorCode.NoValueSupplied)).toBe(true)
   })
 
-  it('writes the transientEmptyPaths field after a numeric clear', async () => {
+  it('writes the blankPaths field after a numeric clear', async () => {
     const root = document.createElement('div')
     document.body.appendChild(root)
     const App = defineComponent({
@@ -213,7 +213,7 @@ describe('persistence — transient-empty round-trips across mount', () => {
 
     const input = document.querySelector('input[data-test="income"]') as HTMLInputElement
     // Type a value to trigger the persistence opt-in path, then
-    // clear to trigger markTransientEmpty + a follow-up persist.
+    // clear to trigger markBlank + a follow-up persist.
     input.value = '5'
     input.dispatchEvent(new Event('input', { bubbles: true }))
     await flushAll()
@@ -227,19 +227,19 @@ describe('persistence — transient-empty round-trips across mount', () => {
     const payload = JSON.parse(raw as string)
     expect(payload.v).toBe(4)
     const incomeKey = canonicalizePath('income').key
-    expect(payload.data.transientEmptyPaths).toContain(incomeKey)
+    expect(payload.data.blankPaths).toContain(incomeKey)
   })
 
   it('hydration overrides construction-time auto-mark — persisted empty list wins', async () => {
     // The form has no defaultValues, so construction-time auto-mark
     // would mark `income`. But a v=3 payload pre-seeded with an EMPTY
-    // `transientEmptyPaths` list (representing "user previously filled
+    // `blankPaths` list (representing "user previously filled
     // this in") must override — the hydrated set is the truth.
     localStorage.setItem(
       fpKey('te-hyd'),
       JSON.stringify({
         v: 4,
-        data: { form: { income: 100 }, transientEmptyPaths: [] },
+        data: { form: { income: 100 }, blankPaths: [] },
       })
     )
 
@@ -269,7 +269,7 @@ describe('persistence — transient-empty round-trips across mount', () => {
     await flushAll()
 
     if (captured === undefined) throw new Error('form not captured')
-    expect(captured.transientEmptyPaths.value.size).toBe(0)
+    expect(captured.blankPaths.value.size).toBe(0)
     expect(captured.getValue('income').value).toBe(100)
   })
 })

--- a/test/composables/transient-empty-persistence.test.ts
+++ b/test/composables/transient-empty-persistence.test.ts
@@ -7,6 +7,7 @@ import { vRegister } from '../../src/runtime/core/directive'
 import { CxErrorCode } from '../../src/runtime/core/error-codes'
 import { canonicalizePath } from '../../src/runtime/core/paths'
 import { fingerprintZodSchema } from '../../src/runtime/adapters/zod-v4/fingerprint'
+import { hashStableString } from '../../src/runtime/core/hash'
 import { createChemicalXForms } from '../../src/runtime/core/plugin'
 
 /**
@@ -53,7 +54,10 @@ afterAll(() => {
 })
 
 const schema = z.object({ income: z.number() })
-const FP = fingerprintZodSchema(schema)
+// Storage keys hash the structural fingerprint via cyrb53; mirror that
+// transformation here so tests pre-seeding or reading keys directly
+// resolve to the same suffix the form looks up.
+const FP = hashStableString(fingerprintZodSchema(schema))
 const fpKey = (base: string): string => `${base}:${FP}`
 
 async function flushAll(rounds = 12): Promise<void> {

--- a/test/composables/transient-empty-validation.test.ts
+++ b/test/composables/transient-empty-validation.test.ts
@@ -10,7 +10,7 @@ import type { UseAbstractFormReturnType } from '../../src/runtime/types/types-ap
 
 /**
  * `handleSubmit` / `validate` / `validateAsync` synthesise a "Required"
- * error for every path in the form's `transientEmptyPaths` set whose
+ * error for every path in the form's `blankPaths` set whose
  * schema is required (no `.optional()` / `.nullable()` / `.default()` /
  * `.catch()` wrapper). This is the public-housing footgun fix: a user
  * who didn't answer "what is your income?" must NOT silently submit
@@ -47,7 +47,7 @@ describe('handleSubmit — required-empty raises a synthesised error', () => {
     while (apps.length > 0) apps.pop()?.unmount()
   })
 
-  it('raises "Required" for a transient-empty z.number() path', async () => {
+  it('raises "Required" for a blank z.number() path', async () => {
     const schema = z.object({
       income: z.number(),
       name: z.string(),
@@ -57,7 +57,7 @@ describe('handleSubmit — required-empty raises a synthesised error', () => {
     apps.push(app)
 
     const incomeKey = canonicalizePath('income').key
-    // Mark income as transient-empty via the runtime channel.
+    // Mark income as blank via the runtime channel.
     // setValueWithInternalPath isn't exposed; call setValueAtPath
     // directly through the form store via setValue's leaf form +
     // a meta-aware injector. For this test we reach into the store
@@ -73,10 +73,10 @@ describe('handleSubmit — required-empty raises a synthesised error', () => {
     const binding = form.register('income') as unknown as {
       setValueWithInternalPath: (
         v: unknown,
-        meta?: { transientEmpty?: boolean; persist?: boolean }
+        meta?: { blank?: boolean; persist?: boolean }
       ) => boolean
     }
-    binding.setValueWithInternalPath(0, { transientEmpty: true })
+    binding.setValueWithInternalPath(0, { blank: true })
 
     const onSubmit = vi.fn()
     const onError = vi.fn()
@@ -99,7 +99,7 @@ describe('handleSubmit — required-empty raises a synthesised error', () => {
     void incomeKey
   })
 
-  it('does NOT raise for an optional path even when transient-empty', async () => {
+  it('does NOT raise for an optional path even when blank', async () => {
     const schema = z.object({
       income: z.number().optional(),
     })
@@ -107,9 +107,9 @@ describe('handleSubmit — required-empty raises a synthesised error', () => {
     apps.push(app)
 
     const binding = form.register('income') as unknown as {
-      setValueWithInternalPath: (v: unknown, meta?: { transientEmpty?: boolean }) => boolean
+      setValueWithInternalPath: (v: unknown, meta?: { blank?: boolean }) => boolean
     }
-    binding.setValueWithInternalPath(undefined, { transientEmpty: true })
+    binding.setValueWithInternalPath(undefined, { blank: true })
 
     const onSubmit = vi.fn()
     const onError = vi.fn()
@@ -120,7 +120,7 @@ describe('handleSubmit — required-empty raises a synthesised error', () => {
     expect(onError).not.toHaveBeenCalled()
   })
 
-  it('does NOT raise for a .default(N) path even when transient-empty', async () => {
+  it('does NOT raise for a .default(N) path even when blank', async () => {
     const schema = z.object({
       income: z.number().default(0),
     })
@@ -128,9 +128,9 @@ describe('handleSubmit — required-empty raises a synthesised error', () => {
     apps.push(app)
 
     const binding = form.register('income') as unknown as {
-      setValueWithInternalPath: (v: unknown, meta?: { transientEmpty?: boolean }) => boolean
+      setValueWithInternalPath: (v: unknown, meta?: { blank?: boolean }) => boolean
     }
-    binding.setValueWithInternalPath(0, { transientEmpty: true })
+    binding.setValueWithInternalPath(0, { blank: true })
 
     const onSubmit = vi.fn()
     const onError = vi.fn()
@@ -141,7 +141,7 @@ describe('handleSubmit — required-empty raises a synthesised error', () => {
     expect(onError).not.toHaveBeenCalled()
   })
 
-  it('does NOT raise for a .nullable() path even when transient-empty', async () => {
+  it('does NOT raise for a .nullable() path even when blank', async () => {
     const schema = z.object({
       income: z.number().nullable(),
     })
@@ -149,9 +149,9 @@ describe('handleSubmit — required-empty raises a synthesised error', () => {
     apps.push(app)
 
     const binding = form.register('income') as unknown as {
-      setValueWithInternalPath: (v: unknown, meta?: { transientEmpty?: boolean }) => boolean
+      setValueWithInternalPath: (v: unknown, meta?: { blank?: boolean }) => boolean
     }
-    binding.setValueWithInternalPath(null, { transientEmpty: true })
+    binding.setValueWithInternalPath(null, { blank: true })
 
     const onSubmit = vi.fn()
     const onError = vi.fn()
@@ -170,9 +170,9 @@ describe('handleSubmit — required-empty raises a synthesised error', () => {
     apps.push(app)
 
     const binding = form.register('name') as unknown as {
-      setValueWithInternalPath: (v: unknown, meta?: { transientEmpty?: boolean }) => boolean
+      setValueWithInternalPath: (v: unknown, meta?: { blank?: boolean }) => boolean
     }
-    binding.setValueWithInternalPath('', { transientEmpty: true })
+    binding.setValueWithInternalPath('', { blank: true })
 
     const onSubmit = vi.fn()
     const onError = vi.fn()
@@ -198,9 +198,9 @@ describe('handleSubmit — required-empty raises a synthesised error', () => {
     apps.push(app)
 
     const binding = form.register('agreed') as unknown as {
-      setValueWithInternalPath: (v: unknown, meta?: { transientEmpty?: boolean }) => boolean
+      setValueWithInternalPath: (v: unknown, meta?: { blank?: boolean }) => boolean
     }
-    binding.setValueWithInternalPath(false, { transientEmpty: true })
+    binding.setValueWithInternalPath(false, { blank: true })
 
     const onSubmit = vi.fn()
     const onError = vi.fn()
@@ -224,9 +224,9 @@ describe('validateAsync — surfaces required-empty errors', () => {
     apps.push(app)
 
     const binding = form.register('income') as unknown as {
-      setValueWithInternalPath: (v: unknown, meta?: { transientEmpty?: boolean }) => boolean
+      setValueWithInternalPath: (v: unknown, meta?: { blank?: boolean }) => boolean
     }
-    binding.setValueWithInternalPath(0, { transientEmpty: true })
+    binding.setValueWithInternalPath(0, { blank: true })
 
     const result = await form.validateAsync()
     expect(result.success).toBe(false)
@@ -245,13 +245,13 @@ describe('validateAsync — surfaces required-empty errors', () => {
     apps.push(app)
 
     const incomeBinding = form.register('income') as unknown as {
-      setValueWithInternalPath: (v: unknown, meta?: { transientEmpty?: boolean }) => boolean
+      setValueWithInternalPath: (v: unknown, meta?: { blank?: boolean }) => boolean
     }
     const nameBinding = form.register('name') as unknown as {
-      setValueWithInternalPath: (v: unknown, meta?: { transientEmpty?: boolean }) => boolean
+      setValueWithInternalPath: (v: unknown, meta?: { blank?: boolean }) => boolean
     }
-    incomeBinding.setValueWithInternalPath(0, { transientEmpty: true })
-    nameBinding.setValueWithInternalPath('', { transientEmpty: true })
+    incomeBinding.setValueWithInternalPath(0, { blank: true })
+    nameBinding.setValueWithInternalPath('', { blank: true })
 
     // Validate just the income subtree — the name's required-empty
     // error should NOT contribute (different path scope).
@@ -280,13 +280,13 @@ describe('public-housing scenario', () => {
     apps.push(app)
 
     // Simulate the user opening the form and immediately clicking
-    // submit. The directive (commit 5) marks transient-empty on
+    // submit. The directive (commit 5) marks blank on
     // numeric clear; here we mark income directly to mirror the
     // user's "didn't type anything" state.
     const incomeBinding = form.register('income') as unknown as {
-      setValueWithInternalPath: (v: unknown, meta?: { transientEmpty?: boolean }) => boolean
+      setValueWithInternalPath: (v: unknown, meta?: { blank?: boolean }) => boolean
     }
-    incomeBinding.setValueWithInternalPath(0, { transientEmpty: true })
+    incomeBinding.setValueWithInternalPath(0, { blank: true })
 
     // Fill in name + agreedToTerms so the only error is Required on income.
     form.setValue('name', 'alice')
@@ -316,9 +316,9 @@ describe('public-housing scenario', () => {
     apps.push(app)
 
     const incomeBinding = form.register('income') as unknown as {
-      setValueWithInternalPath: (v: unknown, meta?: { transientEmpty?: boolean }) => boolean
+      setValueWithInternalPath: (v: unknown, meta?: { blank?: boolean }) => boolean
     }
-    incomeBinding.setValueWithInternalPath(undefined, { transientEmpty: true })
+    incomeBinding.setValueWithInternalPath(undefined, { blank: true })
     form.setValue('name', 'alice')
 
     const onSubmit = vi.fn()

--- a/test/composables/transient-empty.test.ts
+++ b/test/composables/transient-empty.test.ts
@@ -11,8 +11,8 @@ import type { UseAbstractFormReturnType } from '../../src/runtime/types/types-ap
  * Public API coverage for the `unset` symbol — declarative
  * (`defaultValues: { x: unset }`) and imperative
  * (`setValue('x', unset)`, `reset({ x: unset })`). Plus the bulk
- * `form.transientEmptyPaths` introspection accessor and the per-field
- * `getFieldState(...).value.pendingEmpty` view.
+ * `form.blankPaths` introspection accessor and the per-field
+ * `getFieldState(...).value.blank` view.
  */
 
 function setupForm<F extends z.ZodObject<Record<string, z.ZodType>>>(
@@ -46,21 +46,21 @@ describe('defaultValues with `unset`', () => {
     const { app, form } = setupForm(z.object({ count: z.number() }), { count: unset })
     apps.push(app)
     expect(form.getValue('count').value).toBe(0)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('count').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('count').key)).toBe(true)
   })
 
   it('string leaf: storage is "", set is populated', () => {
     const { app, form } = setupForm(z.object({ name: z.string() }), { name: unset })
     apps.push(app)
     expect(form.getValue('name').value).toBe('')
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('name').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('name').key)).toBe(true)
   })
 
   it('boolean leaf: storage is false, set is populated', () => {
     const { app, form } = setupForm(z.object({ agreed: z.boolean() }), { agreed: unset })
     apps.push(app)
     expect(form.getValue('agreed').value).toBe(false)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('agreed').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('agreed').key)).toBe(true)
   })
 
   it('multiple leaves can be marked', () => {
@@ -69,7 +69,7 @@ describe('defaultValues with `unset`', () => {
       name: unset,
     })
     apps.push(app)
-    expect(form.transientEmptyPaths.value.size).toBe(2)
+    expect(form.blankPaths.value.size).toBe(2)
   })
 
   it('nested leaves are marked at their canonical paths', () => {
@@ -78,8 +78,8 @@ describe('defaultValues with `unset`', () => {
       { user: { name: unset, age: unset } }
     )
     apps.push(app)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('user.name').key)).toBe(true)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('user.age').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('user.name').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('user.age').key)).toBe(true)
   })
 
   it('mixed marked and unmarked leaves coexist', () => {
@@ -88,8 +88,8 @@ describe('defaultValues with `unset`', () => {
       name: 'alice',
     })
     apps.push(app)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('income').key)).toBe(true)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('name').key)).toBe(false)
+    expect(form.blankPaths.value.has(canonicalizePath('income').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('name').key)).toBe(false)
     expect(form.getValue('name').value).toBe('alice')
   })
 })
@@ -104,21 +104,21 @@ describe('setValue(path, unset)', () => {
     const { app, form } = setupForm(z.object({ count: z.number() }))
     apps.push(app)
     form.setValue('count', 99)
-    expect(form.transientEmptyPaths.value.size).toBe(0)
+    expect(form.blankPaths.value.size).toBe(0)
 
     form.setValue('count', unset)
     expect(form.getValue('count').value).toBe(0)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('count').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('count').key)).toBe(true)
   })
 
   it('subsequent regular write removes the path', () => {
     const { app, form } = setupForm(z.object({ count: z.number() }))
     apps.push(app)
     form.setValue('count', unset)
-    expect(form.transientEmptyPaths.value.size).toBe(1)
+    expect(form.blankPaths.value.size).toBe(1)
 
     form.setValue('count', 42)
-    expect(form.transientEmptyPaths.value.size).toBe(0)
+    expect(form.blankPaths.value.size).toBe(0)
     expect(form.getValue('count').value).toBe(42)
   })
 
@@ -128,7 +128,7 @@ describe('setValue(path, unset)', () => {
     form.setValue('count', 5)
     form.setValue('count', () => unset)
     expect(form.getValue('count').value).toBe(0)
-    expect(form.transientEmptyPaths.value.size).toBe(1)
+    expect(form.blankPaths.value.size).toBe(1)
   })
 })
 
@@ -142,27 +142,27 @@ describe('reset(args) with unset', () => {
     const { app, form } = setupForm(z.object({ count: z.number() }))
     apps.push(app)
     form.setValue('count', 42)
-    expect(form.transientEmptyPaths.value.size).toBe(0)
+    expect(form.blankPaths.value.size).toBe(0)
 
     form.reset({ count: unset })
     expect(form.getValue('count').value).toBe(0)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('count').key)).toBe(true)
-    // Dirty resets to false: the new baseline is "transient-empty for this path".
+    expect(form.blankPaths.value.has(canonicalizePath('count').key)).toBe(true)
+    // Dirty resets to false: the new baseline is "blank for this path".
     expect(form.state.isDirty).toBe(false)
   })
 })
 
-describe('getFieldState meta.pendingEmpty + flat pendingEmpty', () => {
+describe('getFieldState meta.blank + flat blank', () => {
   const apps: App[] = []
   afterEach(() => {
     while (apps.length > 0) apps.pop()?.unmount()
   })
 
-  it('reports pendingEmpty for a path marked via defaultValues', () => {
+  it('reports blank for a path marked via defaultValues', () => {
     const { app, form } = setupForm(z.object({ count: z.number() }), { count: unset })
     apps.push(app)
     const fs = form.getFieldState('count').value
-    expect((fs as unknown as { pendingEmpty: boolean }).pendingEmpty).toBe(true)
+    expect((fs as unknown as { blank: boolean }).blank).toBe(true)
   })
 
   it('flips back to false after a real write', () => {
@@ -170,11 +170,11 @@ describe('getFieldState meta.pendingEmpty + flat pendingEmpty', () => {
     apps.push(app)
     form.setValue('count', 5)
     const fs = form.getFieldState('count').value
-    expect((fs as unknown as { pendingEmpty: boolean }).pendingEmpty).toBe(false)
+    expect((fs as unknown as { blank: boolean }).blank).toBe(false)
   })
 })
 
-describe('form.transientEmptyPaths bulk accessor', () => {
+describe('form.blankPaths bulk accessor', () => {
   const apps: App[] = []
   afterEach(() => {
     while (apps.length > 0) apps.pop()?.unmount()
@@ -183,7 +183,7 @@ describe('form.transientEmptyPaths bulk accessor', () => {
   it('returns a readonly snapshot — consumers cannot mutate', () => {
     const { app, form } = setupForm(z.object({ count: z.number() }), { count: unset })
     apps.push(app)
-    const snapshot = form.transientEmptyPaths.value
+    const snapshot = form.blankPaths.value
     // The snapshot is a Proxy that traps add / delete / clear so
     // consumers can't pollute the cached view. `Object.isFrozen` is
     // not a meaningful test here: frozen Sets remain mutable, so the
@@ -198,11 +198,11 @@ describe('form.transientEmptyPaths bulk accessor', () => {
     // leaf auto-mark covered separately in the auto-mark suite below.
     const { app, form } = setupForm(z.object({ count: z.number() }), { count: 0 })
     apps.push(app)
-    expect(form.transientEmptyPaths.value.size).toBe(0)
+    expect(form.blankPaths.value.size).toBe(0)
     form.setValue('count', unset)
-    expect(form.transientEmptyPaths.value.size).toBe(1)
+    expect(form.blankPaths.value.size).toBe(1)
     form.setValue('count', 5)
-    expect(form.transientEmptyPaths.value.size).toBe(0)
+    expect(form.blankPaths.value.size).toBe(0)
   })
 })
 
@@ -224,14 +224,14 @@ describe('runtime guard: unset on non-primitive leaf', () => {
     apps.push(app)
     // Object path itself NOT marked — `unset` at non-primitive is a
     // misuse; the dev-warn signals "library is recovering."
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('profile').key)).toBe(false)
+    expect(form.blankPaths.value.has(canonicalizePath('profile').key)).toBe(false)
     // Children auto-marked: the consumer didn't supply `profile.name`,
     // so it's logically "blank" in the freshly opened form.
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('profile.name').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('profile.name').key)).toBe(true)
   })
 })
 
-describe('auto-mark: unspecified primitive leaves are pendingEmpty on construction', () => {
+describe('auto-mark: unspecified primitive leaves are blank on construction', () => {
   // Rationale: a freshly opened form has no user input yet, so every
   // primitive leaf the consumer didn't explicitly fill is logically
   // "blank." This is the public-housing footgun fix taken to its
@@ -246,8 +246,8 @@ describe('auto-mark: unspecified primitive leaves are pendingEmpty on constructi
   it('email example: useForm({ schema: z.object({ email: z.string() }) }) marks email', () => {
     const { app, form } = setupForm(z.object({ email: z.string() }))
     apps.push(app)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('email').key)).toBe(true)
-    expect(form.transientEmptyPaths.value.size).toBe(1)
+    expect(form.blankPaths.value.has(canonicalizePath('email').key)).toBe(true)
+    expect(form.blankPaths.value.size).toBe(1)
   })
 
   it('marks every primitive leaf when defaultValues is omitted entirely', () => {
@@ -255,10 +255,10 @@ describe('auto-mark: unspecified primitive leaves are pendingEmpty on constructi
       z.object({ name: z.string(), age: z.number(), agreed: z.boolean() })
     )
     apps.push(app)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('name').key)).toBe(true)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('age').key)).toBe(true)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('agreed').key)).toBe(true)
-    expect(form.transientEmptyPaths.value.size).toBe(3)
+    expect(form.blankPaths.value.has(canonicalizePath('name').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('age').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('agreed').key)).toBe(true)
+    expect(form.blankPaths.value.size).toBe(3)
   })
 
   it('partial defaults: auto-marks only unspecified leaves', () => {
@@ -266,21 +266,21 @@ describe('auto-mark: unspecified primitive leaves are pendingEmpty on constructi
       name: 'alice',
     })
     apps.push(app)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('name').key)).toBe(false)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('age').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('name').key)).toBe(false)
+    expect(form.blankPaths.value.has(canonicalizePath('age').key)).toBe(true)
     expect(form.getValue('name').value).toBe('alice')
     expect(form.getValue('age').value).toBe(0)
   })
 
   it('explicit slim-default value still opts the leaf out of auto-mark', () => {
     // `defaultValues: { count: 0 }` — the consumer wrote 0 explicitly,
-    // so the leaf is NOT transient-empty even though storage matches
+    // so the leaf is NOT blank even though storage matches
     // the slim default. The opt-out signal is "consumer supplied a
     // non-`unset` value", not "consumer supplied a non-default value".
     const { app, form } = setupForm(z.object({ count: z.number() }), { count: 0 })
     apps.push(app)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('count').key)).toBe(false)
-    expect(form.transientEmptyPaths.value.size).toBe(0)
+    expect(form.blankPaths.value.has(canonicalizePath('count').key)).toBe(false)
+    expect(form.blankPaths.value.size).toBe(0)
   })
 
   it('nested object: marks unspecified leaves at their canonical paths', () => {
@@ -289,8 +289,8 @@ describe('auto-mark: unspecified primitive leaves are pendingEmpty on constructi
       { user: { name: 'alice' } }
     )
     apps.push(app)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('user.name').key)).toBe(false)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('user.age').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('user.name').key)).toBe(false)
+    expect(form.blankPaths.value.has(canonicalizePath('user.age').key)).toBe(true)
   })
 
   it('nested object: omitting the outer object recurses to mark all primitive leaves below', () => {
@@ -298,16 +298,16 @@ describe('auto-mark: unspecified primitive leaves are pendingEmpty on constructi
       z.object({ user: z.object({ name: z.string(), age: z.number() }) })
     )
     apps.push(app)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('user.name').key)).toBe(true)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('user.age').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('user.name').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('user.age').key)).toBe(true)
     // The object path itself is NOT marked — only primitive leaves are.
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('user').key)).toBe(false)
+    expect(form.blankPaths.value.has(canonicalizePath('user').key)).toBe(false)
   })
 
   it('optional leaf: marks the path even though slim default is undefined', () => {
     const { app, form } = setupForm(z.object({ note: z.string().optional() }))
     apps.push(app)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('note').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('note').key)).toBe(true)
     // Storage is undefined per the optional schema — the mark is
     // about UI/display intent, not about validation requiredness.
     expect(form.getValue('note').value).toBeUndefined()
@@ -316,14 +316,14 @@ describe('auto-mark: unspecified primitive leaves are pendingEmpty on constructi
   it('nullable leaf: marks the path even though slim default is null', () => {
     const { app, form } = setupForm(z.object({ note: z.string().nullable() }))
     apps.push(app)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('note').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('note').key)).toBe(true)
     expect(form.getValue('note').value).toBeNull()
   })
 
   it('.default(N): marks the path; storage holds N (the default-author intent)', () => {
     const { app, form } = setupForm(z.object({ count: z.number().default(7) }))
     apps.push(app)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('count').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('count').key)).toBe(true)
     expect(form.getValue('count').value).toBe(7)
   })
 
@@ -331,9 +331,9 @@ describe('auto-mark: unspecified primitive leaves are pendingEmpty on constructi
     const { app, form } = setupForm(z.object({ tags: z.array(z.string()) }))
     apps.push(app)
     // `tags` itself is a non-primitive leaf — not marked.
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('tags').key)).toBe(false)
+    expect(form.blankPaths.value.has(canonicalizePath('tags').key)).toBe(false)
     // No spurious indexed marks either.
-    expect(form.transientEmptyPaths.value.size).toBe(0)
+    expect(form.blankPaths.value.size).toBe(0)
   })
 
   it('explicit value at a leaf does NOT mark even if value happens to equal slim default', () => {
@@ -344,7 +344,7 @@ describe('auto-mark: unspecified primitive leaves are pendingEmpty on constructi
     apps.push(app)
     // Both leaves had user-supplied values (matching slim defaults)
     // — neither is auto-marked.
-    expect(form.transientEmptyPaths.value.size).toBe(0)
+    expect(form.blankPaths.value.size).toBe(0)
   })
 
   it('explicit unset still works alongside auto-mark', () => {
@@ -355,21 +355,21 @@ describe('auto-mark: unspecified primitive leaves are pendingEmpty on constructi
       count: unset,
     })
     apps.push(app)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('count').key)).toBe(true)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('name').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('count').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('name').key)).toBe(true)
   })
 
   it('auto-marks ride into the post-construction baseline (reset restores them)', () => {
     const { app, form } = setupForm(z.object({ count: z.number() }))
     apps.push(app)
     // Construction auto-marks `count`.
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('count').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('count').key)).toBe(true)
     // User types a value — mark is removed.
     form.setValue('count', 42)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('count').key)).toBe(false)
+    expect(form.blankPaths.value.has(canonicalizePath('count').key)).toBe(false)
     // reset() with no args should restore the construction baseline.
     form.reset()
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('count').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('count').key)).toBe(true)
   })
 
   it('reset(args) auto-marks unspecified leaves in the new defaults', () => {
@@ -378,11 +378,11 @@ describe('auto-mark: unspecified primitive leaves are pendingEmpty on constructi
       age: 30,
     })
     apps.push(app)
-    expect(form.transientEmptyPaths.value.size).toBe(0)
+    expect(form.blankPaths.value.size).toBe(0)
     // Reset with a partial — `age` is omitted, so it gets auto-marked.
     form.reset({ name: 'bob' })
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('name').key)).toBe(false)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('age').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('name').key)).toBe(false)
+    expect(form.blankPaths.value.has(canonicalizePath('age').key)).toBe(true)
     expect(form.getValue('name').value).toBe('bob')
     expect(form.getValue('age').value).toBe(0)
   })

--- a/test/composables/use-form-v3-forwarding.test.ts
+++ b/test/composables/use-form-v3-forwarding.test.ts
@@ -7,6 +7,7 @@ import { vRegister } from '../../src/runtime/core/directive'
 import { createChemicalXForms } from '../../src/runtime/core/plugin'
 import { useForm } from '../../src/zod-v3'
 import { fingerprintZodSchema } from '../../src/runtime/adapters/zod-v3/fingerprint'
+import { hashStableString } from '../../src/runtime/core/hash'
 
 /**
  * Regression pin: the zod v3 `useForm` wrapper used to hand-pick the
@@ -134,7 +135,7 @@ describe('v3 useForm forwards opt-in options to useAbstractForm', () => {
 
     expect(setItem).toHaveBeenCalled()
     const [key, payload] = setItem.mock.calls[0] ?? []
-    const fp = fingerprintZodSchema(schema)
+    const fp = hashStableString(fingerprintZodSchema(schema))
     expect(key).toBe(`chemical-x-forms:v3-persist:${fp}`)
     expect(payload).toMatchObject({
       v: 4,

--- a/test/core/directive-cleanup.test.ts
+++ b/test/core/directive-cleanup.test.ts
@@ -32,7 +32,7 @@ function makeRegisterValue<T>(initial: T): {
   const value: RegisterValue<T> = {
     innerRef: ref(initial) as RegisterValue<T>['innerRef'],
     displayValue: ref('') as Readonly<Ref<string>>,
-    markTransientEmpty: () => true,
+    markBlank: () => true,
     lastTypedForm: ref<string | null>(null),
     registerElement: register,
     deregisterElement: deregister,

--- a/test/core/directive-modifiers.test.ts
+++ b/test/core/directive-modifiers.test.ts
@@ -1062,3 +1062,105 @@ describe('regression: vRegisterText × type="number" × backspace-to-empty', () 
     expect(markTransientEmpty).toHaveBeenCalledTimes(1)
   })
 })
+
+// ─────────────────────────────────────────────────────────────────
+// `<input type="checkbox">` setChecked: hydration-with-static-attribute case
+// ─────────────────────────────────────────────────────────────────
+
+/**
+ * Repro for the playground bug where SSR rendered `<input type="checkbox"
+ * value="banana">` with a static `value` attribute. On client hydration
+ * Vue's static-attr fast path skips `patchProp`, so `el._value` is
+ * never set AND `vnode.props['value']` is undefined for hoisted attrs.
+ * The directive's `setChecked` was reading `vnode.props?.['value']`
+ * exclusively — got undefined — and unchecked the box even though state
+ * contained 'banana' and the DOM attribute was set.
+ *
+ * The fix routes setChecked's option-value lookup through the same
+ * `getValue(el)` helper the change handler uses (post the prior
+ * static-attr fix), which falls back to the DOM `value` property
+ * when neither `_value` nor a vnode prop is present.
+ */
+describe('vRegisterCheckbox.setChecked — hydration with static value attribute', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('mounts with el.checked=true when array model contains the static-attribute value (no vnode.props.value, no _value)', () => {
+    const input = document.createElement('input')
+    input.type = 'checkbox'
+    // Static attribute path — sets the attribute AND el.value, but
+    // crucially does NOT set el._value (Vue's renderer would).
+    input.setAttribute('value', 'banana')
+    document.body.appendChild(input)
+
+    const { value } = makeRegisterValue<string[]>(['banana'])
+
+    // Both vnode.props.value AND el._value are absent — the exact
+    // shape the directive sees on a hydrated static-attr checkbox.
+    hooks.created?.(input, makeBinding(value), makeVNode({ type: 'checkbox' }), null)
+    hooks.mounted?.(input, makeBinding(value), makeVNode({ type: 'checkbox' }), null)
+
+    expect(input.checked).toBe(true)
+  })
+
+  it('mounts with el.checked=false when array model does NOT contain the static-attribute value', () => {
+    const input = document.createElement('input')
+    input.type = 'checkbox'
+    input.setAttribute('value', 'apple')
+    document.body.appendChild(input)
+
+    const { value } = makeRegisterValue<string[]>(['banana'])
+    hooks.created?.(input, makeBinding(value), makeVNode({ type: 'checkbox' }), null)
+    hooks.mounted?.(input, makeBinding(value), makeVNode({ type: 'checkbox' }), null)
+
+    expect(input.checked).toBe(false)
+  })
+
+  it('Set model: mounts with el.checked=true when the Set contains the static-attribute value', () => {
+    const input = document.createElement('input')
+    input.type = 'checkbox'
+    input.setAttribute('value', 'banana')
+    document.body.appendChild(input)
+
+    const { value } = makeRegisterValue<Set<string>>(new Set(['banana']))
+    hooks.created?.(input, makeBinding(value), makeVNode({ type: 'checkbox' }), null)
+    hooks.mounted?.(input, makeBinding(value), makeVNode({ type: 'checkbox' }), null)
+
+    expect(input.checked).toBe(true)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────
+// `<input type="radio">` created/beforeUpdate: same hydration shape
+// ─────────────────────────────────────────────────────────────────
+
+describe('vRegisterRadio — hydration with static value attribute', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('mounts with el.checked=true when state matches the static-attribute value (no vnode.props.value, no _value)', () => {
+    const input = document.createElement('input')
+    input.type = 'radio'
+    input.setAttribute('value', 'banana')
+    document.body.appendChild(input)
+
+    const { value } = makeRegisterValue<string>('banana')
+    hooks.created?.(input, makeBinding(value), makeVNode({ type: 'radio' }), null)
+
+    expect(input.checked).toBe(true)
+  })
+
+  it('mounts with el.checked=false when state does NOT match the static-attribute value', () => {
+    const input = document.createElement('input')
+    input.type = 'radio'
+    input.setAttribute('value', 'apple')
+    document.body.appendChild(input)
+
+    const { value } = makeRegisterValue<string>('banana')
+    hooks.created?.(input, makeBinding(value), makeVNode({ type: 'radio' }), null)
+
+    expect(input.checked).toBe(false)
+  })
+})

--- a/test/core/directive-modifiers.test.ts
+++ b/test/core/directive-modifiers.test.ts
@@ -36,7 +36,7 @@ function makeRegisterValue<T>(initial: T): {
   const value: RegisterValue<T> = {
     innerRef: ref(initial) as RegisterValue<T>['innerRef'],
     displayValue: ref('') as Readonly<Ref<string>>,
-    markTransientEmpty: () => true,
+    markBlank: () => true,
     lastTypedForm: ref<string | null>(null),
     registerElement: register,
     deregisterElement: deregister,
@@ -193,30 +193,30 @@ describe('vRegisterText — `.number`', () => {
     expect(setValue).toHaveBeenCalledWith(12.5, expect.objectContaining({}))
   })
 
-  it('input event marks transient-empty for non-numeric strings instead of attempting the write', () => {
+  it('input event marks blank for non-numeric strings instead of attempting the write', () => {
     // Pre-commit-5 the directive forwarded the unparseable string to
     // the slim-primitive gate, which rejected it and emitted a noisy
     // dev warning. Post-commit-5 the directive treats non-castable
     // input the same as the empty case: route through
-    // `markTransientEmpty` so storage holds the slim default and the
+    // `markBlank` so storage holds the slim default and the
     // user retains the empty / partial DOM. Submit-time validation
     // raises "Required" for required schemas.
     const input = document.createElement('input')
     input.type = 'text'
     document.body.appendChild(input)
     const { value, setValue } = makeRegisterValue('' as unknown as never)
-    const markTransientEmpty = vi.fn(() => true)
-    value.markTransientEmpty = markTransientEmpty
+    const markBlank = vi.fn(() => true)
+    value.markBlank = markBlank
 
     hooks.created?.(input, makeBinding(value, { number: true }), makeVNode({}), null)
 
     // `'xyz'` is non-castable AND has no `e`/`E` — keeps this test on
-    // the immediate markTransientEmpty path. Strings containing `e`
+    // the immediate markBlank path. Strings containing `e`
     // hit the scientific-notation deferral instead (covered separately).
     input.value = 'xyz'
     input.dispatchEvent(new Event('input'))
     expect(setValue).not.toHaveBeenCalled()
-    expect(markTransientEmpty).toHaveBeenCalledTimes(1)
+    expect(markBlank).toHaveBeenCalledTimes(1)
   })
 
   it('change event normalizes the visible DOM after Vue 3.5.33 parity fix', () => {
@@ -733,20 +733,20 @@ describe('chemical-x interactions: `.number` × slim-primitive gate', () => {
     document.body.innerHTML = ''
   })
 
-  it('non-castable input never reaches the gate — directive marks transient-empty instead', () => {
+  it('non-castable input never reaches the gate — directive marks blank instead', () => {
     // Post-commit-5 the directive's `.number` listener short-circuits
     // BEFORE the assigner when `looseToNumber` returns a non-number,
     // so the slim-primitive gate never sees the bogus write. The
     // user's typed input stays in the DOM (the directive doesn't
-    // roll back on transient-empty either) and submit-time
+    // roll back on blank either) and submit-time
     // validation raises "Required" if the schema demands a number.
     const input = document.createElement('input')
     input.type = 'text'
     document.body.appendChild(input)
 
     const { value, setValue } = makeRegisterValue(0 as unknown as never)
-    const markTransientEmpty = vi.fn(() => true)
-    value.markTransientEmpty = markTransientEmpty
+    const markBlank = vi.fn(() => true)
+    value.markBlank = markBlank
 
     hooks.created?.(input, makeBinding(value, { number: true }), makeVNode({}), null)
 
@@ -754,7 +754,7 @@ describe('chemical-x interactions: `.number` × slim-primitive gate', () => {
     expect(() => input.dispatchEvent(new Event('input'))).not.toThrow()
 
     expect(setValue).not.toHaveBeenCalled()
-    expect(markTransientEmpty).toHaveBeenCalledTimes(1)
+    expect(markBlank).toHaveBeenCalledTimes(1)
     expect(input.value).toBe('abc')
   })
 })
@@ -1013,40 +1013,40 @@ describe('regression: vRegisterText × type="number" × backspace-to-empty', () 
     expect(setValue).not.toHaveBeenCalled()
   })
 
-  it('non-empty non-numeric input routes through markTransientEmpty (no gate-rejection warning)', () => {
+  it('non-empty non-numeric input routes through markBlank (no gate-rejection warning)', () => {
     // Post-commit-5 the directive treats both "" and non-castable
     // input ('abc') as the empty case: the assigner doesn't fire,
-    // and `markTransientEmpty` writes the slim default with the
-    // transient-empty meta. Submit-time validation raises "Required"
+    // and `markBlank` writes the slim default with the
+    // blank meta. Submit-time validation raises "Required"
     // for required schemas — the dev-warn-via-gate-rejection that
     // pre-commit-5 surfaced was a worse UX than this.
     const input = document.createElement('input')
     input.type = 'text'
     document.body.appendChild(input)
     const { value, setValue } = makeRegisterValue(0 as unknown as never)
-    const markTransientEmpty = vi.fn(() => true)
-    value.markTransientEmpty = markTransientEmpty
+    const markBlank = vi.fn(() => true)
+    value.markBlank = markBlank
 
     hooks.created?.(input, makeBinding(value, { number: true }), makeVNode({}), null)
 
     input.value = 'abc'
     input.dispatchEvent(new Event('input'))
     expect(setValue).not.toHaveBeenCalled()
-    expect(markTransientEmpty).toHaveBeenCalledTimes(1)
+    expect(markBlank).toHaveBeenCalledTimes(1)
   })
 
-  it('backspace-to-empty also routes through markTransientEmpty (commit 5)', () => {
+  it('backspace-to-empty also routes through markBlank (commit 5)', () => {
     // Pre-commit-5 the directive skipped the assigner silently — UI
     // showed empty but storage held the previous valid number, so
     // submit could ship a stale value. Post-commit-5 the empty case
-    // marks transient-empty: storage flips to the slim default and
+    // marks blank: storage flips to the slim default and
     // submit raises "Required" if the schema demands a number.
     const input = document.createElement('input')
     input.type = 'number'
     document.body.appendChild(input)
     const { value, setValue } = makeRegisterValue(0 as unknown as never)
-    const markTransientEmpty = vi.fn(() => true)
-    value.markTransientEmpty = markTransientEmpty
+    const markBlank = vi.fn(() => true)
+    value.markBlank = markBlank
 
     hooks.created?.(input, makeBinding(value, {}), makeVNode({ type: 'number' }), null)
 
@@ -1059,7 +1059,7 @@ describe('regression: vRegisterText × type="number" × backspace-to-empty', () 
     input.value = ''
     input.dispatchEvent(new Event('input'))
     expect(setValue).not.toHaveBeenCalled()
-    expect(markTransientEmpty).toHaveBeenCalledTimes(1)
+    expect(markBlank).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/test/core/directive-modifiers.test.ts
+++ b/test/core/directive-modifiers.test.ts
@@ -1147,7 +1147,12 @@ describe('vRegisterRadio — hydration with static value attribute', () => {
     document.body.appendChild(input)
 
     const { value } = makeRegisterValue<string>('banana')
+    // Initial checked-state sync moved from `created` to `mounted` —
+    // `created` fires BEFORE Vue patches type / value / _value onto
+    // the element, so reading them at that point would always come
+    // back undefined. Call both hooks here to mirror Vue's lifecycle.
     hooks.created?.(input, makeBinding(value), makeVNode({ type: 'radio' }), null)
+    hooks.mounted?.(input, makeBinding(value), makeVNode({ type: 'radio' }), null)
 
     expect(input.checked).toBe(true)
   })
@@ -1160,6 +1165,7 @@ describe('vRegisterRadio — hydration with static value attribute', () => {
 
     const { value } = makeRegisterValue<string>('banana')
     hooks.created?.(input, makeBinding(value), makeVNode({ type: 'radio' }), null)
+    hooks.mounted?.(input, makeBinding(value), makeVNode({ type: 'radio' }), null)
 
     expect(input.checked).toBe(false)
   })

--- a/test/core/directive-transient-empty.test.ts
+++ b/test/core/directive-transient-empty.test.ts
@@ -11,7 +11,7 @@ import type { RegisterValue } from '../../src/runtime/types/types-api'
 
 /**
  * Coverage for commit 5's directive wiring: empty / non-castable input
- * routes through `markTransientEmpty` instead of the silent skip-on-empty
+ * routes through `markBlank` instead of the silent skip-on-empty
  * (which left UI and storage desynced) or the slim-primitive gate
  * rejection (which surfaced a noisy dev warn). Plus the `.number` ×
  * text-input `beforeinput` filter that blocks non-numeric characters
@@ -22,15 +22,15 @@ type Spy = ReturnType<typeof vi.fn>
 
 function makeRegisterValue<T>(initial: T): {
   value: RegisterValue<T>
-  markTransientEmpty: Spy
+  markBlank: Spy
   setValue: Spy
 } {
-  const markTransientEmpty = vi.fn(() => true)
+  const markBlank = vi.fn(() => true)
   const setValue = vi.fn(() => true)
   const value: RegisterValue<T> = {
     innerRef: ref(initial) as RegisterValue<T>['innerRef'],
     displayValue: ref('') as Readonly<Ref<string>>,
-    markTransientEmpty,
+    markBlank,
     lastTypedForm: ref<string | null>(null),
     registerElement: vi.fn(),
     deregisterElement: vi.fn(),
@@ -41,7 +41,7 @@ function makeRegisterValue<T>(initial: T): {
     acknowledgeSensitive: false,
     persistOptIns: createPersistOptInRegistry(),
   }
-  return { value, markTransientEmpty, setValue }
+  return { value, markBlank, setValue }
 }
 
 function makeBinding<T>(
@@ -66,16 +66,16 @@ const hooks = vRegister as unknown as {
   created?: (el: HTMLElement, binding: DirectiveBinding, vnode: VNode, prev: unknown) => void
 }
 
-describe('directive — transient-empty on numeric clear', () => {
+describe('directive — blank on numeric clear', () => {
   beforeEach(() => {
     document.body.innerHTML = ''
   })
 
-  it('<input type="number"> backspaced to empty calls markTransientEmpty', () => {
+  it('<input type="number"> backspaced to empty calls markBlank', () => {
     const input = document.createElement('input')
     input.type = 'number'
     document.body.appendChild(input)
-    const { value, markTransientEmpty, setValue } = makeRegisterValue(0 as unknown as never)
+    const { value, markBlank, setValue } = makeRegisterValue(0 as unknown as never)
 
     hooks.created?.(input, makeBinding(value, {}), makeVNode({ type: 'number' }), null)
 
@@ -84,19 +84,19 @@ describe('directive — transient-empty on numeric clear', () => {
     expect(setValue).toHaveBeenLastCalledWith(5, expect.objectContaining({}))
 
     setValue.mockClear()
-    markTransientEmpty.mockClear()
+    markBlank.mockClear()
     input.value = ''
     input.dispatchEvent(new Event('input'))
 
     expect(setValue).not.toHaveBeenCalled()
-    expect(markTransientEmpty).toHaveBeenCalledTimes(1)
+    expect(markBlank).toHaveBeenCalledTimes(1)
   })
 
-  it('<input type="text" v-register.number> empty input calls markTransientEmpty', () => {
+  it('<input type="text" v-register.number> empty input calls markBlank', () => {
     const input = document.createElement('input')
     input.type = 'text'
     document.body.appendChild(input)
-    const { value, markTransientEmpty, setValue } = makeRegisterValue(0 as unknown as never)
+    const { value, markBlank, setValue } = makeRegisterValue(0 as unknown as never)
 
     hooks.created?.(input, makeBinding(value, { number: true }), makeVNode({}), null)
 
@@ -105,42 +105,42 @@ describe('directive — transient-empty on numeric clear', () => {
     expect(setValue).toHaveBeenLastCalledWith(7, expect.objectContaining({}))
 
     setValue.mockClear()
-    markTransientEmpty.mockClear()
+    markBlank.mockClear()
     input.value = ''
     input.dispatchEvent(new Event('input'))
 
     expect(setValue).not.toHaveBeenCalled()
-    expect(markTransientEmpty).toHaveBeenCalledTimes(1)
+    expect(markBlank).toHaveBeenCalledTimes(1)
   })
 
-  it('non-numeric input on `.number` text input calls markTransientEmpty (no gate-rejection)', () => {
+  it('non-numeric input on `.number` text input calls markBlank (no gate-rejection)', () => {
     const input = document.createElement('input')
     input.type = 'text'
     document.body.appendChild(input)
-    const { value, markTransientEmpty, setValue } = makeRegisterValue(0 as unknown as never)
+    const { value, markBlank, setValue } = makeRegisterValue(0 as unknown as never)
 
     hooks.created?.(input, makeBinding(value, { number: true }), makeVNode({}), null)
 
-    // `'xyz'` keeps this test on the immediate markTransientEmpty path
+    // `'xyz'` keeps this test on the immediate markBlank path
     // (no `e`/`E`, so the scientific-notation deferral does not apply).
     input.value = 'xyz'
     input.dispatchEvent(new Event('input'))
 
     expect(setValue).not.toHaveBeenCalled()
-    expect(markTransientEmpty).toHaveBeenCalledTimes(1)
+    expect(markBlank).toHaveBeenCalledTimes(1)
   })
 
   it('typing a real value after clear sends the value through the assigner (implicit unmark)', () => {
     const input = document.createElement('input')
     input.type = 'number'
     document.body.appendChild(input)
-    const { value, markTransientEmpty, setValue } = makeRegisterValue(0 as unknown as never)
+    const { value, markBlank, setValue } = makeRegisterValue(0 as unknown as never)
 
     hooks.created?.(input, makeBinding(value, {}), makeVNode({ type: 'number' }), null)
 
     input.value = ''
     input.dispatchEvent(new Event('input'))
-    expect(markTransientEmpty).toHaveBeenCalledTimes(1)
+    expect(markBlank).toHaveBeenCalledTimes(1)
     expect(setValue).not.toHaveBeenCalled()
 
     input.value = '12'
@@ -152,7 +152,7 @@ describe('directive — transient-empty on numeric clear', () => {
     const input = document.createElement('input')
     input.type = 'text'
     document.body.appendChild(input)
-    const { value, markTransientEmpty, setValue } = makeRegisterValue('' as unknown as never)
+    const { value, markBlank, setValue } = makeRegisterValue('' as unknown as never)
 
     hooks.created?.(input, makeBinding(value, {}), makeVNode({}), null)
 
@@ -161,16 +161,16 @@ describe('directive — transient-empty on numeric clear', () => {
     expect(setValue).toHaveBeenCalledTimes(1)
 
     setValue.mockClear()
-    markTransientEmpty.mockClear()
+    markBlank.mockClear()
     input.value = ''
     input.dispatchEvent(new Event('input'))
 
     // String inputs send '' through the regular assigner — no auto-mark.
     // The DOM doesn't tell us "user typed empty" vs "user hasn't typed",
-    // so the dev opts in to transient-empty via the unset symbol if
+    // so the dev opts in to blank via the unset symbol if
     // they want that semantic.
     expect(setValue).toHaveBeenCalledWith('', expect.objectContaining({}))
-    expect(markTransientEmpty).not.toHaveBeenCalled()
+    expect(markBlank).not.toHaveBeenCalled()
   })
 })
 
@@ -525,18 +525,18 @@ describe('directive — `.number` blur cleanup (16d regression: lone period)', (
   it('clears the DOM under `.lazy.number` when blur leaves a lone period', () => {
     // The lazy variant uses the `change` event for the input
     // listener AND the blur normalizer — both fire on blur. Order:
-    // listener-1 markTransientEmpty's, listener-2 cleans the DOM.
+    // listener-1 markBlank's, listener-2 cleans the DOM.
     const input = document.createElement('input')
     input.type = 'text'
     document.body.appendChild(input)
-    const { value, markTransientEmpty } = makeRegisterValue(0 as unknown as never)
+    const { value, markBlank } = makeRegisterValue(0 as unknown as never)
 
     hooks.created?.(input, makeBinding(value, { lazy: true, number: true }), makeVNode({}), null)
 
     input.value = '.'
     input.dispatchEvent(new Event('change'))
     expect(input.value).toBe('')
-    expect(markTransientEmpty).toHaveBeenCalled()
+    expect(markBlank).toHaveBeenCalled()
   })
 })
 
@@ -653,18 +653,18 @@ describe('directive — `.number` real-time storage updates with mid-typing DOM 
     expect(value.lastTypedForm.value).toBeNull()
   })
 
-  it('non-castable input (`xyz`) markTransientEmpty fires immediately, not deferred to blur', () => {
+  it('non-castable input (`xyz`) markBlank fires immediately, not deferred to blur', () => {
     const input = document.createElement('input')
     input.type = 'text'
     document.body.appendChild(input)
-    const { value, markTransientEmpty } = makeRegisterValue(0 as unknown as never)
+    const { value, markBlank } = makeRegisterValue(0 as unknown as never)
 
     hooks.created?.(input, makeBinding(value, { number: true }), makeVNode({}), null)
 
     input.value = 'xyz'
     input.dispatchEvent(new Event('input'))
     // No deferral — the keystroke listener marks immediately.
-    expect(markTransientEmpty).toHaveBeenCalledTimes(1)
+    expect(markBlank).toHaveBeenCalledTimes(1)
     expect(value.lastTypedForm.value).toBeNull()
   })
 
@@ -722,7 +722,7 @@ describe('directive — `.number` overflow (Infinity) refusal', () => {
   //     number" (its quirky error for non-finite numerics)
   // The directive refuses non-finite at the boundary: storage stays
   // at the last good value (snap-back during typing), and blur
-  // clears + markTransientEmpty.
+  // clears + markBlank.
   beforeEach(() => {
     document.body.innerHTML = ''
   })
@@ -766,18 +766,18 @@ describe('directive — `.number` overflow (Infinity) refusal', () => {
     expect(input.value).toBe('1e308')
   })
 
-  it('blur on an overflow residue clears the DOM and fires markTransientEmpty', () => {
+  it('blur on an overflow residue clears the DOM and fires markBlank', () => {
     const input = document.createElement('input')
     input.type = 'text'
     document.body.appendChild(input)
-    const { value, markTransientEmpty } = makeRegisterValue(0 as unknown as never)
+    const { value, markBlank } = makeRegisterValue(0 as unknown as never)
 
     hooks.created?.(input, makeBinding(value, { number: true }), makeVNode({}), null)
 
     input.value = '1e309'
     input.dispatchEvent(new Event('change'))
     expect(input.value).toBe('')
-    expect(markTransientEmpty).toHaveBeenCalled()
+    expect(markBlank).toHaveBeenCalled()
   })
 
   it('refuses negative overflow (`-1e309` → -Infinity)', () => {
@@ -815,7 +815,7 @@ describe('directive — `<input type="number">` mid-typing badInput is not a cle
   // malformed mid-edit input (because `1e` isn't a complete scientific
   // notation literal) even though `1e` is still visible in the DOM.
   // Pre-fix the directive's input listener saw the empty value and
-  // fired `markTransientEmpty`, which made `displayValue` recompute
+  // fired `markBlank`, which made `displayValue` recompute
   // to `''`; Vue's `:value` patch then yanked the user's typed `1e`
   // away. The fix uses `validity.badInput` to distinguish a real
   // user-clear (`badInput === false`) from a transient mid-edit
@@ -839,31 +839,31 @@ describe('directive — `<input type="number">` mid-typing badInput is not a cle
     })
   }
 
-  it('skips markTransientEmpty when `validity.badInput` is true on empty el.value', () => {
+  it('skips markBlank when `validity.badInput` is true on empty el.value', () => {
     const input = document.createElement('input')
     input.type = 'number'
     document.body.appendChild(input)
-    const { value, markTransientEmpty, setValue } = makeRegisterValue(0 as unknown as never)
+    const { value, markBlank, setValue } = makeRegisterValue(0 as unknown as never)
 
     hooks.created?.(input, makeBinding(value, {}), makeVNode({ type: 'number' }), null)
 
     // User typed `1e` — browser shows it in DOM but blanks el.value
-    // and flags badInput. The directive must NOT markTransientEmpty.
+    // and flags badInput. The directive must NOT markBlank.
     input.value = ''
     withBadInput(input, true)
     input.dispatchEvent(new Event('input'))
 
-    expect(markTransientEmpty).not.toHaveBeenCalled()
+    expect(markBlank).not.toHaveBeenCalled()
     expect(setValue).not.toHaveBeenCalled()
     // lastTypedForm untouched — display continues to track storage.
     expect(value.lastTypedForm.value).toBeNull()
   })
 
-  it('marks transient-empty when `validity.badInput` is false on empty el.value (real user clear)', () => {
+  it('marks blank when `validity.badInput` is false on empty el.value (real user clear)', () => {
     const input = document.createElement('input')
     input.type = 'number'
     document.body.appendChild(input)
-    const { value, markTransientEmpty } = makeRegisterValue(0 as unknown as never)
+    const { value, markBlank } = makeRegisterValue(0 as unknown as never)
 
     hooks.created?.(input, makeBinding(value, {}), makeVNode({ type: 'number' }), null)
 
@@ -871,7 +871,7 @@ describe('directive — `<input type="number">` mid-typing badInput is not a cle
     withBadInput(input, false)
     input.dispatchEvent(new Event('input'))
 
-    expect(markTransientEmpty).toHaveBeenCalledTimes(1)
+    expect(markBlank).toHaveBeenCalledTimes(1)
   })
 
   it('the badInput skip lets the eventual valid `1e2` commit live (post-fix smoke test)', () => {

--- a/test/core/plugin.test.ts
+++ b/test/core/plugin.test.ts
@@ -58,7 +58,7 @@ describe('createChemicalXForms', () => {
       expect(secondRegistry).toBe(firstRegistry)
       // Single dev warning fired.
       const matched = warnSpy.mock.calls.filter((c: unknown[]) =>
-        String(c[0]).includes('createChemicalXForms() install was called more than once')
+        String(c[0]).includes('createChemicalXForms() install was called twice')
       )
       expect(matched.length).toBe(1)
     } finally {

--- a/test/core/register-api.test.ts
+++ b/test/core/register-api.test.ts
@@ -146,7 +146,7 @@ describe('buildRegister', () => {
         register('email', { persist: true })
         const matches = warnSpy.mock.calls
           .map((args) => args.join(' '))
-          .filter((msg) => /no `persist:` option is configured/.test(msg))
+          .filter((msg) => /no `persist` option configured/.test(msg))
         expect(matches).toEqual([])
       } finally {
         warnSpy.mockRestore()
@@ -163,7 +163,7 @@ describe('buildRegister', () => {
         register('note', { persist: true })
         const matches = warnSpy.mock.calls
           .map((args) => args.join(' '))
-          .filter((msg) => /no `persist:` option is configured/.test(msg))
+          .filter((msg) => /no `persist` option configured/.test(msg))
         expect(matches.length).toBe(1)
       } finally {
         warnSpy.mockRestore()

--- a/test/core/transient-empty-form-store.test.ts
+++ b/test/core/transient-empty-form-store.test.ts
@@ -7,10 +7,10 @@ const incomeKey = canonicalizePath('income').key
 const nameKey = canonicalizePath('name').key
 
 /**
- * Direct FormStore-level coverage for the transient-empty mechanism
+ * Direct FormStore-level coverage for the blank mechanism
  * landed in commit 2. The public API doesn't expose `unset` until
  * commit 7, so these tests exercise the runtime channel through
- * `setValueAtPath`'s `WriteMeta.transientEmpty` flag and reset's
+ * `setValueAtPath`'s `WriteMeta.blank` flag and reset's
  * snapshot semantics.
  */
 
@@ -31,143 +31,143 @@ const defaults: Form = {
   meta: { notes: '', score: 0 },
 }
 
-describe('FormStore — transient-empty gate hook', () => {
+describe('FormStore — blank gate hook', () => {
   it('exposes both reactive and snapshot Sets, empty by default', () => {
     const state = createFormStore<Form>({
       formKey: 'cx-1',
       schema: fakeSchema(defaults),
     })
-    expect(state.transientEmptyPaths.size).toBe(0)
-    expect(state.originalsTransientEmpty.size).toBe(0)
+    expect(state.blankPaths.size).toBe(0)
+    expect(state.originalBlankPaths.size).toBe(0)
   })
 
-  it('seeds the reactive Set + originals snapshot from initialTransientEmpty', () => {
+  it('seeds the reactive Set + originals snapshot from initialBlankPaths', () => {
     const state = createFormStore<Form>({
       formKey: 'cx-2',
       schema: fakeSchema(defaults),
-      initialTransientEmpty: [incomeKey, nameKey],
+      initialBlankPaths: [incomeKey, nameKey],
     })
-    expect(state.transientEmptyPaths.has(incomeKey)).toBe(true)
-    expect(state.transientEmptyPaths.has(nameKey)).toBe(true)
-    expect(state.originalsTransientEmpty.has(incomeKey)).toBe(true)
-    expect(state.originalsTransientEmpty.has(nameKey)).toBe(true)
+    expect(state.blankPaths.has(incomeKey)).toBe(true)
+    expect(state.blankPaths.has(nameKey)).toBe(true)
+    expect(state.originalBlankPaths.has(incomeKey)).toBe(true)
+    expect(state.originalBlankPaths.has(nameKey)).toBe(true)
   })
 
-  it('hydration.transientEmptyPaths overrides initialTransientEmpty', () => {
+  it('hydration.blankPaths overrides initialBlankPaths', () => {
     const state = createFormStore<Form>({
       formKey: 'cx-3',
       schema: fakeSchema(defaults),
-      initialTransientEmpty: [incomeKey],
+      initialBlankPaths: [incomeKey],
       hydration: {
         form: defaults,
         schemaErrors: [],
         userErrors: [],
         fields: [],
-        transientEmptyPaths: [nameKey],
+        blankPaths: [nameKey],
       },
     })
-    expect(state.transientEmptyPaths.has(incomeKey)).toBe(false)
-    expect(state.transientEmptyPaths.has(nameKey)).toBe(true)
-    expect(state.originalsTransientEmpty.has(incomeKey)).toBe(false)
-    expect(state.originalsTransientEmpty.has(nameKey)).toBe(true)
+    expect(state.blankPaths.has(incomeKey)).toBe(false)
+    expect(state.blankPaths.has(nameKey)).toBe(true)
+    expect(state.originalBlankPaths.has(incomeKey)).toBe(false)
+    expect(state.originalBlankPaths.has(nameKey)).toBe(true)
   })
 
-  it('hydration without transientEmptyPaths leaves the set empty', () => {
+  it('hydration without blankPaths leaves the set empty', () => {
     const state = createFormStore<Form>({
       formKey: 'cx-4',
       schema: fakeSchema(defaults),
       hydration: { form: defaults, schemaErrors: [], userErrors: [], fields: [] },
     })
-    expect(state.transientEmptyPaths.size).toBe(0)
+    expect(state.blankPaths.size).toBe(0)
   })
 
-  it('setValueAtPath with transientEmpty: true adds the path', () => {
+  it('setValueAtPath with blank: true adds the path', () => {
     const state = createFormStore<Form>({ formKey: 'cx-5', schema: fakeSchema(defaults) })
-    const ok = state.setValueAtPath(['income'], 0, { transientEmpty: true })
+    const ok = state.setValueAtPath(['income'], 0, { blank: true })
     expect(ok).toBe(true)
-    expect(state.transientEmptyPaths.has(incomeKey)).toBe(true)
+    expect(state.blankPaths.has(incomeKey)).toBe(true)
   })
 
-  it('subsequent write without transientEmpty meta removes the path (implicit unmark)', () => {
+  it('subsequent write without blank meta removes the path (implicit unmark)', () => {
     const state = createFormStore<Form>({ formKey: 'cx-6', schema: fakeSchema(defaults) })
-    state.setValueAtPath(['income'], 0, { transientEmpty: true })
-    expect(state.transientEmptyPaths.has(incomeKey)).toBe(true)
+    state.setValueAtPath(['income'], 0, { blank: true })
+    expect(state.blankPaths.has(incomeKey)).toBe(true)
 
     state.setValueAtPath(['income'], 50000)
-    expect(state.transientEmptyPaths.has(incomeKey)).toBe(false)
+    expect(state.blankPaths.has(incomeKey)).toBe(false)
     expect(state.form.value.income).toBe(50000)
   })
 
-  it('marks transient-empty even when storage value is unchanged (typing 0 over slim-default 0)', () => {
+  it('marks blank even when storage value is unchanged (typing 0 over slim-default 0)', () => {
     const state = createFormStore<Form>({ formKey: 'cx-7', schema: fakeSchema(defaults) })
-    // Storage is 0 from defaults; mark with transientEmpty: true. The
+    // Storage is 0 from defaults; mark with blank: true. The
     // identity short-circuit on Object.is(0, 0) would otherwise skip
     // the bookkeeping, but the gate-hook runs before that check.
-    state.setValueAtPath(['income'], 0, { transientEmpty: true })
-    expect(state.transientEmptyPaths.has(incomeKey)).toBe(true)
+    state.setValueAtPath(['income'], 0, { blank: true })
+    expect(state.blankPaths.has(incomeKey)).toBe(true)
   })
 
   it('unmarks even when storage value is unchanged (typing 0 after marking)', () => {
     const state = createFormStore<Form>({ formKey: 'cx-8', schema: fakeSchema(defaults) })
-    state.setValueAtPath(['income'], 0, { transientEmpty: true })
-    expect(state.transientEmptyPaths.has(incomeKey)).toBe(true)
-    // Same value, no transientEmpty meta — should unmark.
+    state.setValueAtPath(['income'], 0, { blank: true })
+    expect(state.blankPaths.has(incomeKey)).toBe(true)
+    // Same value, no blank meta — should unmark.
     state.setValueAtPath(['income'], 0)
-    expect(state.transientEmptyPaths.has(incomeKey)).toBe(false)
+    expect(state.blankPaths.has(incomeKey)).toBe(false)
   })
 
-  it('does not mutate originalsTransientEmpty on regular writes', () => {
+  it('does not mutate originalBlankPaths on regular writes', () => {
     const state = createFormStore<Form>({
       formKey: 'cx-9',
       schema: fakeSchema(defaults),
-      initialTransientEmpty: [incomeKey],
+      initialBlankPaths: [incomeKey],
     })
-    state.setValueAtPath(['income'], 100, { transientEmpty: true })
+    state.setValueAtPath(['income'], 100, { blank: true })
     state.setValueAtPath(['income'], 200)
     // originals snapshot stays at construction-time membership.
-    expect(state.originalsTransientEmpty.has(incomeKey)).toBe(true)
+    expect(state.originalBlankPaths.has(incomeKey)).toBe(true)
   })
 })
 
 describe('FormStore — reset', () => {
-  it('reset() restores transientEmptyPaths from the originals snapshot', () => {
+  it('reset() restores blankPaths from the originals snapshot', () => {
     const state = createFormStore<Form>({
       formKey: 'cx-10',
       schema: fakeSchema(defaults),
-      initialTransientEmpty: [incomeKey],
+      initialBlankPaths: [incomeKey],
     })
     // User clears the path (manual unmark via a non-transient write).
     state.setValueAtPath(['income'], 100)
-    expect(state.transientEmptyPaths.has(incomeKey)).toBe(false)
+    expect(state.blankPaths.has(incomeKey)).toBe(false)
 
     state.reset()
-    expect(state.transientEmptyPaths.has(incomeKey)).toBe(true)
+    expect(state.blankPaths.has(incomeKey)).toBe(true)
     // Snapshot itself is unchanged.
-    expect(state.originalsTransientEmpty.has(incomeKey)).toBe(true)
+    expect(state.originalBlankPaths.has(incomeKey)).toBe(true)
   })
 
   it('reset(args) clears both sets (commit 7 wires the unset walker)', () => {
     const state = createFormStore<Form>({
       formKey: 'cx-11',
       schema: fakeSchema(defaults),
-      initialTransientEmpty: [incomeKey, nameKey],
+      initialBlankPaths: [incomeKey, nameKey],
     })
     state.reset({ income: 5 })
-    expect(state.transientEmptyPaths.size).toBe(0)
-    expect(state.originalsTransientEmpty.size).toBe(0)
+    expect(state.blankPaths.size).toBe(0)
+    expect(state.originalBlankPaths.size).toBe(0)
   })
 
   it('after reset(args) followed by reset(), the post-reset(args) baseline returns', () => {
     const state = createFormStore<Form>({
       formKey: 'cx-12',
       schema: fakeSchema(defaults),
-      initialTransientEmpty: [incomeKey],
+      initialBlankPaths: [incomeKey],
     })
     state.reset({ income: 5 })
     // Now snapshot is empty; reset() restores empty.
-    state.setValueAtPath(['income'], 7, { transientEmpty: true })
+    state.setValueAtPath(['income'], 7, { blank: true })
     state.reset()
-    expect(state.transientEmptyPaths.size).toBe(0)
+    expect(state.blankPaths.size).toBe(0)
   })
 })
 
@@ -180,15 +180,15 @@ describe('FormStore — reactive Set tracking', () => {
     const stopHandle = (() => {
       // Manual computation via ref-style — we use Vue's reactivity via
       // computed. For the unit test, we just call .has() each time.
-      const initial = state.transientEmptyPaths.has(incomeKey)
+      const initial = state.blankPaths.has(incomeKey)
       observed = initial ? 1 : 0
       return () => undefined
     })()
     expect(observed).toBe(0)
-    state.transientEmptyPaths.add(incomeKey)
-    expect(state.transientEmptyPaths.has(incomeKey)).toBe(true)
-    state.transientEmptyPaths.delete(incomeKey)
-    expect(state.transientEmptyPaths.has(incomeKey)).toBe(false)
+    state.blankPaths.add(incomeKey)
+    expect(state.blankPaths.has(incomeKey)).toBe(true)
+    state.blankPaths.delete(incomeKey)
+    expect(state.blankPaths.has(incomeKey)).toBe(false)
     stopHandle()
   })
 })

--- a/test/transforms/input-text-area.test.ts
+++ b/test/transforms/input-text-area.test.ts
@@ -155,4 +155,66 @@ describe('inputTextAreaNodeTransform', () => {
       expect(code).not.toMatch(/\bvalue:\s*"ignored"/)
     })
   })
+
+  /**
+   * Repro for the playground newsletter bug: the checkbox flashed
+   * checked → unchecked → checked on every refresh.
+   *
+   * Pre-fix the synthesized `:checked` equality compared the model
+   * against a SINGLE element-side value (the static `value=` attr,
+   * defaulting to `''` when missing) for ALL three branches —
+   * Array.includes, Set.has, AND scalar `===`. That works for the
+   * array / Set group case (where `value="apple"` is the option-value)
+   * but is wrong for two scalar shapes:
+   *
+   *   1. Single boolean (`z.boolean()` with no value attr): the
+   *      equality is `model === ''` — always false, even when the
+   *      box should be checked. SSR renders unchecked, the directive's
+   *      setChecked corrects after mount → visible flash.
+   *   2. Single string mapped via `:true-value` (e.g. `z.enum([...])`
+   *      with `:true-value="'subscribe'"`): the equality is
+   *      `model === ''` instead of `model === 'subscribe'`. Same
+   *      flash.
+   *
+   * Post-fix the scalar branch uses the `:true-value` (or, for the
+   * boolean case, the literal `true`) — matching the runtime's
+   * `getCheckboxValue(el, true)` fallback. SSR renders checked when
+   * it should be, and there's no flash on hydration.
+   */
+  describe('checkbox scalar equality target', () => {
+    it('uses :true-value as the scalar equality target', () => {
+      const code = compileWithTransform(
+        `<input type="checkbox" :true-value="'subscribe'" v-register="newsletter" />`
+      )
+      // The scalar leg should compare against 'subscribe', not ''.
+      // We assert the literal appears in an equality position
+      // immediately followed by `)` (the scalar branch's closing).
+      expect(code).toMatch(/===\s*\('subscribe'\)/)
+    })
+
+    it('uses literal `true` as the scalar equality target when no value / true-value', () => {
+      const code = compileWithTransform(`<input type="checkbox" v-register="agreed" />`)
+      // Boolean checkbox: the scalar branch must compare against
+      // `true`, not `''` (which would always evaluate false against
+      // `false`/`true` model values).
+      expect(code).toMatch(/===\s*\(true\)/)
+    })
+
+    it('uses value= as the scalar equality target on radio', () => {
+      // Radio model is always scalar; the option-value (`value=`)
+      // IS the right discriminator there.
+      const code = compileWithTransform(`<input type="radio" value="apple" v-register="fruit" />`)
+      expect(code).toMatch(/===\s*\("apple"\)/)
+    })
+
+    it('checkbox group keeps option-value for the array/Set legs', () => {
+      // The group case must still use `value="apple"` for
+      // includes / has — only the scalar branch changes.
+      const code = compileWithTransform(
+        `<input type="checkbox" value="apple" v-register="fruits" />`
+      )
+      expect(code).toContain('?.includes("apple")')
+      expect(code).toContain('?.has("apple")')
+    })
+  })
 })

--- a/test/transforms/input-text-area.test.ts
+++ b/test/transforms/input-text-area.test.ts
@@ -154,6 +154,31 @@ describe('inputTextAreaNodeTransform', () => {
       // that's expected and unrelated.)
       expect(code).not.toMatch(/\bvalue:\s*"ignored"/)
     })
+
+    it('matches type="CHECKBOX" / "Radio" case-insensitively', () => {
+      // HTML spec: `type` is ASCII case-insensitive. The compile-time
+      // `isStaticTypeOneOf` already normalises, but the runtime
+      // selection-label expression compares the type string against
+      // lowercase 'checkbox' / 'radio' — without case folding there,
+      // a `type="CHECKBOX"` input has its static `value` preserved
+      // (per `keepStaticValue`) but still emits `:value=` instead of
+      // `:checked=`, breaking SSR initial checked state. Both halves
+      // need the case-insensitive treatment.
+      const upperCheckbox = compileWithTransform(
+        `<input type="CHECKBOX" value="apple" v-register="fruits" />`
+      )
+      expect(upperCheckbox).toMatch(/\bvalue:\s*"apple"/)
+      // Selection-label expression must lowercase the type before
+      // comparing — String(...).toLowerCase() shows up in the
+      // generated render code.
+      expect(upperCheckbox).toContain('.toLowerCase()')
+
+      const mixedRadio = compileWithTransform(
+        `<input type="Radio" value="apple" v-register="fruit" />`
+      )
+      expect(mixedRadio).toMatch(/\bvalue:\s*"apple"/)
+      expect(mixedRadio).toContain('.toLowerCase()')
+    })
   })
 
   /**

--- a/test/transforms/input-text-area.test.ts
+++ b/test/transforms/input-text-area.test.ts
@@ -108,4 +108,51 @@ describe('inputTextAreaNodeTransform', () => {
       expect(() => compileWithTransform(`<input v-register />`)).not.toThrow()
     })
   })
+
+  /**
+   * Repro for the playground bug: `<input type="checkbox" value="apple"
+   * v-register="...">` lost its static `value` attribute in the
+   * generated render code, so SSR HTML had no `value` attribute. Post-
+   * hydration the directive's change handler couldn't determine the
+   * option-value of the checkbox in an array group.
+   *
+   * The static `value=` on a checkbox / radio is the OPTION-value (a
+   * discriminator within the group), not display state — it must
+   * survive the transform. The synthesized binding the transform
+   * injects resolves to `:checked` for checkbox / radio at runtime,
+   * which is a different attribute key from `value`, so keeping the
+   * static `value` attribute alongside it is conflict-free.
+   */
+  describe('preserves static value attribute on checkbox / radio', () => {
+    // The assertions look for the literal in the form `value: "apple"`
+    // — that's how Vue's compiler emits an object-property entry for a
+    // static attribute. The literal `"apple"` ALSO appears inside the
+    // synthesized equality expression (`...?.includes("apple")`), so
+    // `toContain('"apple"')` would false-pass even pre-fix; the
+    // key-value-pair regex is what specifically catches "did the
+    // static attribute survive as an own prop on the props object".
+    it('keeps value="apple" on a static-type checkbox', () => {
+      const code = compileWithTransform(
+        `<input type="checkbox" value="apple" v-register="fruits" />`
+      )
+      expect(code).toMatch(/\bvalue:\s*"apple"/)
+    })
+
+    it('keeps value="apple" on a static-type radio', () => {
+      const code = compileWithTransform(`<input type="radio" value="apple" v-register="fruit" />`)
+      expect(code).toMatch(/\bvalue:\s*"apple"/)
+    })
+
+    it('still strips a colliding value attr on a text-type input', () => {
+      // Negative case — for text inputs, the synthesized binding
+      // resolves to `:value` and would clash with a static `value`.
+      // The transform's removal still applies there.
+      const code = compileWithTransform(`<input type="text" value="ignored" v-register="email" />`)
+      // The static `value: "ignored"` key-value pair must NOT appear
+      // in the props object. (The literal `"ignored"` itself does
+      // appear inside the synthesized conditional's equality leg —
+      // that's expected and unrelated.)
+      expect(code).not.toMatch(/\bvalue:\s*"ignored"/)
+    })
+  })
 })

--- a/test/utils/form-harness.ts
+++ b/test/utils/form-harness.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared mount harness for tests that exercise the runtime form
+ * pipeline (directive, store, persistence). Centralises the
+ * `createApp + useForm + plugin install + mount` boilerplate so
+ * test files don't reimplement it.
+ *
+ * Parameterised on `useFormFn` so v3 and v4 callers can pass their
+ * own typed import without the harness coupling to either zod major.
+ */
+import { createApp, defineComponent, h, nextTick, type App } from 'vue'
+import { createChemicalXForms } from '../../src/runtime/core/plugin'
+
+/**
+ * Drain microtasks + Vue's queue four times. Four is empirical —
+ * enough for the directive's optimistic-connect IIFE, the field's
+ * validate-on-init effect, and any `nextTick`-deferred dev warns to
+ * settle. Three was occasionally too few; five was wasteful.
+ */
+export async function flush(): Promise<void> {
+  for (let i = 0; i < 4; i++) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyUseForm = (opts: any) => any
+
+/**
+ * Returns a thunk that mounts a fresh Vue app with `useFormFn(opts)`
+ * called inside the root component's setup. Each invocation produces
+ * an isolated app + form key (random suffix) so tests in the same
+ * file don't collide.
+ *
+ * Defaults `validationMode: 'lax'` because the property tests focus
+ * on write-gate semantics, not refinement-time validation. Override
+ * via `options` for tests that need strict mode.
+ */
+export function makeMounter<S>(
+  useFormFn: AnyUseForm,
+  schema: S,
+  options: Record<string, unknown> = {}
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): () => { api: any; app: App } {
+  return function mount() {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const captured: { api?: any } = {}
+    const App = defineComponent({
+      setup() {
+        captured.api = useFormFn({
+          schema,
+          key: `slim-${Math.random().toString(36).slice(2)}`,
+          validationMode: 'lax',
+          ...options,
+        })
+        return () => h('div')
+      },
+    })
+    const app = createApp(App).use(createChemicalXForms())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return { api: captured.api as any, app }
+  }
+}

--- a/test/utils/schema-manifest.ts
+++ b/test/utils/schema-manifest.ts
@@ -1,0 +1,230 @@
+/**
+ * Schema-with-manifest arbitrary for property-based tests of the
+ * slim-primitive write gate.
+ *
+ * The "manifest" is a list of every leaf the generator emitted:
+ * its canonical path AND the exact `Set<SlimPrimitiveKind>` we know
+ * the schema accepts there. Tests assert against the manifest, NOT
+ * against `adapter.getSlimPrimitiveTypesAtPath`, because the latter
+ * is one of the things under test — using it as the oracle would
+ * make the test pass even if both adapter and gate drifted in
+ * lockstep.
+ *
+ * This module is loosely typed (`type ZNs = any`) so both v3 and v4
+ * callers can pass their own `z` namespace, mirroring the pattern in
+ * `./zod-arbitraries.ts`. The constructor surfaces we use
+ * (`z.string`, `z.number`, `z.boolean`, `z.bigint`, `z.date`,
+ * `z.literal`, `z.enum`, `.optional`, `.nullable`, `z.object`) match
+ * across the major boundary.
+ */
+import { fc } from '@fast-check/vitest'
+import type { Path } from '../../src/runtime/core/paths'
+import type { SlimPrimitiveKind } from '../../src/runtime/types/types-api'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ZNs = any
+
+export type LeafEntry = {
+  /** Canonical path from the form root to the leaf. */
+  path: Path
+  /** Slim primitive kinds the schema accepts at this leaf, by construction. */
+  acceptSet: Set<SlimPrimitiveKind>
+}
+
+export type SchemaWithManifest = {
+  /** A `z.ZodObject` (root form schema). */
+  schema: unknown
+  /** Every primitive leaf the generator produced, with its accept set. */
+  leaves: LeafEntry[]
+}
+
+/**
+ * Object keys are restricted to alphanumeric + underscore so dotted
+ * path strings round-trip through `setValue('a.b.c', value)` without
+ * key-segment ambiguity. The slim-gate's downstream walker
+ * (`canonicalizePath`) splits on `.`; keys containing `.` would split
+ * into multiple segments and not match the manifest path.
+ */
+const objectKey = fc
+  .string({ minLength: 1, maxLength: 4 })
+  .filter((s) => /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(s))
+
+/**
+ * One leaf shape: a `(z) => { schema, acceptSet }` factory paired
+ * with the fast-check arbitrary that drives any random parameters
+ * the leaf needs (literal value, enum members, default value).
+ *
+ * Each entry's `acceptSet` is the schema's slim-kind contract,
+ * computed from the constructor we picked. They MUST match the
+ * adapters' `getSlimPrimitiveTypesAtPath` output for the same
+ * schema — the manifest sanity property catches drift.
+ */
+function leafBuilders(z: ZNs): fc.Arbitrary<{
+  schema: unknown
+  acceptSet: Set<SlimPrimitiveKind>
+}>[] {
+  return [
+    fc.constant({ schema: z.string(), acceptSet: new Set<SlimPrimitiveKind>(['string']) }),
+    fc.constant({ schema: z.number(), acceptSet: new Set<SlimPrimitiveKind>(['number']) }),
+    fc.constant({ schema: z.boolean(), acceptSet: new Set<SlimPrimitiveKind>(['boolean']) }),
+    fc.constant({ schema: z.bigint(), acceptSet: new Set<SlimPrimitiveKind>(['bigint']) }),
+    fc.constant({ schema: z.date(), acceptSet: new Set<SlimPrimitiveKind>(['date']) }),
+    // .optional() / .nullable() add 'undefined' / 'null' to the inner
+    // accept set. Per the AbstractSchema contract docs at
+    // src/runtime/types/types-api.ts:251-253.
+    fc.constant({
+      schema: z.string().optional(),
+      acceptSet: new Set<SlimPrimitiveKind>(['string', 'undefined']),
+    }),
+    fc.constant({
+      schema: z.number().optional(),
+      acceptSet: new Set<SlimPrimitiveKind>(['number', 'undefined']),
+    }),
+    fc.constant({
+      schema: z.string().nullable(),
+      acceptSet: new Set<SlimPrimitiveKind>(['string', 'null']),
+    }),
+    fc.constant({
+      schema: z.number().nullable(),
+      acceptSet: new Set<SlimPrimitiveKind>(['number', 'null']),
+    }),
+    // Enums: string-only members, slim kind is 'string'. uniqueArray
+    // because zod requires distinct enum members.
+    fc
+      .uniqueArray(fc.string({ minLength: 1, maxLength: 4 }), { minLength: 1, maxLength: 4 })
+      .map((members) => ({
+        schema: z.enum(members as [string, ...string[]]),
+        acceptSet: new Set<SlimPrimitiveKind>(['string']),
+      })),
+    // Literals: per-kind. The slim-set is the literal's primitive kind.
+    fc.string({ minLength: 0, maxLength: 5 }).map((s) => ({
+      schema: z.literal(s),
+      acceptSet: new Set<SlimPrimitiveKind>(['string']),
+    })),
+    fc.integer({ min: -1_000, max: 1_000 }).map((n) => ({
+      schema: z.literal(n),
+      acceptSet: new Set<SlimPrimitiveKind>(['number']),
+    })),
+    fc.boolean().map((b) => ({
+      schema: z.literal(b),
+      acceptSet: new Set<SlimPrimitiveKind>(['boolean']),
+    })),
+  ]
+}
+
+/**
+ * A "node" is either a leaf (`{ schema, acceptSet }`, contributes one
+ * manifest entry at the current path) or a nested object (recursively
+ * expanded, contributes multiple entries below the current path).
+ */
+type Node = {
+  /** A zod schema (leaf or `z.ZodObject`). */
+  schema: unknown
+  /** Manifest entries this node contributes, with paths RELATIVE to itself. */
+  entries: LeafEntry[]
+}
+
+function buildNode(z: ZNs, depth: number): fc.Arbitrary<Node> {
+  // Leaves at any depth — and at depth 0 they're the only option.
+  const leafNode = fc.oneof(...leafBuilders(z)).map<Node>((leaf) => ({
+    schema: leaf.schema,
+    entries: [{ path: [], acceptSet: leaf.acceptSet }],
+  }))
+  if (depth <= 0) return leafNode
+
+  // Recursive object container: 1–3 child keys, each carrying a
+  // recursively-generated node. Child paths get prefixed with the
+  // child's key.
+  const objectNode = fc
+    .uniqueArray(
+      fc.tuple(objectKey, buildNode(z, depth - 1)),
+      // Keys must be unique within a single z.object shape; uniqueArray
+      // over the (key, node) pairs uses the key as the dedupe selector.
+      { minLength: 1, maxLength: 3, selector: ([k]) => k }
+    )
+    .map<Node>((children) => {
+      const shape: Record<string, unknown> = {}
+      const entries: LeafEntry[] = []
+      for (const [key, child] of children) {
+        shape[key] = child.schema
+        for (const sub of child.entries) {
+          entries.push({ path: [key, ...sub.path], acceptSet: sub.acceptSet })
+        }
+      }
+      return { schema: z.object(shape), entries }
+    })
+
+  return fc.oneof(leafNode, objectNode)
+}
+
+/**
+ * Root arbitrary: always a `z.ZodObject` (form schemas must be).
+ * `depth` counts the maximum nesting below the root.
+ */
+export function buildSchemaWithManifest(z: ZNs, depth: number): fc.Arbitrary<SchemaWithManifest> {
+  return fc
+    .uniqueArray(fc.tuple(objectKey, buildNode(z, Math.max(0, depth - 1))), {
+      minLength: 1,
+      maxLength: 4,
+      selector: ([k]) => k,
+    })
+    .map<SchemaWithManifest>((children) => {
+      const shape: Record<string, unknown> = {}
+      const leaves: LeafEntry[] = []
+      for (const [key, child] of children) {
+        shape[key] = child.schema
+        for (const sub of child.entries) {
+          leaves.push({ path: [key, ...sub.path], acceptSet: sub.acceptSet })
+        }
+      }
+      return { schema: z.object(shape), leaves }
+    })
+}
+
+/**
+ * Comparable slim-primitive kinds — the ones whose values can be
+ * deep-equal-compared via `expect(...).toEqual(...)`. Excludes
+ * `'symbol'` / `'function'` (incomparable) and `'object'` /
+ * `'array'` / `'map'` / `'set'` (compound — out of v1 scope, the
+ * gate's leaf-write semantic is what we're testing).
+ */
+export const COMPARABLE_KINDS = [
+  'string',
+  'number',
+  'boolean',
+  'bigint',
+  'date',
+  'null',
+  'undefined',
+] as const satisfies readonly SlimPrimitiveKind[]
+
+export type ComparableKind = (typeof COMPARABLE_KINDS)[number]
+
+/**
+ * Arbitrary value of a given slim-primitive kind. Restricted to
+ * "comparable" kinds (see `COMPARABLE_KINDS`).
+ *
+ * NaN is filtered out of the number arbitrary because `NaN === NaN`
+ * is `false`, which would false-fail the "form value matches written
+ * value" assertion.
+ */
+export function arbitraryValueOfKind(kind: ComparableKind): fc.Arbitrary<unknown> {
+  switch (kind) {
+    case 'string':
+      return fc.string({ maxLength: 16 })
+    case 'number':
+      return fc.float({ noNaN: true })
+    case 'boolean':
+      return fc.boolean()
+    case 'bigint':
+      return fc.bigInt({ min: -1_000n, max: 1_000n })
+    case 'date':
+      // Constrain to representable ms range; fc.date() can produce
+      // Invalid Date which compares unequal to itself.
+      return fc.date({ noInvalidDate: true })
+    case 'null':
+      return fc.constant(null)
+    case 'undefined':
+      return fc.constant(undefined)
+  }
+}

--- a/test/utils/schema-manifest.ts
+++ b/test/utils/schema-manifest.ts
@@ -213,7 +213,10 @@ export function arbitraryValueOfKind(kind: ComparableKind): fc.Arbitrary<unknown
     case 'string':
       return fc.string({ maxLength: 16 })
     case 'number':
-      return fc.float({ noNaN: true })
+      // `noNaN` blocks Number.NaN but fast-check still emits ±Infinity
+      // by default (min/max default to ±Infinity). Both options are
+      // needed to guarantee a finite, deep-equal-comparable number.
+      return fc.float({ noNaN: true, noDefaultInfinity: true })
     case 'boolean':
       return fc.boolean()
     case 'bigint':


### PR DESCRIPTION
## Summary

- **Fix the unknown-path write bug** (`02092ac`): `register('address.salary')` against a schema with `address: { city }` no longer silently materialises an `address.salary` slot in the form on first keystroke. Both adapters' `getSlimPrimitiveTypesAtPath` now return an empty Set for unresolvable paths instead of `PERMISSIVE`; the slim-gate's membership check rejects the write. Also fixes a latent v3 path-walker bug — over-deep paths (`['A', 'unknown']` against `z.object({A: z.number()})`) were silently truncated to the parent's leaf schema instead of returning empty.
- **Property test for the slim-gate contract** (`bb3acd1`): three properties per adapter (manifest sanity / known leaf paths / unknown paths) over arbitrary zod schemas. The unknown-path property would have caught the original bug instantly. The first run of the v3 test surfaced the over-deep walker bug above. Helper modules (`schema-manifest.ts`, `form-harness.ts`) sit alongside the existing `zod-arbitraries.ts`.
- **KISS rewrite of dev warns / thrown errors** (`fd7ccf6`, `4c83200`): every user-facing message in `src/runtime` now leads with the problem in one sentence and states the fix on the next line. Drops filler ("Please check..."), inverted ordering ("Please add..." before stating the issue), and library-implementation noise leaking into user copy. Rewrote ~16 sites; left ~10 already-KISS messages alone. Behavioural changes: none.
- **Playground** (`39e54ec`): added a bare-path alias for `@chemical-x/forms` to fix the SSR worker crashing with `IPC connection closed` whenever a playground component imported from the bare path. Also added `Child.vue` / `Grandchild.vue` mirroring the user-side reproduction case.

## Test plan

- [ ] `pnpm test` — 1415 passing (previously 1407)
- [ ] `pnpm typecheck`
- [ ] `pnpm lint`
- [ ] Manual: `pnpm dev`, type any non-numeric chars into a `z.number()`-bound `<input v-register="register('field')">` — confirm the rejection warn shows both fix paths verbatim (`type="number"` and `.number` modifier).
- [ ] Manual: register a typo path (`register('address.salary')` against a schema with no such key) — confirm the warn says "this path is not in your schema" with a copy-paste of the bad path.
- [ ] Optional bug-teeth check (manual, both adapters): temporarily revert the unknown-path branch in either `src/runtime/adapters/zod-v4/adapter.ts:307` or `src/runtime/adapters/zod-v3/index.ts:380` to `return new Set(PERMISSIVE)`; rerun the property file — the unknown-path property should fail within a handful of runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Playground: new persisted login demo and nested child/grandchild components for form examples.
  * Exposed stable string hash utility for deterministic persistence keys.

* **Bug Fixes**
  * Tightened schema write-gate to reject writes to unknown paths.
  * Fixed checkbox/radio hydration and value resolution to avoid incorrect option binding.

* **Developer Experience**
  * Clearer, shorter dev warnings and a new anonymous-form persistence error to guide fixes.

* **Tests**
  * Added property, E2E, and harness utilities to strengthen runtime coverage.

* **Chores**
  * Updated .gitignore to exclude local AI artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->