### PR TITLE
fix(types): register accepts the array root for every primitive item type

### DIFF
--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -838,16 +838,19 @@ export type MetaTrackerValue = {
 export type MetaTracker = Record<string, MetaTrackerValue>
 export type MetaTrackerStore = Map<FormKey, MetaTracker>
 
-// This generic generates full paths and paths that point to string arrays
-// This staisfies ts edge case for multi-select and multi-checkbox elements
+// Generates every registrable path inside `Form`. Arrays of primitive
+// items (string / number / boolean / bigint) expose BOTH the array root
+// AND `${Key}.${number}` so multi-select and multi-checkbox bindings
+// can register at the array root; arrays of objects expose only the
+// indexed-and-deeper paths.
 export type RegisterFlatPath<Form, Key extends keyof Form = keyof Form> =
   IsObjectOrArray<Form> extends true
     ? Key extends string
       ? Form[Key] extends infer Value
         ? Value extends Array<infer ArrayItem>
-          ? ArrayItem extends string
-            ? `${Key}` | `${Key}.${number}`
-            : `${Key}.${number}.${RegisterFlatPath<ArrayItem>}`
+          ? IsObjectOrArray<ArrayItem> extends true
+            ? `${Key}.${number}.${RegisterFlatPath<ArrayItem>}`
+            : `${Key}` | `${Key}.${number}`
           : Value extends GenericForm
             ? `${Key}.${RegisterFlatPath<Value>}`
             : `${Key}`
@@ -860,9 +863,7 @@ export type RegisterFlatPath<Form, Key extends keyof Form = keyof Form> =
                 : Form[Key] extends Array<infer ArrayItem>
                   ? IsObjectOrArray<ArrayItem> extends true
                     ? `${Key}.${number}.${RegisterFlatPath<ArrayItem>}`
-                    : ArrayItem extends string
-                      ? `${Key}` | `${Key}.${number}`
-                      : `${Key}.${number}`
+                    : `${Key}` | `${Key}.${number}`
                   : never)
         : never
     : never

--- a/test/composables/type-inference.test.ts
+++ b/test/composables/type-inference.test.ts
@@ -246,6 +246,46 @@ describe('Phase 4: WithIndexedUndefined + strict SetValuePayload', () => {
   })
 })
 
+describe('useForm type inference — primitive-array register paths', () => {
+  // Multi-select / multi-checkbox bindings register at the array root.
+  // The directive accepts arrays of any slim primitive (string, number,
+  // boolean, bigint), so the type must allow root registration on each.
+  const _multiSchema = z.object({
+    multiStrings: z.array(z.string()),
+    multiNumbers: z.array(z.number()),
+    multiBooleans: z.array(z.boolean()),
+    multiBigints: z.array(z.bigint()),
+  })
+  type MultiForm = ReturnType<typeof useForm<typeof _multiSchema>>
+  const multiForm = (() => {
+    const handler: ProxyHandler<() => unknown> = { get: () => proxy, apply: () => proxy }
+    const proxy: unknown = new Proxy(() => undefined, handler)
+    return proxy as MultiForm
+  })()
+
+  it('register accepts the array root for every primitive item type', () => {
+    expectTypeOf(multiForm.register('multiStrings').innerRef.value).toEqualTypeOf<string[]>()
+    expectTypeOf(multiForm.register('multiNumbers').innerRef.value).toEqualTypeOf<number[]>()
+    expectTypeOf(multiForm.register('multiBooleans').innerRef.value).toEqualTypeOf<boolean[]>()
+    expectTypeOf(multiForm.register('multiBigints').innerRef.value).toEqualTypeOf<bigint[]>()
+  })
+
+  it('register accepts indexed positions on every primitive array', () => {
+    expectTypeOf(multiForm.register('multiStrings.0').innerRef.value).toEqualTypeOf<
+      string | undefined
+    >()
+    expectTypeOf(multiForm.register('multiNumbers.0').innerRef.value).toEqualTypeOf<
+      number | undefined
+    >()
+    expectTypeOf(multiForm.register('multiBooleans.0').innerRef.value).toEqualTypeOf<
+      boolean | undefined
+    >()
+    expectTypeOf(multiForm.register('multiBigints.0').innerRef.value).toEqualTypeOf<
+      bigint | undefined
+    >()
+  })
+})
+
 describe('useForm type inference — handleSubmit', () => {
   it('callback `values` parameter is the fully inferred Form', () => {
     form.handleSubmit((values) => {


### PR DESCRIPTION
## Summary

- `register('multiSelectNumbers')` against `z.array(z.number())` was rejected by the type even though the runtime's slim-primitive gate accepts `'array'` for any primitive item kind. Same hole for `boolean[]` and `bigint[]` — only `string[]` was special-cased to expose the array root.
- Fix: replace the `ArrayItem extends string` branch in `RegisterFlatPath` with `IsObjectOrArray<ArrayItem> extends true`. All primitive-item arrays now expose both `${Key}` and `${Key}.${number}`; arrays of objects keep the existing recursive behaviour. Same change mirrored in the `Key extends number` arrays-of-arrays branch.
- Strictly more permissive — paths that compiled before still compile.

## Repro before the fix

```ts
const schema = z.object({ multiSelectNumbers: z.array(z.number()) })
const form = useForm({ schema })
form.register('multiSelectNumbers')
//             ^ Argument of type '"multiSelectNumbers"' is not assignable…
```

## Test plan

- [x] Added 8 `expectTypeOf` assertions in `type-inference.test.ts` covering string / number / boolean / bigint arrays at both the root path and index 0
- [x] `pnpm check` (lint + typecheck + 1486 tests + size + bench + coverage) green
- [x] Existing `posts: { title: string; views: number }[]` (array-of-object) tests still pass — the fix doesn't widen the object-array case

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved type inference for registering array fields: primitive-item arrays now allow both root and indexed registration paths; object/array-item arrays expose only indexed (deep) paths. Applies to string- and number-keyed arrays for clearer, safer registrations.
* **Tests**
  * Added type-level tests validating root vs indexed registration behavior for primitive arrays and index typing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->