### PR TITLE
feat!: Pinia-style read API + persist throws + SSR fixes

### DIFF
--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+  import { parseApiErrors } from '@chemical-x/forms'
   import { useForm } from '@chemical-x/forms/zod'
   import z from 'zod'
   import Child from './components/Child.vue'

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -3,65 +3,70 @@
   import z from 'zod'
   import Child from './components/Child.vue'
 
-  const login = z.object({
-    email: z.email(),
-    password: z.string(),
-    address: z.object({
-      city: z.string(),
-    }),
-    salary: z.number(),
-    // Checkbox demos:
-    //   - boolean → single checkbox (true/false)
-    //   - array → checkbox group (membership add/remove)
-    //   - enum + :true-value/:false-value → single checkbox mapped
-    //     to one of two strings
-    agreedToTerms: z.boolean(),
-    favoriteFruits: z.array(z.string()),
-    newsletter: z.enum(['subscribe', 'unsubscribe']),
-    // Radio group — one register binding shared across multiple
-    // <input type="radio">, each with a distinct value=. Model is
-    // the option-value of the currently-checked radio.
-    subscriptionTier: z.enum(['free', 'pro', 'enterprise']),
-  })
+  // -- Original demo: register + form.values across multiple inputs --
+  const schema = z.object({ fruit: z.string() })
+  const fruitForm = useForm({ schema, key: 'example-form' })
+  const registerValue = fruitForm.register('fruit')
 
-  const { register, getFieldState, handleSubmit, getValue } = useForm({
-    schema: login,
-    // Explicit key required for `persist:` to round-trip reliably —
-    // anon keys drift across mounts (HMR / refresh / SSR↔CSR) and the
-    // persistence layer would orphan entries on every reload.
-    key: 'login',
-    persist: 'session',
-    defaultValues: {
-      favoriteFruits: ['banana'],
-    },
+  // -- Error API demo --
+  const signupSchema = z.object({
+    email: z.string().email('Enter a valid email'),
+    password: z.string().min(8, 'At least 8 characters'),
   })
-  const field = getFieldState('salary')
+  const signupForm = useForm({ schema: signupSchema, key: 'signup' })
 
-  const displayError = computed(() => {
-    if (!field.value.touched) return ''
-    const msg = field.value.errors?.[0]?.message ?? ''
-    return msg
+  const emailReg = signupForm.register('email')
+  const passwordReg = signupForm.register('password')
+
+  // handleSubmit wraps the user callback: validation failure auto-populates
+  // signupForm.errors, success clears it. The user's onSubmit can then parse
+  // a server response via parseApiErrors() and write the result with
+  // setFieldErrors(...) to layer server-side errors on top.
+  const onSubmit = signupForm.handleSubmit(async (values) => {
+    // simulate server returning a 422
+    const apiResult = parseApiErrors(
+      { error: { details: { email: ['Already taken'] } } },
+      { formKey: signupForm.key }
+    )
+    if (apiResult.ok) signupForm.setFieldErrors(apiResult.errors)
+    // eslint-disable-next-line no-console
+    console.log('client-validated values:', values)
   })
-
-  const onSubmit = handleSubmit(
-    (values) => {
-      // eslint-disable-next-line no-console
-      console.log('Success!', values)
-    },
-    (errors) => {
-      // eslint-disable-next-line no-console
-      console.log('Nope!', errors)
-    }
-  )
 </script>
 
 <template>
-  <div>
-    <NuxtRouteAnnouncer />
-    <form @submit="onSubmit">
-      <div>
-        <label for="email">Email</label>
-        <input id="email" v-register.trim="register('email', { persist: true })" />
+  <div style="font-family: system-ui; max-width: 640px; margin: 2rem auto; padding: 0 1rem">
+    <h1>chemical-x-forms playground</h1>
+
+    <h2>Pinia-style read API</h2>
+    <p>current fruit: '{{ fruitForm.values.fruit }}'</p>
+    <input v-register="registerValue" />
+    <hr />
+    <input v-register="registerValue" />
+    <hr />
+    <RootInput :fruit="registerValue" />
+
+    <h2 style="margin-top: 2rem">Error API</h2>
+    <form style="display: flex; flex-direction: column; gap: 1rem" @submit.prevent="onSubmit">
+      <label style="display: flex; flex-direction: column; gap: 0.25rem">
+        <span>Email</span>
+        <input v-register="emailReg" type="email" />
+        <small v-if="signupForm.errors.email?.[0]" style="color: #dc2626">
+          {{ signupForm.errors.email[0].message }}
+        </small>
+      </label>
+
+      <label style="display: flex; flex-direction: column; gap: 0.25rem">
+        <span>Password</span>
+        <input v-register="passwordReg" type="password" />
+        <small v-if="signupForm.errors.password?.[0]" style="color: #dc2626">
+          {{ signupForm.errors.password[0].message }}
+        </small>
+      </label>
+
+      <div style="display: flex; gap: 0.5rem">
+        <button type="submit">Submit</button>
+        <button type="button" @click="signupForm.clearFieldErrors()">Clear errors</button>
       </div>
       <br />
 
@@ -135,7 +140,9 @@
       <button>Log in</button>
     </form>
 
-    <pre>{{ getValue().value }}</pre>
-    <pre>{{ JSON.stringify(field, null, 2) }}</pre>
+    <h3 style="margin-top: 1.5rem">Same data via fieldState (FieldState.errors)</h3>
+    <pre style="background: #f8fafc; padding: 0.75rem; border-radius: 6px">{{
+      JSON.stringify(signupForm.fieldState.email.errors, null, 2)
+    }}</pre>
   </div>
 </template>

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,8 +73,6 @@ export type {
   ApiErrorEntry,
   ApiErrorEnvelope,
   ChemicalXFormsDefaults,
-  CurrentValueContext,
-  CurrentValueWithContext,
   CustomDirectiveRegisterAssignerFn,
   DefaultValuesResponse,
   FieldState,

--- a/src/runtime/composables/use-abstract-form.ts
+++ b/src/runtime/composables/use-abstract-form.ts
@@ -904,7 +904,11 @@ const warnedAnonPersistKeys: Set<string> = new Set<string>()
  */
 function enforceAnonPersistRule(formKey: string, isSSR: boolean): boolean {
   if (!formKey.startsWith(ANONYMOUS_FORM_KEY_PREFIX)) return false
-  if (__DEV__) throw new AnonPersistError()
+  if (__DEV__)
+    throw new AnonPersistError({
+      cause: 'no-key',
+      callSite: captureUserCallSite(),
+    })
   // Production: warn + tell the caller to skip wiring. Client-only
   // warn (skip server logs to avoid spamming SSR per-request output).
   // Persist is still skipped on the SSR pass — same disabling

--- a/src/runtime/composables/use-abstract-form.ts
+++ b/src/runtime/composables/use-abstract-form.ts
@@ -10,6 +10,7 @@ import {
 import { __DEV__ } from '../core/dev'
 import { captureUserCallSite } from '../core/dev-stack-trace'
 import { AnonPersistError, ReservedFormKeyError } from '../core/errors'
+import { extractSchemaFields } from '../core/extract-schema-fields'
 import type { FieldStateView } from '../core/field-state-api'
 import { getComputedSchema } from '../core/get-computed-schema'
 import { createHistoryModule, type HistoryModule } from '../core/history'
@@ -86,6 +87,22 @@ export function useAbstractForm<
   // for consumers whose schema intentionally produces a different runtime
   // shape (e.g. zod's `.transform(...)` narrowing).
   const resolvedSchema = getComputedSchema(key, configuration.schema)
+
+  // Eager throw: persistence configured without an explicit `key:`. An
+  // anonymous synthetic key (`__cx:anon:*`) drifts across mounts (HMR /
+  // route changes / SSR↔CSR) and can collide between unrelated forms —
+  // refusing here keeps the namespace stable and forecloses on the
+  // future encrypted-backend case where collision becomes a key-derivation
+  // overlap. Throws in dev and prod alike. The error body carries the
+  // schema's top-level fields and a captured call-site so the offender
+  // is identifiable from the message alone.
+  if (configuration.persist !== undefined && configuration.key === undefined) {
+    throw new AnonPersistError({
+      cause: 'no-key',
+      schemaFields: extractSchemaFields(resolvedSchema),
+      callSite: captureUserCallSite(),
+    })
+  }
 
   // One FormStore per (app, formKey). Multiple useForm calls with the same
   // key resolve to the same instance — that's the shared-store semantic
@@ -681,34 +698,13 @@ function wirePersistence<F extends GenericForm>(
     }
   })()
 
-  // Dev-mode warning: persistence is configured but no field opted in.
-  // Common confusion mode — `persist: { storage: 'local' }` is set on
-  // the form but every `register()` call omits `{ persist: true }`, so
-  // drafts mysteriously never save. Wait one microtask AFTER the
-  // initial mount task settles so the directive's `created` hooks have
-  // had a chance to populate opt-ins; then check once. One-shot —
-  // re-mounts within the same FormStore lifetime don't re-warn.
-  if (__DEV__) {
-    void Promise.resolve().then(() => {
-      if (disposed) return
-      // Two microtask hops: the first lets the current setup() return
-      // and Vue mount the directive subtree; the second runs after
-      // Vue's own queued effects so any `register({ persist: true })`
-      // has landed in the registry.
-      void Promise.resolve().then(() => {
-        if (disposed) return
-        if (state.persistOptIns.isEmpty()) {
-          console.warn(
-            `[@chemical-x/forms] useForm({ persist: ... }) is configured on form ` +
-              `"${state.formKey}" but no fields opted in — nothing will be saved. ` +
-              `Fix: add \`{ persist: true }\` to register() calls, ` +
-              `e.g. register('email', { persist: true }). ` +
-              `See ./docs/recipes/persistence.md.`
-          )
-        }
-      })
-    })
-  }
+  // Note: a "configured but no fields opted in" check used to live here
+  // (microtask-deferred warn). Removed — having the persist capability
+  // configured without spending it on a register() call is a valid
+  // dormant state (scaffolding, A/B'd opt-ins, future-flagged fields).
+  // The library shouldn't lecture the consumer for not exercising every
+  // configured option. Eager throws only fire on actual contradictions
+  // (no-key + persist; register-with-persist + no useForm-persist).
 
   /**
    * Imperative one-shot write. Read-merge-write strategy: flush any

--- a/src/runtime/composables/use-register.ts
+++ b/src/runtime/composables/use-register.ts
@@ -38,6 +38,7 @@
 import {
   computed,
   getCurrentInstance,
+  onBeforeMount,
   onBeforeUpdate,
   onMounted,
   shallowRef,
@@ -112,7 +113,18 @@ export function useRegister(): ComputedRef<RegisterValue | undefined> {
     if ('registerValue' in rawAttrs) delete rawAttrs['registerValue']
     if ('value' in rawAttrs) delete rawAttrs['value']
   }
-  refreshAndStripBridgeAttrs()
+  // Defer the initial capture to `onBeforeMount` rather than running it
+  // synchronously in setup. Setup-time reads of `instance.attrs` race
+  // Vue's prop-patch lifecycle: under SSR (and on first CSR hydration
+  // for some patterns) the parent's `:registerValue` binding hasn't
+  // been propagated to attrs by the time setup runs, and the captured
+  // value lands as `undefined` — fingering the consumer with the
+  // "no parent registerValue prop" warn even though the parent passed
+  // v-register correctly. By onBeforeMount the prop has been wired,
+  // and the returned computed is read lazily by templates after
+  // mount-pass setup completes. Mirrors the radio directive's
+  // `created` → `mounted` fix (commit b0720c4).
+  onBeforeMount(refreshAndStripBridgeAttrs)
   onBeforeUpdate(refreshAndStripBridgeAttrs)
 
   return computed(() => {

--- a/src/runtime/composables/use-register.ts
+++ b/src/runtime/composables/use-register.ts
@@ -109,21 +109,35 @@ export function useRegister(): ComputedRef<RegisterValue | undefined> {
 
   const refreshAndStripBridgeAttrs = (): void => {
     const rawAttrs = instance.attrs as Record<string, unknown>
-    capturedRegisterValue.value = rawAttrs['registerValue'] as RegisterValue | undefined
-    if ('registerValue' in rawAttrs) delete rawAttrs['registerValue']
+    // Capture only when the bridge key is present. The strip below
+    // removes `registerValue` from attrs, so a second invocation of
+    // this function (e.g. `onBeforeMount` after the synchronous setup
+    // call) would otherwise overwrite the captured rv with `undefined`.
+    // Vue's `setFullProps` re-populates attrs on every parent render,
+    // so the `onBeforeUpdate` invocation correctly sees the key again
+    // and re-captures.
+    if ('registerValue' in rawAttrs) {
+      capturedRegisterValue.value = rawAttrs['registerValue'] as RegisterValue | undefined
+      delete rawAttrs['registerValue']
+    }
     if ('value' in rawAttrs) delete rawAttrs['value']
   }
-  // Defer the initial capture to `onBeforeMount` rather than running it
-  // synchronously in setup. Setup-time reads of `instance.attrs` race
-  // Vue's prop-patch lifecycle: under SSR (and on first CSR hydration
-  // for some patterns) the parent's `:registerValue` binding hasn't
-  // been propagated to attrs by the time setup runs, and the captured
-  // value lands as `undefined` — fingering the consumer with the
-  // "no parent registerValue prop" warn even though the parent passed
-  // v-register correctly. By onBeforeMount the prop has been wired,
-  // and the returned computed is read lazily by templates after
-  // mount-pass setup completes. Mirrors the radio directive's
-  // `created` → `mounted` fix (commit b0720c4).
+  // Capture+strip three times: synchronously in setup, then on
+  // beforeMount, then on every beforeUpdate. The synchronous call is
+  // load-bearing for SSR — Vue skips lifecycle hooks during
+  // `renderToString`, so an `onBeforeMount`-only capture leaves
+  // `capturedRegisterValue` at `undefined` and the directive's first
+  // server-side template read fires the no-parent-RV warn even when the
+  // parent passed v-register correctly. Vue's `setupComponent` runs
+  // `initProps` (which populates `instance.attrs.registerValue` from the
+  // parent's `:registerValue` binding injected by `selectNodeTransform`)
+  // before `setup()` runs, so the sync read sees the correct value on
+  // both server and client. The `onBeforeMount` hook stays as a defence
+  // in depth against any re-population that could happen after setup
+  // (e.g. from a parent's directive re-running) — idempotent, safe to
+  // duplicate. The `onBeforeUpdate` hook handles parent re-renders,
+  // where Vue's `setFullProps` runs again and re-puts the bridge keys.
+  refreshAndStripBridgeAttrs()
   onBeforeMount(refreshAndStripBridgeAttrs)
   onBeforeUpdate(refreshAndStripBridgeAttrs)
 

--- a/src/runtime/composables/use-register.ts
+++ b/src/runtime/composables/use-register.ts
@@ -66,17 +66,6 @@ export function useRegister(): ComputedRef<RegisterValue | undefined> {
     return computed(() => undefined)
   }
 
-  // Mark the rendered root DOM element after mount. `instance.vnode.el`
-  // is set during the patch of the child's subtree; reading it here
-  // (post-mount) gets the actual rendered element. The marker is what
-  // the parent's directive's deferred warn check reads.
-  onMounted(() => {
-    const el = instance.vnode.el
-    if (el !== null && el !== undefined && typeof el === 'object') {
-      ;(el as unknown as { [k: symbol]: unknown })[REGISTER_OWNER_MARKER] = true
-    }
-  })
-
   // Capture the bridge `registerValue` from instance.attrs into a
   // local ref, then STRIP the bridge keys (`registerValue` + `value`)
   // from the attrs object. This prevents fallthrough to the rendered
@@ -127,27 +116,45 @@ export function useRegister(): ComputedRef<RegisterValue | undefined> {
   // load-bearing for SSR — Vue skips lifecycle hooks during
   // `renderToString`, so an `onBeforeMount`-only capture leaves
   // `capturedRegisterValue` at `undefined` and the directive's first
-  // server-side template read fires the no-parent-RV warn even when the
-  // parent passed v-register correctly. Vue's `setupComponent` runs
-  // `initProps` (which populates `instance.attrs.registerValue` from the
-  // parent's `:registerValue` binding injected by `selectNodeTransform`)
-  // before `setup()` runs, so the sync read sees the correct value on
-  // both server and client. The `onBeforeMount` hook stays as a defence
-  // in depth against any re-population that could happen after setup
-  // (e.g. from a parent's directive re-running) — idempotent, safe to
-  // duplicate. The `onBeforeUpdate` hook handles parent re-renders,
-  // where Vue's `setFullProps` runs again and re-puts the bridge keys.
+  // server-side template read would otherwise misrender. Vue's
+  // `setupComponent` runs `initProps` (which populates
+  // `instance.attrs.registerValue` from the parent's `:registerValue`
+  // binding injected by `selectNodeTransform`) before `setup()` runs,
+  // so the sync read sees the correct value on both server and client.
+  // The `onBeforeMount` hook stays as defence in depth against any
+  // re-population that could happen after setup (e.g. from a parent's
+  // directive re-running) — idempotent, safe to duplicate. The
+  // `onBeforeUpdate` hook handles parent re-renders, where Vue's
+  // `setFullProps` runs again and re-puts the bridge keys.
   refreshAndStripBridgeAttrs()
   onBeforeMount(refreshAndStripBridgeAttrs)
   onBeforeUpdate(refreshAndStripBridgeAttrs)
 
-  return computed(() => {
-    const rv = capturedRegisterValue.value
-    if (rv === undefined) {
+  // Single post-mount hook does two jobs: (1) marks the rendered root
+  // DOM element with `REGISTER_OWNER_MARKER` so the parent directive's
+  // deferred warn check skips the "is a no-op" warn for components that
+  // handle binding via an inner v-register, and (2) emits the
+  // no-parent-RV diagnostic exactly once per instance if the captured
+  // value is still `undefined` by mount time — by then the parent has
+  // had its full lifecycle to bind, so still-undefined is conclusive
+  // misuse. The computed factory below stays pure: reads don't trigger
+  // diagnostics, so a consumer that conditionally consumes the value
+  // (or reads it many times) gets exactly the right behaviour. SSR is
+  // intentionally silent — `onMounted` doesn't fire on the server, and
+  // the CSR hydration pass surfaces the diagnostic on the only surface
+  // a developer can act on without double-counting through the Nuxt
+  // `dev:ssr-logs` channel.
+  onMounted(() => {
+    const el = instance.vnode.el
+    if (el !== null && el !== undefined && typeof el === 'object') {
+      ;(el as unknown as { [k: symbol]: unknown })[REGISTER_OWNER_MARKER] = true
+    }
+    if (capturedRegisterValue.value === undefined) {
       warnNoParentRV(instance as unknown as object)
     }
-    return rv
   })
+
+  return computed(() => capturedRegisterValue.value)
 }
 
 function warnOutsideSetup(): void {

--- a/src/runtime/core/build-form-api.ts
+++ b/src/runtime/core/build-form-api.ts
@@ -3,7 +3,6 @@ import type {
   CurrentValueContext,
   CurrentValueWithContext,
   FieldState,
-  FieldStateMap,
   FormErrorRecord,
   FormFieldErrors,
   FormState,
@@ -463,7 +462,10 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
         WithIndexedUndefined<WriteShape<GetValueFormType>>
       >
     },
-    fieldState: fieldStateProxy as unknown as FieldStateMap<GetValueFormType>,
+    fieldState: fieldStateProxy as unknown as UseAbstractFormReturnType<
+      Form,
+      GetValueFormType
+    >['fieldState'],
     setValue: setValueImpl as UseAbstractFormReturnType<Form, GetValueFormType>['setValue'],
     validate: validate as UseAbstractFormReturnType<Form, GetValueFormType>['validate'],
     validateAsync: validateAsync as UseAbstractFormReturnType<

--- a/src/runtime/core/build-form-api.ts
+++ b/src/runtime/core/build-form-api.ts
@@ -13,7 +13,13 @@ import type {
   ValidationError,
   ValidationResponseWithoutValue,
 } from '../types/types-api'
-import type { DeepPartial, DefaultValuesShape, GenericForm } from '../types/types-core'
+import type {
+  DeepPartial,
+  DefaultValuesShape,
+  GenericForm,
+  WithIndexedUndefined,
+  WriteShape,
+} from '../types/types-core'
 import { __DEV__ } from './dev'
 import type { FormStore } from './create-form-store'
 import { buildFieldArrayApi } from './field-arrays'
@@ -27,6 +33,7 @@ import { buildProcessForm } from './process-form'
 import { buildRegister } from './register-api'
 import { isUnset } from './unset'
 import { walkUnsetSentinels } from './unset-walker'
+import { buildValuesProxy } from './values-proxy'
 
 export type BuildFormApiOptions = {
   /** Forwarded to buildProcessForm. See `UseFormConfiguration.onInvalidSubmit`. */
@@ -419,6 +426,16 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
     return readonlySetSnapshot(state.blankPaths)
   })
 
+  // --- Pinia-style reactive readonly proxy over the form's value ---
+  // `valuesProxyComputed.value` is a deeply-readonly Vue proxy. The
+  // computed wrapping ensures `state.form.value` reassignments (the
+  // `applyFormReplacement` path used by `reset()` and whole-form
+  // `setValue`) invalidate the cached proxy and produce a fresh one
+  // keyed to the new target. The public `values` getter on the return
+  // object reads `.value` so consumers get the proxy directly with no
+  // `.value` access from their side.
+  const valuesProxyComputed = buildValuesProxy(state.form)
+
   return {
     getFieldState: getFieldState as UseAbstractFormReturnType<
       Form,
@@ -426,6 +443,16 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
     >['getFieldState'],
     handleSubmit,
     getValue: getValueImpl as UseAbstractFormReturnType<Form, GetValueFormType>['getValue'],
+    // `values` is a getter so reads route through the wrapping computed
+    // and pick up reactivity at the call site (every consumer template
+    // / effect that reads `form.values.<x>` subscribes to the underlying
+    // form ref). A plain property assignment (`values: valuesProxyComputed.value`)
+    // would snapshot once at buildFormApi time and never invalidate.
+    get values() {
+      return valuesProxyComputed.value as Readonly<
+        WithIndexedUndefined<WriteShape<GetValueFormType>>
+      >
+    },
     setValue: setValueImpl as UseAbstractFormReturnType<Form, GetValueFormType>['setValue'],
     validate: validate as UseAbstractFormReturnType<Form, GetValueFormType>['validate'],
     validateAsync: validateAsync as UseAbstractFormReturnType<

--- a/src/runtime/core/build-form-api.ts
+++ b/src/runtime/core/build-form-api.ts
@@ -1,8 +1,5 @@
 import { computed, reactive, readonly, type ComputedRef, type Ref } from 'vue'
 import type {
-  CurrentValueContext,
-  CurrentValueWithContext,
-  FieldState,
   FormErrorRecord,
   FormFieldErrors,
   FormState,
@@ -23,7 +20,6 @@ import type {
 import { __DEV__ } from './dev'
 import type { FormStore } from './create-form-store'
 import { buildFieldArrayApi } from './field-arrays'
-import { buildFieldStateAccessor } from './field-state-api'
 import { buildFieldStateProxy } from './field-state-proxy'
 import type { HistoryModule } from './history'
 import { getAtPath } from './path-walker'
@@ -89,7 +85,6 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
   options: BuildFormApiOptions = {}
 ): UseAbstractFormReturnType<Form, GetValueFormType> {
   const register = buildRegister(state) as (path: string | Path) => RegisterValue<unknown>
-  const getFieldStateBuilt = buildFieldStateAccessor(state)
   // Don't set `onInvalidSubmit: undefined` — exactOptionalPropertyTypes
   // treats an explicit-undefined value differently from an omitted
   // property. Only pass the key when the consumer opted in.
@@ -101,30 +96,18 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
     handleSubmit,
   } = buildProcessForm(state, processOptions)
 
-  const getFieldState = (pathInput: string) =>
-    getFieldStateBuilt(pathInput) as unknown as Ref<FieldState>
-
   const validate = (pathInput?: string) =>
     validateBuilt(pathInput) as Ref<ReactiveValidationStatus<Form>>
 
   const validateAsync = (pathInput?: string) =>
     validateAsyncBuilt(pathInput) as Promise<ValidationResponseWithoutValue<Form>>
 
-  // --- getValue / setValue (overloaded) ---
-  function getValueImpl(
-    pathOrContext?: string | CurrentValueContext<boolean>,
-    maybeContext?: CurrentValueContext<boolean>
-  ): unknown {
-    if (pathOrContext === undefined) {
-      return state.form as unknown as Readonly<Ref<GetValueFormType>>
-    }
-    if (typeof pathOrContext === 'object') {
-      return contextualiseValue(state, [], pathOrContext)
-    }
-    const segments = canonicalizePath(pathOrContext).segments
-    if (maybeContext !== undefined) {
-      return contextualiseValue(state, segments, maybeContext)
-    }
+  // --- toRef escape hatch — Readonly<Ref<...>> for the rare case
+  // a consumer needs ref-shaped interop (external composables that
+  // expect a Vue ref, watchers reading a single path). Writes still
+  // funnel through `setValue`, never via the ref.
+  function pathToRef(pathInput: string): Readonly<Ref<unknown>> {
+    const segments = canonicalizePath(pathInput).segments
     return computed(() => getAtPath(state.form.value, segments)) as Readonly<Ref<unknown>>
   }
 
@@ -446,12 +429,7 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
   const fieldStateProxy = buildFieldStateProxy(state)
 
   return {
-    getFieldState: getFieldState as UseAbstractFormReturnType<
-      Form,
-      GetValueFormType
-    >['getFieldState'],
     handleSubmit,
-    getValue: getValueImpl as UseAbstractFormReturnType<Form, GetValueFormType>['getValue'],
     // `values` is a getter so reads route through the wrapping computed
     // and pick up reactivity at the call site (every consumer template
     // / effect that reads `form.values.<x>` subscribes to the underlying
@@ -474,20 +452,8 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
     >['validateAsync'],
     register: register as UseAbstractFormReturnType<Form, GetValueFormType>['register'],
     key: state.formKey,
-    fieldErrors: fieldErrors as unknown as Readonly<FormFieldErrors<Form>>,
-    // `errors` is the renamed surface — same Proxy, new property name.
-    // Both names coexist during Phase B so C1 can sweep test sites
-    // mechanically; C2 deletes `fieldErrors`.
     errors: fieldErrors as unknown as Readonly<FormFieldErrors<Form>>,
-    // `toRef(path)` — escape hatch for the rare case a consumer wants
-    // a Ref. Delegates to `getValueImpl` with the path-overload, which
-    // already returns `Readonly<Ref<...>>`. The slim-primitive write
-    // gate stays the only way into storage; readonly here matches.
-    toRef: ((path: string) =>
-      getValueImpl(path) as Readonly<Ref<unknown>>) as UseAbstractFormReturnType<
-      Form,
-      GetValueFormType
-    >['toRef'],
+    toRef: pathToRef as UseAbstractFormReturnType<Form, GetValueFormType>['toRef'],
     setFieldErrors,
     addFieldErrors,
     clearFieldErrors,
@@ -535,21 +501,6 @@ function appendStoreToRecord(
       else existingForKey.push(err)
     }
   }
-}
-
-function contextualiseValue<F extends GenericForm>(
-  state: FormStore<F>,
-  segments: Path,
-  context: CurrentValueContext<boolean>
-): unknown {
-  const currentValue = computed(() => getAtPath(state.form.value, segments))
-  if (context.withMeta === true) {
-    return {
-      currentValue: currentValue as Readonly<Ref<unknown>>,
-      meta: computed(() => ({})) as Readonly<Ref<unknown>>,
-    } as unknown as CurrentValueWithContext<unknown>
-  }
-  return currentValue as Readonly<Ref<unknown>>
 }
 
 /**

--- a/src/runtime/core/build-form-api.ts
+++ b/src/runtime/core/build-form-api.ts
@@ -3,6 +3,7 @@ import type {
   CurrentValueContext,
   CurrentValueWithContext,
   FieldState,
+  FieldStateMap,
   FormErrorRecord,
   FormFieldErrors,
   FormState,
@@ -24,6 +25,7 @@ import { __DEV__ } from './dev'
 import type { FormStore } from './create-form-store'
 import { buildFieldArrayApi } from './field-arrays'
 import { buildFieldStateAccessor } from './field-state-api'
+import { buildFieldStateProxy } from './field-state-proxy'
 import type { HistoryModule } from './history'
 import { getAtPath } from './path-walker'
 import { canonicalizePath, type Path, type PathKey, type Segment } from './paths'
@@ -436,6 +438,14 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
   // `.value` access from their side.
   const valuesProxyComputed = buildValuesProxy(state.form)
 
+  // --- Pinia-style reactive per-field state proxy ---
+  // Allocated once per buildFormApi call (one per consumer). Each Proxy
+  // node memoizes its descendants and the per-path FieldStateView
+  // computed it reads through, so repeated access to the same path
+  // (`form.fieldState.email` twice) returns the same object — useful
+  // for downstream `===` checks and Vue's render diff.
+  const fieldStateProxy = buildFieldStateProxy(state)
+
   return {
     getFieldState: getFieldState as UseAbstractFormReturnType<
       Form,
@@ -453,6 +463,7 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
         WithIndexedUndefined<WriteShape<GetValueFormType>>
       >
     },
+    fieldState: fieldStateProxy as unknown as FieldStateMap<GetValueFormType>,
     setValue: setValueImpl as UseAbstractFormReturnType<Form, GetValueFormType>['setValue'],
     validate: validate as UseAbstractFormReturnType<Form, GetValueFormType>['validate'],
     validateAsync: validateAsync as UseAbstractFormReturnType<

--- a/src/runtime/core/build-form-api.ts
+++ b/src/runtime/core/build-form-api.ts
@@ -473,6 +473,19 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
     register: register as UseAbstractFormReturnType<Form, GetValueFormType>['register'],
     key: state.formKey,
     fieldErrors: fieldErrors as unknown as Readonly<FormFieldErrors<Form>>,
+    // `errors` is the renamed surface — same Proxy, new property name.
+    // Both names coexist during Phase B so C1 can sweep test sites
+    // mechanically; C2 deletes `fieldErrors`.
+    errors: fieldErrors as unknown as Readonly<FormFieldErrors<Form>>,
+    // `toRef(path)` — escape hatch for the rare case a consumer wants
+    // a Ref. Delegates to `getValueImpl` with the path-overload, which
+    // already returns `Readonly<Ref<...>>`. The slim-primitive write
+    // gate stays the only way into storage; readonly here matches.
+    toRef: ((path: string) =>
+      getValueImpl(path) as Readonly<Ref<unknown>>) as UseAbstractFormReturnType<
+      Form,
+      GetValueFormType
+    >['toRef'],
     setFieldErrors,
     addFieldErrors,
     clearFieldErrors,

--- a/src/runtime/core/errors.ts
+++ b/src/runtime/core/errors.ts
@@ -94,17 +94,9 @@ export class ReservedFormKeyError extends Error {
  * `console.warn` so a deployed third-party app shipping the
  * anti-pattern doesn't hard-crash.
  */
-export class AnonPersistError extends Error {
-  override readonly name = 'AnonPersistError'
-  constructor() {
-    super(
-      '[@chemical-x/forms] persist: requires an explicit key on useForm().\n' +
-        '  Why: anonymous keys drift on remount AND can collide between forms — your data could leak across unrelated forms.\n' +
-        "  Fix: useForm({ schema, key: 'login', persist: '...' })\n" +
-        '  In prod: no throw — persistence is silently disabled and a one-time warn is logged.'
-    )
-  }
-}
+// (AnonPersistError class declaration is below; this docblock is the
+// historical preamble — kept here so blame/PR review can trace the
+// original intent. The richer class supersedes the earlier basic version.)
 
 /**
  * Thrown when `register(path, { persist: true })` or `form.persist(path)`

--- a/src/runtime/core/errors.ts
+++ b/src/runtime/core/errors.ts
@@ -159,8 +159,8 @@ export class AnonPersistError extends Error {
   readonly callSite: string | undefined
   override readonly cause: 'no-key' | 'register-without-config'
   constructor(opts: {
-    schemaFields?: readonly string[]
-    callSite?: string
+    schemaFields?: readonly string[] | undefined
+    callSite?: string | undefined
     cause: 'no-key' | 'register-without-config'
   }) {
     super(formatAnonPersistMessage(opts))
@@ -171,8 +171,8 @@ export class AnonPersistError extends Error {
 }
 
 function formatAnonPersistMessage(opts: {
-  schemaFields?: readonly string[]
-  callSite?: string
+  schemaFields?: readonly string[] | undefined
+  callSite?: string | undefined
   cause: 'no-key' | 'register-without-config'
 }): string {
   const head =

--- a/src/runtime/core/errors.ts
+++ b/src/runtime/core/errors.ts
@@ -132,3 +132,61 @@ export class SensitivePersistFieldError extends Error {
     )
   }
 }
+
+/**
+ * Thrown when persistence is misconfigured in a way that would either
+ * (a) silently drop writes, or (b) namespace storage under a
+ * non-deterministic synthetic key — both of which become security bugs
+ * the moment encrypted persistence backends are added (the same key
+ * may be derived for two unrelated forms).
+ *
+ * Two `cause` values, one error shape:
+ *
+ *   - `'no-key'` — `useForm({ persist: ... })` called without `key:`.
+ *     Anonymous keys (`__cx:anon:*`) drift across mounts; persisting
+ *     to a non-deterministic location is refused outright.
+ *
+ *   - `'register-without-config'` — `register(_, { persist: true })`
+ *     declared on a form whose `useForm()` options omit `persist:`.
+ *     The opt-in is recorded but nothing would ever land in storage.
+ *
+ * Fix: align the two layers — set `persist:` + `key:` on `useForm()`,
+ * or remove `{ persist: true }` from the offending `register()` call.
+ */
+export class AnonPersistError extends Error {
+  override readonly name = 'AnonPersistError'
+  readonly schemaFields: readonly string[] | undefined
+  readonly callSite: string | undefined
+  override readonly cause: 'no-key' | 'register-without-config'
+  constructor(opts: {
+    schemaFields?: readonly string[]
+    callSite?: string
+    cause: 'no-key' | 'register-without-config'
+  }) {
+    super(formatAnonPersistMessage(opts))
+    this.schemaFields = opts.schemaFields
+    this.callSite = opts.callSite
+    this.cause = opts.cause
+  }
+}
+
+function formatAnonPersistMessage(opts: {
+  schemaFields?: readonly string[]
+  callSite?: string
+  cause: 'no-key' | 'register-without-config'
+}): string {
+  const head =
+    opts.cause === 'no-key'
+      ? `useForm({ persist: ... }) requires an explicit \`key:\`. Anonymous synthetic keys (\`__cx:anon:*\`) drift across mounts and can collide between unrelated forms — refusing to persist to a non-deterministic location.`
+      : `register(_, { persist: true }) declared on a form whose useForm() options have no \`persist:\` configured. The opt-in is recorded but nothing would ever land in storage.`
+  const fields =
+    opts.schemaFields !== undefined && opts.schemaFields.length > 0
+      ? ` Form fields: { ${opts.schemaFields.join(', ')} }.`
+      : ''
+  const fix =
+    opts.cause === 'no-key'
+      ? ` Fix: add \`key: '<stable-id>'\` to useForm().`
+      : ` Fix: add \`persist: 'session'\` (or 'local') and \`key:\` to useForm(), or remove \`{ persist: true }\` from this register() call.`
+  const where = opts.callSite !== undefined ? ` ${opts.callSite}` : ''
+  return `[@chemical-x/forms] ${head}${fields}${fix}${where}`
+}

--- a/src/runtime/core/extract-schema-fields.ts
+++ b/src/runtime/core/extract-schema-fields.ts
@@ -1,0 +1,27 @@
+import type { AbstractSchema } from '../types/types-api'
+import type { GenericForm } from '../types/types-core'
+
+/**
+ * Best-effort top-level field hint for diagnostic error messages.
+ * Walks the schema's slim default at the root and returns its keys
+ * — sufficient for object-rooted schemas (the overwhelming majority).
+ * Non-object roots return `[]`; the message degrades by omitting the
+ * fields clause rather than throwing.
+ *
+ * No adapter contract change: every adapter already implements
+ * `getDefaultAtPath([])` for the structural-fill pipeline, so this
+ * helper is free.
+ */
+export function extractSchemaFields(
+  schema: AbstractSchema<GenericForm, GenericForm>
+): readonly string[] {
+  try {
+    const root = schema.getDefaultAtPath([])
+    if (root !== null && typeof root === 'object' && !Array.isArray(root)) {
+      return Object.keys(root as object)
+    }
+  } catch {
+    // Adapter threw — degrade gracefully so the diagnostic still fires.
+  }
+  return []
+}

--- a/src/runtime/core/field-state-proxy.ts
+++ b/src/runtime/core/field-state-proxy.ts
@@ -33,7 +33,7 @@ const FIELD_STATE_KEYS: ReadonlySet<string> = new Set<keyof FieldStateView>([
   'updatedAt',
   'errors',
   'path',
-  'pendingEmpty',
+  'blank',
 ])
 
 /**

--- a/src/runtime/core/field-state-proxy.ts
+++ b/src/runtime/core/field-state-proxy.ts
@@ -1,0 +1,135 @@
+import type { ComputedRef } from 'vue'
+import type { GenericForm } from '../types/types-core'
+import type { FormStore } from './create-form-store'
+import { buildFieldStateAccessor, type FieldStateView } from './field-state-api'
+import type { Segment } from './paths'
+
+/**
+ * The leaf-prop set of a `FieldStateView`. Reads at any non-root path
+ * with a key in this set are resolved against the FieldStateView at
+ * that path; reads with any other key descend one level deeper.
+ *
+ * Shadowing trade-off: a schema field with one of these names at depth
+ * 2 or deeper is unreachable by dotted access through the proxy
+ * (`form.fieldState.user.dirty` reads the `dirty` boolean of `user`,
+ * not the FieldStateView for a `user.dirty` field). Documented edge
+ * case; rename the schema field or read via the legacy
+ * `getFieldState('user.dirty')` until C2 deletes that surface.
+ *
+ * Top-level fields are NOT shadowed — the root proxy treats every
+ * access as descent, so `form.fieldState.dirty` resolves to the
+ * FieldStateView for a top-level `dirty` field (if your schema has
+ * one). Form-level boolean aggregates live on `form.state.isDirty`.
+ */
+const FIELD_STATE_KEYS: ReadonlySet<string> = new Set<keyof FieldStateView>([
+  'value',
+  'original',
+  'pristine',
+  'dirty',
+  'focused',
+  'blurred',
+  'touched',
+  'isConnected',
+  'updatedAt',
+  'errors',
+  'path',
+  'pendingEmpty',
+])
+
+/**
+ * Build the `form.fieldState` reactive proxy. At every level the trap
+ * disambiguates:
+ *
+ *   - Known FieldStateView prop names → read the reactive prop value
+ *     of the FieldStateView at the current path.
+ *
+ *   - Other keys → return a deeper proxy at \`segments + key\`.
+ *
+ * Memoizes per-path proxies so repeated reads (`form.fieldState.email`
+ * twice) return the same object — referential equality matters for
+ * downstream effect tracking and Vue's render diff. Memoizes
+ * per-path FieldStateView computeds via `buildFieldStateAccessor` so
+ * dependency tracking is fine-grained on the underlying state slices.
+ *
+ * The root proxy (segments === []) treats EVERY key as descent — no
+ * FieldStateView exists at the form root, so a top-level field whose
+ * name happens to be in the FieldState prop set (e.g. a schema field
+ * named `dirty`) is reachable as `form.fieldState.dirty`. Shadowing
+ * only kicks in at depth 2+.
+ */
+export function buildFieldStateProxy<F extends GenericForm>(
+  state: FormStore<F>
+): Record<string, unknown> {
+  const getFieldStateAt = buildFieldStateAccessor(state)
+
+  // Per-path Proxy cache. Lifetime is tied to this buildFormApi
+  // invocation (one cache per FormStore consumer), which means two
+  // consumers of the same FormStore get separate proxies — fine, since
+  // the underlying state is shared and identity differences only show
+  // up in tests that compare proxy references across calls.
+  const proxyCache = new Map<string, Record<string, unknown>>()
+
+  // Per-path FieldStateView cache. `buildFieldStateAccessor` already
+  // memoizes nothing internally — every call creates a fresh computed
+  // — so the cache here amortises the computed allocation across
+  // multiple reads of the same path.
+  const viewCache = new Map<string, ComputedRef<FieldStateView>>()
+
+  function proxyAt(segments: readonly Segment[]): Record<string, unknown> {
+    const cacheKey = JSON.stringify(segments)
+    const existing = proxyCache.get(cacheKey)
+    if (existing !== undefined) return existing
+
+    const isRoot = segments.length === 0
+    const view = isRoot
+      ? null
+      : (viewCache.get(cacheKey) ??
+        (() => {
+          const fresh = getFieldStateAt(segments as Segment[])
+          viewCache.set(cacheKey, fresh)
+          return fresh
+        })())
+
+    const proxy = new Proxy(
+      {},
+      {
+        get(_, key) {
+          if (typeof key !== 'string') return undefined
+          // Leaf-prop access: read off the FieldStateView at this path.
+          // Wrapping `view.value[key]` inside the trap (rather than
+          // pre-extracting) keeps the read inside the consumer's
+          // active effect — Vue tracks the dependency at access time.
+          if (view !== null && FIELD_STATE_KEYS.has(key)) {
+            return (view.value as Record<string, unknown>)[key]
+          }
+          // Descent: return the deeper proxy at segments + key.
+          return proxyAt([...segments, key])
+        },
+        has(_, key) {
+          if (typeof key !== 'string') return false
+          if (view !== null && FIELD_STATE_KEYS.has(key)) return true
+          // Descent reachability is conservatively `true` — the proxy
+          // can navigate any path; whether the path resolves to a
+          // schema-defined slot is the FormStore's concern, not the
+          // proxy's.
+          return true
+        },
+        // Block writes at the proxy boundary. Mutations go through
+        // `setValue`, the directive, or the field-array helpers.
+        set() {
+          return false
+        },
+        deleteProperty() {
+          return false
+        },
+        defineProperty() {
+          return false
+        },
+      }
+    )
+    proxyCache.set(cacheKey, proxy)
+    return proxy
+  }
+
+  return proxyAt([])
+}

--- a/src/runtime/core/field-state-proxy.ts
+++ b/src/runtime/core/field-state-proxy.ts
@@ -114,6 +114,27 @@ export function buildFieldStateProxy<F extends GenericForm>(
           // proxy's.
           return true
         },
+        // Iteration support: at non-root paths, expose the FieldStateLeaf
+        // keys so `JSON.stringify(form.fieldState.email)` produces the
+        // expected leaf snapshot (matching the legacy
+        // `JSON.stringify(form.getFieldState('email').value)` shape).
+        // At the root, return `[]` — the root has no FieldStateView and
+        // schema field names aren't enumerable through the proxy.
+        ownKeys() {
+          return view !== null ? Array.from(FIELD_STATE_KEYS) : []
+        },
+        getOwnPropertyDescriptor(_, key) {
+          if (typeof key !== 'string') return undefined
+          if (view !== null && FIELD_STATE_KEYS.has(key)) {
+            return {
+              configurable: true,
+              enumerable: true,
+              value: (view.value as Record<string, unknown>)[key],
+              writable: false,
+            }
+          }
+          return undefined
+        },
         // Block writes at the proxy boundary. Mutations go through
         // `setValue`, the directive, or the field-array helpers.
         set() {

--- a/src/runtime/core/register-api.ts
+++ b/src/runtime/core/register-api.ts
@@ -2,7 +2,9 @@ import { computed, ref, type Ref } from 'vue'
 import type { RegisterOptions, RegisterValue, WriteMeta } from '../types/types-api'
 import type { GenericForm } from '../types/types-core'
 import type { FormStore } from './create-form-store'
-import { __DEV__ } from './dev'
+import { captureUserCallSite } from './dev-stack-trace'
+import { AnonPersistError } from './errors'
+import { extractSchemaFields } from './extract-schema-fields'
 import { canonicalizePath, type Path, type PathKey } from './paths'
 import { PERSISTENCE_MODULE_KEY } from './persistence'
 
@@ -55,20 +57,6 @@ function detachFocusListeners(element: HTMLElement): void {
   element.removeEventListener('blur', listeners.handleBlur)
   delete target[cxListenersSymbol]
 }
-
-/**
- * Dedupes the dev-mode "register({ persist: true }) without `persist:`
- * configured" warning. Keyed by FormStore so each form warns at most
- * once across all of its `register()` call sites — multiple paths
- * opting in produce one warning, not N. WeakSet auto-clears when the
- * FormStore is GC'd, so a remount with a different config gets a
- * fresh check.
- *
- * `null` in production so the WeakSet allocation tree-shakes out.
- */
-const warnedMissingPersistConfig: WeakSet<FormStore<GenericForm>> | null = __DEV__
-  ? new WeakSet<FormStore<GenericForm>>()
-  : null
 
 export function buildRegister<F extends GenericForm>(state: FormStore<F>) {
   // Path-keyed cache of typed-form refs. Lifted out of the per-call
@@ -142,49 +130,29 @@ export function buildRegister<F extends GenericForm>(state: FormStore<F>) {
     const persist = options?.persist === true
     const acknowledgeSensitive = options?.acknowledgeSensitive === true
 
-    // Dev-only: opt-in declared but the form has no persistence wired.
-    // Without this warning the directive silently records the opt-in,
-    // no writes ever land, and the dev concludes "persistence is broken"
-    // when the actual issue is a missing `persist:` option on `useForm()`.
-    // Symmetric to wirePersistence's "configured but no opt-ins" warning;
-    // together they cover both halves of the misuse space. Deduped per
-    // FormStore so a template with N opted-in paths produces one warning,
-    // not N.
+    // Eager throw: opt-in declared but the form has no persistence wired.
+    // Without the throw the directive silently records the opt-in, no
+    // writes ever land, and the dev concludes "persistence is broken"
+    // when the actual issue is a missing `persist:` option on useForm().
+    // Throws in dev and prod — contradictions are bugs, not rate-limited
+    // drift. The error body carries the schema's top-level fields and a
+    // captured call-site frame so the offending form is identifiable
+    // from the message alone (script-setup stacks collapse misleadingly).
     //
     // Skipped during SSR: `wirePersistence` is intentionally not run on
     // the server (persistence is a client-only concern), so
     // `state.modules.has(PERSISTENCE_MODULE_KEY)` is always false during
     // SSR — even for forms that DID configure `persist:`. Without this
-    // gate the warning would falsely fire on every server-rendered
+    // gate the throw would falsely fire on every server-rendered
     // `register({ persist: true })`. The client-side hydration pass
-    // re-runs the check against a freshly-wired module and warns
-    // correctly if the misuse is real.
-    if (__DEV__ && persist && !state.isSSR && warnedMissingPersistConfig !== null) {
-      const formStore = state as FormStore<GenericForm>
-      if (
-        !state.modules.has(PERSISTENCE_MODULE_KEY) &&
-        !warnedMissingPersistConfig.has(formStore)
-      ) {
-        warnedMissingPersistConfig.add(formStore)
-        const display = segments.map((s) => String(s)).join('.')
-        // No inline source frame here. `register()` is overwhelmingly
-        // called from compiled `<template>` render functions, where
-        // Vite's sourcemap for attribute-value expressions
-        // (`v-register="register(...)"`) maps back to the surrounding
-        // element / closing-tag region, not the actual `register(`
-        // token — adding a frame would be actively misleading. The
-        // path name in the message (`'${display}'`) is the reliable
-        // anchor: `grep "register('${display}'"` finds the call site.
-        // The console auto-renders its own clickable stack below the
-        // message anyway.
-        console.warn(
-          `[@chemical-x/forms] register('${display}', { persist: true }) is set on form ` +
-            `"${state.formKey}", but useForm() has no \`persist\` option configured — ` +
-            `nothing will be saved to storage. ` +
-            `Fix: add \`persist: 'local'\` (or 'session' / 'indexeddb') to your useForm() options. ` +
-            `See ./docs/recipes/persistence.md.`
-        )
-      }
+    // re-checks against a freshly-wired module and throws correctly if
+    // the misuse is real.
+    if (persist && !state.isSSR && !state.modules.has(PERSISTENCE_MODULE_KEY)) {
+      throw new AnonPersistError({
+        cause: 'register-without-config',
+        schemaFields: extractSchemaFields(state.schema),
+        callSite: captureUserCallSite(),
+      })
     }
 
     return {

--- a/src/runtime/core/values-proxy.ts
+++ b/src/runtime/core/values-proxy.ts
@@ -1,0 +1,49 @@
+import { computed, readonly, type ComputedRef, type Ref } from 'vue'
+import type { GenericForm } from '../types/types-core'
+
+/**
+ * Build a `ComputedRef<Readonly<F>>` whose `.value` is a deeply-readonly
+ * Vue proxy over the form's storage value. Read identically in script
+ * and template (no `.value` once the consumer accesses it through a
+ * getter on the form return) — Pinia setup-store pattern.
+ *
+ * Reactivity contract:
+ *
+ *   - Writes are blocked. Vue's `readonly()` traps `set` / `delete` /
+ *     `defineProperty` / etc. and emits a dev warn (silent in prod).
+ *     The slim-primitive write gate stays the only path into storage.
+ *
+ *   - Reads track dependencies normally. The outer computed depends on
+ *     `state.form.value` (the Ref); the inner readonly proxy traps each
+ *     property read on the same effect graph as the underlying reactive
+ *     target, so `form.values.email` inside a render effect re-runs on
+ *     either the whole-form swap (`reset` / whole-form `setValue`) or a
+ *     per-key write.
+ *
+ *   - Identity-stable on swap. `state.form.value = next` (the
+ *     `applyFormReplacement` path used by `reset()` and whole-form
+ *     `setValue`) reassigns the Ref's contained value. Vue's `readonly()`
+ *     keys on TARGET identity, so a swap produces a fresh proxy. The
+ *     wrapping `computed` invalidates on the swap and re-evaluates,
+ *     handing out the new proxy. If a consumer caches `form.values`
+ *     across the swap, the cached reference points at the OLD proxy —
+ *     fine, since the old proxy still wraps the old (now-orphaned)
+ *     target object. Re-reading `form.values` on the form return after
+ *     the swap returns the fresh proxy.
+ *
+ *   - `readonly()` recurses. Nested object reads (`form.values.address.city`)
+ *     return readonly proxies wrapping the inner reactive objects, so
+ *     dependency tracking and write-blocking propagate to every depth.
+ *     Arrays are wrapped too — mutating array methods (push, splice)
+ *     throw the dev-mode `readonly` warn.
+ *
+ * Why a `computed` wrapper, not just `readonly(state.form.value)` cached
+ * once: Vue's `readonlyMap` maps target → proxy by target identity. If
+ * we cache `readonly(state.form.value)` at module init and `state.form`
+ * is later swapped, the cache hands out a stale proxy over the
+ * orphaned target. The `computed` re-evaluates on swap and produces a
+ * fresh proxy keyed to the new target.
+ */
+export function buildValuesProxy<F extends GenericForm>(form: Ref<F>): ComputedRef<Readonly<F>> {
+  return computed(() => readonly(form.value)) as ComputedRef<Readonly<F>>
+}

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -1697,6 +1697,10 @@ export type UseAbstractFormReturnType<
    * the FieldStateLeaf for the address object, and `address.city`
    * descends into the nested leaf.
    *
+   * Leaf values follow the slim WriteShape contract: enum-typed leaves
+   * widen to their primitive supertype. The errors array, dirty flag,
+   * focus state, etc. are unaffected.
+   *
    * Shadowing: at depth 2+, FieldStateLeaf keys (`dirty`, `touched`,
    * `errors`, `pendingEmpty`, `focused`, `blurred`, `value`,
    * `original`, `pristine`, `isConnected`, `updatedAt`, `path`) win
@@ -1704,7 +1708,7 @@ export type UseAbstractFormReturnType<
    * Document edge case; rename the offending schema field if the
    * collision matters.
    */
-  fieldState: FieldStateMap<GetValueFormType>
+  fieldState: FieldStateMap<WriteShape<GetValueFormType>>
 
   /**
    * Write to the form programmatically. Two forms:

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -1871,8 +1871,57 @@ export type UseAbstractFormReturnType<
    * Read-only — populate via `setFieldErrors`, `addFieldErrors`, and
    * `clearFieldErrors`. Server-side errors flow through
    * `parseApiErrors` first.
+   *
+   * @deprecated Use `form.errors` (same shape, renamed for Pinia
+   * naming parity). Removed in the next breaking release.
    */
   fieldErrors: Readonly<FormFieldErrors<Form>>
+
+  /**
+   * Reactive map of field errors, keyed by dotted path. Populated
+   * automatically by `handleSubmit` and per-field validation; cleared
+   * on validation success.
+   *
+   * Read in templates with no `.value`:
+   *
+   * ```vue
+   * <p v-if="form.errors.email">{{ form.errors.email[0].message }}</p>
+   * ```
+   *
+   * Watch from script via the getter form:
+   *
+   * ```ts
+   * watch(() => form.errors.email, (errors) => …)
+   * ```
+   *
+   * Use bracket access for nested dotted keys
+   * (`form.errors['user.profile.email']`) — JS dot notation splits
+   * on literal dots.
+   *
+   * Read-only — populate via `setFieldErrors`, `addFieldErrors`, and
+   * `clearFieldErrors`. Server-side errors flow through
+   * `parseApiErrors` first.
+   */
+  errors: Readonly<FormFieldErrors<Form>>
+
+  /**
+   * Escape hatch for the rare case a consumer needs a `Ref<T>` —
+   * e.g. handing the value to an external composable that expects a
+   * Vue ref, or watching a single path with `watch(formRef, ...)`.
+   *
+   * ```ts
+   * const emailRef = form.toRef('email')         // Readonly<Ref<string>>
+   * watch(emailRef, (next) => console.log(next))
+   * ```
+   *
+   * Returns `Readonly<Ref<...>>` — writes go through `setValue`,
+   * `register()`, or the field-array helpers, never via the ref.
+   * Prefer `form.values.email` for direct reads in templates +
+   * scripts; `toRef` is for ref-shaped interop only.
+   */
+  toRef: <Path extends FlatPath<Form>>(
+    path: Path
+  ) => Readonly<Ref<NestedReadType<WriteShape<GetValueFormType>, Path>>>
 
   /**
    * Replace every field error for this form with the provided list.

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -1314,6 +1314,53 @@ export type FieldState<Value = unknown> = DeepFlatten<
     blank: boolean
   }
 >
+
+/**
+ * Runtime shape of a single FieldStateView entry surfaced through
+ * `form.fieldState.<path>`. Matches what `buildFieldStateAccessor`
+ * actually produces (slim shape, readonly across the board), as
+ * opposed to `FieldState<Value>` which is the typed public contract
+ * via `getFieldState(path)`. The runtime accessor's structural keys
+ * are what the proxy disambiguates against on each property read.
+ */
+export type FieldStateLeaf<Value = unknown> = {
+  readonly value: Value
+  readonly original: Value
+  readonly pristine: boolean
+  readonly dirty: boolean
+  readonly focused: boolean | null
+  readonly blurred: boolean | null
+  readonly touched: boolean | null
+  readonly isConnected: boolean
+  readonly updatedAt: string | null
+  readonly errors: readonly ValidationError[]
+  readonly path: ReadonlyArray<string | number>
+  readonly pendingEmpty: boolean
+}
+
+/**
+ * Recursive type behind `form.fieldState`. At every depth ≥ 1 the
+ * proxy exposes both the FieldStateLeaf at the current path AND
+ * descent into named children. FieldStateLeaf keys SHADOW any schema
+ * fields with conflicting names at depth 2+ (a documented edge case;
+ * top-level fields are unshadowed because the root proxy treats every
+ * access as descent — see `buildFieldStateProxy`).
+ */
+export type FieldStateMapEntry<T> = T extends object
+  ? FieldStateLeaf<T> & {
+      readonly [K in Exclude<keyof T, keyof FieldStateLeaf<T>>]: FieldStateMapEntry<T[K]>
+    }
+  : FieldStateLeaf<T>
+
+/**
+ * Type of `form.fieldState`. Object-shape mirroring the form's top
+ * level; descent into nested fields produces FieldStateLeaf-bearing
+ * entries via `FieldStateMapEntry`.
+ */
+export type FieldStateMap<Form extends GenericForm> = {
+  readonly [K in keyof Form]: FieldStateMapEntry<Form[K]>
+}
+
 export type DOMFieldStateStore = Map<string, DOMFieldState | undefined>
 
 /**
@@ -1632,6 +1679,32 @@ export type UseAbstractFormReturnType<
    * `validateAsync()` when you need the post-validation strict type.
    */
   values: Readonly<WithIndexedUndefined<WriteShape<GetValueFormType>>>
+
+  /**
+   * Reactive per-field state proxy. Pinia-style nested object — read
+   * leaf properties (`dirty`, `touched`, `errors`, `blurred`,
+   * `focused`, `pendingEmpty`, `currentValue`, …) directly off the
+   * field's path:
+   *
+   * ```vue
+   * <p v-if="form.fieldState.email.touched && form.fieldState.email.errors.length">
+   *   {{ form.fieldState.email.errors[0].message }}
+   * </p>
+   * <p>City dirty? {{ form.fieldState.address.city.dirty }}</p>
+   * ```
+   *
+   * The same proxy supports descent at every level — `address` reads
+   * the FieldStateLeaf for the address object, and `address.city`
+   * descends into the nested leaf.
+   *
+   * Shadowing: at depth 2+, FieldStateLeaf keys (`dirty`, `touched`,
+   * `errors`, `pendingEmpty`, `focused`, `blurred`, `value`,
+   * `original`, `pristine`, `isConnected`, `updatedAt`, `path`) win
+   * over schema field names. Top-level fields are NOT shadowed.
+   * Document edge case; rename the offending schema field if the
+   * collision matters.
+   */
+  fieldState: FieldStateMap<GetValueFormType>
 
   /**
    * Write to the form programmatically. Two forms:

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -1299,7 +1299,7 @@ export type FieldStateLeaf<Value = unknown> = {
   readonly updatedAt: string | null
   readonly errors: readonly ValidationError[]
   readonly path: ReadonlyArray<string | number>
-  readonly pendingEmpty: boolean
+  readonly blank: boolean
 }
 
 /**

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -838,42 +838,6 @@ export type MetaTrackerValue = {
 export type MetaTracker = Record<string, MetaTrackerValue>
 export type MetaTrackerStore = Map<FormKey, MetaTracker>
 
-/**
- * Options for the `getValue(...)` overloads that opt into metadata.
- *
- * ```ts
- * const view = form.getValue({ withMeta: true })
- * view.currentValue.value // the form value
- * view.meta.value         // per-leaf metadata
- * ```
- */
-export type CurrentValueContext<WithMeta extends boolean = false> = {
-  /** Set to `true` to receive both the value ref and a per-leaf metadata ref. */
-  withMeta?: WithMeta
-}
-
-type RemapLeafNodes<T, V, Q = NonNullable<T>> =
-  Q extends Record<string, unknown>
-    ? { [K in keyof Q]: RemapLeafNodes<Q[K], V> }
-    : Q extends Array<infer U>
-      ? Array<RemapLeafNodes<U, V>>
-      : V
-
-/**
- * Return value of `getValue({ withMeta: true })` and
- * `getValue(path, { withMeta: true })`.
- *
- * `currentValue` carries the live reactive value at the requested
- * scope; `meta` carries a parallel tree where each leaf is the
- * `MetaTrackerValue` for the corresponding field.
- */
-export type CurrentValueWithContext<Value, FormSubtree = Value> = {
-  /** Live reactive value at the requested scope. */
-  currentValue: Readonly<Ref<Value>>
-  /** Parallel metadata tree — leaves are `MetaTrackerValue` records. */
-  meta: Readonly<Ref<DeepPartial<RemapLeafNodes<FormSubtree, MetaTrackerValue>>>>
-}
-
 // This generic generates full paths and paths that point to string arrays
 // This staisfies ts edge case for multi-select and multi-checkbox elements
 export type RegisterFlatPath<Form, Key extends keyof Form = keyof Form> =
@@ -1542,19 +1506,6 @@ export type UseAbstractFormReturnType<
   GetValueFormType extends GenericForm = Form,
 > = {
   /**
-   * Reactive per-field state at `path`: `currentValue`, focus/blur
-   * flags, dirty/pristine, errors, etc. See `FieldState` for the
-   * full shape.
-   *
-   * ```ts
-   * const state = form.getFieldState('email')
-   * // <p v-if="state.touched && state.errors.length">…</p>
-   * ```
-   */
-  getFieldState: <Path extends FlatPath<Form, keyof Form, true>>(
-    path: Path
-  ) => Ref<FieldState<NestedReadType<WriteShape<GetValueFormType>, Path>>>
-  /**
    * Wraps your submit logic with validation and error routing.
    *
    * ```ts
@@ -1568,90 +1519,6 @@ export type UseAbstractFormReturnType<
    * fired, so `data.email` is guaranteed to satisfy `.email()`.
    */
   handleSubmit: HandleSubmit<Form>
-  /**
-   * Read the form's current value as a reactive ref.
-   *
-   * - `getValue()` — whole form.
-   * - `getValue(path)` — value at `path`.
-   * - `getValue({ withMeta: true })` — whole form + a sibling
-   *   `meta` ref carrying per-leaf metadata.
-   * - `getValue(path, { withMeta: true })` — same, scoped to `path`.
-   *
-   * ```ts
-   * const email = form.getValue('email')      // Readonly<Ref<string>>
-   * const all = form.getValue()               // Readonly<Ref<Form>>
-   * ```
-   *
-   * Reads reflect what's storable: enum-typed slots widen to their
-   * primitive supertype (e.g. `string`) so refinement-invalid but
-   * structurally-valid values are visible. Use `handleSubmit` /
-   * `validate*()` when you need the post-validation strict type.
-   */
-  getValue: {
-    /**
-     * Read the whole form as a reactive ref.
-     *
-     * ```ts
-     * const all = form.getValue() // Readonly<Ref<Form>>
-     * ```
-     *
-     * Reads reflect what's storable: enum-typed slots widen to their
-     * primitive supertype (e.g. `string`) so refinement-invalid but
-     * structurally-valid values are visible. Use `handleSubmit` /
-     * `validate*()` when you need the post-validation strict type.
-     */
-    (): Readonly<Ref<WithIndexedUndefined<WriteShape<GetValueFormType>>>>
-    /**
-     * Read the value at `path` as a reactive ref.
-     *
-     * ```ts
-     * const email = form.getValue('email') // Readonly<Ref<string>>
-     * ```
-     *
-     * Reads reflect what's storable: enum-typed slots widen to their
-     * primitive supertype (e.g. `string`) so refinement-invalid but
-     * structurally-valid values are visible. Use `handleSubmit` /
-     * `validate*()` when you need the post-validation strict type.
-     */
-    <Path extends FlatPath<Form>>(
-      path: Path
-    ): Readonly<Ref<NestedReadType<WriteShape<GetValueFormType>, Path>>>
-    /**
-     * Read the whole form along with per-leaf metadata.
-     *
-     * ```ts
-     * const view = form.getValue({ withMeta: true })
-     * view.currentValue.value // the form value
-     * view.meta.value         // per-leaf MetaTrackerValue tree
-     * ```
-     *
-     * Pass `{ withMeta: false }` (or omit `withMeta`) for the same
-     * shape as `getValue()`.
-     */
-    <WithMeta extends boolean>(
-      context: CurrentValueContext<WithMeta>
-    ): WithMeta extends true
-      ? CurrentValueWithContext<WithIndexedUndefined<WriteShape<GetValueFormType>>>
-      : Readonly<Ref<WithIndexedUndefined<WriteShape<GetValueFormType>>>>
-    /**
-     * Read the value at `path` along with per-leaf metadata.
-     *
-     * ```ts
-     * const view = form.getValue('email', { withMeta: true })
-     * view.currentValue.value // the email value
-     * view.meta.value         // metadata for that leaf
-     * ```
-     *
-     * Pass `{ withMeta: false }` (or omit `withMeta`) for the same
-     * shape as `getValue(path)`.
-     */
-    <Path extends FlatPath<Form>, WithMeta extends boolean>(
-      path: Path,
-      context: CurrentValueContext<WithMeta>
-    ): WithMeta extends true
-      ? CurrentValueWithContext<NestedReadType<WriteShape<GetValueFormType>, Path>>
-      : Readonly<Ref<NestedReadType<WriteShape<GetValueFormType>, Path>>>
-  }
 
   /**
    * Reactive readonly proxy over the form's storage value. Read
@@ -1872,16 +1739,6 @@ export type UseAbstractFormReturnType<
    * (`form.fieldErrors['user.profile.email']`) — JS dot notation
    * splits on literal dots.
    *
-   * Read-only — populate via `setFieldErrors`, `addFieldErrors`, and
-   * `clearFieldErrors`. Server-side errors flow through
-   * `parseApiErrors` first.
-   *
-   * @deprecated Use `form.errors` (same shape, renamed for Pinia
-   * naming parity). Removed in the next breaking release.
-   */
-  fieldErrors: Readonly<FormFieldErrors<Form>>
-
-  /**
    * Reactive map of field errors, keyed by dotted path. Populated
    * automatically by `handleSubmit` and per-field validation; cleared
    * on validation success.

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -1605,6 +1605,34 @@ export type UseAbstractFormReturnType<
       ? CurrentValueWithContext<NestedReadType<WriteShape<GetValueFormType>, Path>>
       : Readonly<Ref<NestedReadType<WriteShape<GetValueFormType>, Path>>>
   }
+
+  /**
+   * Reactive readonly proxy over the form's storage value. Read
+   * identically in script and template — no `.value`, no auto-unwrap
+   * rules. Pinia setup-store pattern.
+   *
+   * ```vue
+   * <script setup>
+   *   const form = useForm({ schema, key: 'login' })
+   * </script>
+   *
+   * <template>
+   *   <p>{{ form.values.email }}</p>
+   *   <p>{{ form.values.address.city }}</p>
+   * </template>
+   * ```
+   *
+   * Writes are blocked at the proxy boundary — go through `setValue`,
+   * `setValues`, the directive, or one of the field-array helpers. The
+   * slim-primitive write gate stays the only path into storage.
+   *
+   * Reads reflect what's storable: enum-typed slots widen to their
+   * primitive supertype (`string`), so refinement-invalid but
+   * structurally-valid values are visible. Use `handleSubmit` /
+   * `validateAsync()` when you need the post-validation strict type.
+   */
+  values: Readonly<WithIndexedUndefined<WriteShape<GetValueFormType>>>
+
   /**
    * Write to the form programmatically. Two forms:
    *

--- a/test/composables/anonymous-form.test.ts
+++ b/test/composables/anonymous-form.test.ts
@@ -63,8 +63,8 @@ describe('anonymous useForm — independent state per setup call', () => {
 
     // Writing to one form must not leak into the other.
     captured.a?.setValue('name', 'Alice')
-    expect(captured.a?.getValue('name').value).toBe('Alice')
-    expect(captured.b?.getValue('name').value).toBe('')
+    expect(captured.a?.values.name).toBe('Alice')
+    expect(captured.b?.values.name).toBe('')
 
     app.unmount()
   })
@@ -99,7 +99,7 @@ describe('anonymous useForm — ambient useFormContext access', () => {
 
     // Writes land on the same form.
     captured.owner?.setValue('name', 'Bob')
-    expect(captured.consumer?.getValue('name').value).toBe('Bob')
+    expect(captured.consumer?.values.name).toBe('Bob')
 
     app.unmount()
   })

--- a/test/composables/app-defaults.test.ts
+++ b/test/composables/app-defaults.test.ts
@@ -99,8 +99,8 @@ describe('app-level defaults — validationMode', () => {
     // errors.
     const { app, api } = mountWithDefaults({ validationMode: 'lax' }, {})
     apps.push(app)
-    expect(api.fieldErrors.email).toBeUndefined()
-    expect(api.fieldErrors.password).toBeUndefined()
+    expect(api.errors.email).toBeUndefined()
+    expect(api.errors.password).toBeUndefined()
     expect(api.state.isValid).toBe(true)
   })
 
@@ -109,8 +109,8 @@ describe('app-level defaults — validationMode', () => {
     // errors get seeded.
     const { app, api } = mountWithDefaults({ validationMode: 'lax' }, { validationMode: 'strict' })
     apps.push(app)
-    expect(api.fieldErrors.email?.[0]?.message).toBe('bad email')
-    expect(api.fieldErrors.password?.[0]?.message).toBe('min 8 chars')
+    expect(api.errors.email?.[0]?.message).toBe('bad email')
+    expect(api.errors.password?.[0]?.message).toBe('min 8 chars')
     expect(api.state.isValid).toBe(false)
   })
 
@@ -119,7 +119,7 @@ describe('app-level defaults — validationMode', () => {
     // createFormStore applies → 'strict' → seed fires.
     const { app, api } = mountWithDefaults({}, {})
     apps.push(app)
-    expect(api.fieldErrors.email?.[0]?.message).toBe('bad email')
+    expect(api.errors.email?.[0]?.message).toBe('bad email')
     expect(api.state.isValid).toBe(false)
   })
 })
@@ -150,7 +150,7 @@ describe('app-level defaults — fieldValidation field-level merge', () => {
     // need to wait the library default (125ms).
     await vi.advanceTimersByTimeAsync(75)
     await drainMicrotasks()
-    expect(api.fieldErrors.email?.[0]?.message).toBe('bad email')
+    expect(api.errors.email?.[0]?.message).toBe('bad email')
   })
 
   it('per-form debounceMs overrides default debounceMs', async () => {
@@ -165,7 +165,7 @@ describe('app-level defaults — fieldValidation field-level merge', () => {
     // Per-form debounceMs wins → 25ms, not 500ms.
     await vi.advanceTimersByTimeAsync(40)
     await drainMicrotasks()
-    expect(api.fieldErrors.email?.[0]?.message).toBe('bad email')
+    expect(api.errors.email?.[0]?.message).toBe('bad email')
   })
 
   it("default fieldValidation applies entirely when per-form doesn't pass any", async () => {
@@ -179,7 +179,7 @@ describe('app-level defaults — fieldValidation field-level merge', () => {
     api.setValue('password', 'x')
     await vi.advanceTimersByTimeAsync(50)
     await drainMicrotasks()
-    expect(api.fieldErrors.password?.[0]?.message).toBe('min 8 chars')
+    expect(api.errors.password?.[0]?.message).toBe('min 8 chars')
   })
 })
 
@@ -194,7 +194,7 @@ describe('app-level defaults — anonymous + multi-form', () => {
     // should still apply.
     const { app, api } = mountWithDefaults({ validationMode: 'lax' }, {})
     apps.push(app)
-    expect(api.fieldErrors.email).toBeUndefined()
+    expect(api.errors.email).toBeUndefined()
     // Sanity: this anonymous form's key starts with the reserved prefix.
     expect(api.key.startsWith(ANONYMOUS_FORM_KEY_PREFIX)).toBe(true)
   })
@@ -223,8 +223,8 @@ describe('app-level defaults — anonymous + multi-form', () => {
     document.body.appendChild(root)
     app.mount(root)
     apps.push(app)
-    expect(handles.a?.fieldErrors.email).toBeUndefined()
-    expect(handles.b?.fieldErrors.email).toBeUndefined()
+    expect(handles.a?.errors.email).toBeUndefined()
+    expect(handles.b?.errors.email).toBeUndefined()
   })
 })
 
@@ -264,7 +264,7 @@ describe('app-level defaults — v3 wrapper regression', () => {
     app.mount(root)
     apps.push(app)
     // Lax → no construction-time seed → fieldErrors empty.
-    expect(handle.api?.fieldErrors.email).toBeUndefined()
-    expect(handle.api?.fieldErrors.password).toBeUndefined()
+    expect(handle.api?.errors.email).toBeUndefined()
+    expect(handle.api?.errors.password).toBeUndefined()
   })
 })

--- a/test/composables/array-index-paths.test.ts
+++ b/test/composables/array-index-paths.test.ts
@@ -72,8 +72,8 @@ describe('z.array(z.string()) — integer-keyed paths', () => {
       tags: ['x', 'y'],
     })
     apps.push(app)
-    expect(form.getValue('tags.0').value).toBe('x')
-    expect(form.getValue('tags.1').value).toBe('y')
+    expect(form.values.tags[0]).toBe('x')
+    expect(form.values.tags[1]).toBe('y')
   })
 
   it('setValue(`tags.1`, …) updates only that index — siblings preserved', () => {
@@ -83,7 +83,7 @@ describe('z.array(z.string()) — integer-keyed paths', () => {
     apps.push(app)
     const ok = form.setValue('tags.1', 'BANG')
     expect(ok).toBe(true)
-    expect(form.getValue('tags').value).toEqual(['a', 'BANG', 'c'])
+    expect(form.values.tags).toEqual(['a', 'BANG', 'c'])
   })
 
   it('setValue with array-form path writes equivalently (runtime cast)', () => {
@@ -95,7 +95,7 @@ describe('z.array(z.string()) — integer-keyed paths', () => {
     const setValue = form.setValue as unknown as AnySetValue
     const ok = setValue(['tags', 2], 'POW')
     expect(ok).toBe(true)
-    expect(form.getValue('tags').value).toEqual(['a', 'b', 'POW'])
+    expect(form.values.tags).toEqual(['a', 'b', 'POW'])
   })
 
   it('per-index write of the wrong primitive type is rejected by the gate', () => {
@@ -108,7 +108,7 @@ describe('z.array(z.string()) — integer-keyed paths', () => {
     apps.push(app)
     const ok = form.setValue('tags.0', 99 as unknown as string)
     expect(ok).toBe(false)
-    expect(form.getValue('tags').value).toEqual(['a', 'b'])
+    expect(form.values.tags).toEqual(['a', 'b'])
   })
 
   it('register binding for an index reflects subsequent setValue at that index', () => {
@@ -129,9 +129,9 @@ describe('z.array(z.string()) — integer-keyed paths', () => {
     })
     apps.push(app)
     form.setValue('tags.1', 'changed')
-    expect(form.getValue('tags').value).toEqual(['a', 'changed', 'c'])
+    expect(form.values.tags).toEqual(['a', 'changed', 'c'])
     form.reset()
-    expect(form.getValue('tags').value).toEqual(['a', 'b', 'c'])
+    expect(form.values.tags).toEqual(['a', 'b', 'c'])
   })
 
   it('nested object inside array — `posts.0.title` resolves a deep leaf', () => {
@@ -148,7 +148,7 @@ describe('z.array(z.string()) — integer-keyed paths', () => {
     expect(form.register('posts.0.title').innerRef.value).toBe('first')
     expect(form.register('posts.1.views').innerRef.value).toBe(20)
     form.setValue('posts.0.title', 'edited')
-    expect(form.getValue('posts').value).toEqual([
+    expect(form.values.posts).toEqual([
       { title: 'edited', views: 10 },
       { title: 'second', views: 20 },
     ])

--- a/test/composables/async-validation.test.ts
+++ b/test/composables/async-validation.test.ts
@@ -93,7 +93,7 @@ describe('async validation — handleSubmit awaits async refinements', () => {
     )
     await handler()
     expect(onErrorFired).toBe(true)
-    const emailErrors = api.fieldErrors.email
+    const emailErrors = api.errors.email
     expect(emailErrors?.[0]?.message).toBe('Email already registered')
   })
 

--- a/test/composables/checkbox.test.ts
+++ b/test/composables/checkbox.test.ts
@@ -70,17 +70,17 @@ describe('<input type="checkbox" v-register> — single boolean', () => {
     if (captured.api === undefined) throw new Error('unreachable')
     const cb = root.querySelector('input.agreed') as HTMLInputElement
     expect(cb.checked).toBe(false)
-    expect(captured.api.getValue('agreed').value).toBe(false)
+    expect(captured.api.values.agreed).toBe(false)
 
     cb.checked = true
     dispatchChange(cb)
     await flush()
-    expect(captured.api.getValue('agreed').value).toBe(true)
+    expect(captured.api.values.agreed).toBe(true)
 
     cb.checked = false
     dispatchChange(cb)
     await flush()
-    expect(captured.api.getValue('agreed').value).toBe(false)
+    expect(captured.api.values.agreed).toBe(false)
   })
 
   it('mounts with el.checked synced to the form value', async () => {
@@ -153,7 +153,7 @@ describe('<input type="checkbox" v-register> — array group', () => {
     await flush()
 
     if (captured.api === undefined) throw new Error('unreachable')
-    expect(captured.api.getValue('fruits').value).toEqual([])
+    expect(captured.api.values.fruits).toEqual([])
 
     const apple = root.querySelector('input.apple') as HTMLInputElement
     const banana = root.querySelector('input.banana') as HTMLInputElement
@@ -162,22 +162,22 @@ describe('<input type="checkbox" v-register> — array group', () => {
     apple.checked = true
     dispatchChange(apple)
     await flush()
-    expect(captured.api.getValue('fruits').value).toEqual(['apple'])
+    expect(captured.api.values.fruits).toEqual(['apple'])
 
     banana.checked = true
     dispatchChange(banana)
     await flush()
-    expect(captured.api.getValue('fruits').value).toEqual(['apple', 'banana'])
+    expect(captured.api.values.fruits).toEqual(['apple', 'banana'])
 
     apple.checked = false
     dispatchChange(apple)
     await flush()
-    expect(captured.api.getValue('fruits').value).toEqual(['banana'])
+    expect(captured.api.values.fruits).toEqual(['banana'])
 
     cherry.checked = true
     dispatchChange(cherry)
     await flush()
-    expect(captured.api.getValue('fruits').value).toEqual(['banana', 'cherry'])
+    expect(captured.api.values.fruits).toEqual(['banana', 'cherry'])
   })
 
   it('mounts with each checkbox checked iff its value is in the array', async () => {
@@ -261,7 +261,7 @@ describe('<input type="checkbox" v-register> — array group', () => {
     dispatchChange(apple)
     await flush()
 
-    expect(captured.api.getValue('fruits').value).toEqual(['apple'])
+    expect(captured.api.values.fruits).toEqual(['apple'])
   })
 
   it('warns once when an array-bound checkbox is missing a value attribute', async () => {
@@ -295,7 +295,7 @@ describe('<input type="checkbox" v-register> — array group', () => {
 
       if (captured.api === undefined) throw new Error('unreachable')
       // No state change — directive bailed at the missing-value check.
-      expect(captured.api.getValue('fruits').value).toEqual([])
+      expect(captured.api.values.fruits).toEqual([])
 
       const matched = warnSpy.mock.calls
         .map((args) => args.join(' '))
@@ -348,7 +348,7 @@ describe('<input type="checkbox" v-register> — Set group', () => {
     await flush()
 
     if (captured.api === undefined) throw new Error('unreachable')
-    expect((captured.api.getValue('tags').value as Set<string>).size).toBe(0)
+    expect((captured.api.values.tags as Set<string>).size).toBe(0)
 
     const red = root.querySelector('input.red') as HTMLInputElement
     const green = root.querySelector('input.green') as HTMLInputElement
@@ -356,20 +356,17 @@ describe('<input type="checkbox" v-register> — Set group', () => {
     red.checked = true
     dispatchChange(red)
     await flush()
-    expect([...(captured.api.getValue('tags').value as Set<string>)]).toEqual(['red'])
+    expect([...(captured.api.values.tags as Set<string>)]).toEqual(['red'])
 
     green.checked = true
     dispatchChange(green)
     await flush()
-    expect([...(captured.api.getValue('tags').value as Set<string>)].sort()).toEqual([
-      'green',
-      'red',
-    ])
+    expect([...(captured.api.values.tags as Set<string>)].sort()).toEqual(['green', 'red'])
 
     red.checked = false
     dispatchChange(red)
     await flush()
-    expect([...(captured.api.getValue('tags').value as Set<string>)]).toEqual(['green'])
+    expect([...(captured.api.values.tags as Set<string>)]).toEqual(['green'])
   })
 })
 
@@ -422,17 +419,17 @@ describe('<input type="checkbox" v-register> — :true-value / :false-value', ()
     if (captured.api === undefined) throw new Error('unreachable')
     const cb = root.querySelector('input.newsletter') as HTMLInputElement
     expect(cb.checked).toBe(false)
-    expect(captured.api.getValue('newsletter').value).toBe('unsubscribe')
+    expect(captured.api.values.newsletter).toBe('unsubscribe')
 
     cb.checked = true
     dispatchChange(cb)
     await flush()
-    expect(captured.api.getValue('newsletter').value).toBe('subscribe')
+    expect(captured.api.values.newsletter).toBe('subscribe')
 
     cb.checked = false
     dispatchChange(cb)
     await flush()
-    expect(captured.api.getValue('newsletter').value).toBe('unsubscribe')
+    expect(captured.api.values.newsletter).toBe('unsubscribe')
   })
 })
 
@@ -470,7 +467,7 @@ describe('checkbox slim-primitive gate interactions', () => {
     if (captured.api === undefined) throw new Error('unreachable')
     const setVal = captured.api.setValue as (path: 'agreed', value: unknown) => boolean
     expect(setVal('agreed', 'yes')).toBe(false)
-    expect(captured.api.getValue('agreed').value).toBe(false)
+    expect(captured.api.values.agreed).toBe(false)
   })
 
   it('rejects a string write to an array checkbox path', async () => {
@@ -494,6 +491,6 @@ describe('checkbox slim-primitive gate interactions', () => {
     const setVal = captured.api.setValue as (path: 'fruits', value: unknown) => boolean
     // Wrong slim primitive: 'apple' is a string, but the path expects 'array'.
     expect(setVal('fruits', 'apple')).toBe(false)
-    expect(captured.api.getValue('fruits').value).toEqual([])
+    expect(captured.api.values.fruits).toEqual([])
   })
 })

--- a/test/composables/custom-defaults-e2e.test.ts
+++ b/test/composables/custom-defaults-e2e.test.ts
@@ -13,7 +13,7 @@ import { createChemicalXForms } from '../../src/runtime/core/plugin'
  * behavior:
  *
  *   1. Form construction: `useForm({ schema })` with `.default('user')`
- *      on a field produces `'user'` at `form.getValue('role').value`.
+ *      on a field produces `'user'` at `form.values.role`.
  *   2. Path-form callback prev auto-default: when the slot is missing,
  *      `setValue('field', cb)` hands the consumer the `.default(x)`
  *      value (not the natural falsy primitive default).
@@ -60,21 +60,21 @@ describe('custom .default() values flow through the consumer surface', () => {
       const schema = z.object({ role: z.string().default('user') })
       const { app, form } = harness(schema)
       apps.push(app)
-      expect(form.getValue('role').value).toBe('user')
+      expect(form.values.role).toBe('user')
     })
 
     it('number with .default(5) produces 5 — not 0', () => {
       const schema = z.object({ count: z.number().default(5) })
       const { app, form } = harness(schema)
       apps.push(app)
-      expect(form.getValue('count').value).toBe(5)
+      expect(form.values.count).toBe(5)
     })
 
     it('boolean with .default(true) produces true — not false', () => {
       const schema = z.object({ active: z.boolean().default(true) })
       const { app, form } = harness(schema)
       apps.push(app)
-      expect(form.getValue('active').value).toBe(true)
+      expect(form.values.active).toBe(true)
     })
 
     it('object .default({...}) produces the literal default', () => {
@@ -86,7 +86,7 @@ describe('custom .default() values flow through the consumer surface', () => {
       })
       const { app, form } = harness(schema)
       apps.push(app)
-      expect(form.getValue('prefs').value).toEqual({
+      expect(form.values.prefs).toEqual({
         theme: 'dark',
         density: 'comfortable',
       })
@@ -102,7 +102,7 @@ describe('custom .default() values flow through the consumer surface', () => {
       })
       const { app, form } = harness(schema)
       apps.push(app)
-      expect(form.getValue('prefs').value).toEqual({
+      expect(form.values.prefs).toEqual({
         theme: 'dark',
         locale: '',
       })
@@ -126,7 +126,7 @@ describe('custom .default() values flow through the consumer surface', () => {
       // length should pad with the element default — `.default('untitled')`
       // for title.
       form.setValue('posts.2', { title: 'real', views: 100 })
-      expect(form.getValue('posts').value).toEqual([
+      expect(form.values.posts).toEqual([
         { title: 'untitled', views: 0 },
         { title: 'untitled', views: 0 },
         { title: 'real', views: 100 },
@@ -160,7 +160,7 @@ describe('custom .default() values flow through the consumer surface', () => {
       // `.default('comfortable')` values rather than `''`.
       expect(receivedPrev).toEqual({ theme: 'dark', density: 'comfortable' })
       // Final value carries the consumer's override, defaults survive.
-      expect(form.getValue('prefs').value).toEqual({
+      expect(form.values.prefs).toEqual({
         theme: 'light',
         density: 'comfortable',
       })
@@ -208,7 +208,7 @@ describe('custom .default() values flow through the consumer surface', () => {
 
       // Indices 0..2: element default with both .default() values
       // present. Index 3: the consumer's value.
-      expect(form.getValue('posts').value).toEqual([
+      expect(form.values.posts).toEqual([
         { title: 'untitled', views: 10 },
         { title: 'untitled', views: 10 },
         { title: 'untitled', views: 10 },
@@ -225,12 +225,12 @@ describe('custom .default() values flow through the consumer surface', () => {
 
       // Form construction already produces [7, 13, 99] from positional
       // defaults. Verify it directly first.
-      expect(form.getValue('coords').value).toEqual([7, 13, 99])
+      expect(form.values.coords).toEqual([7, 13, 99])
 
       // Now mutate: setValue at position 2 should leave 0,1 as their
       // existing defaults (no fill needed — they're already populated).
       form.setValue('coords.2', 42)
-      expect(form.getValue('coords').value).toEqual([7, 13, 42])
+      expect(form.values.coords).toEqual([7, 13, 42])
     })
   })
 })

--- a/test/composables/field-arrays.test.ts
+++ b/test/composables/field-arrays.test.ts
@@ -60,14 +60,14 @@ describe('useForm — field array helpers', () => {
       const { app, form } = harness({ tags: ['a', 'b'] })
       apps.push(app)
       form.append('tags', 'c')
-      expect(form.getValue('tags').value).toEqual(['a', 'b', 'c'])
+      expect(form.values.tags).toEqual(['a', 'b', 'c'])
     })
 
     it('adds an object item at the end of an array-of-object path', () => {
       const { app, form } = harness({ posts: [{ title: 'first', views: 1 }] })
       apps.push(app)
       form.append('posts', { title: 'second', views: 0 })
-      expect(form.getValue('posts').value).toEqual([
+      expect(form.values.posts).toEqual([
         { title: 'first', views: 1 },
         { title: 'second', views: 0 },
       ])
@@ -77,7 +77,7 @@ describe('useForm — field array helpers', () => {
       const { app, form } = harness()
       apps.push(app)
       form.append('tags', 'first')
-      expect(form.getValue('tags').value).toEqual(['first'])
+      expect(form.values.tags).toEqual(['first'])
     })
   })
 
@@ -86,7 +86,7 @@ describe('useForm — field array helpers', () => {
       const { app, form } = harness({ tags: ['b', 'c'] })
       apps.push(app)
       form.prepend('tags', 'a')
-      expect(form.getValue('tags').value).toEqual(['a', 'b', 'c'])
+      expect(form.values.tags).toEqual(['a', 'b', 'c'])
     })
   })
 
@@ -95,14 +95,14 @@ describe('useForm — field array helpers', () => {
       const { app, form } = harness({ tags: ['a', 'c'] })
       apps.push(app)
       form.insert('tags', 1, 'b')
-      expect(form.getValue('tags').value).toEqual(['a', 'b', 'c'])
+      expect(form.values.tags).toEqual(['a', 'b', 'c'])
     })
 
     it('inserting past `length` appends (Array.splice clamping)', () => {
       const { app, form } = harness({ tags: ['a'] })
       apps.push(app)
       form.insert('tags', 99, 'b')
-      expect(form.getValue('tags').value).toEqual(['a', 'b'])
+      expect(form.values.tags).toEqual(['a', 'b'])
     })
   })
 
@@ -111,16 +111,16 @@ describe('useForm — field array helpers', () => {
       const { app, form } = harness({ tags: ['a', 'b', 'c'] })
       apps.push(app)
       form.remove('tags', 1)
-      expect(form.getValue('tags').value).toEqual(['a', 'c'])
+      expect(form.values.tags).toEqual(['a', 'c'])
     })
 
     it('no-ops on an out-of-range index (never grows or shrinks incorrectly)', () => {
       const { app, form } = harness({ tags: ['a', 'b'] })
       apps.push(app)
       form.remove('tags', 5)
-      expect(form.getValue('tags').value).toEqual(['a', 'b'])
+      expect(form.values.tags).toEqual(['a', 'b'])
       form.remove('tags', -1)
-      expect(form.getValue('tags').value).toEqual(['a', 'b'])
+      expect(form.values.tags).toEqual(['a', 'b'])
     })
   })
 
@@ -129,22 +129,22 @@ describe('useForm — field array helpers', () => {
       const { app, form } = harness({ tags: ['a', 'b', 'c', 'd'] })
       apps.push(app)
       form.swap('tags', 1, 2)
-      expect(form.getValue('tags').value).toEqual(['a', 'c', 'b', 'd'])
+      expect(form.values.tags).toEqual(['a', 'c', 'b', 'd'])
     })
 
     it('no-ops on out-of-range indices', () => {
       const { app, form } = harness({ tags: ['a', 'b'] })
       apps.push(app)
       form.swap('tags', 0, 10)
-      expect(form.getValue('tags').value).toEqual(['a', 'b'])
+      expect(form.values.tags).toEqual(['a', 'b'])
     })
 
     it('no-ops when a === b', () => {
       const { app, form } = harness({ tags: ['a', 'b'] })
       apps.push(app)
-      const before = form.getValue('tags').value
+      const before = form.values.tags
       form.swap('tags', 1, 1)
-      expect(form.getValue('tags').value).toEqual(before)
+      expect(form.values.tags).toEqual(before)
     })
   })
 
@@ -153,21 +153,21 @@ describe('useForm — field array helpers', () => {
       const { app, form } = harness({ tags: ['a', 'b', 'c', 'd'] })
       apps.push(app)
       form.move('tags', 0, 2)
-      expect(form.getValue('tags').value).toEqual(['b', 'c', 'a', 'd'])
+      expect(form.values.tags).toEqual(['b', 'c', 'a', 'd'])
     })
 
     it('moves to 0 puts the item at the start', () => {
       const { app, form } = harness({ tags: ['a', 'b', 'c'] })
       apps.push(app)
       form.move('tags', 2, 0)
-      expect(form.getValue('tags').value).toEqual(['c', 'a', 'b'])
+      expect(form.values.tags).toEqual(['c', 'a', 'b'])
     })
 
     it('clamps `to` to length (moving to past-end appends)', () => {
       const { app, form } = harness({ tags: ['a', 'b', 'c'] })
       apps.push(app)
       form.move('tags', 0, 99)
-      expect(form.getValue('tags').value).toEqual(['b', 'c', 'a'])
+      expect(form.values.tags).toEqual(['b', 'c', 'a'])
     })
   })
 
@@ -176,32 +176,32 @@ describe('useForm — field array helpers', () => {
       const { app, form } = harness({ tags: ['a', 'b', 'c'] })
       apps.push(app)
       form.replace('tags', 1, 'B')
-      expect(form.getValue('tags').value).toEqual(['a', 'B', 'c'])
+      expect(form.values.tags).toEqual(['a', 'B', 'c'])
     })
 
     it('does NOT grow the array on out-of-range index', () => {
       const { app, form } = harness({ tags: ['a'] })
       apps.push(app)
       form.replace('tags', 3, 'BAD')
-      expect(form.getValue('tags').value).toEqual(['a'])
+      expect(form.values.tags).toEqual(['a'])
     })
 
     it('replaces an object item', () => {
       const { app, form } = harness({ posts: [{ title: 'first', views: 1 }] })
       apps.push(app)
       form.replace('posts', 0, { title: 'second', views: 2 })
-      expect(form.getValue('posts').value).toEqual([{ title: 'second', views: 2 }])
+      expect(form.values.posts).toEqual([{ title: 'second', views: 2 }])
     })
   })
 
-  it('mutations trigger reactivity (form-level getValue sees the update)', () => {
+  it('mutations trigger reactivity (form.values sees the update)', () => {
     const { app, form } = harness({ tags: ['a'] })
     apps.push(app)
-    const tags = form.getValue('tags')
-    expect(tags.value).toEqual(['a'])
+    expect(form.values.tags).toEqual(['a'])
     form.append('tags', 'b')
-    // Computed ref should now reflect the new array — reactivity round-trip.
-    expect(tags.value).toEqual(['a', 'b'])
+    // Reading through the proxy re-tracks the underlying form ref, so
+    // the second read reflects the post-mutation array.
+    expect(form.values.tags).toEqual(['a', 'b'])
   })
 
   it('append flips isDirty (newly-introduced leaves count as mutations)', () => {

--- a/test/composables/field-errors-view.test.ts
+++ b/test/composables/field-errors-view.test.ts
@@ -10,8 +10,8 @@ import { createChemicalXForms } from '../../src/runtime/core/plugin'
  * exists to fix a longstanding template footgun:
  *
  *   <template>
- *     {{ form.fieldErrors.email }}        ✅ works (this file proves it)
- *     {{ form.fieldErrors.value.email }}  ❌ no longer compiles, no .value
+ *     {{ form.errors.email }}        ✅ works (this file proves it)
+ *     {{ form.errors.value.email }}  ❌ no longer compiles, no .value
  *   </template>
  *
  * Vue auto-unwraps refs when they are TOP-LEVEL setup-return bindings.
@@ -68,29 +68,29 @@ describe('fieldErrors — template-friendly Proxy view', () => {
     ])
 
     // The whole point of this change: dot-access returns the array directly.
-    expect(api.fieldErrors.email?.[0]?.message).toBe('bad email')
+    expect(api.errors.email?.[0]?.message).toBe('bad email')
   })
 
   it('reflects updates after setFieldErrors / clearFieldErrors', () => {
     const { app, api } = mount()
     apps.push(app)
 
-    expect(api.fieldErrors.email).toBeUndefined()
+    expect(api.errors.email).toBeUndefined()
 
     api.setFieldErrors([
       { path: ['email'], message: 'taken', formKey: api.key, code: 'api:validation' },
     ])
-    expect(api.fieldErrors.email?.[0]?.message).toBe('taken')
+    expect(api.errors.email?.[0]?.message).toBe('taken')
 
     api.clearFieldErrors('email')
-    expect(api.fieldErrors.email).toBeUndefined()
+    expect(api.errors.email).toBeUndefined()
   })
 
   it('exposes only the keys present in the underlying record', () => {
     const { app, api } = mount()
     apps.push(app)
 
-    expect(Object.keys(api.fieldErrors)).toEqual([])
+    expect(Object.keys(api.errors)).toEqual([])
 
     api.setFieldErrors([
       { path: ['email'], message: 'bad email', formKey: api.key, code: 'api:validation' },
@@ -99,7 +99,7 @@ describe('fieldErrors — template-friendly Proxy view', () => {
 
     // Object.keys traverses the Proxy's ownKeys + getOwnPropertyDescriptor
     // traps; the result must match the underlying record exactly.
-    expect(new Set(Object.keys(api.fieldErrors))).toEqual(new Set(['email', 'password']))
+    expect(new Set(Object.keys(api.errors))).toEqual(new Set(['email', 'password']))
   })
 
   it('JSON.stringify produces the same shape as the underlying record', () => {
@@ -110,7 +110,7 @@ describe('fieldErrors — template-friendly Proxy view', () => {
       { path: ['email'], message: 'bad email', formKey: api.key, code: 'api:validation' },
     ])
 
-    const serialised = JSON.parse(JSON.stringify(api.fieldErrors))
+    const serialised = JSON.parse(JSON.stringify(api.errors))
     expect(serialised).toEqual({
       email: [{ path: ['email'], message: 'bad email', formKey: api.key, code: 'api:validation' }],
     })
@@ -120,13 +120,13 @@ describe('fieldErrors — template-friendly Proxy view', () => {
     const { app, api } = mount()
     apps.push(app)
 
-    expect('email' in api.fieldErrors).toBe(false)
+    expect('email' in api.errors).toBe(false)
 
     api.setFieldErrors([
       { path: ['email'], message: 'bad email', formKey: api.key, code: 'api:validation' },
     ])
-    expect('email' in api.fieldErrors).toBe(true)
-    expect('password' in api.fieldErrors).toBe(false)
+    expect('email' in api.errors).toBe(true)
+    expect('password' in api.errors).toBe(false)
   })
 })
 
@@ -152,13 +152,13 @@ describe('fieldErrors — readonly contract', () => {
     expect(() => {
       // @ts-expect-error — fieldErrors is Readonly at the type level;
       // we're proving the runtime trap matches the type promise.
-      api.fieldErrors.email = [
+      api.errors.email = [
         { path: ['email'], message: 'mutated directly', formKey: api.key, code: 'api:validation' },
       ]
     }).toThrow(TypeError)
 
     // Underlying record must remain empty.
-    expect(api.fieldErrors.email).toBeUndefined()
+    expect(api.errors.email).toBeUndefined()
     expect(warnSpy).toHaveBeenCalled()
   })
 
@@ -172,11 +172,11 @@ describe('fieldErrors — readonly contract', () => {
 
     expect(() => {
       // @ts-expect-error — see above.
-      delete api.fieldErrors.email
+      delete api.errors.email
     }).toThrow(TypeError)
 
     // Entry survives the rejected delete.
-    expect(api.fieldErrors.email?.[0]?.message).toBe('bad email')
+    expect(api.errors.email?.[0]?.message).toBe('bad email')
     expect(warnSpy).toHaveBeenCalled()
   })
 })
@@ -194,7 +194,7 @@ describe('fieldErrors — reactivity in render scope', () => {
       setup() {
         api = useForm({ schema, key: 'fielderrs-reactive', validationMode: 'lax' })
         return () => {
-          renderedMessage = api.fieldErrors.email?.[0]?.message ?? ''
+          renderedMessage = api.errors.email?.[0]?.message ?? ''
           return h('div', renderedMessage)
         }
       },
@@ -226,7 +226,7 @@ describe('fieldErrors — reactivity in render scope', () => {
     const stop = vi.fn()
     const { watch } = await import('vue')
     const watcher = watch(
-      () => api.fieldErrors.email?.[0]?.message,
+      () => api.errors.email?.[0]?.message,
       (next) => {
         observed.push(next)
       }

--- a/test/composables/field-state-proxy.test.ts
+++ b/test/composables/field-state-proxy.test.ts
@@ -153,7 +153,12 @@ describe('form.fieldState — errors propagation', () => {
     const mounted = mountForm()
     app = mounted.app
     mounted.api.setFieldErrors([
-      { path: ['email'], message: 'taken' as const, code: 'custom' as const },
+      {
+        path: ['email'],
+        message: 'taken',
+        code: 'custom',
+        formKey: mounted.api.key,
+      },
     ])
     expect(mounted.api.fieldState.email.errors).toHaveLength(1)
     expect(mounted.api.fieldState.email.errors[0]?.message).toBe('taken')
@@ -163,29 +168,14 @@ describe('form.fieldState — errors propagation', () => {
     const mounted = mountForm()
     app = mounted.app
     mounted.api.setFieldErrors([
-      { path: ['email'], message: 'taken' as const, code: 'custom' as const },
+      {
+        path: ['email'],
+        message: 'taken',
+        code: 'custom',
+        formKey: mounted.api.key,
+      },
     ])
     expect(mounted.api.fieldState.email.errors).toHaveLength(1)
     expect(mounted.api.fieldState.password.errors).toEqual([])
-  })
-})
-
-describe('form.fieldState — coexists with legacy getFieldState', () => {
-  let app: App | undefined
-  afterEach(() => {
-    app?.unmount()
-    app = undefined
-    document.body.innerHTML = ''
-  })
-
-  it('both surfaces read the same underlying state', () => {
-    const mounted = mountForm()
-    app = mounted.app
-    mounted.api.setValue('email', 'sync@x.com')
-
-    const legacy = mounted.api.getFieldState('email').value
-    const proxy = mounted.api.fieldState.email
-    expect(legacy.value).toBe(proxy.value)
-    expect(legacy.dirty).toBe(proxy.dirty)
   })
 })

--- a/test/composables/field-state-proxy.test.ts
+++ b/test/composables/field-state-proxy.test.ts
@@ -1,0 +1,191 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, nextTick, watch, type App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { createChemicalXForms } from '../../src/runtime/core/plugin'
+
+/**
+ * `form.fieldState` — Pinia-style nested reactive proxy. Each path
+ * exposes the FieldStateLeaf at that path AND descent into named
+ * children. FieldStateLeaf keys (`dirty`, `touched`, `errors`,
+ * `pendingEmpty`, `currentValue`, `focused`, `blurred`, `pristine`,
+ * `value`, `original`, `isConnected`, `updatedAt`, `path`) shadow
+ * schema fields with conflicting names at depth 2+.
+ */
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(4),
+  address: z.object({
+    city: z.string(),
+    zip: z.string(),
+  }),
+})
+
+async function flush(): Promise<void> {
+  for (let i = 0; i < 4; i++) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+function mountForm(): {
+  api: ReturnType<typeof useForm<typeof schema>>
+  app: App
+} {
+  let captured: ReturnType<typeof useForm<typeof schema>> | undefined
+  const App = defineComponent({
+    setup() {
+      captured = useForm({
+        schema,
+        key: `field-state-proxy-${Math.random().toString(36).slice(2)}`,
+        defaultValues: {
+          email: 'a@b.com',
+          password: 'secret',
+          address: { city: 'NYC', zip: '10001' },
+        },
+      })
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createChemicalXForms())
+  const root = document.createElement('div')
+  document.body.appendChild(root)
+  app.mount(root)
+  if (captured === undefined) throw new Error('mountForm: useForm never returned')
+  return { api: captured, app }
+}
+
+describe('form.fieldState — top-level leaf reads', () => {
+  let app: App | undefined
+  afterEach(() => {
+    app?.unmount()
+    app = undefined
+    document.body.innerHTML = ''
+  })
+
+  it('exposes leaf props directly without .value', () => {
+    const mounted = mountForm()
+    app = mounted.app
+    const fs = mounted.api.fieldState.email
+    expect(fs.value).toBe('a@b.com')
+    expect(fs.dirty).toBe(false)
+    expect(fs.pristine).toBe(true)
+    expect(fs.errors).toEqual([])
+    expect(fs.touched).toBe(null)
+  })
+
+  it('reflects setValue mutations on subsequent reads', () => {
+    const mounted = mountForm()
+    app = mounted.app
+    expect(mounted.api.fieldState.email.value).toBe('a@b.com')
+    mounted.api.setValue('email', 'changed@x.com')
+    expect(mounted.api.fieldState.email.value).toBe('changed@x.com')
+    expect(mounted.api.fieldState.email.dirty).toBe(true)
+  })
+
+  it('triggers a watch effect when an underlying field changes', async () => {
+    const mounted = mountForm()
+    app = mounted.app
+    const seen: boolean[] = []
+    const stop = watch(
+      () => mounted.api.fieldState.email.dirty,
+      (next) => {
+        seen.push(next)
+      }
+    )
+    mounted.api.setValue('email', 'first@x.com')
+    await flush()
+    mounted.api.setValue('email', 'a@b.com')
+    await flush()
+    stop()
+    expect(seen).toEqual([true, false])
+  })
+})
+
+describe('form.fieldState — nested descent', () => {
+  let app: App | undefined
+  afterEach(() => {
+    app?.unmount()
+    app = undefined
+    document.body.innerHTML = ''
+  })
+
+  it('descends into nested object paths', () => {
+    const mounted = mountForm()
+    app = mounted.app
+    expect(mounted.api.fieldState.address.city.value).toBe('NYC')
+    expect(mounted.api.fieldState.address.zip.value).toBe('10001')
+    expect(mounted.api.fieldState.address.city.dirty).toBe(false)
+  })
+
+  it('reflects nested mutations', () => {
+    const mounted = mountForm()
+    app = mounted.app
+    mounted.api.setValue('address.city', 'Boston')
+    expect(mounted.api.fieldState.address.city.value).toBe('Boston')
+    expect(mounted.api.fieldState.address.city.dirty).toBe(true)
+  })
+
+  it('returns the same proxy reference on repeated path access', () => {
+    const mounted = mountForm()
+    app = mounted.app
+    const a = mounted.api.fieldState.email
+    const b = mounted.api.fieldState.email
+    expect(a).toBe(b)
+
+    const ac = mounted.api.fieldState.address.city
+    const bc = mounted.api.fieldState.address.city
+    expect(ac).toBe(bc)
+  })
+})
+
+describe('form.fieldState — errors propagation', () => {
+  let app: App | undefined
+  afterEach(() => {
+    app?.unmount()
+    app = undefined
+    document.body.innerHTML = ''
+  })
+
+  it('surfaces user-injected errors at the path', () => {
+    const mounted = mountForm()
+    app = mounted.app
+    mounted.api.setFieldErrors([
+      { path: ['email'], message: 'taken' as const, code: 'custom' as const },
+    ])
+    expect(mounted.api.fieldState.email.errors).toHaveLength(1)
+    expect(mounted.api.fieldState.email.errors[0]?.message).toBe('taken')
+  })
+
+  it('errors at one path do not leak to another', () => {
+    const mounted = mountForm()
+    app = mounted.app
+    mounted.api.setFieldErrors([
+      { path: ['email'], message: 'taken' as const, code: 'custom' as const },
+    ])
+    expect(mounted.api.fieldState.email.errors).toHaveLength(1)
+    expect(mounted.api.fieldState.password.errors).toEqual([])
+  })
+})
+
+describe('form.fieldState — coexists with legacy getFieldState', () => {
+  let app: App | undefined
+  afterEach(() => {
+    app?.unmount()
+    app = undefined
+    document.body.innerHTML = ''
+  })
+
+  it('both surfaces read the same underlying state', () => {
+    const mounted = mountForm()
+    app = mounted.app
+    mounted.api.setValue('email', 'sync@x.com')
+
+    const legacy = mounted.api.getFieldState('email').value
+    const proxy = mounted.api.fieldState.email
+    expect(legacy.value).toBe(proxy.value)
+    expect(legacy.dirty).toBe(proxy.dirty)
+  })
+})

--- a/test/composables/field-validation.test.ts
+++ b/test/composables/field-validation.test.ts
@@ -73,14 +73,14 @@ describe('fieldValidation: { on: "change", debounceMs }', () => {
     api.setValue('email', 'no')
     api.setValue('email', 'notanemail')
     // Nothing written yet — debounce hasn't elapsed.
-    expect(api.fieldErrors.email).toBeUndefined()
+    expect(api.errors.email).toBeUndefined()
 
     // Advance past the debounce and flush microtasks to let the async
     // safeParseAsync settle.
     await vi.advanceTimersByTimeAsync(250)
     await drainMicrotasks()
 
-    const err = api.fieldErrors.email?.[0]
+    const err = api.errors.email?.[0]
     expect(err?.message).toBe('bad email')
   })
 
@@ -92,12 +92,12 @@ describe('fieldValidation: { on: "change", debounceMs }', () => {
     api.setValue('email', 'not-email')
     await vi.advanceTimersByTimeAsync(100)
     await drainMicrotasks()
-    expect(api.fieldErrors.email?.[0]?.message).toBe('bad email')
+    expect(api.errors.email?.[0]?.message).toBe('bad email')
 
     api.setValue('email', 'fixed@example.com')
     await vi.advanceTimersByTimeAsync(100)
     await drainMicrotasks()
-    expect(api.fieldErrors.email).toBeUndefined()
+    expect(api.errors.email).toBeUndefined()
   })
 
   it('submit entry aborts pending field runs — submit result wins', async () => {
@@ -119,8 +119,8 @@ describe('fieldValidation: { on: "change", debounceMs }', () => {
     // Submit's full-form validation has populated errors for every
     // failing field — including email ('bad email') and password
     // ('min 8 chars').
-    expect(api.fieldErrors.email?.[0]?.message).toBe('bad email')
-    expect(api.fieldErrors.password?.[0]?.message).toBe('min 8 chars')
+    expect(api.errors.email?.[0]?.message).toBe('bad email')
+    expect(api.errors.password?.[0]?.message).toBe('min 8 chars')
   })
 
   it('on="change" is the default: writes schedule a debounced field run', async () => {
@@ -132,7 +132,7 @@ describe('fieldValidation: { on: "change", debounceMs }', () => {
     // Default debounceMs is 125; advance past it.
     await vi.advanceTimersByTimeAsync(175)
     await drainMicrotasks()
-    expect(api.fieldErrors.email?.[0]?.message).toBe('bad email')
+    expect(api.errors.email?.[0]?.message).toBe('bad email')
   })
 
   it('explicit on="none" opts out: writes never schedule a field run', async () => {
@@ -143,7 +143,7 @@ describe('fieldValidation: { on: "change", debounceMs }', () => {
     api.setValue('email', 'not-an-email')
     await vi.advanceTimersByTimeAsync(1000)
     await drainMicrotasks()
-    expect(api.fieldErrors.email).toBeUndefined()
+    expect(api.errors.email).toBeUndefined()
   })
 })
 
@@ -160,7 +160,7 @@ describe('fieldValidation: { on: "blur" }', () => {
     api.setValue('email', 'invalid')
     await drainMicrotasks()
     // No write-path validation in blur mode.
-    expect(api.fieldErrors.email).toBeUndefined()
+    expect(api.errors.email).toBeUndefined()
   })
 })
 
@@ -181,6 +181,6 @@ describe('fieldValidation: reset cancels pending runs', () => {
     await vi.advanceTimersByTimeAsync(500)
     await drainMicrotasks()
     // Reset cleared the timer — no field-run wrote anything to errors.
-    expect(api.fieldErrors.email).toBeUndefined()
+    expect(api.errors.email).toBeUndefined()
   })
 })

--- a/test/composables/history.test.ts
+++ b/test/composables/history.test.ts
@@ -62,14 +62,14 @@ describe('history — default (history: true)', () => {
     apps.push(app)
     api.setValue('email', 'first@example.com')
     api.setValue('email', 'second@example.com')
-    expect(api.getValue('email').value).toBe('second@example.com')
+    expect(api.values.email).toBe('second@example.com')
     expect(api.undo()).toBe(true)
-    expect(api.getValue('email').value).toBe('first@example.com')
+    expect(api.values.email).toBe('first@example.com')
     expect(api.undo()).toBe(true)
-    expect(api.getValue('email').value).toBe('')
+    expect(api.values.email).toBe('')
     // One more undo bottoms out at the initial snapshot.
     expect(api.undo()).toBe(false)
-    expect(api.getValue('email').value).toBe('')
+    expect(api.values.email).toBe('')
   })
 
   it('redo replays an undone mutation', () => {
@@ -80,7 +80,7 @@ describe('history — default (history: true)', () => {
     api.undo()
     expect(api.state.canRedo).toBe(true)
     expect(api.redo()).toBe(true)
-    expect(api.getValue('email').value).toBe('two@example.com')
+    expect(api.values.email).toBe('two@example.com')
   })
 
   it('new mutation after undo clears the redo stack', () => {
@@ -121,12 +121,12 @@ describe('history — default (history: true)', () => {
     // snapshot captures the cleared state.
     api.clearFieldErrors('email')
     api.setValue('email', 'c')
-    expect(api.fieldErrors.email).toBeUndefined()
+    expect(api.errors.email).toBeUndefined()
     // Undo once — snapshot taken at the 'b' mutation carried the
     // errors that were set just before it.
     api.undo()
-    expect(api.getValue('email').value).toBe('b')
-    expect(api.fieldErrors.email?.[0]?.message).toBe('bad')
+    expect(api.values.email).toBe('b')
+    expect(api.errors.email?.[0]?.message).toBe('bad')
   })
 })
 
@@ -150,7 +150,7 @@ describe('history — bounded stack', () => {
     // Stack had 3 entries; undo from the current settles us on the
     // oldest-retained — we can undo (max - 1) times.
     expect(depth).toBe(2)
-    expect(['value-2', 'value-3'].includes(api.getValue('email').value as string)).toBe(true)
+    expect(['value-2', 'value-3'].includes(api.values.email as string)).toBe(true)
   })
 
   it('historySize tracks both stacks', () => {
@@ -180,6 +180,6 @@ describe('history — disabled (no config)', () => {
     expect(api.state.canUndo).toBe(false)
     expect(api.state.canRedo).toBe(false)
     expect(api.state.historySize).toBe(0)
-    expect(api.getValue('email').value).toBe('mutated')
+    expect(api.values.email).toBe('mutated')
   })
 })

--- a/test/composables/initial-validation-seed.test.ts
+++ b/test/composables/initial-validation-seed.test.ts
@@ -90,7 +90,7 @@ describe('initial validation seed — strict mode', () => {
     expect(typeof handle.api?.register).toBe('function')
     // No construction-time errors for async refines — they need
     // validateAsync() or a user mutation to fire.
-    expect(handle.api?.fieldErrors.email).toBeUndefined()
+    expect(handle.api?.errors.email).toBeUndefined()
   })
 
   it('strict is the default — omitting validationMode populates schemaErrors', () => {
@@ -100,8 +100,8 @@ describe('initial validation seed — strict mode', () => {
     // function of (value, schema) at all times."
     const { app, api } = mountWithZod({})
     apps.push(app)
-    expect(api.fieldErrors.email?.[0]?.message).toBe('bad email')
-    expect(api.fieldErrors.password?.[0]?.message).toBe('min 8 chars')
+    expect(api.errors.email?.[0]?.message).toBe('bad email')
+    expect(api.errors.password?.[0]?.message).toBe('min 8 chars')
     expect(api.state.isValid).toBe(false)
   })
 
@@ -110,8 +110,8 @@ describe('initial validation seed — strict mode', () => {
     apps.push(app)
     // Empty defaults: '' fails .email(), '' fails .min(8). Both errors
     // surface in fieldErrors before any user interaction.
-    expect(api.fieldErrors.email?.[0]?.message).toBe('bad email')
-    expect(api.fieldErrors.password?.[0]?.message).toBe('min 8 chars')
+    expect(api.errors.email?.[0]?.message).toBe('bad email')
+    expect(api.errors.password?.[0]?.message).toBe('min 8 chars')
     expect(api.state.isValid).toBe(false)
   })
 
@@ -121,8 +121,8 @@ describe('initial validation seed — strict mode', () => {
       defaultValues: { email: 'a@a.com', password: 'longenough' },
     })
     apps.push(app)
-    expect(api.fieldErrors.email).toBeUndefined()
-    expect(api.fieldErrors.password).toBeUndefined()
+    expect(api.errors.email).toBeUndefined()
+    expect(api.errors.password).toBeUndefined()
     expect(api.state.isValid).toBe(true)
   })
 })
@@ -139,8 +139,8 @@ describe('initial validation seed — lax mode', () => {
     // be surprised to see errors before they've touched anything.
     const { app, api } = mountWithZod({ validationMode: 'lax' })
     apps.push(app)
-    expect(api.fieldErrors.email).toBeUndefined()
-    expect(api.fieldErrors.password).toBeUndefined()
+    expect(api.errors.email).toBeUndefined()
+    expect(api.errors.password).toBeUndefined()
     expect(api.state.isValid).toBe(true)
   })
 })

--- a/test/composables/persistence.test.ts
+++ b/test/composables/persistence.test.ts
@@ -5,6 +5,7 @@ import { createApp, defineComponent, h, nextTick, withDirectives, type App } fro
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
 import { vRegister } from '../../src/runtime/core/directive'
+import { AnonPersistError } from '../../src/runtime/core/errors'
 import { __resetIndexedDbForTests } from '../../src/runtime/core/persistence/indexeddb'
 import { createChemicalXForms } from '../../src/runtime/core/plugin'
 import { fingerprintZodSchema } from '../../src/runtime/adapters/zod-v4/fingerprint'
@@ -1184,17 +1185,20 @@ describe('persistence — reset wipes the persisted draft', () => {
     expect(api.getValue('password').value).toBe('')
   })
 
-  it('dev warns when persist is configured but no field opted in', async () => {
-    // No <input v-register> at all → no opt-ins. The dev warning should
-    // fire one microtask after construction.
+  it('dormant config (key + persist + zero opt-ins) does NOT throw and does NOT warn', async () => {
+    // Configuring the persistence capability without spending it on a
+    // register() call is a valid scaffolding state — the library
+    // shouldn't lecture the consumer for not exercising every option.
+    // No throw on construct, no microtask warn, no console noise.
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
     try {
       const App = defineComponent({
         setup() {
           useForm({
             schema,
-            key: 'no-opt-ins-warn',
-            persist: { storage: 'local', key: 'test-no-opt-warn', debounceMs: 20 },
+            key: 'dormant-config',
+            persist: { storage: 'local', key: 'test-dormant', debounceMs: 20 },
           })
           return () => h('div')
         },
@@ -1202,123 +1206,97 @@ describe('persistence — reset wipes the persisted draft', () => {
       const app = createApp(App).use(createChemicalXForms())
       const root = document.createElement('div')
       document.body.appendChild(root)
+      // Construct-time should NOT throw.
+      expect(() => app.mount(root)).not.toThrow()
+      apps.push(app)
+      await drain()
+      const warnCalls = warnSpy.mock.calls.map((args) => args.join(' '))
+      const errorCalls = errorSpy.mock.calls.map((args) => args.join(' '))
+      const cxNoise = [...warnCalls, ...errorCalls].filter((m) => m.includes('[@chemical-x/forms]'))
+      expect(cxNoise).toEqual([])
+    } finally {
+      warnSpy.mockRestore()
+      errorSpy.mockRestore()
+    }
+  })
+
+  it('throws AnonPersistError(no-key) when useForm({ persist }) is called without key:', () => {
+    // Anonymous keys (`__cx:anon:*`) drift across mounts; persistence
+    // wired against one is unsafe and forecloses on future encrypted
+    // backends. Throw at construct time with schemaFields + callSite
+    // baked into the error so the offender is identifiable from the
+    // message body alone.
+    const App = defineComponent({
+      setup() {
+        useForm({
+          schema,
+          // intentionally no key:
+          persist: { storage: 'local', key: 'whatever' },
+        })
+        return () => h('div')
+      },
+    })
+    const app = createApp(App).use(createChemicalXForms())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+
+    let thrown: unknown
+    try {
       app.mount(root)
-      apps.push(app)
-      // Drain the microtasks so the deferred warning fires.
-      await drain()
-      const warnCalls = warnSpy.mock.calls.map((args) => args.join(' '))
-      const matched = warnCalls.find((msg) => /persist:.*configured.*no fields opted in/.test(msg))
-      expect(matched).toBeDefined()
-    } finally {
-      warnSpy.mockRestore()
+    } catch (e) {
+      thrown = e
     }
+    expect(thrown).toBeInstanceOf(AnonPersistError)
+    const err = thrown as AnonPersistError
+    expect(err.cause).toBe('no-key')
+    expect(err.schemaFields).toEqual(['email', 'password'])
+    expect(err.message).toContain('useForm({ persist: ... })')
+    expect(err.message).toContain('{ email, password }')
   })
 
-  it('does NOT warn when at least one field opted in', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
-    try {
-      const { app } = mountForm({ storage: 'local', key: 'test-warn-skip', debounceMs: 20 })
-      apps.push(app)
-      await drain()
-      const warnCalls = warnSpy.mock.calls.map((args) => args.join(' '))
-      const matched = warnCalls.find((msg) => /persist:.*configured.*no fields opted in/.test(msg))
-      expect(matched).toBeUndefined()
-    } finally {
-      warnSpy.mockRestore()
-    }
-  })
+  it('throws AnonPersistError(register-without-config) when register({ persist: true }) runs on form without persist:', () => {
+    // The opt-in records silently today and nothing ever lands in
+    // storage — eager throw makes the misuse impossible to ignore.
+    const App = defineComponent({
+      setup() {
+        const api = useForm({ schema, key: 'opt-in-without-persist-config' })
+        return () =>
+          h(
+            'div',
+            withDirectives(h('input', { type: 'text' }), [
+              [vRegister, api.register('email', { persist: true })],
+            ])
+          )
+      },
+    })
+    const app = createApp(App).use(createChemicalXForms())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
 
-  it('dev warns when register({ persist: true }) is used on a form with no persist: configured', async () => {
-    // Symmetric to the "persist configured but no opt-ins" warning:
-    // user opted into persistence at the register() call site but
-    // forgot the `persist:` option on useForm(). Without this warning,
-    // the opt-in records silently and nothing ever lands in storage.
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    let thrown: unknown
     try {
-      const App = defineComponent({
-        setup() {
-          const api = useForm({ schema, key: 'opt-in-without-persist-config' })
-          // No persist option on useForm() — but the binding asks for it.
-          return () =>
-            h(
-              'div',
-              withDirectives(h('input', { type: 'text' }), [
-                [vRegister, api.register('email', { persist: true })],
-              ])
-            )
-        },
-      })
-      const app = createApp(App).use(createChemicalXForms())
-      const root = document.createElement('div')
-      document.body.appendChild(root)
       app.mount(root)
-      apps.push(app)
-      await drain()
-      const warnCalls = warnSpy.mock.calls.map((args) => args.join(' '))
-      const matched = warnCalls.find((msg) =>
-        /register\('email', \{ persist: true \}\).*no `persist` option configured/.test(msg)
-      )
-      expect(matched).toBeDefined()
-    } finally {
-      warnSpy.mockRestore()
+    } catch (e) {
+      thrown = e
     }
+    expect(thrown).toBeInstanceOf(AnonPersistError)
+    const err = thrown as AnonPersistError
+    expect(err.cause).toBe('register-without-config')
+    expect(err.schemaFields).toEqual(['email', 'password'])
+    expect(err.message).toContain('register(_, { persist: true })')
   })
 
-  it('does NOT fire the symmetric warning when persist: IS configured', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
-    try {
-      // mountForm wires `persist: { storage: 'local', ... }` AND opts in
-      // both fields — so neither warning should fire.
+  it('does NOT throw when register({ persist: true }) runs on a form with persist: configured', () => {
+    // mountForm wires `persist: { storage: 'local', ... }` AND opts in
+    // both fields — no throw, no diagnostic.
+    expect(() => {
       const { app } = mountForm({
         storage: 'local',
-        key: 'test-no-symmetric-warn',
+        key: 'test-no-symmetric-throw',
         debounceMs: 20,
       })
       apps.push(app)
-      await drain()
-      const warnCalls = warnSpy.mock.calls.map((args) => args.join(' '))
-      const matched = warnCalls.find((msg) => /no `persist` option configured/.test(msg))
-      expect(matched).toBeUndefined()
-    } finally {
-      warnSpy.mockRestore()
-    }
-  })
-
-  it('warns once per form even when multiple paths opt in', async () => {
-    // Dedupe: a template with N opted-in paths should produce ONE warning,
-    // not N. Keyed by FormStore.
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
-    try {
-      const App = defineComponent({
-        setup() {
-          const api = useForm({ schema, key: 'opt-in-dedupe' })
-          return () =>
-            h('div', [
-              withDirectives(h('input', { type: 'text' }), [
-                [vRegister, api.register('email', { persist: true })],
-              ]),
-              withDirectives(h('input', { type: 'text' }), [
-                [
-                  vRegister,
-                  api.register('password', { persist: true, acknowledgeSensitive: true }),
-                ],
-              ]),
-            ])
-        },
-      })
-      const app = createApp(App).use(createChemicalXForms())
-      const root = document.createElement('div')
-      document.body.appendChild(root)
-      app.mount(root)
-      apps.push(app)
-      await drain()
-      const matchCount = warnSpy.mock.calls
-        .map((args) => args.join(' '))
-        .filter((msg) => /no `persist` option configured/.test(msg)).length
-      expect(matchCount).toBe(1)
-    } finally {
-      warnSpy.mockRestore()
-    }
+    }).not.toThrow()
   })
 
   it('form.resetField(path) wipes only the matching subpath from storage', async () => {

--- a/test/composables/persistence.test.ts
+++ b/test/composables/persistence.test.ts
@@ -231,9 +231,9 @@ describe('persistence — localStorage backend', () => {
     // Poll the getValue ref until the replacement lands rather than
     // wagering a fixed sleep — the adapter's dynamic import alone can
     // take a variable number of microtasks on a cold CI runner.
-    await waitUntil(() => (api.getValue('email').value === 'seed@example.com' ? true : null))
-    expect(api.getValue('email').value).toBe('seed@example.com')
-    expect(api.getValue('password').value).toBe('pw')
+    await waitUntil(() => (api.values.email === 'seed@example.com' ? true : null))
+    expect(api.values.email).toBe('seed@example.com')
+    expect(api.values.password).toBe('pw')
   })
 
   it('drops AND wipes a version-mismatched payload', async () => {
@@ -251,7 +251,7 @@ describe('persistence — localStorage backend', () => {
     // Hydration is async, so wait for the wipe to land before asserting.
     await waitUntil(() => (localStorage.getItem(fpKey('test-vmismatch')) === null ? true : null))
     expect(localStorage.getItem(fpKey('test-vmismatch'))).toBeNull()
-    expect(api.getValue('email').value).toBe('')
+    expect(api.values.email).toBe('')
   })
 
   it('wipes a malformed-shape payload on mount', async () => {
@@ -270,7 +270,7 @@ describe('persistence — localStorage backend', () => {
     apps.push(app)
     await waitUntil(() => (localStorage.getItem(fpKey('test-malformed')) === null ? true : null))
     expect(localStorage.getItem(fpKey('test-malformed'))).toBeNull()
-    expect(api.getValue('email').value).toBe('')
+    expect(api.values.email).toBe('')
   })
 
   it('clears the persisted entry on submit success', async () => {
@@ -284,7 +284,7 @@ describe('persistence — localStorage backend', () => {
     // and is async, so wait for the form to actually carry the seed
     // value before we submit. Otherwise a submit-during-hydration
     // races the clear-on-success path.
-    await waitUntil(() => (api.getValue('email').value === 'pre@x.com' ? true : null))
+    await waitUntil(() => (api.values.email === 'pre@x.com' ? true : null))
     const handler = api.handleSubmit(async () => {})
     await handler()
     // The onSubmitSuccess listener fires a fire-and-forget
@@ -600,8 +600,8 @@ describe('persistence — IndexedDB backend', () => {
     __resetIndexedDbForTests()
     const second = mountForm({ storage: 'indexeddb', key: 'test-idb-rt', debounceMs: 20 })
     apps.push(second.app)
-    await waitUntil(() => (second.api.getValue('email').value === 'idb@example.com' ? true : null))
-    expect(second.api.getValue('email').value).toBe('idb@example.com')
+    await waitUntil(() => (second.api.values.email === 'idb@example.com' ? true : null))
+    expect(second.api.values.email).toBe('idb@example.com')
   })
 })
 
@@ -743,7 +743,7 @@ describe('persistence — per-element opt-in', () => {
     expect(localStorage.getItem(fpKey('test-no-flag'))).toBeNull()
     // Sanity: the value still landed in the form ref (writes work, just
     // no persistence).
-    expect(handle.api?.getValue('email').value).toBe('no-opt-in@example.com')
+    expect(handle.api?.values.email).toBe('no-opt-in@example.com')
   })
 
   it('two inputs on the same path: only the opted-in one persists', async () => {
@@ -1006,7 +1006,7 @@ describe('persistence — form.persist / form.clearPersistedDraft', () => {
     app.mount(root)
     apps.push(app)
     // Wait for hydration to land.
-    await waitUntil(() => (handle.api?.getValue('email').value === 'prev@x.com' ? true : null))
+    await waitUntil(() => (handle.api?.values.email === 'prev@x.com' ? true : null))
 
     handle.api?.setValue('email', 'updated@example.com')
     await handle.api?.persist('email')
@@ -1040,7 +1040,7 @@ describe('persistence — form.persist / form.clearPersistedDraft', () => {
     document.body.appendChild(root)
     app.mount(root)
     apps.push(app)
-    await waitUntil(() => (handle.api?.getValue('email').value === 'a@x.com' ? true : null))
+    await waitUntil(() => (handle.api?.values.email === 'a@x.com' ? true : null))
 
     // Subpath wipe — email gone, password remains.
     await handle.api?.clearPersistedDraft('email')
@@ -1100,7 +1100,7 @@ describe('persistence — reset wipes the persisted draft', () => {
     // Storage wipe is fire-and-forget — poll for the entry to disappear.
     await waitUntil(() => (localStorage.getItem(fpKey('test-reset')) === null ? true : null))
     expect(localStorage.getItem(fpKey('test-reset'))).toBeNull()
-    expect(api.getValue('email').value).toBe('')
+    expect(api.values.email).toBe('')
   })
 
   it('sparse payload — only opted-in paths reach storage', async () => {
@@ -1163,7 +1163,7 @@ describe('persistence — reset wipes the persisted draft', () => {
     // password is in the form value (in memory) but NOT in the
     // persisted payload — sparse payload contract.
     expect('password' in payload.data.form).toBe(false)
-    expect(handle.api?.getValue('password').value).toBe('never-persisted')
+    expect(handle.api?.values.password).toBe('never-persisted')
   })
 
   it('sparse hydration — opted-in paths restore; non-opted paths come from schema defaults', async () => {
@@ -1179,10 +1179,10 @@ describe('persistence — reset wipes the persisted draft', () => {
       debounceMs: 20,
     })
     apps.push(app)
-    await waitUntil(() => (api.getValue('email').value === 'sparse-seed@x.com' ? true : null))
-    expect(api.getValue('email').value).toBe('sparse-seed@x.com')
+    await waitUntil(() => (api.values.email === 'sparse-seed@x.com' ? true : null))
+    expect(api.values.email).toBe('sparse-seed@x.com')
     // password wasn't in the persisted payload → schema default ('').
-    expect(api.getValue('password').value).toBe('')
+    expect(api.values.password).toBe('')
   })
 
   it('dormant config (key + persist + zero opt-ins) does NOT throw and does NOT warn', async () => {
@@ -1312,7 +1312,7 @@ describe('persistence — reset wipes the persisted draft', () => {
       debounceMs: 20,
     })
     apps.push(app)
-    await waitUntil(() => (api.getValue('email').value === 'seed@x.com' ? true : null))
+    await waitUntil(() => (api.values.email === 'seed@x.com' ? true : null))
 
     api.resetField('email')
     // Wait for the fire-and-forget clearPersistedDraft to land.
@@ -1662,7 +1662,7 @@ describe('persistence — fingerprint-keyed storage + orphan cleanup', () => {
     const { app, api } = mountForm({ storage: 'local', key: 'fp-mismatch', debounceMs: 20 })
     apps.push(app)
     await drain()
-    expect(api.getValue('email').value).toBe('')
+    expect(api.values.email).toBe('')
   })
 
   it('orphan cleanup: stale-fingerprint entries wiped on mount of the same form', async () => {
@@ -1678,7 +1678,7 @@ describe('persistence — fingerprint-keyed storage + orphan cleanup', () => {
     )
     const { app, api } = mountForm({ storage: 'local', key: 'fp-orphan', debounceMs: 20 })
     apps.push(app)
-    await waitUntil(() => (api.getValue('email').value === 'live@x.com' ? true : null))
+    await waitUntil(() => (api.values.email === 'live@x.com' ? true : null))
     await waitUntil(() =>
       localStorage.getItem('fp-orphan:OLD-FP-1') === null &&
       localStorage.getItem('fp-orphan:OLD-FP-2') === null

--- a/test/composables/persistence.test.ts
+++ b/test/composables/persistence.test.ts
@@ -399,13 +399,11 @@ describe('persistence — non-opted-in blank paths survive hydration', () => {
     // Wait for the persistence hydrate to land (it's async — dynamic
     // import + adapter.getItem + apply).
     if (captured.api === undefined) throw new Error('unreachable')
-    await waitUntil(() =>
-      captured.api?.getValue('email').value === 'seed@example.com' ? true : null
-    )
+    await waitUntil(() => (captured.api?.values.email === 'seed@example.com' ? true : null))
 
     // Sanity: email did hydrate (otherwise the test below isn't
     // exercising the post-hydrate state at all).
-    expect(captured.api.getValue('email').value).toBe('seed@example.com')
+    expect(captured.api.values.email).toBe('seed@example.com')
 
     // Critical assertion: the salary path is STILL in the
     // blank set after hydration. Pre-fix the persistence
@@ -425,7 +423,7 @@ describe('persistence — non-opted-in blank paths survive hydration', () => {
     // so the DOM-side check would only pass if we compiled the
     // template — overkill for this regression.)
     expect(captured.api.register('salary').displayValue.value).toBe('')
-    expect(captured.api.getValue('salary').value).toBe(0)
+    expect(captured.api.values.salary).toBe(0)
   })
 })
 
@@ -514,11 +512,11 @@ describe('persistence — anonymous useForm() rejects persist (dev throw)', () =
         .flat()
         .some(
           (arg) =>
-            (arg instanceof Error && /persist:.*requires an explicit key/.test(arg.message)) ||
-            (typeof arg === 'string' && /persist:.*requires an explicit key/.test(arg))
+            (arg instanceof Error && /persist.*requires.*\bkey\b/.test(arg.message)) ||
+            (typeof arg === 'string' && /persist.*requires.*\bkey\b/.test(arg))
         )
       const seenViaCatch =
-        caught instanceof Error && /persist:.*requires an explicit key/.test(caught.message)
+        caught instanceof Error && /persist.*requires.*\bkey\b/.test(caught.message)
       expect(seenViaErrSpy || seenViaCatch).toBe(true)
     } finally {
       errSpy.mockRestore()

--- a/test/composables/radio.test.ts
+++ b/test/composables/radio.test.ts
@@ -86,7 +86,7 @@ describe('<input type="radio" v-register> — single-group selection', () => {
     expect(free.checked).toBe(false)
     expect(pro.checked).toBe(true)
     expect(ent.checked).toBe(false)
-    expect(captured.api.getValue('tier').value).toBe('pro')
+    expect(captured.api.values.tier).toBe('pro')
 
     // User selects `enterprise` — fire the change handler. (Setting
     // .checked = true on a radio doesn't auto-uncheck siblings in
@@ -96,7 +96,7 @@ describe('<input type="radio" v-register> — single-group selection', () => {
     ent.checked = true
     dispatchChange(ent)
     await flush()
-    expect(captured.api.getValue('tier').value).toBe('enterprise')
+    expect(captured.api.values.tier).toBe('enterprise')
 
     // User selects `free`.
     free.checked = true
@@ -104,7 +104,7 @@ describe('<input type="radio" v-register> — single-group selection', () => {
     ent.checked = false
     dispatchChange(free)
     await flush()
-    expect(captured.api.getValue('tier').value).toBe('free')
+    expect(captured.api.values.tier).toBe('free')
   })
 
   it('mounts with el.checked synced to the model', async () => {
@@ -166,7 +166,7 @@ describe('<input type="radio" v-register> — single-group selection', () => {
           validationMode: 'lax',
         })
         captured.api = form
-        const tierRef = form.getValue('tier')
+        const tierRef = form.toRef('tier')
         return () =>
           h('div', [
             // Read tierRef so the parent re-renders on form-state
@@ -275,7 +275,7 @@ describe('<input type="radio" v-register> — hydration with static value attrib
         // state and the directive's beforeUpdate never fires.
         // (The compile-time input-text-area transform's synthesized
         // `:checked` binding makes this implicit in real templates.)
-        const tierRef = form.getValue('tier')
+        const tierRef = form.toRef('tier')
         return () =>
           h('div', [
             h('span', { class: 'tier-label' }, String(tierRef.value)),
@@ -353,7 +353,7 @@ describe('<input type="radio" v-register> — slim-gate interactions', () => {
     // by the slim-primitive gate (kind mismatch).
     const setVal = captured.api.setValue as (path: 'tier', value: unknown) => boolean
     expect(setVal('tier', 1)).toBe(false)
-    expect(captured.api.getValue('tier').value).toBe('free')
+    expect(captured.api.values.tier).toBe('free')
   })
 
   it('accepts an out-of-enum string (refinement check, not a write-time gate)', async () => {
@@ -384,6 +384,6 @@ describe('<input type="radio" v-register> — slim-gate interactions', () => {
     // field-level validation, not the slim-gate.
     const setVal = captured.api.setValue as (path: 'tier', value: unknown) => boolean
     expect(setVal('tier', 'unknown-tier')).toBe(true)
-    expect(captured.api.getValue('tier').value).toBe('unknown-tier')
+    expect(captured.api.values.tier).toBe('unknown-tier')
   })
 })

--- a/test/composables/register-display-value.test.ts
+++ b/test/composables/register-display-value.test.ts
@@ -190,8 +190,8 @@ describe('markBlank', () => {
     const ok = binding.markBlank()
     expect(ok).toBe(true)
     // Slim default for z.number() is 0.
-    expect(form.getValue('count').value).toBe(0)
-    // blank surfaces through the form's blankPaths
+    expect(form.values.count).toBe(0)
+    // pendingEmpty surfaces through the form's transientEmptyPaths
     // (commit 7 wires the public meta accessor; for now we read the
     // FormStore set indirectly via getValue still showing 0 with
     // displayValue '').

--- a/test/composables/reset.test.ts
+++ b/test/composables/reset.test.ts
@@ -66,17 +66,17 @@ describe('useForm — reset()', () => {
     form.setValue('profile.name', 'alice')
 
     form.reset()
-    expect(form.getValue().value).toEqual(defaults)
+    expect(form.values).toEqual(defaults)
   })
 
   it('applies new constraints over schema defaults when given a partial', () => {
     const { app, form } = harness()
     apps.push(app)
     form.reset({ profile: { name: 'seeded' } })
-    expect(form.getValue('profile.name').value).toBe('seeded')
+    expect(form.values.profile.name).toBe('seeded')
     // Unconstrained siblings fall back to schema defaults.
-    expect(form.getValue('email').value).toBe('')
-    expect(form.getValue('profile.age').value).toBe(0)
+    expect(form.values.email).toBe('')
+    expect(form.values.profile.age).toBe(0)
   })
 
   it('clears errors pre-populated via setFieldErrors', () => {
@@ -89,7 +89,7 @@ describe('useForm — reset()', () => {
 
     form.reset()
     expect(form.state.isValid).toBe(true)
-    expect(form.fieldErrors).toEqual({})
+    expect(form.errors).toEqual({})
   })
 
   it('flips isDirty back to false after a mutation + reset', () => {
@@ -145,8 +145,8 @@ describe('useForm — resetField(path)', () => {
     form.setValue('password', 'still-dirty')
 
     form.resetField('email')
-    expect(form.getValue('email').value).toBe('')
-    expect(form.getValue('password').value).toBe('still-dirty')
+    expect(form.values.email).toBe('')
+    expect(form.values.password).toBe('still-dirty')
   })
 
   it('clears errors on the reset path but preserves sibling errors', () => {
@@ -158,8 +158,8 @@ describe('useForm — resetField(path)', () => {
     ])
 
     form.resetField('email')
-    expect(form.fieldErrors).not.toHaveProperty('email')
-    expect(form.fieldErrors.password).toHaveLength(1)
+    expect(form.errors).not.toHaveProperty('email')
+    expect(form.errors.password).toHaveLength(1)
   })
 
   it('restores an entire sub-tree when path names a container', () => {
@@ -170,18 +170,18 @@ describe('useForm — resetField(path)', () => {
     form.setValue('email', 'touched@example.com')
 
     form.resetField('profile')
-    expect(form.getValue('profile.name').value).toBe('')
-    expect(form.getValue('profile.age').value).toBe(0)
+    expect(form.values.profile.name).toBe('')
+    expect(form.values.profile.age).toBe(0)
     // Leaf outside the sub-tree still dirty.
-    expect(form.getValue('email').value).toBe('touched@example.com')
+    expect(form.values.email).toBe('touched@example.com')
   })
 
   it('no-ops on an unknown path', () => {
     const { app, form } = harness()
     apps.push(app)
-    const before = form.getValue().value
+    const before = form.values
     // @ts-expect-error - 'nope' is not a FlatPath of the form
     form.resetField('nope')
-    expect(form.getValue().value).toEqual(before)
+    expect(form.values).toEqual(before)
   })
 })

--- a/test/composables/select-out-of-enum.test.ts
+++ b/test/composables/select-out-of-enum.test.ts
@@ -79,7 +79,7 @@ describe('<select v-register> with out-of-enum option', () => {
 
     if (captured.api === undefined) throw new Error('unreachable')
 
-    const before = captured.api.getValue('color').value
+    const before = captured.api.values.color
     expect(['red', 'green', 'blue']).toContain(before)
 
     const select = root.querySelector('select.colors') as HTMLSelectElement | null
@@ -90,7 +90,7 @@ describe('<select v-register> with out-of-enum option', () => {
     await flush()
 
     // Slim-type contract: 'magenta' is a string → accepted.
-    expect(captured.api.getValue('color').value).toBe('magenta')
+    expect(captured.api.values.color).toBe('magenta')
   })
 
   it('programmatic setValue with a wrong-primitive-type value is REJECTED + dev-warned', async () => {
@@ -117,7 +117,7 @@ describe('<select v-register> with out-of-enum option', () => {
 
     if (captured.api === undefined) throw new Error('unreachable')
 
-    const before = captured.api.getValue('color').value
+    const before = captured.api.values.color
     expect(['red', 'green', 'blue']).toContain(before)
 
     // `1` is a number — slim primitive at `color` is `string`. Cast
@@ -129,7 +129,7 @@ describe('<select v-register> with out-of-enum option', () => {
     // Rejection contract: returns false, value at path unchanged,
     // dev-warn fires once with the path + value.
     expect(ok).toBe(false)
-    expect(captured.api.getValue('color').value).toBe(before)
+    expect(captured.api.values.color).toBe(before)
     expect(warnSpy).toHaveBeenCalled()
     const message = warnSpy.mock.calls.flat().join(' ')
     expect(message).toMatch(/color/)
@@ -166,6 +166,6 @@ describe('<select v-register> with out-of-enum option', () => {
     await flush()
 
     expect(ok).toBe(true)
-    expect(captured.api.getValue('color').value).toBe('magenta')
+    expect(captured.api.values.color).toBe('magenta')
   })
 })

--- a/test/composables/set-value-schema-fill-regression.test.ts
+++ b/test/composables/set-value-schema-fill-regression.test.ts
@@ -79,7 +79,7 @@ describe('setValue — intermediate array slots fill with schema element default
 
     // Indices 0..4 should be schema element defaults — { name: '', age: 0 } —
     // NOT null. Index 5 is the consumer's write.
-    expect(form.getValue('people').value).toEqual([
+    expect(form.values.people).toEqual([
       { name: '', age: 0 },
       { name: '', age: 0 },
       { name: '', age: 0 },
@@ -99,7 +99,7 @@ describe('setValue — intermediate array slots fill with schema element default
     form.setValue('people.5', { name: 'Eve', age: 22 })
 
     // Existing 0,1 preserved. 2..4 are schema element defaults. 5 is the new value.
-    expect(form.getValue('people').value).toEqual([
+    expect(form.values.people).toEqual([
       { name: 'Alice', age: 25 },
       { name: 'Bob', age: 28 },
       { name: '', age: 0 },
@@ -115,7 +115,7 @@ describe('setValue — intermediate array slots fill with schema element default
 
     form.setValue('people.5', () => ({ name: 'Dave', age: 40 }))
 
-    expect(form.getValue('people').value).toEqual([
+    expect(form.values.people).toEqual([
       { name: '', age: 0 },
       { name: '', age: 0 },
       { name: '', age: 0 },
@@ -146,7 +146,7 @@ describe('setValue — path-form callback `prev` is the schema element default w
     expect(receivedPrev).toEqual({ name: '', age: 0 })
 
     // The consumer's spread + override produces a complete Person.
-    expect(form.getValue('people').value[0]).toEqual({ name: 'Alice', age: 0 })
+    expect(form.values.people[0]).toEqual({ name: 'Alice', age: 0 })
   })
 
   it('callback prev for an existing slot is the existing value, not a fresh default', () => {
@@ -160,7 +160,7 @@ describe('setValue — path-form callback `prev` is the schema element default w
     })
 
     expect(receivedPrev).toEqual({ name: 'Existing', age: 99 })
-    expect(form.getValue('people').value[0]).toEqual({ name: 'Existing', age: 100 })
+    expect(form.values.people[0]).toEqual({ name: 'Existing', age: 100 })
   })
 
   it('callback prev for a missing high index also gets the element default', () => {
@@ -177,7 +177,7 @@ describe('setValue — path-form callback `prev` is the schema element default w
     expect(receivedPrev).toEqual({ name: '', age: 0 })
     // Intermediates 0..4 also defaulted (the structural fill from the
     // first describe block); index 5 is the consumer's spread + override.
-    expect(form.getValue('people').value).toEqual([
+    expect(form.values.people).toEqual([
       { name: '', age: 0 },
       { name: '', age: 0 },
       { name: '', age: 0 },
@@ -245,7 +245,7 @@ describe('setValue — intermediate object gaps fill with schema defaults', () =
 
     // Consumer wrote `name`. The lib must fill the rest of `profile`
     // with the schema default, not leave `age`/`bio` as undefined.
-    expect(form.getValue('user.profile').value).toEqual({
+    expect(form.values.user.profile).toEqual({
       name: 'Alice',
       age: 0,
       bio: '',
@@ -265,7 +265,7 @@ describe('setValue — intermediate object gaps fill with schema defaults', () =
     // prev is the whole profile default — every required field present.
     expect(receivedPrev).toEqual({ name: '', age: 0, bio: '' })
     // Result is a structurally-complete profile.
-    expect(form.getValue('user.profile').value).toEqual({
+    expect(form.values.user.profile).toEqual({
       name: 'Bob',
       age: 0,
       bio: '',
@@ -347,7 +347,7 @@ describe('setValue — combined: object + array intermediate fill via callback',
     // The whole address subtree is structurally correct: street preserved
     // from defaultValues, people populated through index 4, intermediates
     // 0..3 are schema element defaults, index 4 is the callback's result.
-    expect(form.getValue('address').value).toEqual({
+    expect(form.values.address).toEqual({
       street: '123 Main St',
       people: [
         { name: '', age: 0 },
@@ -436,7 +436,7 @@ describe('setValue — deep cascade fills every traversed slot completely', () =
     // consumer's `street` overlaid — `city` was filled from the schema
     // element default, NOT dropped just because the path didn't name
     // it.
-    expect(form.getValue('people').value).toEqual([
+    expect(form.values.people).toEqual([
       { name: '', age: 0, addresses: [] },
       { name: '', age: 0, addresses: [] },
       {
@@ -468,7 +468,7 @@ describe('setValue — deep cascade fills every traversed slot completely', () =
     expect(receivedPrev).toEqual({ street: '', city: '' })
 
     // Same shape guarantee as the value-form variant above.
-    expect(form.getValue('people').value).toEqual([
+    expect(form.values.people).toEqual([
       { name: '', age: 0, addresses: [] },
       { name: '', age: 0, addresses: [] },
       {
@@ -493,7 +493,7 @@ describe('setValue — deep cascade fills every traversed slot completely', () =
 
     // Second write should only touch the leaf — every intermediate
     // already exists, no fill triggers, and the value lands cleanly.
-    const people = form.getValue('people').value
+    const people = form.values.people
     expect(people).toHaveLength(3)
     const target = (people as CascadeForm['people'])[2]?.addresses[3]
     expect(target).toEqual({ street: 'Second', city: '' })
@@ -547,7 +547,7 @@ describe('setValue — tuple intermediate positions fill with schema position de
     form.setValue('coords.2', 99)
 
     // Index 1 should be the schema's position-1 default (0), not undefined.
-    expect(form.getValue('coords').value).toEqual([42, 0, 99])
+    expect(form.values.coords).toEqual([42, 0, 99])
   })
 })
 
@@ -580,7 +580,7 @@ describe('reset / resetField — structural completeness preserved', () => {
     // schema-incomplete shape from the prior write.
     form.reset()
 
-    expect(form.getValue('people').value).toEqual([
+    expect(form.values.people).toEqual([
       { name: 'Alice', age: 25 },
       { name: 'Bob', age: 28 },
     ])
@@ -596,7 +596,7 @@ describe('reset / resetField — structural completeness preserved', () => {
     form.setValue('people.0.name', 'Mutated')
     form.resetField('people')
 
-    expect(form.getValue('people').value).toEqual([
+    expect(form.values.people).toEqual([
       { name: 'Alice', age: 25 },
       { name: 'Bob', age: 28 },
     ])
@@ -617,7 +617,7 @@ describe('setValue — partial value writes are filled with schema defaults', ()
     // the lib should fill `age` from the schema default.
     form.setValue('people', [{ name: 'Alice' } as Form['people'][number]])
 
-    expect(form.getValue('people').value).toEqual([{ name: 'Alice', age: 0 }])
+    expect(form.values.people).toEqual([{ name: 'Alice', age: 0 }])
   })
 
   it('writing a partial object via the value form fills missing fields', () => {
@@ -626,7 +626,7 @@ describe('setValue — partial value writes are filled with schema defaults', ()
 
     form.setValue('user.profile', { name: 'Carol' } as ProfileForm['user']['profile'])
 
-    expect(form.getValue('user.profile').value).toEqual({
+    expect(form.values.user.profile).toEqual({
       name: 'Carol',
       age: 0,
       bio: '',

--- a/test/composables/set-value.test.ts
+++ b/test/composables/set-value.test.ts
@@ -71,7 +71,7 @@ describe('setValue — value form (existing behaviour)', () => {
     }
     const result = form.setValue(next)
     expect(result).toBe(true)
-    expect(form.getValue().value).toEqual(next)
+    expect(form.values).toEqual(next)
   })
 
   it('writes a leaf when called with (path, value)', () => {
@@ -79,21 +79,23 @@ describe('setValue — value form (existing behaviour)', () => {
     apps.push(app)
     const result = form.setValue('email', 'bob@example.com')
     expect(result).toBe(true)
-    expect(form.getValue('email').value).toBe('bob@example.com')
+    expect(form.values.email).toBe('bob@example.com')
   })
 
   it('writes a nested leaf', () => {
     const { app, form } = harness()
     apps.push(app)
     form.setValue('profile.name', 'carol')
-    expect(form.getValue('profile.name').value).toBe('carol')
+    expect(form.values.profile.name).toBe('carol')
   })
 
   it('writes an array-index nested leaf', () => {
     const { app, form } = harness()
     apps.push(app)
     form.setValue('posts.0.views', 99)
-    expect(form.getValue('posts.0.views').value).toBe(99)
+    // posts[0] is `T | undefined` (array index honesty); the harness
+    // seeds posts so `[0]` exists at this point.
+    expect(form.values.posts[0]?.views).toBe(99)
   })
 })
 
@@ -116,9 +118,9 @@ describe('setValue — callback form', () => {
 
     expect(result).toBe(true)
     expect(received?.email).toBe('alice@example.com')
-    expect(form.getValue('email').value).toBe('changed@example.com')
+    expect(form.values.email).toBe('changed@example.com')
     // Other paths preserved by the spread.
-    expect(form.getValue('counter').value).toBe(0)
+    expect(form.values.counter).toBe(0)
   })
 
   it('path callback receives the leaf value and applies the return', () => {
@@ -134,7 +136,7 @@ describe('setValue — callback form', () => {
 
     expect(result).toBe(true)
     expect(received).toBe('alice@example.com')
-    expect(form.getValue('email').value).toBe('alice@example.com!')
+    expect(form.values.email).toBe('alice@example.com!')
   })
 
   it('nested-path callback receives the nested leaf', () => {
@@ -143,7 +145,7 @@ describe('setValue — callback form', () => {
     form.setValue('profile.name', 'carol')
 
     form.setValue('profile.name', (prev) => prev.toUpperCase())
-    expect(form.getValue('profile.name').value).toBe('CAROL')
+    expect(form.values.profile.name).toBe('CAROL')
   })
 
   it('array-index nested callback receives the indexed leaf', () => {
@@ -151,7 +153,7 @@ describe('setValue — callback form', () => {
     apps.push(app)
 
     form.setValue('posts.0.views', (prev) => prev + 7)
-    expect(form.getValue('posts.0.views').value).toBe(7)
+    expect(form.values.posts[0]?.views).toBe(7)
   })
 
   it('sequential callback invocations each see the latest committed value', () => {
@@ -163,16 +165,15 @@ describe('setValue — callback form', () => {
     form.setValue('counter', (n) => n + 1)
 
     // Each call read the prior committed value, not a stale snapshot.
-    expect(form.getValue('counter').value).toBe(3)
+    expect(form.values.counter).toBe(3)
   })
 
-  it('callback return value flows through reactivity (getValue ref updates)', () => {
+  it('callback return value flows through reactivity (form.values updates)', () => {
     const { app, form } = harness()
     apps.push(app)
-    const ref = form.getValue('counter')
-    expect(ref.value).toBe(0)
+    expect(form.values.counter).toBe(0)
     form.setValue('counter', (n) => n + 41)
-    expect(ref.value).toBe(41)
+    expect(form.values.counter).toBe(41)
   })
 
   it('does not store the function itself in form state', () => {
@@ -180,7 +181,7 @@ describe('setValue — callback form', () => {
     apps.push(app)
 
     form.setValue('email', (prev) => prev + 'x')
-    const stored = form.getValue('email').value
+    const stored = form.values.email
     expect(typeof stored).toBe('string')
     expect(stored).toBe('x')
   })

--- a/test/composables/slim-primitive-defaults.test.ts
+++ b/test/composables/slim-primitive-defaults.test.ts
@@ -71,28 +71,28 @@ describe('slim-primitive defaults — refinement-invalid passes through', () => 
     const schema = z.object({ color: z.enum(['red', 'green', 'blue']) })
     const { api, app } = mountWith(schema, { color: 'teal' as 'red' })
     apps.push(app)
-    expect(api.getValue('color').value).toBe('teal')
+    expect(api.values.color).toBe('teal')
   })
 
   it("defaultValues: { email: 'luigi' } against z.string().email() lands as 'luigi'", async () => {
     const schema = z.object({ email: z.string().email() })
     const { api, app } = mountWith(schema, { email: 'luigi' })
     apps.push(app)
-    expect(api.getValue('email').value).toBe('luigi')
+    expect(api.values.email).toBe('luigi')
   })
 
   it('defaultValues with too-short string against z.string().min(8) lands as the short string', async () => {
     const schema = z.object({ password: z.string().min(8) })
     const { api, app } = mountWith(schema, { password: 'abc' })
     apps.push(app)
-    expect(api.getValue('password').value).toBe('abc')
+    expect(api.values.password).toBe('abc')
   })
 
   it("defaultValues against z.literal('on'): 'off' passes through", async () => {
     const schema = z.object({ mode: z.literal('on') })
     const { api, app } = mountWith(schema, { mode: 'off' as 'on' })
     apps.push(app)
-    expect(api.getValue('mode').value).toBe('off')
+    expect(api.values.mode).toBe('off')
   })
 })
 
@@ -107,14 +107,14 @@ describe('slim-primitive defaults — wrong-primitive fixed to schema default', 
     const schema = z.object({ color: z.enum(['red', 'green', 'blue']) })
     const { api, app } = mountWith(schema, { color: 1 as unknown as 'red' })
     apps.push(app)
-    expect(api.getValue('color').value).toBe('red')
+    expect(api.values.color).toBe('red')
   })
 
   it("defaultValues: { email: 1 } against z.string().email() lands as ''", async () => {
     const schema = z.object({ email: z.string().email() })
     const { api, app } = mountWith(schema, { email: 1 as unknown as string })
     apps.push(app)
-    expect(api.getValue('email').value).toBe('')
+    expect(api.values.email).toBe('')
   })
 
   it('defaultValues with wrong primitive nested in object: only the offending leaf is fixed', async () => {
@@ -129,8 +129,8 @@ describe('slim-primitive defaults — wrong-primitive fixed to schema default', 
     })
     apps.push(app)
     // name passes through ('Bob'); age gets primitive-fixed (0).
-    expect(api.getValue('user.name').value).toBe('Bob')
-    expect(api.getValue('user.age').value).toBe(0)
+    expect(api.values.user.name).toBe('Bob')
+    expect(api.values.user.age).toBe(0)
   })
 })
 
@@ -148,8 +148,8 @@ describe('slim-primitive defaults — strict-mode surfaces refinement errors at 
     // Strict-mode runs the FULL schema's safeParse at construction
     // and surfaces refinement errors. The form value is still 'teal'
     // (passes through), but fieldErrors/color is populated.
-    expect(api.getValue('color').value).toBe('teal')
-    const errs = api.fieldErrors.color
+    expect(api.values.color).toBe('teal')
+    const errs = api.errors.color
     expect(errs).toBeDefined()
     expect(errs?.length).toBeGreaterThan(0)
   })

--- a/test/composables/slim-primitive-write-gate-v3.property.test.ts
+++ b/test/composables/slim-primitive-write-gate-v3.property.test.ts
@@ -76,16 +76,16 @@ describe('slim-primitive write gate — property: known leaf paths (v3)', () => 
       const { api, app } = makeMounter(useForm, sm.schema)()
       apps.push(app)
 
-      const beforeForm = api.getValue().value
+      const beforeForm = api.values
       const ok = (api.setValue as SetValueFn)(leaf.path.join('.'), value)
       await flush()
 
       expect(ok).toBe(expected)
 
       if (expected) {
-        expect(getAtPath(api.getValue().value, leaf.path)).toEqual(value)
+        expect(getAtPath(api.values, leaf.path)).toEqual(value)
       } else {
-        expect(api.getValue().value).toBe(beforeForm)
+        expect(api.values).toBe(beforeForm)
       }
     }
   )
@@ -126,12 +126,12 @@ describe('slim-primitive write gate — property: unknown paths (v3)', () => {
       const { api, app } = makeMounter(useForm, sm.schema)()
       apps.push(app)
 
-      const beforeForm = api.getValue().value
+      const beforeForm = api.values
       const ok = (api.setValue as SetValueFn)(unknownPath, value)
       await flush()
 
       expect(ok).toBe(false)
-      expect(api.getValue().value).toBe(beforeForm)
+      expect(api.values).toBe(beforeForm)
     }
   )
 })

--- a/test/composables/slim-primitive-write-gate.property.test.ts
+++ b/test/composables/slim-primitive-write-gate.property.test.ts
@@ -97,7 +97,7 @@ describe('slim-primitive write gate — property: known leaf paths (v4)', () => 
       // touch the ref. Identity equality is therefore a tight
       // "no mutation happened" check that sidesteps cloning Vue's
       // reactive proxy (structuredClone refuses it).
-      const beforeForm = api.getValue().value
+      const beforeForm = api.values
 
       const ok = (api.setValue as SetValueFn)(leaf.path.join('.'), value)
       await flush()
@@ -107,11 +107,11 @@ describe('slim-primitive write gate — property: known leaf paths (v4)', () => 
       if (expected) {
         // Leaf at the written path must equal the written value.
         // `toEqual` handles Date/BigInt/null/undefined/primitives uniformly.
-        expect(getAtPath(api.getValue().value, leaf.path)).toEqual(value)
+        expect(getAtPath(api.values, leaf.path)).toEqual(value)
       } else {
         // Rejected: form ref must hold the same identity. A "rejected
         // but partially applied" bug would replace the ref and fail this.
-        expect(api.getValue().value).toBe(beforeForm)
+        expect(api.values).toBe(beforeForm)
       }
     }
   )
@@ -159,12 +159,12 @@ describe('slim-primitive write gate — property: unknown paths (v4)', () => {
       const { api, app } = makeMounter(useForm, sm.schema)()
       apps.push(app)
 
-      const beforeForm = api.getValue().value
+      const beforeForm = api.values
       const ok = (api.setValue as SetValueFn)(unknownPath, value)
       await flush()
 
       expect(ok).toBe(false)
-      expect(api.getValue().value).toBe(beforeForm)
+      expect(api.values).toBe(beforeForm)
     }
   )
 })

--- a/test/composables/slim-primitive-write-gate.test.ts
+++ b/test/composables/slim-primitive-write-gate.test.ts
@@ -352,23 +352,23 @@ describe('slim-primitive write gate — unknown schema paths', () => {
     })
     const { api, app } = makeMounter(schema)()
     apps.push(app)
-    const before = JSON.parse(JSON.stringify(api.getValue().value))
+    const before = JSON.parse(JSON.stringify(api.values))
     const ok = (api.setValue as (path: string, value: unknown) => boolean)('address.salary', 'abc')
     await flush()
     expect(ok).toBe(false)
     // Form value unchanged — no `address.salary` slot created.
-    expect(api.getValue().value).toEqual(before)
+    expect(api.values).toEqual(before)
   })
 
   it('rejects writes to an unknown root-level path', async () => {
     const schema = z.object({ name: z.string() })
     const { api, app } = makeMounter(schema)()
     apps.push(app)
-    const before = JSON.parse(JSON.stringify(api.getValue().value))
+    const before = JSON.parse(JSON.stringify(api.values))
     const ok = (api.setValue as (path: string, value: unknown) => boolean)('phantom', 'x')
     await flush()
     expect(ok).toBe(false)
-    expect(api.getValue().value).toEqual(before)
+    expect(api.values).toEqual(before)
   })
 
   it('rejects writes that would create a deeply-nested unknown path', async () => {
@@ -379,14 +379,14 @@ describe('slim-primitive write gate — unknown schema paths', () => {
     })
     const { api, app } = makeMounter(schema)()
     apps.push(app)
-    const before = JSON.parse(JSON.stringify(api.getValue().value))
+    const before = JSON.parse(JSON.stringify(api.values))
     const ok = (api.setValue as (path: string, value: unknown) => boolean)(
       'profile.details.unknown',
       'x'
     )
     await flush()
     expect(ok).toBe(false)
-    expect(api.getValue().value).toEqual(before)
+    expect(api.values).toEqual(before)
   })
 
   it('rejection emits a dev-warn naming the unknown path', async () => {

--- a/test/composables/slim-primitive-write-gate.test.ts
+++ b/test/composables/slim-primitive-write-gate.test.ts
@@ -50,7 +50,7 @@ describe('slim-primitive write gate — accepted writes (slim type matches)', ()
     const ok = (api.setValue as (path: 'email', value: unknown) => boolean)('email', 'luigi')
     await flush()
     expect(ok).toBe(true)
-    expect(api.getValue('email').value).toBe('luigi')
+    expect(api.values.email).toBe('luigi')
   })
 
   it('z.enum accepts any string (out-of-enum passes through)', async () => {
@@ -60,7 +60,7 @@ describe('slim-primitive write gate — accepted writes (slim type matches)', ()
     const ok = (api.setValue as (path: 'color', value: unknown) => boolean)('color', 'magenta')
     await flush()
     expect(ok).toBe(true)
-    expect(api.getValue('color').value).toBe('magenta')
+    expect(api.values.color).toBe('magenta')
   })
 
   it('z.literal(string) accepts any string', async () => {
@@ -70,7 +70,7 @@ describe('slim-primitive write gate — accepted writes (slim type matches)', ()
     const ok = (api.setValue as (path: 'mode', value: unknown) => boolean)('mode', 'off')
     await flush()
     expect(ok).toBe(true)
-    expect(api.getValue('mode').value).toBe('off')
+    expect(api.values.mode).toBe('off')
   })
 
   it('z.union([string, number]) accepts strings AND numbers, rejects booleans', async () => {
@@ -81,16 +81,16 @@ describe('slim-primitive write gate — accepted writes (slim type matches)', ()
 
     expect(setVal('field', 'x')).toBe(true)
     await flush()
-    expect(api.getValue('field').value).toBe('x')
+    expect(api.values.field).toBe('x')
 
     expect(setVal('field', 42)).toBe(true)
     await flush()
-    expect(api.getValue('field').value).toBe(42)
+    expect(api.values.field).toBe(42)
 
     expect(setVal('field', true)).toBe(false)
     await flush()
     // Still 42 — the boolean write was rejected.
-    expect(api.getValue('field').value).toBe(42)
+    expect(api.values.field).toBe(42)
   })
 
   it('z.string().nullable() accepts null', async () => {
@@ -100,7 +100,7 @@ describe('slim-primitive write gate — accepted writes (slim type matches)', ()
     const ok = (api.setValue as (path: 'note', value: unknown) => boolean)('note', null)
     await flush()
     expect(ok).toBe(true)
-    expect(api.getValue('note').value).toBe(null)
+    expect(api.values.note).toBe(null)
   })
 
   it('z.string().optional() accepts undefined', async () => {
@@ -110,7 +110,7 @@ describe('slim-primitive write gate — accepted writes (slim type matches)', ()
     const ok = (api.setValue as (path: 'note', value: unknown) => boolean)('note', undefined)
     await flush()
     expect(ok).toBe(true)
-    expect(api.getValue('note').value).toBe(undefined)
+    expect(api.values.note).toBe(undefined)
   })
 })
 
@@ -131,55 +131,55 @@ describe('slim-primitive write gate — rejected writes (wrong primitive)', () =
     const schema = z.object({ age: z.number() })
     const { api, app } = makeMounter(schema)()
     apps.push(app)
-    const before = api.getValue('age').value
+    const before = api.values.age
     const ok = (api.setValue as (path: 'age', value: unknown) => boolean)('age', 'twenty')
     await flush()
     expect(ok).toBe(false)
-    expect(api.getValue('age').value).toBe(before)
+    expect(api.values.age).toBe(before)
   })
 
   it('z.boolean(): rejects a string write', async () => {
     const schema = z.object({ flag: z.boolean() })
     const { api, app } = makeMounter(schema)()
     apps.push(app)
-    const before = api.getValue('flag').value
+    const before = api.values.flag
     const ok = (api.setValue as (path: 'flag', value: unknown) => boolean)('flag', 'no')
     await flush()
     expect(ok).toBe(false)
-    expect(api.getValue('flag').value).toBe(before)
+    expect(api.values.flag).toBe(before)
   })
 
   it('z.enum([...strings]): rejects a number write', async () => {
     const schema = z.object({ color: z.enum(['red', 'green', 'blue']) })
     const { api, app } = makeMounter(schema)()
     apps.push(app)
-    const before = api.getValue('color').value
+    const before = api.values.color
     const ok = (api.setValue as (path: 'color', value: unknown) => boolean)('color', 1)
     await flush()
     expect(ok).toBe(false)
-    expect(api.getValue('color').value).toBe(before)
+    expect(api.values.color).toBe(before)
   })
 
   it('z.bigint(): rejects a string write', async () => {
     const schema = z.object({ count: z.bigint() })
     const { api, app } = makeMounter(schema)()
     apps.push(app)
-    const before = api.getValue('count').value
+    const before = api.values.count
     const ok = (api.setValue as (path: 'count', value: unknown) => boolean)('count', 'abc')
     await flush()
     expect(ok).toBe(false)
-    expect(api.getValue('count').value).toBe(before)
+    expect(api.values.count).toBe(before)
   })
 
   it('z.string() (non-nullable): rejects null', async () => {
     const schema = z.object({ note: z.string() })
     const { api, app } = makeMounter(schema)()
     apps.push(app)
-    const before = api.getValue('note').value
+    const before = api.values.note
     const ok = (api.setValue as (path: 'note', value: unknown) => boolean)('note', null)
     await flush()
     expect(ok).toBe(false)
-    expect(api.getValue('note').value).toBe(before)
+    expect(api.values.note).toBe(before)
   })
 
   it('rejection emits a dev-warn naming the path + offending kind', async () => {
@@ -239,14 +239,14 @@ describe('slim-primitive write gate — subtree writes', () => {
     })
     const { api, app } = makeMounter(schema)()
     apps.push(app)
-    const before = api.getValue('user').value
+    const before = api.values.user
     const ok = (api.setValue as (path: 'user', value: unknown) => boolean)('user', {
       name: 'Bob',
       age: 'twenty', // wrong primitive at user.age
     })
     await flush()
     expect(ok).toBe(false)
-    expect(api.getValue('user').value).toEqual(before)
+    expect(api.values.user).toEqual(before)
     warnSpy.mockRestore()
   })
 
@@ -262,7 +262,7 @@ describe('slim-primitive write gate — subtree writes', () => {
     })
     await flush()
     expect(ok).toBe(true)
-    expect(api.getValue('user').value).toEqual({ name: 'Bob', age: 30 })
+    expect(api.values.user).toEqual({ name: 'Bob', age: 30 })
   })
 
   it('writing a string at a path expecting an object rejects', async () => {

--- a/test/composables/transient-empty-persistence.test.ts
+++ b/test/composables/transient-empty-persistence.test.ts
@@ -269,7 +269,7 @@ describe('persistence — blank round-trips across mount', () => {
     await flushAll()
 
     if (captured === undefined) throw new Error('form not captured')
-    expect(captured.blankPaths.value.size).toBe(0)
-    expect(captured.getValue('income').value).toBe(100)
+    expect(captured.transientEmptyPaths.value.size).toBe(0)
+    expect(captured.values.income).toBe(100)
   })
 })

--- a/test/composables/transient-empty-persistence.test.ts
+++ b/test/composables/transient-empty-persistence.test.ts
@@ -269,7 +269,7 @@ describe('persistence — blank round-trips across mount', () => {
     await flushAll()
 
     if (captured === undefined) throw new Error('form not captured')
-    expect(captured.transientEmptyPaths.value.size).toBe(0)
+    expect(captured.blankPaths.value.size).toBe(0)
     expect(captured.values.income).toBe(100)
   })
 })

--- a/test/composables/transient-empty-validation.test.ts
+++ b/test/composables/transient-empty-validation.test.ts
@@ -95,7 +95,7 @@ describe('handleSubmit — required-empty raises a synthesised error', () => {
     expect(requiredErr?.path).toEqual(['income'])
     // Anchor the human-readable message once; downstream tests assert on `code`.
     expect(requiredErr?.message).toBe('No value supplied')
-    expect(form.fieldErrors['income']?.[0]?.code).toBe(CxErrorCode.NoValueSupplied)
+    expect(form.errors['income']?.[0]?.code).toBe(CxErrorCode.NoValueSupplied)
     void incomeKey
   })
 

--- a/test/composables/transient-empty.test.ts
+++ b/test/composables/transient-empty.test.ts
@@ -45,22 +45,22 @@ describe('defaultValues with `unset`', () => {
   it('numeric leaf: storage holds the slim default, set is populated', () => {
     const { app, form } = setupForm(z.object({ count: z.number() }), { count: unset })
     apps.push(app)
-    expect(form.getValue('count').value).toBe(0)
-    expect(form.blankPaths.value.has(canonicalizePath('count').key)).toBe(true)
+    expect(form.values.count).toBe(0)
+    expect(form.transientEmptyPaths.value.has(canonicalizePath('count').key)).toBe(true)
   })
 
   it('string leaf: storage is "", set is populated', () => {
     const { app, form } = setupForm(z.object({ name: z.string() }), { name: unset })
     apps.push(app)
-    expect(form.getValue('name').value).toBe('')
-    expect(form.blankPaths.value.has(canonicalizePath('name').key)).toBe(true)
+    expect(form.values.name).toBe('')
+    expect(form.transientEmptyPaths.value.has(canonicalizePath('name').key)).toBe(true)
   })
 
   it('boolean leaf: storage is false, set is populated', () => {
     const { app, form } = setupForm(z.object({ agreed: z.boolean() }), { agreed: unset })
     apps.push(app)
-    expect(form.getValue('agreed').value).toBe(false)
-    expect(form.blankPaths.value.has(canonicalizePath('agreed').key)).toBe(true)
+    expect(form.values.agreed).toBe(false)
+    expect(form.transientEmptyPaths.value.has(canonicalizePath('agreed').key)).toBe(true)
   })
 
   it('multiple leaves can be marked', () => {
@@ -88,9 +88,9 @@ describe('defaultValues with `unset`', () => {
       name: 'alice',
     })
     apps.push(app)
-    expect(form.blankPaths.value.has(canonicalizePath('income').key)).toBe(true)
-    expect(form.blankPaths.value.has(canonicalizePath('name').key)).toBe(false)
-    expect(form.getValue('name').value).toBe('alice')
+    expect(form.transientEmptyPaths.value.has(canonicalizePath('income').key)).toBe(true)
+    expect(form.transientEmptyPaths.value.has(canonicalizePath('name').key)).toBe(false)
+    expect(form.values.name).toBe('alice')
   })
 })
 
@@ -107,8 +107,8 @@ describe('setValue(path, unset)', () => {
     expect(form.blankPaths.value.size).toBe(0)
 
     form.setValue('count', unset)
-    expect(form.getValue('count').value).toBe(0)
-    expect(form.blankPaths.value.has(canonicalizePath('count').key)).toBe(true)
+    expect(form.values.count).toBe(0)
+    expect(form.transientEmptyPaths.value.has(canonicalizePath('count').key)).toBe(true)
   })
 
   it('subsequent regular write removes the path', () => {
@@ -118,8 +118,8 @@ describe('setValue(path, unset)', () => {
     expect(form.blankPaths.value.size).toBe(1)
 
     form.setValue('count', 42)
-    expect(form.blankPaths.value.size).toBe(0)
-    expect(form.getValue('count').value).toBe(42)
+    expect(form.transientEmptyPaths.value.size).toBe(0)
+    expect(form.values.count).toBe(42)
   })
 
   it('callback returning unset is translated', () => {
@@ -127,8 +127,8 @@ describe('setValue(path, unset)', () => {
     apps.push(app)
     form.setValue('count', 5)
     form.setValue('count', () => unset)
-    expect(form.getValue('count').value).toBe(0)
-    expect(form.blankPaths.value.size).toBe(1)
+    expect(form.values.count).toBe(0)
+    expect(form.transientEmptyPaths.value.size).toBe(1)
   })
 })
 
@@ -145,9 +145,9 @@ describe('reset(args) with unset', () => {
     expect(form.blankPaths.value.size).toBe(0)
 
     form.reset({ count: unset })
-    expect(form.getValue('count').value).toBe(0)
-    expect(form.blankPaths.value.has(canonicalizePath('count').key)).toBe(true)
-    // Dirty resets to false: the new baseline is "blank for this path".
+    expect(form.values.count).toBe(0)
+    expect(form.transientEmptyPaths.value.has(canonicalizePath('count').key)).toBe(true)
+    // Dirty resets to false: the new baseline is "transient-empty for this path".
     expect(form.state.isDirty).toBe(false)
   })
 })
@@ -161,16 +161,16 @@ describe('getFieldState meta.blank + flat blank', () => {
   it('reports blank for a path marked via defaultValues', () => {
     const { app, form } = setupForm(z.object({ count: z.number() }), { count: unset })
     apps.push(app)
-    const fs = form.getFieldState('count').value
-    expect((fs as unknown as { blank: boolean }).blank).toBe(true)
+    const fs = form.fieldState.count
+    expect((fs as unknown as { pendingEmpty: boolean }).pendingEmpty).toBe(true)
   })
 
   it('flips back to false after a real write', () => {
     const { app, form } = setupForm(z.object({ count: z.number() }), { count: unset })
     apps.push(app)
     form.setValue('count', 5)
-    const fs = form.getFieldState('count').value
-    expect((fs as unknown as { blank: boolean }).blank).toBe(false)
+    const fs = form.fieldState.count
+    expect((fs as unknown as { pendingEmpty: boolean }).pendingEmpty).toBe(false)
   })
 })
 
@@ -266,10 +266,10 @@ describe('auto-mark: unspecified primitive leaves are blank on construction', ()
       name: 'alice',
     })
     apps.push(app)
-    expect(form.blankPaths.value.has(canonicalizePath('name').key)).toBe(false)
-    expect(form.blankPaths.value.has(canonicalizePath('age').key)).toBe(true)
-    expect(form.getValue('name').value).toBe('alice')
-    expect(form.getValue('age').value).toBe(0)
+    expect(form.transientEmptyPaths.value.has(canonicalizePath('name').key)).toBe(false)
+    expect(form.transientEmptyPaths.value.has(canonicalizePath('age').key)).toBe(true)
+    expect(form.values.name).toBe('alice')
+    expect(form.values.age).toBe(0)
   })
 
   it('explicit slim-default value still opts the leaf out of auto-mark', () => {
@@ -310,21 +310,21 @@ describe('auto-mark: unspecified primitive leaves are blank on construction', ()
     expect(form.blankPaths.value.has(canonicalizePath('note').key)).toBe(true)
     // Storage is undefined per the optional schema — the mark is
     // about UI/display intent, not about validation requiredness.
-    expect(form.getValue('note').value).toBeUndefined()
+    expect(form.values.note).toBeUndefined()
   })
 
   it('nullable leaf: marks the path even though slim default is null', () => {
     const { app, form } = setupForm(z.object({ note: z.string().nullable() }))
     apps.push(app)
-    expect(form.blankPaths.value.has(canonicalizePath('note').key)).toBe(true)
-    expect(form.getValue('note').value).toBeNull()
+    expect(form.transientEmptyPaths.value.has(canonicalizePath('note').key)).toBe(true)
+    expect(form.values.note).toBeNull()
   })
 
   it('.default(N): marks the path; storage holds N (the default-author intent)', () => {
     const { app, form } = setupForm(z.object({ count: z.number().default(7) }))
     apps.push(app)
-    expect(form.blankPaths.value.has(canonicalizePath('count').key)).toBe(true)
-    expect(form.getValue('count').value).toBe(7)
+    expect(form.transientEmptyPaths.value.has(canonicalizePath('count').key)).toBe(true)
+    expect(form.values.count).toBe(7)
   })
 
   it('arrays: pass through without marking elements (runtime-added)', () => {
@@ -381,10 +381,10 @@ describe('auto-mark: unspecified primitive leaves are blank on construction', ()
     expect(form.blankPaths.value.size).toBe(0)
     // Reset with a partial — `age` is omitted, so it gets auto-marked.
     form.reset({ name: 'bob' })
-    expect(form.blankPaths.value.has(canonicalizePath('name').key)).toBe(false)
-    expect(form.blankPaths.value.has(canonicalizePath('age').key)).toBe(true)
-    expect(form.getValue('name').value).toBe('bob')
-    expect(form.getValue('age').value).toBe(0)
+    expect(form.transientEmptyPaths.value.has(canonicalizePath('name').key)).toBe(false)
+    expect(form.transientEmptyPaths.value.has(canonicalizePath('age').key)).toBe(true)
+    expect(form.values.name).toBe('bob')
+    expect(form.values.age).toBe(0)
   })
 
   it('isDirty stays false on construction even with auto-marks', () => {

--- a/test/composables/transient-empty.test.ts
+++ b/test/composables/transient-empty.test.ts
@@ -46,21 +46,21 @@ describe('defaultValues with `unset`', () => {
     const { app, form } = setupForm(z.object({ count: z.number() }), { count: unset })
     apps.push(app)
     expect(form.values.count).toBe(0)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('count').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('count').key)).toBe(true)
   })
 
   it('string leaf: storage is "", set is populated', () => {
     const { app, form } = setupForm(z.object({ name: z.string() }), { name: unset })
     apps.push(app)
     expect(form.values.name).toBe('')
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('name').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('name').key)).toBe(true)
   })
 
   it('boolean leaf: storage is false, set is populated', () => {
     const { app, form } = setupForm(z.object({ agreed: z.boolean() }), { agreed: unset })
     apps.push(app)
     expect(form.values.agreed).toBe(false)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('agreed').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('agreed').key)).toBe(true)
   })
 
   it('multiple leaves can be marked', () => {
@@ -88,8 +88,8 @@ describe('defaultValues with `unset`', () => {
       name: 'alice',
     })
     apps.push(app)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('income').key)).toBe(true)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('name').key)).toBe(false)
+    expect(form.blankPaths.value.has(canonicalizePath('income').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('name').key)).toBe(false)
     expect(form.values.name).toBe('alice')
   })
 })
@@ -108,7 +108,7 @@ describe('setValue(path, unset)', () => {
 
     form.setValue('count', unset)
     expect(form.values.count).toBe(0)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('count').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('count').key)).toBe(true)
   })
 
   it('subsequent regular write removes the path', () => {
@@ -118,7 +118,7 @@ describe('setValue(path, unset)', () => {
     expect(form.blankPaths.value.size).toBe(1)
 
     form.setValue('count', 42)
-    expect(form.transientEmptyPaths.value.size).toBe(0)
+    expect(form.blankPaths.value.size).toBe(0)
     expect(form.values.count).toBe(42)
   })
 
@@ -128,7 +128,7 @@ describe('setValue(path, unset)', () => {
     form.setValue('count', 5)
     form.setValue('count', () => unset)
     expect(form.values.count).toBe(0)
-    expect(form.transientEmptyPaths.value.size).toBe(1)
+    expect(form.blankPaths.value.size).toBe(1)
   })
 })
 
@@ -146,7 +146,7 @@ describe('reset(args) with unset', () => {
 
     form.reset({ count: unset })
     expect(form.values.count).toBe(0)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('count').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('count').key)).toBe(true)
     // Dirty resets to false: the new baseline is "transient-empty for this path".
     expect(form.state.isDirty).toBe(false)
   })
@@ -162,7 +162,7 @@ describe('getFieldState meta.blank + flat blank', () => {
     const { app, form } = setupForm(z.object({ count: z.number() }), { count: unset })
     apps.push(app)
     const fs = form.fieldState.count
-    expect((fs as unknown as { pendingEmpty: boolean }).pendingEmpty).toBe(true)
+    expect((fs as unknown as { blank: boolean }).blank).toBe(true)
   })
 
   it('flips back to false after a real write', () => {
@@ -170,7 +170,7 @@ describe('getFieldState meta.blank + flat blank', () => {
     apps.push(app)
     form.setValue('count', 5)
     const fs = form.fieldState.count
-    expect((fs as unknown as { pendingEmpty: boolean }).pendingEmpty).toBe(false)
+    expect((fs as unknown as { blank: boolean }).blank).toBe(false)
   })
 })
 
@@ -266,8 +266,8 @@ describe('auto-mark: unspecified primitive leaves are blank on construction', ()
       name: 'alice',
     })
     apps.push(app)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('name').key)).toBe(false)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('age').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('name').key)).toBe(false)
+    expect(form.blankPaths.value.has(canonicalizePath('age').key)).toBe(true)
     expect(form.values.name).toBe('alice')
     expect(form.values.age).toBe(0)
   })
@@ -316,14 +316,14 @@ describe('auto-mark: unspecified primitive leaves are blank on construction', ()
   it('nullable leaf: marks the path even though slim default is null', () => {
     const { app, form } = setupForm(z.object({ note: z.string().nullable() }))
     apps.push(app)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('note').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('note').key)).toBe(true)
     expect(form.values.note).toBeNull()
   })
 
   it('.default(N): marks the path; storage holds N (the default-author intent)', () => {
     const { app, form } = setupForm(z.object({ count: z.number().default(7) }))
     apps.push(app)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('count').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('count').key)).toBe(true)
     expect(form.values.count).toBe(7)
   })
 
@@ -381,8 +381,8 @@ describe('auto-mark: unspecified primitive leaves are blank on construction', ()
     expect(form.blankPaths.value.size).toBe(0)
     // Reset with a partial — `age` is omitted, so it gets auto-marked.
     form.reset({ name: 'bob' })
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('name').key)).toBe(false)
-    expect(form.transientEmptyPaths.value.has(canonicalizePath('age').key)).toBe(true)
+    expect(form.blankPaths.value.has(canonicalizePath('name').key)).toBe(false)
+    expect(form.blankPaths.value.has(canonicalizePath('age').key)).toBe(true)
     expect(form.values.name).toBe('bob')
     expect(form.values.age).toBe(0)
   })

--- a/test/composables/type-inference.test.ts
+++ b/test/composables/type-inference.test.ts
@@ -1,6 +1,5 @@
 import { describe, expectTypeOf, it } from 'vitest'
 import { z } from 'zod'
-import type { Ref } from 'vue'
 import type { FormState } from '../../src'
 import type { useForm } from '../../src/zod'
 import type { WithIndexedUndefined } from '../../src/runtime/types/types-core'
@@ -97,49 +96,38 @@ describe('useForm type inference — factory signature', () => {
     void missingSchemaConfig
   })
 
-  it('returns the inferred Form shape at the top-level getValue() (with array taint)', () => {
-    // After the Phase-4 read-type honesty pass, `getValue()` returns the
-    // form wrapped in `WithIndexedUndefined` — `value.tags[N]` etc. is
+  it('returns the inferred Form shape on form.values (with array taint)', () => {
+    // `form.values` is a Pinia-style readonly proxy over the form
+    // wrapped in `WithIndexedUndefined` — `values.tags[N]` etc. is
     // `string | undefined` since arrays can be out-of-bounds at runtime.
-    const whole = form.getValue()
-    expectTypeOf(whole.value).toEqualTypeOf<WithIndexedUndefined<ExpectedForm>>()
+    expectTypeOf(form.values).toEqualTypeOf<Readonly<WithIndexedUndefined<ExpectedForm>>>()
   })
 })
 
-describe('useForm type inference — getValue', () => {
-  it('scalar leaf path → Readonly<Ref<leaf type>>', () => {
-    expectTypeOf(form.getValue('email')).toEqualTypeOf<Readonly<Ref<string>>>()
-    expectTypeOf(form.getValue('age')).toEqualTypeOf<Readonly<Ref<number>>>()
-    expectTypeOf(form.getValue('active')).toEqualTypeOf<Readonly<Ref<boolean>>>()
+describe('useForm type inference — form.values', () => {
+  it('scalar leaf is the leaf type directly (no Ref)', () => {
+    expectTypeOf(form.values.email).toEqualTypeOf<string>()
+    expectTypeOf(form.values.age).toEqualTypeOf<number>()
+    expectTypeOf(form.values.active).toEqualTypeOf<boolean>()
   })
 
-  it('nested object path', () => {
-    expectTypeOf(form.getValue('profile.name')).toEqualTypeOf<Readonly<Ref<string>>>()
+  it('nested object descent', () => {
+    expectTypeOf(form.values.profile.name).toEqualTypeOf<string>()
   })
 
   it('optional nested field preserves `| undefined`', () => {
-    expectTypeOf(form.getValue('profile.bio')).toEqualTypeOf<Readonly<Ref<string | undefined>>>()
+    expectTypeOf(form.values.profile.bio).toEqualTypeOf<string | undefined>()
   })
 
-  it('array index path is undefined-tainted (out-of-bounds is honest)', () => {
-    // After Phase 4, paths through a numeric segment yield `T | undefined`
-    // — `tags[5]` against a length-2 array returns `undefined` at runtime,
-    // and the type now reflects that.
-    expectTypeOf(form.getValue('tags.0')).toEqualTypeOf<Readonly<Ref<string | undefined>>>()
+  it('array index is undefined-tainted (out-of-bounds is honest)', () => {
+    // Numeric index access through a Vue readonly array proxy returns
+    // `T | undefined` — same honesty pass.
+    expectTypeOf(form.values.tags[0]).toEqualTypeOf<string | undefined>()
   })
 
-  it('array-of-object nested path (posts.N.field) is tainted past the array boundary', () => {
-    expectTypeOf(form.getValue('posts.0.title')).toEqualTypeOf<Readonly<Ref<string | undefined>>>()
-    expectTypeOf(form.getValue('posts.0.views')).toEqualTypeOf<Readonly<Ref<number | undefined>>>()
-  })
-
-  it('rejects paths not present in the schema', () => {
-    // @ts-expect-error - 'nope' is not a top-level key
-    form.getValue('nope')
-    // @ts-expect-error - 'profile.nonexistent' not in profile shape
-    form.getValue('profile.nonexistent')
-    // @ts-expect-error - 'posts.0.bad' not on the post shape
-    form.getValue('posts.0.bad')
+  it('array-of-object nested path (posts[N].field) is tainted past the array boundary', () => {
+    expectTypeOf(form.values.posts[0]?.title).toEqualTypeOf<string | undefined>()
+    expectTypeOf(form.values.posts[0]?.views).toEqualTypeOf<number | undefined>()
   })
 })
 
@@ -278,18 +266,17 @@ describe('useForm type inference — handleSubmit', () => {
   })
 })
 
-describe('useForm type inference — getFieldState + fieldErrors', () => {
-  it('getFieldState returns a Ref<FieldState> with a typed errors array', () => {
-    const fs = form.getFieldState('email')
-    expectTypeOf(fs.value.errors).toMatchTypeOf<ReadonlyArray<{ message: string }>>()
+describe('useForm type inference — fieldState + errors', () => {
+  it('form.fieldState exposes a typed errors array on each path', () => {
+    expectTypeOf(form.fieldState.email.errors).toMatchTypeOf<ReadonlyArray<{ message: string }>>()
   })
 
-  it('fieldErrors is a Readonly<FormFieldErrors<Form>> (Proxy view, no .value)', () => {
+  it('form.errors is a Readonly<FormFieldErrors<Form>> (Proxy view, no .value)', () => {
     // Internally backed by a ComputedRef + Proxy; the public type is
     // the unwrapped record so templates can dot-access without `.value`.
-    expectTypeOf(form.fieldErrors).toMatchTypeOf<Record<string, unknown>>()
-    // @ts-expect-error — fieldErrors is no longer a Ref, so `.value` is gone.
-    void form.fieldErrors.value
+    expectTypeOf(form.errors).toMatchTypeOf<Record<string, unknown>>()
+    // @ts-expect-error — errors is not a Ref, so `.value` is gone.
+    void form.errors.value
   })
 })
 

--- a/test/composables/use-form-context.test.ts
+++ b/test/composables/use-form-context.test.ts
@@ -54,9 +54,9 @@ describe('useFormContext — ambient provide/inject', () => {
     expect(shared.parent).toBeDefined()
     expect(shared.child).toBeDefined()
     shared.parent?.setValue('email', 'first@x')
-    expect(shared.child?.getValue('email').value).toBe('first@x')
+    expect(shared.child?.values.email).toBe('first@x')
     shared.child?.setValue('profile.name', 'alice')
-    expect(shared.parent?.getValue('profile.name').value).toBe('alice')
+    expect(shared.parent?.values.profile.name).toBe('alice')
 
     app.unmount()
   })
@@ -238,7 +238,7 @@ describe('useFormContext — explicit key resolution', () => {
     // the same key is read. We prove that by reading back via the same
     // sibling handle; the registry is a single source of truth.
     shared.sibling?.setValue('email', 'from-sibling@x')
-    expect(shared.sibling?.getValue('email').value).toBe('from-sibling@x')
+    expect(shared.sibling?.values.email).toBe('from-sibling@x')
     app.unmount()
   })
 

--- a/test/composables/use-form-v3-forwarding.test.ts
+++ b/test/composables/use-form-v3-forwarding.test.ts
@@ -78,7 +78,7 @@ describe('v3 useForm forwards opt-in options to useAbstractForm', () => {
     await wait(60)
     await drain()
 
-    expect(api.fieldErrors.email?.[0]?.message).toBe('bad email')
+    expect(api.errors.email?.[0]?.message).toBe('bad email')
   })
 
   it('forwards persist — custom FormStorage receives setItem calls', async () => {

--- a/test/composables/use-register-template.test.ts
+++ b/test/composables/use-register-template.test.ts
@@ -139,7 +139,7 @@ describe('useRegister — template-compiled v-register reaches inner input', () 
     innerInput.dispatchEvent(new Event('input', { bubbles: true }))
     await flush()
 
-    expect(captured.api.getValue('email').value).toBe('typed-via-template')
+    expect(captured.api.values.email).toBe('typed-via-template')
   })
 
   it('focus on the inner input flips the form-state focused flag (template-compiled)', async () => {
@@ -184,7 +184,7 @@ describe('useRegister — template-compiled v-register reaches inner input', () 
     // The inner input is what FormStore registered (via the directive
     // that landed on it from the inner `<input v-register>`). Focus
     // listeners are installed at registerElement time on that element.
-    expect(captured.api.getFieldState('email').value.focused).toBe(true)
+    expect(captured.api.fieldState.email.focused).toBe(true)
   })
 
   // Direct assertion that the directive used in the template path is

--- a/test/composables/use-register.test.ts
+++ b/test/composables/use-register.test.ts
@@ -70,7 +70,14 @@ describe('useRegister — inside child setup', () => {
     document.body.innerHTML = ''
   })
 
-  it('with NO parent registerValue → returns ComputedRef<undefined> + one-shot warn', async () => {
+  it('with NO parent registerValue → returns ComputedRef<undefined> + one-shot warn at onMounted', async () => {
+    // Diagnostic shape: the warn fires once per instance in the
+    // `onMounted` hook, after the parent has had its full mount
+    // lifecycle to bind v-register. Reading `.value` does NOT fire the
+    // warn — the computed factory is pure, so consumers that handle
+    // the undefined branch (storybook, preview pages, conditional
+    // bindings) read freely. Re-reads on the same instance never
+    // re-warn.
     const captured: { register?: ReturnType<typeof useRegister> } = {}
     const warnings: string[] = []
 
@@ -99,9 +106,6 @@ describe('useRegister — inside child setup', () => {
     app.mount(root)
     await flush()
 
-    // Computed is lazy — `.value` triggers evaluation, which is what
-    // fires the no-parent-RV warn. Read it BEFORE restoring the spy
-    // so the warn lands in the captured `warnings` array.
     expect(captured.register).toBeDefined()
     if (captured.register === undefined) throw new Error('unreachable')
     expect(captured.register.value).toBeUndefined()
@@ -109,7 +113,45 @@ describe('useRegister — inside child setup', () => {
     warnSpy.mockRestore()
 
     const matched = warnings.filter((w) => w.includes('useRegister'))
-    expect(matched.length).toBeGreaterThanOrEqual(1)
+    expect(matched.length).toBe(1)
+  })
+
+  it('with NO parent registerValue → re-reading the computed many times produces exactly one warn', async () => {
+    // The computed factory is pure — only the `onMounted` hook emits
+    // the diagnostic. A consumer that reads `register.value` in a
+    // conditional, a watcher, and a render must not see the warn
+    // multiplied per read.
+    const captured: { register?: ReturnType<typeof useRegister> } = {}
+    const warnings: string[] = []
+
+    const Child = defineComponent({
+      name: 'Child',
+      inheritAttrs: false,
+      setup() {
+        captured.register = useRegister()
+        return () => h('input', { type: 'text' })
+      },
+    })
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+      warnings.push(args.map((a) => String(a)).join(' '))
+    })
+
+    app = createApp(defineComponent({ render: () => h(Child) })).use(createChemicalXForms())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await flush()
+
+    if (captured.register === undefined) throw new Error('unreachable')
+    // Hammer the computed.
+    for (let i = 0; i < 10; i++) {
+      void captured.register.value
+    }
+
+    warnSpy.mockRestore()
+    const matched = warnings.filter((w) => w.includes('useRegister: no parent registerValue prop'))
+    expect(matched.length).toBe(1)
   })
 
   it('with parent registerValue → does NOT emit the no-parent-RV warn during initial render (regression: pre-onBeforeMount capture race)', async () => {

--- a/test/composables/use-register.test.ts
+++ b/test/composables/use-register.test.ts
@@ -371,7 +371,7 @@ describe('useRegister — sentinel suppresses parent-directive warn', () => {
 
     if (formApi === undefined) throw new Error('unreachable')
     formApi.setValue('email', 'seed@example.com')
-    expect(formApi.getValue('email').value).toBe('seed@example.com')
+    expect(formApi.values.email).toBe('seed@example.com')
 
     // Type into the inner input. Without the bail, the wrapper's
     // bubbled `input` listener would read `el.value` off the div and
@@ -382,7 +382,7 @@ describe('useRegister — sentinel suppresses parent-directive warn', () => {
     innerInput.dispatchEvent(new Event('input', { bubbles: true }))
     await flush()
 
-    expect(formApi.getValue('email').value).toBe('seed@example.com')
+    expect(formApi.values.email).toBe('seed@example.com')
   })
 })
 
@@ -444,7 +444,7 @@ describe('useRegister — inner v-register receives full directive lifecycle', (
     innerInput.focus()
     innerInput.dispatchEvent(new Event('focus', { bubbles: true }))
     await flush()
-    expect(captured.api.getFieldState('email').value.focused).toBe(true)
+    expect(captured.api.fieldState.email.focused).toBe(true)
   })
 })
 

--- a/test/composables/use-register.test.ts
+++ b/test/composables/use-register.test.ts
@@ -112,6 +112,68 @@ describe('useRegister — inside child setup', () => {
     expect(matched.length).toBeGreaterThanOrEqual(1)
   })
 
+  it('with parent registerValue → does NOT emit the no-parent-RV warn during initial render (regression: pre-onBeforeMount capture race)', async () => {
+    // Setup-time reads of `instance.attrs.registerValue` race Vue's
+    // prop-patch lifecycle. Before this test was added, useRegister
+    // captured the binding synchronously in setup — under SSR (and
+    // some CSR patterns) the binding wasn't on attrs yet, so the
+    // captured value was `undefined` and the computed warned on the
+    // first read despite the parent passing v-register correctly.
+    // The capture is now deferred to onBeforeMount; this test asserts
+    // that the deferred capture lands the binding before the child's
+    // render function reads the computed for the first time.
+    const captured: { childRegister?: ReturnType<typeof useRegister> } = {}
+
+    const Child = defineComponent({
+      name: 'Child',
+      inheritAttrs: false,
+      setup() {
+        captured.childRegister = useRegister()
+        // Read the computed inside the render function — same pattern
+        // a real consumer's template uses.
+        return () => {
+          const rv = captured.childRegister?.value
+          return h('input', { type: 'text', 'data-rv-bound': rv !== undefined ? '1' : '0' })
+        }
+      },
+    })
+
+    const Parent = defineComponent({
+      setup() {
+        const form = useForm({ schema, key: 'no-warn-on-mount-test' })
+        const rv = form.register('email')
+        return () =>
+          withDirectives(h(Child, { registerValue: rv, value: rv.innerRef.value }), [
+            [vRegister, rv],
+          ])
+      },
+    })
+
+    const warnings: string[] = []
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+      warnings.push(args.map((a) => String(a)).join(' '))
+    })
+
+    app = createApp(Parent).use(createChemicalXForms())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await flush()
+    warnSpy.mockRestore()
+
+    // The render-time read of `captured.childRegister.value` should
+    // have produced a non-undefined RV — no warn fired.
+    const noParentRvWarn = warnings.filter((w) =>
+      w.includes('useRegister: no parent registerValue prop')
+    )
+    expect(noParentRvWarn).toEqual([])
+
+    // Sanity: the data attribute reflects the RV being bound at first
+    // render (i.e. the child saw the binding before its template ran).
+    const inputEl = root.querySelector('input')
+    expect(inputEl?.getAttribute('data-rv-bound')).toBe('1')
+  })
+
   it("with parent registerValue → returns ComputedRef whose .value === parent's RV (referential)", async () => {
     const captured: {
       parentRV?: ReturnType<ReturnType<typeof useForm<typeof schema>>['register']>

--- a/test/composables/v-register-component-runtime.test.ts
+++ b/test/composables/v-register-component-runtime.test.ts
@@ -61,7 +61,14 @@ async function mountWithChild(
 
   const Parent = defineComponent({
     setup() {
-      const api = useForm({ schema, key: `comp-${Math.random().toString(36).slice(2)}` })
+      // When the test opts into per-element `persist: true`, the form
+      // must also configure `persist:` — opting a field into a feature
+      // the form doesn't have is now a contradiction throw.
+      const api = useForm({
+        schema,
+        key: `comp-${Math.random().toString(36).slice(2)}`,
+        ...(options?.persist ? { persist: { storage: 'local' as const, debounceMs: 1000 } } : {}),
+      })
       handle.api = api
       const rv = api.register('email', {
         ...(options?.persist ? { persist: true } : {}),

--- a/test/composables/v-register-component-runtime.test.ts
+++ b/test/composables/v-register-component-runtime.test.ts
@@ -144,7 +144,7 @@ describe('pattern 1: v-register on a component whose root is <input>', () => {
     input.dispatchEvent(new Event('input', { bubbles: true }))
     await flush()
 
-    expect(mounted.api.getValue('email').value).toBe('alice@example.com')
+    expect(mounted.api.values.email).toBe('alice@example.com')
   })
 
   it('does NOT fire the unsupported-element dev-warn (input is in SUPPORTED_TAGS)', async () => {
@@ -201,7 +201,7 @@ describe('pattern 2: v-register on a non-form root WITH useRegister (recommended
     innerInput.dispatchEvent(new Event('input', { bubbles: true }))
     await flush()
 
-    expect(mounted.api.getValue('email').value).toBe('typed')
+    expect(mounted.api.values.email).toBe('typed')
   })
 
   it('does NOT fire the unsupported-element dev-warn (sentinel suppresses)', async () => {
@@ -222,7 +222,7 @@ describe('pattern 2: v-register on a non-form root WITH useRegister (recommended
     innerInput.focus()
     innerInput.dispatchEvent(new Event('focus', { bubbles: true }))
     await flush()
-    expect(mounted.api.getFieldState('email').value.focused).toBe(true)
+    expect(mounted.api.fieldState.email.focused).toBe(true)
   })
 })
 
@@ -253,7 +253,7 @@ describe('non-pattern: v-register on a non-form root WITHOUT useRegister/assignK
   it('does NOT clobber the seeded form value — no listeners attached to the div root', async () => {
     mounted = await mountWithChild(PlainDivChild)
     mounted.api.setValue('email', 'seed@example.com')
-    expect(mounted.api.getValue('email').value).toBe('seed@example.com')
+    expect(mounted.api.values.email).toBe('seed@example.com')
 
     const innerInput = mounted.rootEl.querySelector('input.inner') as HTMLInputElement
     innerInput.value = 'typed'
@@ -264,12 +264,12 @@ describe('non-pattern: v-register on a non-form root WITHOUT useRegister/assignK
     // doesn't reach a directive listener, doesn't read `el.value` off
     // the div, and doesn't write the empty/undefined string to the
     // form. The seeded value survives.
-    expect(mounted.api.getValue('email').value).toBe('seed@example.com')
+    expect(mounted.api.values.email).toBe('seed@example.com')
   })
 
   it('FormStore element registry SKIPS non-INTERACTIVE roots (silent no-op)', async () => {
     mounted = await mountWithChild(PlainDivChild)
-    const fs = mounted.api.getFieldState('email').value
+    const fs = mounted.api.fieldState.email
     expect(fs.focused).toBeNull()
     expect(fs.blurred).toBeNull()
     expect(fs.touched).toBeNull()
@@ -401,7 +401,7 @@ describe('pattern 3: @update:registerValue prop on a component', () => {
     expect(received).toContain('typed')
     // Default assigner was bypassed — the FormStore did NOT receive
     // the write because the listener didn't forward.
-    expect(mounted.api.getValue('email').value).toBe('')
+    expect(mounted.api.values.email).toBe('')
   })
 })
 

--- a/test/composables/values-proxy.test.ts
+++ b/test/composables/values-proxy.test.ts
@@ -1,0 +1,230 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, isReactive, isReadonly, nextTick, watch } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { createChemicalXForms } from '../../src/runtime/core/plugin'
+
+/**
+ * `form.values` — Pinia-style reactive readonly proxy over the form
+ * value. Read identically in script + template (no `.value`), writes
+ * blocked at the proxy boundary, deeply reactive, identity-stable
+ * across `reset()` swaps.
+ */
+
+const schema = z.object({
+  email: z.string(),
+  age: z.number(),
+  address: z.object({
+    city: z.string(),
+    zip: z.string(),
+  }),
+  tags: z.array(z.string()),
+})
+
+type Form = z.infer<typeof schema>
+
+async function flush(): Promise<void> {
+  for (let i = 0; i < 4; i++) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+function mountForm(): {
+  api: ReturnType<typeof useForm<typeof schema>>
+  unmount: () => void
+} {
+  let captured: ReturnType<typeof useForm<typeof schema>> | undefined
+  const App = defineComponent({
+    setup() {
+      captured = useForm({
+        schema,
+        key: `values-proxy-${Math.random().toString(36).slice(2)}`,
+        defaultValues: {
+          email: 'a@b.com',
+          age: 30,
+          address: { city: 'NYC', zip: '10001' },
+          tags: ['alpha', 'beta'],
+        } as Form,
+      })
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createChemicalXForms())
+  const root = document.createElement('div')
+  document.body.appendChild(root)
+  app.mount(root)
+  if (captured === undefined) throw new Error('mountForm: useForm never returned')
+  return {
+    api: captured,
+    unmount: () => {
+      app.unmount()
+      document.body.removeChild(root)
+    },
+  }
+}
+
+describe('form.values — readonly reactive proxy', () => {
+  it('reads primitive leaves directly with no .value', () => {
+    const { api, unmount } = mountForm()
+    try {
+      expect(api.values.email).toBe('a@b.com')
+      expect(api.values.age).toBe(30)
+    } finally {
+      unmount()
+    }
+  })
+
+  it('reads nested object leaves through dotted access', () => {
+    const { api, unmount } = mountForm()
+    try {
+      expect(api.values.address.city).toBe('NYC')
+      expect(api.values.address.zip).toBe('10001')
+    } finally {
+      unmount()
+    }
+  })
+
+  it('reads array entries with index access', () => {
+    const { api, unmount } = mountForm()
+    try {
+      expect(api.values.tags[0]).toBe('alpha')
+      expect(api.values.tags[1]).toBe('beta')
+      expect(api.values.tags.length).toBe(2)
+    } finally {
+      unmount()
+    }
+  })
+
+  it('reflects setValue mutations on subsequent reads', () => {
+    const { api, unmount } = mountForm()
+    try {
+      api.setValue('email', 'changed@x.com')
+      expect(api.values.email).toBe('changed@x.com')
+      api.setValue('address.city', 'Boston')
+      expect(api.values.address.city).toBe('Boston')
+    } finally {
+      unmount()
+    }
+  })
+
+  it('returns a deeply readonly proxy (writes warn-and-noop, not throw)', () => {
+    const { api, unmount } = mountForm()
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    try {
+      // Vue's readonly() emits a dev-warn and returns true (write rejected).
+      // The mutation does NOT take effect.
+      expect(isReadonly(api.values)).toBe(true)
+      const before = api.values.email
+      ;(api.values as { email: string }).email = 'should-not-stick'
+      expect(api.values.email).toBe(before)
+    } finally {
+      warnSpy.mockRestore()
+      unmount()
+    }
+  })
+
+  it('nested objects are themselves readonly + reactive', () => {
+    const { api, unmount } = mountForm()
+    try {
+      expect(isReactive(api.values.address)).toBe(true)
+      expect(isReadonly(api.values.address)).toBe(true)
+    } finally {
+      unmount()
+    }
+  })
+
+  it('triggers a watch effect when the underlying form value changes', async () => {
+    const { api, unmount } = mountForm()
+    const seen: string[] = []
+    const stop = watch(
+      () => api.values.email,
+      (next) => {
+        seen.push(next)
+      }
+    )
+    try {
+      api.setValue('email', 'first@x.com')
+      await flush()
+      api.setValue('email', 'second@x.com')
+      await flush()
+      expect(seen).toEqual(['first@x.com', 'second@x.com'])
+    } finally {
+      stop()
+      unmount()
+    }
+  })
+
+  it('survives reset() — produces a fresh readonly proxy keyed to the new target', async () => {
+    const { api, unmount } = mountForm()
+    try {
+      api.setValue('email', 'pre-reset@x.com')
+      expect(api.values.email).toBe('pre-reset@x.com')
+
+      api.reset()
+      await flush()
+      expect(api.values.email).toBe('a@b.com')
+      expect(api.values.address.city).toBe('NYC')
+    } finally {
+      unmount()
+    }
+  })
+
+  it('triggers a watch effect when reset() swaps the whole form value', async () => {
+    const { api, unmount } = mountForm()
+    const seen: string[] = []
+    const stop = watch(
+      () => api.values.email,
+      (next) => {
+        seen.push(next)
+      }
+    )
+    try {
+      api.setValue('email', 'before-reset@x.com')
+      await flush()
+      api.reset()
+      await flush()
+      // First entry: setValue. Second: reset (back to default).
+      expect(seen).toEqual(['before-reset@x.com', 'a@b.com'])
+    } finally {
+      stop()
+      unmount()
+    }
+  })
+
+  it('reflects field-array mutations via append/prepend/remove', async () => {
+    const { api, unmount } = mountForm()
+    try {
+      api.append('tags', 'gamma')
+      await flush()
+      expect(api.values.tags).toEqual(['alpha', 'beta', 'gamma'])
+
+      api.prepend('tags', 'pre')
+      await flush()
+      expect(api.values.tags).toEqual(['pre', 'alpha', 'beta', 'gamma'])
+
+      api.remove('tags', 0)
+      await flush()
+      expect(api.values.tags).toEqual(['alpha', 'beta', 'gamma'])
+    } finally {
+      unmount()
+    }
+  })
+
+  it('coexists with the legacy getValue API during the proxy migration', () => {
+    const { api, unmount } = mountForm()
+    try {
+      // Both surfaces read the same underlying storage.
+      const fromLegacy = api.getValue('email').value
+      const fromProxy = api.values.email
+      expect(fromLegacy).toBe(fromProxy)
+
+      api.setValue('age', 42)
+      expect(api.getValue('age').value).toBe(42)
+      expect(api.values.age).toBe(42)
+    } finally {
+      unmount()
+    }
+  })
+})

--- a/test/composables/values-proxy.test.ts
+++ b/test/composables/values-proxy.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi } from 'vitest'
-import { createApp, defineComponent, h, isReactive, isReadonly, nextTick, watch } from 'vue'
+import { createApp, defineComponent, h, isReactive, isReadonly, isRef, nextTick, watch } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
 import { createChemicalXForms } from '../../src/runtime/core/plugin'
@@ -211,18 +211,48 @@ describe('form.values — readonly reactive proxy', () => {
       unmount()
     }
   })
+})
 
-  it('coexists with the legacy getValue API during the proxy migration', () => {
+describe('form.errors — readonly proxy over the form error map', () => {
+  it('reflects user-injected errors on dotted-key access', () => {
     const { api, unmount } = mountForm()
     try {
-      // Both surfaces read the same underlying storage.
-      const fromLegacy = api.getValue('email').value
-      const fromProxy = api.values.email
-      expect(fromLegacy).toBe(fromProxy)
+      api.setFieldErrors([
+        {
+          path: ['email'],
+          message: 'taken',
+          code: 'custom',
+          formKey: api.key,
+        },
+      ])
+      expect(api.errors.email).toHaveLength(1)
+      expect(api.errors.email?.[0]?.message).toBe('taken')
+      expect(api.errors.age).toBeUndefined()
+    } finally {
+      unmount()
+    }
+  })
+})
 
-      api.setValue('age', 42)
-      expect(api.getValue('age').value).toBe(42)
-      expect(api.values.age).toBe(42)
+describe('form.toRef — escape hatch for ref-shaped interop', () => {
+  it('returns a Readonly<Ref<T>> matching the path value', () => {
+    const { api, unmount } = mountForm()
+    try {
+      const emailRef = api.toRef('email')
+      expect(isRef(emailRef)).toBe(true)
+      expect(emailRef.value).toBe('a@b.com')
+    } finally {
+      unmount()
+    }
+  })
+
+  it('the returned ref reflects subsequent setValue mutations', async () => {
+    const { api, unmount } = mountForm()
+    try {
+      const emailRef = api.toRef('email')
+      api.setValue('email', 'changed@x.com')
+      await flush()
+      expect(emailRef.value).toBe('changed@x.com')
     } finally {
       unmount()
     }

--- a/test/composables/write-shape.test.ts
+++ b/test/composables/write-shape.test.ts
@@ -175,52 +175,47 @@ const _readForm = makeFormProxy<ReturnType<typeof useForm<typeof _readSchema>>>(
 
 /**
  * Read-side widening: storage holds slim-primitive-correct values
- * under the write contract, so reads must reflect that. `getValue`,
- * `getFieldState(...).value.currentValue`, and `register(path).innerRef`
- * all widen leaves to the slim primitive type. Strict post-validation
- * shapes only appear on `handleSubmit` / `validate*()`.
+ * under the write contract, so reads must reflect that. `form.values`,
+ * `form.fieldState(path)`, and `register(path).innerRef` all widen
+ * leaves to the slim primitive type. Strict post-validation shapes
+ * only appear on `handleSubmit` / `validate*()`.
  */
-describe('WriteShape — applied to getValue', () => {
-  it('getValue at an enum-typed path returns Ref<string>', () => {
+describe('WriteShape — applied to form.values', () => {
+  it('form.values at an enum-typed path is string', () => {
     // The store can hold `'teal'` (refinement-invalid but slim-correct);
-    // the read type must admit it. Pre-widen this was Ref<'red'|'green'|'blue'>.
-    const ref = _readForm.getValue('color')
-    expectTypeOf(ref.value).toEqualTypeOf<string>()
+    // the read type must admit it. Pre-widen this was 'red'|'green'|'blue'.
+    expectTypeOf(_readForm.values.color).toEqualTypeOf<string>()
   })
 
-  it('getValue at an int-typed path returns Ref<number>', () => {
-    const ref = _readForm.getValue('age')
-    expectTypeOf(ref.value).toEqualTypeOf<number>()
+  it('form.values at an int-typed path is number', () => {
+    expectTypeOf(_readForm.values.age).toEqualTypeOf<number>()
   })
 
-  it('getValue at the email path returns Ref<string>', () => {
-    const ref = _readForm.getValue('email')
-    expectTypeOf(ref.value).toEqualTypeOf<string>()
+  it('form.values at the email path is string', () => {
+    expectTypeOf(_readForm.values.email).toEqualTypeOf<string>()
   })
 
-  it('getValue() (whole-form) widens every leaf', () => {
-    const ref = _readForm.getValue()
-    expectTypeOf(ref.value).toEqualTypeOf<{
-      color: string
-      age: number
-      email: string
-    }>()
+  it('form.values (whole-form) widens every leaf', () => {
+    expectTypeOf(_readForm.values).toEqualTypeOf<
+      Readonly<{
+        color: string
+        age: number
+        email: string
+      }>
+    >()
   })
 })
 
-describe('WriteShape — applied to getFieldState', () => {
-  it('getFieldState at an enum-typed path narrows currentValue/originalValue/previousValue to string', () => {
-    const fieldStateRef = _readForm.getFieldState('color')
-    expectTypeOf(fieldStateRef.value.currentValue).toEqualTypeOf<string>()
-    expectTypeOf(fieldStateRef.value.originalValue).toEqualTypeOf<string>()
-    expectTypeOf(fieldStateRef.value.previousValue).toEqualTypeOf<string>()
+describe('WriteShape — applied to form.fieldState', () => {
+  it('fieldState at an enum-typed path narrows value/original to string', () => {
+    expectTypeOf(_readForm.fieldState.color.value).toEqualTypeOf<string>()
+    expectTypeOf(_readForm.fieldState.color.original).toEqualTypeOf<string>()
   })
 
-  it('getFieldState metadata stays untouched (errors / dirty / pristine / focused)', () => {
-    const fieldStateRef = _readForm.getFieldState('color')
-    expectTypeOf(fieldStateRef.value.dirty).toEqualTypeOf<boolean>()
-    expectTypeOf(fieldStateRef.value.pristine).toEqualTypeOf<boolean>()
-    expectTypeOf(fieldStateRef.value.focused).toEqualTypeOf<boolean | null>()
+  it('fieldState metadata stays untouched (errors / dirty / pristine / focused)', () => {
+    expectTypeOf(_readForm.fieldState.color.dirty).toEqualTypeOf<boolean>()
+    expectTypeOf(_readForm.fieldState.color.pristine).toEqualTypeOf<boolean>()
+    expectTypeOf(_readForm.fieldState.color.focused).toEqualTypeOf<boolean | null>()
   })
 })
 

--- a/test/core/errors.test.ts
+++ b/test/core/errors.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  AnonPersistError,
   InvalidPathError,
   OutsideSetupError,
   RegistryNotInstalledError,
@@ -66,6 +67,76 @@ describe('error classes', () => {
       expect(err.message).toContain('outside Vue setup')
       // Point at the recovery path users actually need.
       expect(err.message).toContain('child component')
+    })
+  })
+
+  describe('AnonPersistError', () => {
+    it('extends Error with correct name', () => {
+      const err = new AnonPersistError({ cause: 'no-key' })
+      expect(err).toBeInstanceOf(Error)
+      expect(err).toBeInstanceOf(AnonPersistError)
+      expect(err.name).toBe('AnonPersistError')
+    })
+
+    it('exposes schemaFields, callSite, and cause as readable properties', () => {
+      const err = new AnonPersistError({
+        cause: 'no-key',
+        schemaFields: ['email', 'password'],
+        callSite: 'spike-cx.vue:171:21',
+      })
+      expect(err.schemaFields).toEqual(['email', 'password'])
+      expect(err.callSite).toBe('spike-cx.vue:171:21')
+      expect(err.cause).toBe('no-key')
+    })
+
+    it('cause "no-key" message describes anonymous-key drift and points at key:', () => {
+      const err = new AnonPersistError({ cause: 'no-key' })
+      expect(err.message).toContain('useForm({ persist: ... })')
+      expect(err.message).toContain('key:')
+      expect(err.message).toContain('Fix:')
+    })
+
+    it('cause "register-without-config" message describes the dropped opt-in and offers two fixes', () => {
+      const err = new AnonPersistError({ cause: 'register-without-config' })
+      expect(err.message).toContain('register(')
+      expect(err.message).toContain('persist:')
+      // Both directions of the fix should be visible:
+      expect(err.message).toMatch(/add `persist:|remove `\{ persist: true \}`/)
+    })
+
+    it('embeds schema fields when provided', () => {
+      const err = new AnonPersistError({
+        cause: 'no-key',
+        schemaFields: ['email', 'password'],
+      })
+      expect(err.message).toContain('{ email, password }')
+    })
+
+    it('omits the fields clause gracefully when schemaFields is empty', () => {
+      const err = new AnonPersistError({
+        cause: 'no-key',
+        schemaFields: [],
+      })
+      expect(err.message).not.toContain('Form fields:')
+    })
+
+    it('appends the callSite at the end of the message when provided', () => {
+      const err = new AnonPersistError({
+        cause: 'no-key',
+        callSite: 'spike-cx.vue:171:21',
+      })
+      expect(err.message).toContain('spike-cx.vue:171:21')
+    })
+
+    it('throws with instanceof-checkable type across module boundaries', () => {
+      const thrown = ((): unknown => {
+        try {
+          throw new AnonPersistError({ cause: 'no-key' })
+        } catch (e) {
+          return e
+        }
+      })()
+      expect(thrown).toBeInstanceOf(AnonPersistError)
     })
   })
 })

--- a/test/core/register-api.test.ts
+++ b/test/core/register-api.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { createFormStore } from '../../src/runtime/core/create-form-store'
+import { AnonPersistError } from '../../src/runtime/core/errors'
 import { buildRegister } from '../../src/runtime/core/register-api'
 import { fakeSchema } from '../utils/fake-schema'
 
@@ -132,42 +133,29 @@ describe('buildRegister', () => {
     })
   })
 
-  describe('dev warnings', () => {
-    it('does NOT warn during SSR even when persistence module is absent', () => {
+  describe('persist contradiction throw', () => {
+    it('does NOT throw during SSR even when persistence module is absent', () => {
       // SSR deliberately skips wirePersistence (persistence is a
       // client-only concern), so during the server pass `state.modules`
       // never carries a persistence entry — even when the consumer DID
-      // configure `persist:` on useForm(). Without an SSR gate, the
-      // "register({ persist: true }) without persist: configured"
-      // warning would falsely fire on every server render.
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
-      try {
-        const { register } = makeRegister({ isSSR: true })
-        register('email', { persist: true })
-        const matches = warnSpy.mock.calls
-          .map((args) => args.join(' '))
-          .filter((msg) => /no `persist` option configured/.test(msg))
-        expect(matches).toEqual([])
-      } finally {
-        warnSpy.mockRestore()
-      }
+      // configure `persist:` on useForm(). Without an SSR gate, every
+      // server render of `register({ persist: true })` would falsely
+      // throw. The client-side hydration pass re-checks against a
+      // freshly-wired module and throws correctly if the misuse is real.
+      const { register } = makeRegister({ isSSR: true })
+      expect(() => register('email', { persist: true })).not.toThrow()
     })
 
-    it('DOES warn off-SSR when persistence module is absent and the binding opts in', () => {
-      // The actual misuse case: client-side render, no persistence module
-      // (because `useForm()` had no `persist:` option), but a binding asks
-      // to opt in. This is the warning's intended trigger.
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    it('throws AnonPersistError(register-without-config) off-SSR when persistence module is absent and the binding opts in', () => {
+      const { register } = makeRegister()
+      let thrown: unknown
       try {
-        const { register } = makeRegister()
         register('note', { persist: true })
-        const matches = warnSpy.mock.calls
-          .map((args) => args.join(' '))
-          .filter((msg) => /no `persist` option configured/.test(msg))
-        expect(matches.length).toBe(1)
-      } finally {
-        warnSpy.mockRestore()
+      } catch (e) {
+        thrown = e
       }
+      expect(thrown).toBeInstanceOf(AnonPersistError)
+      expect((thrown as AnonPersistError).cause).toBe('register-without-config')
     })
   })
 })

--- a/test/fixtures/ssr/app.vue
+++ b/test/fixtures/ssr/app.vue
@@ -14,7 +14,7 @@
   // -- Error API SSR fixtures --
   // Destructured at setup level so the refs become top-level template
   // bindings (Vue auto-unwraps top-level refs but not refs nested in plain
-  // objects, so `directErrorForm.fieldErrors.value` would not unwrap reliably).
+  // objects, so `directErrorForm.errors.value` would not unwrap reliably).
 
   // Direct setFieldErrors on the server, rendered into HTML so the SSR test
   // can prove the reactive error store survives serialisation/hydration.
@@ -22,20 +22,16 @@
     email: z.string().email(),
     password: z.string().min(8),
   })
-  const {
-    fieldErrors: directErrors,
-    setFieldErrors: setDirectErrors,
-    getFieldState: getDirectFieldState,
-  } = useForm({
+  const directForm = useForm({
     schema: directErrorSchema,
     key: 'errors-direct',
     // Pin lax: this fixture proves user-injected errors render across
     // the SSR boundary. Strict-mode default would also seed schema
     // errors from the empty defaults, displacing the user-injected
-    // entries at fieldErrors[0] (schema-first ordering).
+    // entries at errors[0] (schema-first ordering).
     validationMode: 'lax',
   })
-  setDirectErrors([
+  directForm.setFieldErrors([
     { message: 'Email already in use', path: ['email'], formKey: 'errors-direct' },
     {
       message: 'Password must be at least 8 characters',
@@ -43,7 +39,6 @@
       formKey: 'errors-direct',
     },
   ])
-  const directEmailState = getDirectFieldState('email')
 
   // Parsed-from-API helper applied during setup, simulating a 422 from
   // the server being mapped onto fields before the page renders.
@@ -51,7 +46,6 @@
     schema: z.object({ username: z.string() }),
     key: 'errors-from-api',
   })
-  const { fieldErrors: apiErrors, setFieldErrors: setApiErrors } = apiErrorForm
   const parsedApi = parseApiErrors(
     {
       error: {
@@ -67,7 +61,7 @@
     },
     { formKey: apiErrorForm.key }
   )
-  if (parsedApi.ok) setApiErrors(parsedApi.errors)
+  if (parsedApi.ok) apiErrorForm.setFieldErrors(parsedApi.errors)
 
   // -- handleSubmit return-shape fixture --
   // Proves handleSubmit(cb) returns a function (not a Promise) so it can be
@@ -88,7 +82,6 @@
     key: 'hydration-check',
   })
   hydrationForm.setValue('hydratedField', 'server-written-value')
-  const hydratedFieldValue = hydrationForm.getValue('hydratedField')
 </script>
 
 <template>
@@ -158,22 +151,26 @@
       <!-- Direct setFieldErrors -->
       <div id="errors-direct">
         <span id="errors-direct-fielderrors-email">{{
-          directErrors.email?.[0]?.message ?? ''
+          directForm.errors.email?.[0]?.message ?? ''
         }}</span>
         <span id="errors-direct-fielderrors-password">{{
-          directErrors.password?.[0]?.message ?? ''
+          directForm.errors.password?.[0]?.message ?? ''
         }}</span>
         <span id="errors-direct-fieldstate-email">{{
-          directEmailState.errors[0]?.message ?? ''
+          directForm.fieldState.email.errors[0]?.message ?? ''
         }}</span>
-        <span id="errors-direct-count">{{ Object.keys(directErrors).length }}</span>
+        <span id="errors-direct-count">{{ Object.keys(directForm.errors).length }}</span>
       </div>
 
       <!-- parseApiErrors → setFieldErrors -->
       <div id="errors-from-api">
-        <span id="errors-from-api-first">{{ apiErrors.username?.[0]?.message ?? '' }}</span>
-        <span id="errors-from-api-second">{{ apiErrors.username?.[1]?.message ?? '' }}</span>
-        <span id="errors-from-api-count">{{ apiErrors.username?.length ?? 0 }}</span>
+        <span id="errors-from-api-first">{{
+          apiErrorForm.errors.username?.[0]?.message ?? ''
+        }}</span>
+        <span id="errors-from-api-second">{{
+          apiErrorForm.errors.username?.[1]?.message ?? ''
+        }}</span>
+        <span id="errors-from-api-count">{{ apiErrorForm.errors.username?.length ?? 0 }}</span>
       </div>
 
       <!-- handleSubmit return shape -->
@@ -183,9 +180,7 @@
 
       <!-- Hydration round-trip -->
       <div id="hydration-check">
-        <!-- Vue templates auto-unwrap top-level refs; the `.value` goes on
-             the <script setup> side, not here. -->
-        <span id="hydration-check-value">{{ hydratedFieldValue }}</span>
+        <span id="hydration-check-value">{{ hydrationForm.values.hydratedField }}</span>
       </div>
     </section>
   </div>

--- a/test/ssr-bare-vue/optimistic-is-connected.test.ts
+++ b/test/ssr-bare-vue/optimistic-is-connected.test.ts
@@ -178,7 +178,7 @@ describe('SSR isConnected — read-before-input (preamble) via both transforms',
     // exactly the state that gets serialised into the hydration
     // payload.
     const template = `<div>
-      <span class="readout">{{ JSON.stringify(form.getFieldState('password').value) }}</span>
+      <span class="readout">{{ JSON.stringify(form.fieldState.password) }}</span>
       <input v-register="form.register('password')" />
     </div>`
     const app = makeAppWithTemplate(template, 'preamble+hint')
@@ -200,7 +200,7 @@ describe('SSR isConnected — read-before-input (preamble) via both transforms',
     // an expression that reads the field state earlier in the
     // top-to-bottom render pass captures the still-false value.
     const template = `<div>
-      <span class="readout">{{ JSON.stringify(form.getFieldState('password').value) }}</span>
+      <span class="readout">{{ JSON.stringify(form.fieldState.password) }}</span>
       <input v-register="form.register('password')" />
     </div>`
     const app = makeAppWithTemplate(template, 'hint-only')
@@ -292,7 +292,7 @@ describe('SSR isConnected — cross-component sync via shared form key', () => {
     })
 
     const readerRender = compileTemplate(
-      `<div class="reader">{{ JSON.stringify(form.getFieldState('email').value) }}</div>`,
+      `<div class="reader">{{ JSON.stringify(form.fieldState.email) }}</div>`,
       'preamble+hint'
     )
     const Reader = defineComponent({
@@ -396,7 +396,7 @@ describe('SSR isConnected — cross-component sync via shared form key', () => {
         return { form }
       },
       render: compileTemplate(
-        `<div class="setup-only-reader">{{ JSON.stringify(form.getFieldState('email').value) }}</div>`,
+        `<div class="setup-only-reader">{{ JSON.stringify(form.fieldState.email) }}</div>`,
         'preamble+hint'
       ),
     })
@@ -477,7 +477,7 @@ describe('SSR isConnected — cross-component sync via shared form key', () => {
         return { form }
       },
       render: compileTemplate(
-        `<div class="case-b-reader">{{ JSON.stringify(form.getFieldState('email').value) }}</div>`,
+        `<div class="case-b-reader">{{ JSON.stringify(form.fieldState.email) }}</div>`,
         'preamble+hint'
       ),
     })

--- a/test/ssr-bare-vue/round-trip.test.ts
+++ b/test/ssr-bare-vue/round-trip.test.ts
@@ -28,8 +28,7 @@ function makeApp(opts: { ssr: boolean; initialEmail?: string }) {
         schema: fakeSchema<Form>({ email: opts.initialEmail ?? '', password: '' }),
         key: 'signup',
       })
-      const emailRef = form.getValue('email')
-      return () => h('div', { id: 'root' }, [h('span', { id: 'email' }, String(emailRef.value))])
+      return () => h('div', { id: 'root' }, [h('span', { id: 'email' }, String(form.values.email))])
     },
   })
   const app = createSSRApp(App)

--- a/test/ssr-bare-vue/use-register-ssr.test.ts
+++ b/test/ssr-bare-vue/use-register-ssr.test.ts
@@ -168,10 +168,13 @@ describe('useRegister — SSR (renderToString)', () => {
     expect(noParentRvWarns).toEqual([])
   })
 
-  it('genuinely standalone child (no parent v-register) DOES warn — negative case (regression baseline)', async () => {
-    // Pin the diagnostic for the legitimate misuse case. If this ever
-    // flips to silent, the warn lost its detector and the SSR test
-    // above is no longer asserting anything.
+  it('genuinely standalone child (no parent v-register) is SILENT during SSR — diagnostic deferred to onMounted (CSR-only)', async () => {
+    // Design choice: the no-parent-RV warn fires once at `onMounted`,
+    // which Vue intentionally skips during `renderToString`. Pinning
+    // this so SSR never double-counts a diagnostic the CSR hydration
+    // pass will surface anyway. The CSR-side warn is covered by
+    // `test/composables/use-register.test.ts` ("with NO parent
+    // registerValue → returns ComputedRef<undefined> + one-shot warn").
     const Child = makeChildWithUseRegister()
     const Parent = defineComponent({
       components: { CxRegisterChild: Child },
@@ -190,6 +193,6 @@ describe('useRegister — SSR (renderToString)', () => {
     const noParentRvWarns = warnings.filter((w) =>
       w.includes('useRegister: no parent registerValue prop')
     )
-    expect(noParentRvWarns.length).toBe(1)
+    expect(noParentRvWarns).toEqual([])
   })
 })

--- a/test/ssr-bare-vue/use-register-ssr.test.ts
+++ b/test/ssr-bare-vue/use-register-ssr.test.ts
@@ -1,0 +1,195 @@
+import { baseCompile } from '@vue/compiler-core'
+import { renderToString } from '@vue/server-renderer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as Vue from 'vue'
+import { createSSRApp, defineComponent } from 'vue'
+import { useForm, useRegister } from '../../src'
+import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { selectNodeTransform } from '../../src/runtime/lib/core/transforms/select-transform'
+import { vRegisterHintTransform } from '../../src/runtime/lib/core/transforms/v-register-hint-transform'
+import { vRegisterPreambleTransform } from '../../src/runtime/lib/core/transforms/v-register-preamble-transform'
+import { fakeSchema } from '../utils/fake-schema'
+
+/**
+ * SSR coverage for `useRegister()` — closes the gap left by
+ * `use-register.test.ts`, which mounts via `createApp(...).mount(root)`
+ * under jsdom (jsdom's prop-patch + lifecycle order matches CSR closely
+ * enough that the SSR-specific failure mode never surfaced). Reproduces
+ * the cubic-forms regression where a child component calling
+ * `useRegister()` warned `"no parent registerValue prop"` during
+ * `renderToString` despite the parent template binding `v-register`.
+ *
+ * Root cause: Vue intentionally skips lifecycle hooks during SSR (the
+ * directive lifecycle docstring at `directive.ts:10` is the formal
+ * statement), so an `onBeforeMount`-only capture of
+ * `instance.attrs.registerValue` leaves the captured value at
+ * `undefined`. The first server-side template read of the returned
+ * `ComputedRef<RegisterValue | undefined>` then fires the
+ * no-parent-RV warn — a confusing diagnostic for the consumer who
+ * passed `v-register` correctly. Fix: capture synchronously in setup
+ * (when `initProps` has already populated `instance.attrs`), retain
+ * `onBeforeMount` + `onBeforeUpdate` as defence-in-depth.
+ */
+
+type Form = { email: string; password: string; color: string }
+
+function compileWithCxTransforms(template: string): (this: unknown, ctx: unknown) => unknown {
+  // Full transform stack — `selectNodeTransform` is what injects
+  // `:registerValue` on a `<MyChild v-register="...">` component vnode,
+  // and that's the binding `useRegister` reads back via
+  // `instance.attrs.registerValue`. Without it the parent's directive
+  // never reaches the child as a prop.
+  const result = baseCompile(template, {
+    nodeTransforms: [selectNodeTransform, vRegisterPreambleTransform, vRegisterHintTransform],
+    mode: 'function',
+    prefixIdentifiers: true,
+    hoistStatic: false,
+  })
+  const fn = new Function('Vue', `${result.code}\nreturn render`)
+  return fn(Vue) as (this: unknown, ctx: unknown) => unknown
+}
+
+function makeChildWithUseRegister() {
+  return defineComponent({
+    name: 'CxRegisterChild',
+    inheritAttrs: false,
+    setup() {
+      // Match the cubic-forms `SpikeCxStyledInput` shape: child reads
+      // the parent's binding via `useRegister` and re-binds onto an
+      // inner native input. Reading `register.value` directly in
+      // render mirrors the template auto-unwrap path
+      // (`<input v-register="register">` desugars to a setup-state
+      // access that calls `unref(register)`, which invokes the
+      // computed factory). That's the read that fires the
+      // no-parent-RV warn when `capturedRegisterValue` is `undefined`.
+      const register = useRegister()
+      return () => {
+        const rv = register.value
+        return Vue.h('label', null, [
+          Vue.h('span', null, 'inner-label'),
+          Vue.h('input', {
+            type: 'text',
+            'data-cx-rv-bound': rv !== undefined ? '1' : '0',
+          }),
+        ])
+      }
+    },
+  })
+}
+
+function makeAppWithParentChildTemplate(parentTemplate: string) {
+  const Child = makeChildWithUseRegister()
+  const Parent = defineComponent({
+    name: 'CxRegisterParent',
+    components: { CxRegisterChild: Child },
+    setup() {
+      const form = useForm<Form>({
+        schema: fakeSchema<Form>({ email: '', password: '', color: 'green' }),
+        key: 'use-register-ssr',
+      })
+      return { form }
+    },
+    render: compileWithCxTransforms(parentTemplate),
+  })
+  const app = createSSRApp(Parent)
+  app.use(createChemicalXForms({ override: true /* SSR */ }))
+  return app
+}
+
+describe('useRegister — SSR (renderToString)', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+  let warnings: string[]
+
+  beforeEach(() => {
+    warnings = []
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+      warnings.push(args.map((a) => String(a)).join(' '))
+    })
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  it('does NOT emit the no-parent-RV warn during renderToString when the parent passes v-register', async () => {
+    // The exact regression: cubic-forms surfaced 5 of these warnings
+    // per page render, one per child component using `useRegister()`,
+    // each false-positive because `onBeforeMount` doesn't fire on the
+    // server.
+    const app = makeAppWithParentChildTemplate(
+      `<div>
+         <CxRegisterChild v-register="form.register('email')" />
+       </div>`
+    )
+    const html = await renderToString(app)
+
+    const noParentRvWarns = warnings.filter((w) =>
+      w.includes('useRegister: no parent registerValue prop')
+    )
+    expect(noParentRvWarns).toEqual([])
+    // Positive proof: the child saw the parent's RV during SSR render.
+    expect(html).toContain('data-cx-rv-bound="1"')
+  })
+
+  it('strips bridge keys (`registerValue`, `value`) so the child root does not leak them as DOM attrs', async () => {
+    // The strip is the second job of `refreshAndStripBridgeAttrs`. If
+    // sync-stripping regresses, the child's `<label>` root would render
+    // as `<label registerValue="[object Object]" value="">` server-side
+    // — ugly DOM, hydration mismatch on every paint.
+    const app = makeAppWithParentChildTemplate(
+      `<div>
+         <CxRegisterChild v-register="form.register('email')" />
+       </div>`
+    )
+    const html = await renderToString(app)
+    expect(html).not.toContain('registerValue')
+    // The `value=""` attribute would only appear on the OUTER label
+    // (the child's root) — the inner `<input>` has no value binding in
+    // this fixture. So any `value=` in the rendered HTML is the leak.
+    expect(html).not.toMatch(/<label[^>]*\svalue=/)
+  })
+
+  it('multiple children with v-register render without false-positive warns', async () => {
+    // Cubic-forms reproduced 5+ warns in one page; this asserts the
+    // single-child case generalises so a regression on instance-keyed
+    // dedup doesn't mask a real failure.
+    const app = makeAppWithParentChildTemplate(
+      `<div>
+         <CxRegisterChild v-register="form.register('email')" />
+         <CxRegisterChild v-register="form.register('password')" />
+         <CxRegisterChild v-register="form.register('color')" />
+       </div>`
+    )
+    await renderToString(app)
+
+    const noParentRvWarns = warnings.filter((w) =>
+      w.includes('useRegister: no parent registerValue prop')
+    )
+    expect(noParentRvWarns).toEqual([])
+  })
+
+  it('genuinely standalone child (no parent v-register) DOES warn — negative case (regression baseline)', async () => {
+    // Pin the diagnostic for the legitimate misuse case. If this ever
+    // flips to silent, the warn lost its detector and the SSR test
+    // above is no longer asserting anything.
+    const Child = makeChildWithUseRegister()
+    const Parent = defineComponent({
+      components: { CxRegisterChild: Child },
+      setup() {
+        useForm<Form>({
+          schema: fakeSchema<Form>({ email: '', password: '', color: '' }),
+          key: 'use-register-ssr-standalone',
+        })
+        return () => Vue.h(Child) // no v-register on the child
+      },
+    })
+    const app = createSSRApp(Parent)
+    app.use(createChemicalXForms({ override: true }))
+    await renderToString(app)
+
+    const noParentRvWarns = warnings.filter((w) =>
+      w.includes('useRegister: no parent registerValue prop')
+    )
+    expect(noParentRvWarns.length).toBe(1)
+  })
+})

--- a/test/ssr.test.ts
+++ b/test/ssr.test.ts
@@ -190,7 +190,7 @@ describe('SSR behavior of useForm', async () => {
     Focus: Errors set on the server (via setFieldErrors, including ones
     parsed from API responses via parseApiErrors) must serialise into
     the rendered HTML and survive hydration. Also covers that
-    getFieldState(path).value.errors mirrors the underlying store.
+    form.fieldState.<path>.errors mirrors the underlying store.
   */
   describe('SSR behavior of error API >>', () => {
     it('renders direct setFieldErrors output for each path', async () => {
@@ -208,7 +208,7 @@ describe('SSR behavior of useForm', async () => {
       expect(countEl?.textContent?.trim()).toBe('2')
     })
 
-    it('exposes the same errors via getFieldState(path).errors', async () => {
+    it('exposes the same errors via form.fieldState.<path>.errors', async () => {
       const html = await $fetch('/')
       assertHTML(html)
       const window = new JSDOM(html).window

--- a/test/transforms/v-register-component.test.ts
+++ b/test/transforms/v-register-component.test.ts
@@ -71,7 +71,7 @@ describe('v-register on Vue components — AST behaviour', () => {
     it('hoists a component binding into :data-cx-pre-mark on the first root element', () => {
       const code = compileWith(
         `<div>
-           <pre>{{ form.getFieldState('email').value }}</pre>
+           <pre>{{ form.fieldState.email }}</pre>
            <MyInput v-register="form.register('email')" />
          </div>`,
         [vRegisterPreambleTransform, vRegisterHintTransform]
@@ -243,7 +243,7 @@ describe('v-register on Vue components — AST behaviour', () => {
       expect(() =>
         compileFull(
           `<div>
-             <pre>{{ form.getFieldState('email').value }}</pre>
+             <pre>{{ form.fieldState.email }}</pre>
              <MyInput v-register="form.register('email')" />
            </div>`
         )
@@ -253,7 +253,7 @@ describe('v-register on Vue components — AST behaviour', () => {
     it('combines select-transform component-prop injection + hint wrapper + preamble hoist', () => {
       const code = compileFull(
         `<div>
-           <pre>{{ form.getFieldState('email').value }}</pre>
+           <pre>{{ form.fieldState.email }}</pre>
            <MyInput v-register="form.register('email')" />
          </div>`
       )

--- a/test/transforms/v-register-preamble.test.ts
+++ b/test/transforms/v-register-preamble.test.ts
@@ -29,7 +29,7 @@ describe('vRegisterPreambleTransform', () => {
     it('emits a data-cx-pre-mark prop on the root element when v-register bindings exist', () => {
       const code = compileWithTransforms(
         `<div>
-           <pre>{{ form.getFieldState('password').value }}</pre>
+           <pre>{{ form.fieldState.password }}</pre>
            <input v-register="form.register('password')" />
          </div>`
       )


### PR DESCRIPTION
## Summary

Coordinated redesign addressing friction findings from a cubic-forms dogfooding session. The public read surface becomes Pinia-style proxies (no \`.value\`, no auto-unwrap rules), persist contradictions throw at construct time with rich context, and the SSR \`useRegister\` false-positive is fixed.

**Breaking changes:**

- \`getValue\` removed → use \`form.values.<path>\` (or \`form.toRef(path)\` for ref-shaped interop)
- \`getFieldState\` removed → use \`form.fieldState.<path>.<leaf>\`
- \`fieldErrors\` renamed → \`errors\` (same Proxy shape; auto-unwraps in templates and scripts identically)
- \`useForm({ persist })\` without \`key:\` now throws \`AnonPersistError\` (was a microtask warn at mount)
- \`register({ persist: true })\` on a form without \`persist:\` now throws \`AnonPersistError\` (was a one-shot \`console.warn\`)
- \`useRegister\` SSR diagnostic moved to \`onMounted\`; SSR is silent for standalone usage

**New surface:**

- \`form.values\` — \`Readonly<WriteShape<Form>>\` proxy; dot-access leaves directly
- \`form.fieldState\` — recursive proxy; \`form.fieldState.email.dirty\`, \`form.fieldState.address.city.errors\`, etc.
- \`form.errors\` — same Proxy as the old \`fieldErrors\`, renamed
- \`form.toRef(path)\` — escape hatch returning \`Readonly<Ref<...>>\` for \`watch()\` / external composables
- \`AnonPersistError\` — new error class with \`schemaFields\` + \`callSite\` context

**Internal changes:**

- New \`values-proxy.ts\` and \`field-state-proxy.ts\` modules
- \`AnonPersistError\` thrown eagerly at \`useAbstractForm\` and \`register-api\` boundaries; the prior microtask "no fields opted in" check dropped (valid dormant config no longer warns)
- SSR fix: \`useRegister\` captures \`registerValue\` synchronously in setup (Vue's \`initProps\` populates \`instance.attrs\` before \`setup()\` runs); \`onBeforeMount\` + \`onBeforeUpdate\` retain the strip+capture as defence in depth

## Test plan

- [x] \`pnpm check\` (lint + format + typecheck + 1436 tests + size + bench + coverage) green
- [x] New SSR fixture at \`test/ssr-bare-vue/use-register-ssr.test.ts\` reproduces and validates the original cubic-forms regression
- [x] CSR test \`use-register.test.ts\` asserts exactly one warn per instance (was \`>= 1\`)
- [x] Persist throws covered in \`test/composables/persistence.test.ts\` (Cases A + B + dormant + production-mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redesigned form API with direct property access: `form.values` for form data and `form.fieldState` for field metadata, replacing accessor methods.
  * Added `toRef(path)` method for converting field paths to reactive refs when needed.
  * Enhanced error diagnostics for persistence misconfiguration with detailed messages and call-site information.

* **Bug Fixes**
  * Anonymous persistence now validates eagerly and throws immediate, actionable errors instead of deferring warnings.

* **Breaking Changes**
  * Replaced `getValue()` and `getFieldState()` methods with `values` and `fieldState` properties.
  * Renamed `fieldErrors` property to `errors`.
  * Removed `CurrentValueContext` and `CurrentValueWithContext` types from public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->