### PR TITLE
refactor!: rebrand @chemical-x/forms → decant

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Stub @chemical-x/forms (Nuxt + playground types)
+      - name: Stub decant (Nuxt + playground types)
         run: pnpm dev:prepare
 
       # `pnpm check` runs the full gate: lint → format:check → typecheck →
@@ -149,7 +149,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Stub @chemical-x/forms
+      - name: Stub decant
         run: pnpm dev:prepare
 
       - name: Run coverage

--- a/.github/workflows/peer-matrix.yml
+++ b/.github/workflows/peer-matrix.yml
@@ -99,7 +99,7 @@ jobs:
         # committed from this runner).
         run: pnpm install --no-frozen-lockfile
 
-      - name: Stub @chemical-x/forms
+      - name: Stub decant
         run: pnpm dev:prepare
 
       - name: Typecheck

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -62,7 +62,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Stub @chemical-x/forms
+      - name: Stub decant
         run: pnpm dev:prepare
 
       - name: Validate ESLint and Types
@@ -168,7 +168,7 @@ jobs:
             echo "- Commit: [\`$SHORT_SHA\`]($REPO_URL/commit/$COMMIT_SHA) — $COMMIT_TITLE"
             echo "- Author: **$COMMIT_AUTHOR_NAME** <$COMMIT_AUTHOR_EMAIL>"
             echo "- Published via: [workflow run]($REPO_URL/actions/runs/${{ github.run_id }})"
-            echo "- npm: [\`@chemical-x/forms@$VERSION\`](https://www.npmjs.com/package/@chemical-x/forms/v/$VERSION)"
+            echo "- npm: [\`decant@$VERSION\`](https://www.npmjs.com/package/decant/v/$VERSION)"
             echo ""
             echo "---"
             echo ""

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,12 +1,16 @@
 name: Publish to NPM and Version Bump
-run-name: Publish ${{ github.event.inputs.version_type }} release to NPM and Version Bump
+run-name: Publish ${{ github.event.inputs.prerelease_id != '' && format('{0} ({1})', github.event.inputs.version_type, github.event.inputs.prerelease_id) || github.event.inputs.version_type }} release to NPM
 on:
   workflow_dispatch:
     inputs:
       version_type:
-        description: 'Version type (major, minor, patch)'
+        description: 'Version type (major, minor, patch). For prereleases, this is the base bump that the prerelease attaches to (used only when starting a NEW prerelease cycle).'
         required: true
         default: 'patch'
+      prerelease_id:
+        description: 'Prerelease identifier (alpha, beta, rc, next, ...). Leave EMPTY for a stable release. Example flow: 0.2.1 → 0.2.2-beta.0 → 0.2.2-beta.1 → 0.2.2.'
+        required: false
+        default: ''
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -21,18 +25,68 @@ jobs:
 
       - name: Calculate next version
         id: calculate-next-version
+        env:
+          VERSION_TYPE: ${{ github.event.inputs.version_type }}
+          PRERELEASE_ID: ${{ github.event.inputs.prerelease_id }}
         run: |
-          CURRENT=$(node -p "require('./package.json').version")
-          # Using semver.org compliant version incrementing
-          if [ "${{ github.event.inputs.version_type }}" = "major" ]; then
-            NEXT=$(echo $CURRENT | awk -F. '{print $1+1".0.0"}')
-          elif [ "${{ github.event.inputs.version_type }}" = "minor" ]; then
-            NEXT=$(echo $CURRENT | awk -F. '{print $1"."$2+1".0"}')
-          else
-            NEXT=$(echo $CURRENT | awk -F. '{print $1"."$2"."$3+1}')
-          fi
+          # Computed in Node so we can handle prerelease semantics without
+          # depending on `semver` being installed (this step runs BEFORE
+          # `pnpm install`). Pure-JS version inc, matching `semver.inc`:
+          #
+          #   stable + no preid    → bump <type>           e.g. 0.13.0 → 0.13.1
+          #   stable + preid       → pre<type> + .0        e.g. 0.13.0 → 0.13.1-beta.0
+          #   prerelease + no preid → drop suffix          e.g. 0.13.1-beta.5 → 0.13.1
+          #   prerelease + same preid → bump counter       e.g. 0.13.1-beta.5 → 0.13.1-beta.6
+          #   prerelease + new preid → switch preid, .0    e.g. 0.13.1-beta.5 → 0.13.1-rc.0
+          #
+          # version_type is consulted ONLY when starting a new prerelease
+          # cycle from stable. Once you're inside a prerelease cycle, base
+          # bumps are deferred until you exit (run with empty prerelease_id
+          # then bump separately, or pass version_type=patch which drops
+          # the suffix without re-bumping).
+          NEXT=$(node -e '
+            const v = require("./package.json").version;
+            const type = process.env.VERSION_TYPE;
+            const preid = process.env.PRERELEASE_ID;
+            const m = v.match(/^(\d+)\.(\d+)\.(\d+)(?:-([\w.-]+?)(?:\.(\d+))?)?$/);
+            if (!m) { console.error("Unparseable version: " + v); process.exit(1); }
+            let [, maj, min, pat, curId, curN] = m;
+            maj = +maj; min = +min; pat = +pat;
+            curN = curN === undefined ? null : +curN;
+            const onPrerelease = curId !== undefined;
+            const bumpBase = (t) => {
+              if (t === "major") { maj++; min = 0; pat = 0; }
+              else if (t === "minor") { min++; pat = 0; }
+              else { pat++; }
+            };
+            let next;
+            if (preid) {
+              if (onPrerelease) {
+                if (curId === preid && curN !== null) {
+                  next = `${maj}.${min}.${pat}-${preid}.${curN + 1}`;
+                } else {
+                  next = `${maj}.${min}.${pat}-${preid}.0`;
+                }
+              } else {
+                bumpBase(type);
+                next = `${maj}.${min}.${pat}-${preid}.0`;
+              }
+            } else {
+              if (onPrerelease) {
+                next = `${maj}.${min}.${pat}`;
+              } else {
+                bumpBase(type);
+                next = `${maj}.${min}.${pat}`;
+              }
+            }
+            console.log(next);
+          ')
           echo "next_version=$NEXT" >> $GITHUB_OUTPUT
-          echo "WORKFLOW_TITLE=Publish ${{ github.event.inputs.version_type }} release to NPM (v. $NEXT)" >> $GITHUB_ENV
+          if [ -n "$PRERELEASE_ID" ]; then
+            echo "WORKFLOW_TITLE=Publish $VERSION_TYPE prerelease ($PRERELEASE_ID) to NPM (v. $NEXT)" >> $GITHUB_ENV
+          else
+            echo "WORKFLOW_TITLE=Publish $VERSION_TYPE release to NPM (v. $NEXT)" >> $GITHUB_ENV
+          fi
 
       - name: Update version
         run: echo "::notice title=Version::Publishing version ${{ steps.calculate-next-version.outputs.next_version }}"
@@ -99,11 +153,29 @@ jobs:
         # generate-notes endpoint).
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION_TYPE: ${{ github.event.inputs.version_type }}
+          PRERELEASE_ID: ${{ github.event.inputs.prerelease_id }}
         run: |
-          if [ -z "${{ github.event.inputs.version_type }}" ]; then
-            pnpm version patch
+          if [ -n "$PRERELEASE_ID" ]; then
+            # Prerelease modes match the calculate-next-version logic.
+            #   Already on a prerelease (any preid) → `prerelease --preid <id>`:
+            #     this either bumps the counter (same preid) or switches
+            #     preid + resets counter to 0 (different preid). Either way
+            #     the base does NOT advance — that's handled when exiting.
+            #   Stable → `pre<type> --preid <id>`: bumps base by <type>
+            #     and adds `-<id>.0` to start the cycle.
+            CURRENT=$(node -p "require('./package.json').version")
+            if echo "$CURRENT" | grep -qE -- "-[A-Za-z]"; then
+              pnpm version prerelease --preid "$PRERELEASE_ID"
+            else
+              pnpm version "pre${VERSION_TYPE}" --preid "$PRERELEASE_ID"
+            fi
           else
-            pnpm version ${{ github.event.inputs.version_type }}
+            # Stable release. If currently on a prerelease, `pnpm version
+            # <type>` drops the prerelease suffix and keeps the base
+            # (e.g. 0.2.2-beta.5 + patch → 0.2.2). If on stable, it bumps
+            # by <type> as usual.
+            pnpm version "${VERSION_TYPE:-patch}"
           fi
 
       - name: Build
@@ -115,9 +187,21 @@ jobs:
         # already declares `id-token: write`; npm's registry records
         # the statement so consumers can verify a tarball came from
         # this repo via `npm audit signatures`.
-        run: pnpm publish --access public --provenance
+        #
+        # Prereleases publish under a dist-tag matching the preid (e.g.
+        # `decant@beta`, `decant@alpha`) — `npm install decant` still
+        # resolves to `latest` (the stable line), and consumers opt in
+        # via `npm install decant@beta`. Without `--tag`, pnpm publish
+        # defaults to `latest`, which would shadow the stable release.
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          PRERELEASE_ID: ${{ github.event.inputs.prerelease_id }}
+        run: |
+          if [ -n "$PRERELEASE_ID" ]; then
+            pnpm publish --access public --provenance --tag "$PRERELEASE_ID"
+          else
+            pnpm publish --access public --provenance
+          fi
 
       - name: Push version bump
         if: success()
@@ -178,14 +262,22 @@ jobs:
           # `--verify-tag` confirms the tag exists on the remote before
           # creating the release, so a failed `git push --follow-tags`
           # above would short-circuit here rather than produce an
-          # orphan release. `--latest` marks this as the primary
-          # release on the repo's releases page — valid for patch /
-          # minor / major bumps (the only modes this workflow accepts).
-          gh release create "$TAG" \
-            --title "$TAG" \
-            --notes-file "$RUNNER_TEMP/release-body.md" \
-            --verify-tag \
-            --latest
+          # orphan release. Stable releases use `--latest` (primary on
+          # the repo's releases page); prereleases use `--prerelease`
+          # so they don't shadow the stable line.
+          if [ -n "${{ github.event.inputs.prerelease_id }}" ]; then
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --notes-file "$RUNNER_TEMP/release-body.md" \
+              --verify-tag \
+              --prerelease
+          else
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --notes-file "$RUNNER_TEMP/release-body.md" \
+              --verify-tag \
+              --latest
+          fi
 
       - name: Rollback version bump if failed
         if: failure()

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -51,7 +51,7 @@ export default [
     //     expanded SENSITIVE_NAME_PATTERNS) for the timeline + inspector
     //   - one-shot adapter dev warnings (localStorage / sessionStorage /
     //     IDB) on quota / open / abort failures
-    //   - createChemicalXForms idempotent install dev-warn
+    //   - createDecant idempotent install dev-warn
     //   - v-register unsupported-element dev-warn (vRegisterDynamic)
     //   - validate() outside-effect-scope dev-warn (process-form)
     //   - schema-error gen-check on the submit success/failure paths

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to `@chemical-x/forms`
+# Contributing to `decant`
 
 Short-form guide. The canonical source of truth is the codebase —
 everything below leads you to the file that actually does the thing.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# 🧪 Chemical X Forms
+# Decant
 
 [![npm version][npm-version-src]][npm-version-href]
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
 [![License][license-src]][license-href]
-[![Node.js Test Suite](https://github.com/cubicforms/chemical-x-forms/actions/workflows/matrix.yml/badge.svg)](https://github.com/cubicforms/chemical-x-forms/actions/workflows/matrix.yml)
+[![Node.js Test Suite](https://github.com/decantjs/forms/actions/workflows/matrix.yml/badge.svg)](https://github.com/decantjs/forms/actions/workflows/matrix.yml)
 [![Nuxt][nuxt-src]][nuxt-href]
 
 A type-safe, schema-driven form library for Vue 3 and Nuxt with first-class Zod support.
@@ -11,7 +11,7 @@ A type-safe, schema-driven form library for Vue 3 and Nuxt with first-class Zod 
 ## Installation
 
 ```bash
-npm install @chemical-x/forms zod
+npm install decant zod
 ```
 
 **Nuxt 3 / 4** — install the module:
@@ -19,7 +19,7 @@ npm install @chemical-x/forms zod
 ```ts
 // nuxt.config.ts
 export default defineNuxtConfig({
-  modules: ['@chemical-x/forms/nuxt'],
+  modules: ['decant/nuxt'],
 })
 ```
 
@@ -28,18 +28,18 @@ export default defineNuxtConfig({
 ```ts
 // main.ts
 import { createApp } from 'vue'
-import { createChemicalXForms } from '@chemical-x/forms'
+import { createDecant } from 'decant'
 
-createApp(App).use(createChemicalXForms()).mount('#app')
+createApp(App).use(createDecant()).mount('#app')
 ```
 
 ```ts
 // vite.config.ts
 import vue from '@vitejs/plugin-vue'
-import { chemicalXForms } from '@chemical-x/forms/vite'
+import { decant } from 'decant/vite'
 
 export default defineConfig({
-  plugins: [vue(), chemicalXForms()],
+  plugins: [vue(), decant()],
 })
 ```
 
@@ -63,7 +63,7 @@ It catches stale `form.values.contacts[N]` reads at compile time. Nuxt 3 / 4 set
 ```vue
 <script setup lang="ts">
   import { z } from 'zod'
-  import { useForm } from '@chemical-x/forms/zod' // zod v4; use /zod-v3 for v3
+  import { useForm } from 'decant/zod' // zod v4; use /zod-v3 for v3
 
   const schema = z.object({
     email: z.email(),
@@ -112,7 +112,7 @@ It catches stale `form.values.contacts[N]` reads at compile time. Nuxt 3 / 4 set
 - **Server errors** — `parseApiErrors(payload)` normalises a `{ message, code }[]` wire format; pair with `form.setFieldErrors(...)`. User errors survive schema revalidation.
 - **Stable error codes** — every `ValidationError` carries `code: string`. Library codes (`cx:`) live on the exported `CxErrorCode` enum; adapter codes use a `zod:` prefix; consumers pick their own (`api:`, `auth:`, …).
 - **Clearable required fields** — the `unset` sentinel marks a field displayed-empty while storage holds the schema's slim default. Submit fails with `'No value supplied'` for required schemas; `.optional()` / `.nullable()` / `.default(N)` opt out.
-- **SSR** — Nuxt handles the payload round-trip automatically; bare Vue uses `renderChemicalXState` / `hydrateChemicalXState` ([recipe](./docs/recipes/ssr-hydration.md)).
+- **SSR** — Nuxt handles the payload round-trip automatically; bare Vue uses `renderDecantState` / `hydrateDecantState` ([recipe](./docs/recipes/ssr-hydration.md)).
 
 ## Documentation
 
@@ -133,11 +133,11 @@ MIT — see [LICENSE](./LICENSE).
 
 <!-- Badges -->
 
-[npm-version-src]: https://img.shields.io/npm/v/@chemical-x/forms/latest.svg?style=flat&colorA=020420&colorB=00DC82
-[npm-version-href]: https://npmjs.com/package/@chemical-x/forms
-[npm-downloads-src]: https://img.shields.io/npm/dm/@chemical-x/forms.svg?style=flat&colorA=020420&colorB=00DC82
-[npm-downloads-href]: https://npm.chart.dev/@chemical-x/forms
-[license-src]: https://img.shields.io/npm/l/@chemical-x/forms.svg?style=flat&colorA=020420&colorB=00DC82
-[license-href]: https://npmjs.com/package/@chemical-x/forms
+[npm-version-src]: https://img.shields.io/npm/v/decant/latest.svg?style=flat&colorA=020420&colorB=00DC82
+[npm-version-href]: https://npmjs.com/package/decant
+[npm-downloads-src]: https://img.shields.io/npm/dm/decant.svg?style=flat&colorA=020420&colorB=00DC82
+[npm-downloads-href]: https://npm.chart.dev/decant
+[license-src]: https://img.shields.io/npm/l/decant.svg?style=flat&colorA=020420&colorB=00DC82
+[license-href]: https://npmjs.com/package/decant
 [nuxt-src]: https://img.shields.io/badge/Nuxt-020420?logo=nuxt.js
 [nuxt-href]: https://nuxt.com

--- a/bench/discriminated-union.bench.ts
+++ b/bench/discriminated-union.bench.ts
@@ -14,7 +14,7 @@ import { createSSRApp, defineComponent, h } from 'vue'
 import { renderToString } from '@vue/server-renderer'
 import { z } from 'zod'
 import { useForm } from '../src/runtime/adapters/zod-v4'
-import { createChemicalXForms } from '../src/runtime/core/plugin'
+import { createDecant } from '../src/runtime/core/plugin'
 
 const schema = z.object({
   event: z.discriminatedUnion('kind', [
@@ -33,7 +33,7 @@ function mount() {
     },
   })
   const app = createSSRApp(App)
-  app.use(createChemicalXForms({ override: true }))
+  app.use(createDecant({ override: true }))
   void renderToString(app)
   if (captured === undefined) throw new Error('useForm setup did not run')
   return captured

--- a/bench/field-arrays.bench.ts
+++ b/bench/field-arrays.bench.ts
@@ -19,7 +19,7 @@ import { createSSRApp, defineComponent, h } from 'vue'
 import { renderToString } from '@vue/server-renderer'
 import { z } from 'zod'
 import { useForm } from '../src/runtime/adapters/zod-v4'
-import { createChemicalXForms } from '../src/runtime/core/plugin'
+import { createDecant } from '../src/runtime/core/plugin'
 
 type Post = { title: string; body: string; tags: string[] }
 const schema = z.object({
@@ -52,7 +52,7 @@ function mountAndCaptureForm(seedCount: number) {
     },
   })
   const app = createSSRApp(App)
-  app.use(createChemicalXForms({ override: true }))
+  app.use(createDecant({ override: true }))
   // renderToString drives setup(); we don't care about the HTML itself.
   void renderToString(app)
   if (captured === undefined) throw new Error('useForm setup did not run')

--- a/bench/reset.bench.ts
+++ b/bench/reset.bench.ts
@@ -14,7 +14,7 @@ import { createSSRApp, defineComponent, h } from 'vue'
 import { renderToString } from '@vue/server-renderer'
 import { z } from 'zod'
 import { useForm } from '../src/runtime/adapters/zod-v4'
-import { createChemicalXForms } from '../src/runtime/core/plugin'
+import { createDecant } from '../src/runtime/core/plugin'
 
 // 100 leaves via 10 groups of 10 fields each. Enough shape for the
 // originals / fields maps to have real data without making each bench
@@ -42,7 +42,7 @@ function mount() {
     },
   })
   const app = createSSRApp(App)
-  app.use(createChemicalXForms({ override: true }))
+  app.use(createDecant({ override: true }))
   void renderToString(app)
   if (captured === undefined) throw new Error('useForm setup did not run')
   return captured

--- a/bench/submit-lifecycle.bench.ts
+++ b/bench/submit-lifecycle.bench.ts
@@ -17,7 +17,7 @@ import { renderToString } from '@vue/server-renderer'
 import { z } from 'zod'
 import { useForm } from '../src/runtime/adapters/zod-v4'
 import { parseApiErrors } from '../src/runtime/core/parse-api-errors'
-import { createChemicalXForms } from '../src/runtime/core/plugin'
+import { createDecant } from '../src/runtime/core/plugin'
 
 const schema = z.object({
   email: z.string(),
@@ -42,7 +42,7 @@ function mount() {
     },
   })
   const app = createSSRApp(App)
-  app.use(createChemicalXForms({ override: true }))
+  app.use(createDecant({ override: true }))
   void renderToString(app)
   if (captured === undefined) throw new Error('useForm setup did not run')
   return captured

--- a/build.config.ts
+++ b/build.config.ts
@@ -3,13 +3,13 @@ import { defineBuildConfig } from 'unbuild'
 
 export default defineBuildConfig({
   // Multiple published entry points. `module` is the Nuxt module (used via
-  // `@chemical-x/forms/nuxt`); `index` is the framework-agnostic core used
-  // by bare Vue consumers; the rest are narrow-purpose subpaths.
+  // `decant/nuxt`); `index` is the framework-agnostic core used by bare
+  // Vue consumers; the rest are narrow-purpose subpaths.
   //
-  // `src/runtime/plugins/chemical-x` is a Nuxt-only plugin file that
+  // `src/runtime/plugins/decant` is a Nuxt-only plugin file that
   // `src/nuxt.ts` registers via `addPlugin({ src: resolver.resolve(...) })`.
-  // It needs to exist on disk at `dist/runtime/plugins/chemical-x.mjs` in
-  // the published package (otherwise the resolver raises ENOENT and the
+  // It needs to exist on disk at `dist/runtime/plugins/decant.mjs` in the
+  // published package (otherwise the resolver raises ENOENT and the
   // plugin never installs, leaving `useForm` to throw `Registry not
   // found`). Unbuild's shared-chunk splitter deduplicates `core/plugin` +
   // `core/serialize` across this entry and `src/zod` / `src/index`, so
@@ -21,7 +21,7 @@ export default defineBuildConfig({
     'src/transforms',
     'src/zod',
     'src/zod-v3',
-    'src/runtime/plugins/chemical-x',
+    'src/runtime/plugins/decant',
   ],
   externals: [
     '@vue/compiler-core',
@@ -127,5 +127,5 @@ export default defineBuildConfig({
   },
   sourcemap: true,
   parallel: false,
-  name: '@chemical-x/forms',
+  name: 'decant',
 })

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,28 +1,28 @@
 # API reference
 
-Every public export of `@chemical-x/forms`, grouped by subpath. Each
+Every public export of `decant`, grouped by subpath. Each
 entry gives the signature, the shape of the return value, and the
 minimal example you need to wire it up.
 
 ## Contents
 
-- [`@chemical-x/forms/zod`](#chemical-xformszod) — recommended entry
-- [`@chemical-x/forms/zod-v3`](#chemical-xformszod-v3) — legacy
-- [`@chemical-x/forms`](#chemical-xforms) — framework-agnostic core
-- [`@chemical-x/forms/nuxt`](#chemical-xformsnuxt) — Nuxt module
-- [`@chemical-x/forms/vite`](#chemical-xformsvite) — Vite plugin
-- [`@chemical-x/forms/transforms`](#chemical-xformstransforms) — raw transforms
+- [`decant/zod`](#decantformszod) — recommended entry
+- [`decant/zod-v3`](#decantformszod-v3) — legacy
+- [`decant`](#decantforms) — framework-agnostic core
+- [`decant/nuxt`](#decantformsnuxt) — Nuxt module
+- [`decant/vite`](#decantformsvite) — Vite plugin
+- [`decant/transforms`](#decantformstransforms) — raw transforms
 - [The useForm return value](#the-useform-return-value)
 - [Types](#types)
 
 ---
 
-## `@chemical-x/forms/zod`
+## `decant/zod`
 
 Zod v4 adapter. Requires `zod@^4`.
 
 ```ts
-import { useForm, zodAdapter, kindOf, assertZodVersion } from '@chemical-x/forms/zod'
+import { useForm, zodAdapter, kindOf, assertZodVersion } from 'decant/zod'
 ```
 
 ### `useForm<Schema>(options)`
@@ -73,13 +73,13 @@ Union of the strings returned by `kindOf`.
 
 ---
 
-## `@chemical-x/forms/zod-v3`
+## `decant/zod-v3`
 
 Zod v3 adapter. Requires `zod@^3`. New projects should use `/zod`
 (v4).
 
 ```ts
-import { useForm, zodAdapter, isZodSchemaType } from '@chemical-x/forms/zod-v3'
+import { useForm, zodAdapter, isZodSchemaType } from 'decant/zod-v3'
 ```
 
 Same surface as `/zod` for the functions that apply. Helper types
@@ -88,41 +88,41 @@ for v3 introspection (`UnwrapZodObject`, `ZodTypeWithInnerType`,
 
 ---
 
-## `@chemical-x/forms`
+## `decant`
 
 The framework-agnostic core. Use this if you're bringing your own
 schema library or wiring SSR by hand.
 
 ```ts
 import {
-  createChemicalXForms,
+  createDecant,
   useForm, // re-export of useAbstractForm
   injectForm,
   useRegistry,
-  renderChemicalXState,
-  hydrateChemicalXState,
+  renderDecantState,
+  hydrateDecantState,
   escapeForInlineScript,
   vRegister,
   canonicalizePath,
   parseApiErrors,
-} from '@chemical-x/forms'
+} from 'decant'
 ```
 
-### `createChemicalXForms(options?)`
+### `createDecant(options?)`
 
 The Vue plugin. Install once per app.
 
 ```ts
-createApp(App).use(createChemicalXForms()).mount('#app')
+createApp(App).use(createDecant()).mount('#app')
 ```
 
 Options:
 
-| Field      | Type                     | Description                                                                                         |
-| ---------- | ------------------------ | --------------------------------------------------------------------------------------------------- |
-| `override` | `boolean`                | Force `isSSR` to `true` / `false`. Auto-detected otherwise.                                         |
-| `devtools` | `boolean`                | Enable the Vue DevTools plugin. Default `true`. See [recipe](./recipes/devtools.md).                |
-| `defaults` | `ChemicalXFormsDefaults` | App-level option defaults applied to every `useForm` call. See [recipe](./recipes/app-defaults.md). |
+| Field      | Type             | Description                                                                                         |
+| ---------- | ---------------- | --------------------------------------------------------------------------------------------------- |
+| `override` | `boolean`        | Force `isSSR` to `true` / `false`. Auto-detected otherwise.                                         |
+| `devtools` | `boolean`        | Enable the Vue DevTools plugin. Default `true`. See [recipe](./recipes/devtools.md).                |
+| `defaults` | `DecantDefaults` | App-level option defaults applied to every `useForm` call. See [recipe](./recipes/app-defaults.md). |
 
 ### `useForm<Form>({ schema, key, ... })`
 
@@ -150,16 +150,16 @@ independent of component-tree position.
 
 ### `useRegistry()`
 
-Returns the current app's `ChemicalXRegistry`. Must be called inside
+Returns the current app's `DecantRegistry`. Must be called inside
 a component's `setup()`.
 
-### `renderChemicalXState(app) → SerializedChemicalXState`
+### `renderDecantState(app) → SerializedDecantState`
 
 Server-side: serialize every form in the app to a plain object safe
-for `JSON.stringify`. Pair with `hydrateChemicalXState` on the
+for `JSON.stringify`. Pair with `hydrateDecantState` on the
 client.
 
-### `hydrateChemicalXState(app, payload)`
+### `hydrateDecantState(app, payload)`
 
 Client-side: rehydrate forms from the serialized payload. Call
 before `app.mount(...)`.
@@ -168,18 +168,18 @@ before `app.mount(...)`.
 
 Takes a JSON string and escapes the characters that would let a
 form value break out of an inline `<script>` tag: `<`, `>`, `&`,
-U+2028, U+2029. Pair with `renderChemicalXState` when hand-rolling
+U+2028, U+2029. Pair with `renderDecantState` when hand-rolling
 SSR; Nuxt handles it for you via `devalue`.
 
 ```ts
-const payload = escapeForInlineScript(JSON.stringify(renderChemicalXState(app)))
+const payload = escapeForInlineScript(JSON.stringify(renderDecantState(app)))
 // `<script>window.__STATE__ = ${payload}</script>` is safe to inline.
 ```
 
 ### `vRegister`
 
 The `v-register` directive. Registered automatically by
-`createChemicalXForms`; exported for consumers installing directives
+`createDecant`; exported for consumers installing directives
 manually.
 
 Bind to a native input, select, textarea, checkbox, or radio:
@@ -201,7 +201,7 @@ handles it and `useRegister` is unnecessary.
 
 <!-- MyField.vue (root is <label>, not <input>) -->
 <script setup lang="ts">
-  import { useRegister } from '@chemical-x/forms'
+  import { useRegister } from 'decant'
   defineProps<{ label: string }>()
   const register = useRegister()
 </script>
@@ -247,7 +247,7 @@ already-extracted value plus the `RegisterValue`, and decides what
 
 ```vue
 <script setup lang="ts">
-  import type { RegisterValue } from '@chemical-x/forms'
+  import type { RegisterValue } from 'decant'
 
   const form = useForm({ schema, defaultValues: { username: '' } })
 
@@ -308,7 +308,7 @@ directive's assigner, and applies uniformly across every
 `<input type="checkbox">`, `<input type="radio">`).
 
 ```ts
-import type { RegisterTransform } from '@chemical-x/forms'
+import type { RegisterTransform } from 'decant'
 
 const trim: RegisterTransform = (v) => (typeof v === 'string' ? v.trim() : v)
 
@@ -476,8 +476,8 @@ machine identification. Convention is `<scope>:<kebab-case>`:
 The library exports `CxErrorCode` for branching on internal codes:
 
 ```ts
-import { CxErrorCode } from '@chemical-x/forms'
-// or '@chemical-x/forms/zod' / '@chemical-x/forms/zod-v3'
+import { CxErrorCode } from 'decant'
+// or 'decant/zod' / 'decant/zod-v3'
 
 if (error.code === CxErrorCode.NoValueSupplied) {
   // user opened the form and hasn't filled this field yet
@@ -504,7 +504,7 @@ A brand-typed sentinel symbol used to mark a primitive leaf as
 `z.boolean()`, `0n` for `z.bigint()`).
 
 ```ts
-import { unset, useForm } from '@chemical-x/forms/zod'
+import { unset, useForm } from 'decant/zod'
 import { z } from 'zod'
 
 const form = useForm({
@@ -579,14 +579,14 @@ brand-typed `unique symbol` flavor for type-level usage.
 
 ---
 
-## `@chemical-x/forms/nuxt`
+## `decant/nuxt`
 
 A Nuxt module that installs the plugin, registers the node
 transforms, and auto-imports `useForm`. Add to `nuxt.config.ts`:
 
 ```ts
 export default defineNuxtConfig({
-  modules: ['@chemical-x/forms/nuxt'],
+  modules: ['decant/nuxt'],
 })
 ```
 
@@ -595,7 +595,7 @@ needed.
 
 ---
 
-## `@chemical-x/forms/vite`
+## `decant/vite`
 
 A Vite plugin that injects the `v-register` node transforms into
 `@vitejs/plugin-vue`. Required under bare Vue + Vite for SSR-
@@ -605,23 +605,23 @@ correct `v-register` bindings on `<input>`, `<textarea>`, and
 ```ts
 // vite.config.ts
 import vue from '@vitejs/plugin-vue'
-import { chemicalXForms } from '@chemical-x/forms/vite'
+import { decant } from 'decant/vite'
 
 export default defineConfig({
-  plugins: [vue(), chemicalXForms()],
+  plugins: [vue(), decant()],
 })
 ```
 
 ---
 
-## `@chemical-x/forms/transforms`
+## `decant/transforms`
 
 The raw Vue compiler-core node transforms. Use this subpath only
 when you're rolling your own bundler pipeline (esbuild, Rspack,
 custom Rollup).
 
 ```ts
-import { inputTextAreaNodeTransform, selectNodeTransform } from '@chemical-x/forms/transforms'
+import { inputTextAreaNodeTransform, selectNodeTransform } from 'decant/transforms'
 ```
 
 ---
@@ -933,7 +933,7 @@ import type {
   ValidationResponse,
   ValidationResponseWithoutValue,
   WriteShape,
-} from '@chemical-x/forms'
+} from 'decant'
 ```
 
 The ones you'll touch most:
@@ -968,7 +968,7 @@ The ones you'll touch most:
   `z.date()` is a type error.
 - **`Unset`** — the brand-typed `unique symbol` flavor of the
   `unset` sentinel for type-level usage. The runtime symbol is
-  exported alongside under the same name from `@chemical-x/forms`.
+  exported alongside under the same name from `decant`.
 - **`IsTuple<T>`** — `true` for tuples (literal `length`), `false`
   for unbounded arrays (`length: number`). Used internally by
   `NestedReadType` to decide whether to taint past a numeric

--- a/docs/blank.md
+++ b/docs/blank.md
@@ -101,7 +101,7 @@ That's an explicit consumer signal, not runtime inference. Use the
 `unset` sentinel:
 
 ```ts
-import { unset, useForm } from '@chemical-x/forms/zod'
+import { unset, useForm } from 'decant/zod'
 
 useForm({
   schema: z.object({ agreed: z.boolean(), note: z.string() }),

--- a/docs/migration/0.10-to-0.11.md
+++ b/docs/migration/0.10-to-0.11.md
@@ -108,7 +108,7 @@ proof `state.*` watch.
 `useForm().state` is typed as the exported `FormMeta` interface:
 
 ```ts
-import type { FormMeta } from '@chemical-x/forms'
+import type { FormMeta } from 'decant'
 
 // or via the generic return type:
 type State = ReturnType<typeof useForm<Schema>>['state']
@@ -119,7 +119,7 @@ reject writes at runtime with a dev-mode warning.
 
 ## Breaking (rare): internal `FormMeta` renamed to `FormStore`
 
-If you imported `FormMeta` from `@chemical-x/forms/runtime/core/
+If you imported `FormMeta` from `decant/runtime/core/
 create-form-state` — a deep path we never advertised as public —
 it's now `FormStore` from `./create-form-store`. The module file
 was renamed too.
@@ -178,7 +178,7 @@ The deep-path module `runtime/adapters/zod-v4/initial-state` was
 renamed to `runtime/adapters/zod-v4/default-values`. Only relevant
 if you imported the internal helper `getDefaultValuesFromZodSchema`
 (formerly `getInitialStateFromZodSchema`); the public adapter
-surface re-exports it through `@chemical-x/forms/zod`, which is
+surface re-exports it through `decant/zod`, which is
 unchanged at the entry-point level.
 
 Custom adapters built against `AbstractSchema` need a one-method

--- a/docs/migration/0.11-to-0.12.md
+++ b/docs/migration/0.11-to-0.12.md
@@ -323,19 +323,19 @@ changes only. Consumers shouldn't (and now can't) set it.
 ### What this looks like on disk
 
 ```text
-0.11: chemical-x-forms:signup     (one key, payload contains v: 1)
-0.12: chemical-x-forms:signup:7c3a0b  (key carries fingerprint suffix)
+0.11: decant:signup     (one key, payload contains v: 1)
+0.12: decant:signup:7c3a0b  (key carries fingerprint suffix)
 ```
 
 A schema change in 0.12 produces a different fingerprint:
 
 ```text
-chemical-x-forms:signup:7c3a0b   (old, orphaned at next mount)
-chemical-x-forms:signup:9d2b1f   (new, current — written on first mutation)
+decant:signup:7c3a0b   (old, orphaned at next mount)
+decant:signup:9d2b1f   (new, current — written on first mutation)
 ```
 
 The orphan cleanup pass on mount enumerates keys under
-`chemical-x-forms:signup` (via the new `FormStorage.listKeys`
+`decant:signup` (via the new `FormStorage.listKeys`
 method), keeps the current-fingerprint entry, and removes the rest.
 Pre-0.12 keys without a fingerprint suffix are also treated as
 orphans and swept.
@@ -357,7 +357,7 @@ Three concrete changes:
 
 If you parse persisted payloads outside cx (custom inspectors, server-
 side draft replication, etc.), the storage key is no longer the bare
-configured key — read keys via `listKeys('chemical-x-forms:signup')`
+configured key — read keys via `listKeys('decant:signup')`
 and pick the one matching your current schema's fingerprint, OR
 delegate to cx's reader (it already does this).
 
@@ -797,15 +797,15 @@ O(N) array fills + 1 schema lookup, not O(N×schema-traversal)).
 
 ## Breaking: SSR / FormStoreHydration shape
 
-`SerializedFormData` (in the `renderChemicalXState` payload) and
+`SerializedFormData` (in the `renderDecantState` payload) and
 `FormStoreHydration` (the construction-time hydration payload) both
 split their `errors` field into `schemaErrors` + `userErrors`.
 
 Nuxt consumers using the auto-wired plugin don't need to touch
 anything — the plugin's serialize/hydrate bridge handles it.
 
-Bare-Vue SSR consumers calling `renderChemicalXState` /
-`hydrateChemicalXState` directly are unaffected too; the payload
+Bare-Vue SSR consumers calling `renderDecantState` /
+`hydrateDecantState` directly are unaffected too; the payload
 shape is internal to the bridge.
 
 The only break is for code that read the payload struct directly
@@ -972,7 +972,7 @@ New APIs:
   opt-ins.
 
 - **`SensitivePersistFieldError`** — exported from
-  `@chemical-x/forms`.
+  `decant`.
 
 - **`RegisterOptions`** — public type for the second argument to
   `register(path, options?)`.
@@ -1047,7 +1047,7 @@ exported pure functions you import alongside `useForm`. The new
 pattern is a two-step parse-then-write:
 
 ```ts
-import { useForm, parseApiErrors } from '@chemical-x/forms'
+import { useForm, parseApiErrors } from 'decant'
 
 const form = useForm({ schema, key: 'signup' })
 
@@ -1160,7 +1160,7 @@ matching on `message` strings.
 if (error.message === 'Required') { ... }
 
 // After
-import { CxErrorCode } from '@chemical-x/forms'
+import { CxErrorCode } from 'decant'
 if (error.code === CxErrorCode.NoValueSupplied) { ... }
 ```
 
@@ -1173,8 +1173,8 @@ Convention: `<scope>:<kebab-case>`.
 - consumer-defined — pick a prefix for your app (`api:`, `auth:`)
   and stay consistent.
 
-`CxErrorCode` is exported from `@chemical-x/forms`,
-`@chemical-x/forms/zod`, and `@chemical-x/forms/zod-v3`.
+`CxErrorCode` is exported from `decant`,
+`decant/zod`, and `decant/zod-v3`.
 
 ### `parseApiErrors` wire format change
 

--- a/docs/migration/0.12-to-0.13.md
+++ b/docs/migration/0.12-to-0.13.md
@@ -142,7 +142,7 @@ Three themes:
 - The slim-write contract (writes accept the slim primitive type;
   refinements surface as field errors)
 - The structural-completeness invariant on `setValue`
-- SSR via `renderChemicalXState` / `hydrateChemicalXState`
+- SSR via `renderDecantState` / `hydrateDecantState`
 - Nuxt module wiring
 
 ## Sweep checklist

--- a/docs/migration/0.13-to-0.14.md
+++ b/docs/migration/0.13-to-0.14.md
@@ -54,9 +54,9 @@ themes:
     creates and provides; `injectForm` looks up).
 
     ```diff
-    - import { useFormContext } from '@chemical-x/forms'
+    - import { useFormContext } from 'decant'
     - const form = useFormContext<SignupShape>('signup')
-    + import { injectForm } from '@chemical-x/forms'
+    + import { injectForm } from 'decant'
     + const form = injectForm<SignupShape>('signup')
     ```
 
@@ -142,8 +142,8 @@ themes:
 7.  **`FormState` type → `FormMeta`.** Type imports rename:
 
     ```diff
-    - import type { FormState } from '@chemical-x/forms'
-    + import type { FormMeta } from '@chemical-x/forms'
+    - import type { FormState } from 'decant'
+    + import type { FormMeta } from 'decant'
     ```
 
 8.  **`FormFieldErrors<Form>` shape changes.** No longer
@@ -289,7 +289,7 @@ you upgrade and don't read the surface.
 - The slim-write contract (writes accept the slim primitive type;
   refinements surface as field errors).
 - The structural-completeness invariant on `setValue`.
-- SSR via `renderChemicalXState` / `hydrateChemicalXState`.
+- SSR via `renderDecantState` / `hydrateDecantState`.
 - Nuxt module wiring.
 - The active-path filter on `form.errors.<path>` (preserved
   semantics — inactive-variant errors hidden from the per-leaf

--- a/docs/migration/0.7-to-0.8.md
+++ b/docs/migration/0.7-to-0.8.md
@@ -42,11 +42,11 @@ form has a key.
 
 The Zod adapter is split:
 
-- **`@chemical-x/forms/zod`** — zod v4 (recommended for new projects)
-- **`@chemical-x/forms/zod-v3`** — zod v3 (legacy)
+- **`decant/zod`** — zod v4 (recommended for new projects)
+- **`decant/zod-v3`** — zod v3 (legacy)
 
 If you were already importing from `/zod-v3`, nothing changes. If
-you were importing from the bare `@chemical-x/forms` entry and
+you were importing from the bare `decant` entry and
 relying on a built-in zod adapter, pick the subpath matching your
 installed zod version.
 
@@ -157,7 +157,7 @@ for every registered form. [Recipe](../recipes/devtools.md).
 npm install -D @vue/devtools-api
 ```
 
-Pass `createChemicalXForms({ devtools: false })` to disable.
+Pass `createDecant({ devtools: false })` to disable.
 
 ### `injectForm`
 
@@ -183,7 +183,7 @@ See [`docs/api.md`](../api.md) for the full surface.
 
 ## Additive: `sideEffects: false`
 
-`@chemical-x/forms` now ships `"sideEffects": false` in its
+`decant` now ships `"sideEffects": false` in its
 `package.json`. Bundlers tree-shake unused exports — particularly
 useful if you only need one subpath.
 

--- a/docs/recipes/app-defaults.md
+++ b/docs/recipes/app-defaults.md
@@ -13,11 +13,11 @@ instead of repeating them at every `useForm` call.
 ```ts
 // main.ts
 import { createApp } from 'vue'
-import { createChemicalXForms } from '@chemical-x/forms'
+import { createDecant } from 'decant'
 
 createApp(App)
   .use(
-    createChemicalXForms({
+    createDecant({
       defaults: {
         debounceMs: 100,
         onInvalidSubmit: 'focus-first-error',
@@ -32,8 +32,8 @@ createApp(App)
 ```ts
 // nuxt.config.ts
 export default defineNuxtConfig({
-  modules: ['@chemical-x/forms/nuxt'],
-  chemicalX: {
+  modules: ['decant/nuxt'],
+  decant: {
     defaults: {
       debounceMs: 100,
       onInvalidSubmit: 'focus-first-error',
@@ -47,7 +47,7 @@ export default defineNuxtConfig({
 For each option, the resolved value is the first defined among:
 
 ```
-useForm({ … })  >  createChemicalXForms({ defaults })  >  library default
+useForm({ … })  >  createDecant({ defaults })  >  library default
 ```
 
 So a per-form value always wins, an app-level default fills in when
@@ -60,7 +60,7 @@ level, override anything per-form without losing the rest:
 
 ```ts
 // Plugin side
-createChemicalXForms({
+createDecant({
   defaults: { validateOn: 'change', debounceMs: 100 },
 })
 
@@ -85,10 +85,10 @@ discriminated union enforces that `debounceMs` is only valid when
 
 ## What's supported
 
-`ChemicalXFormsDefaults` covers the form-shaping options:
+`DecantDefaults` covers the form-shaping options:
 
 ```ts
-type ChemicalXFormsDefaults = {
+type DecantDefaults = {
   strict?: boolean
   validateOn?: 'change' | 'blur' | 'submit'
   debounceMs?: number
@@ -117,7 +117,7 @@ call.
 Three patterns:
 
 ```ts
-import { unset } from '@chemical-x/forms/zod'
+import { unset } from 'decant/zod'
 
 // 1. Plain values — explicit defaults flow into storage and the form
 //    is not blank for those leaves.
@@ -168,7 +168,7 @@ your project:
 
 ```ts
 // composables/useAppForm.ts
-import { useForm as cxUseForm } from '@chemical-x/forms/zod'
+import { useForm as cxUseForm } from 'decant/zod'
 import type { z } from 'zod'
 
 export function useAppForm<S extends z.ZodObject>(opts: Parameters<typeof cxUseForm<S>>[0]) {

--- a/docs/recipes/async-validation.md
+++ b/docs/recipes/async-validation.md
@@ -1,14 +1,14 @@
 # Async validation
 
 Use `z.refine(async …)` anywhere in your schema — uniqueness checks,
-allow-lists, server availability. Chemical X awaits the result before
+allow-lists, server availability. Decant awaits the result before
 dispatching your submit handler.
 
 ## Async refinements
 
 ```ts
 import { z } from 'zod'
-import { useForm } from '@chemical-x/forms/zod'
+import { useForm } from 'decant/zod'
 
 const signupSchema = z.object({
   email: z.email().refine(async (value) => {
@@ -90,7 +90,7 @@ POST — parse them via `parseApiErrors` and write them with
 shape.
 
 ```ts
-import { parseApiErrors } from '@chemical-x/forms'
+import { parseApiErrors } from 'decant'
 
 const onSubmit = handleSubmit(async (values) => {
   try {

--- a/docs/recipes/coerce.md
+++ b/docs/recipes/coerce.md
@@ -48,8 +48,8 @@ have to cast inside the body. Spread `defaultCoercionRules` to
 extend rather than replace:
 
 ```ts
-import { defineCoercion, defaultCoercionRules } from '@chemical-x/forms'
-import type { CoercionRegistry } from '@chemical-x/forms'
+import { defineCoercion, defaultCoercionRules } from 'decant'
+import type { CoercionRegistry } from 'decant'
 
 const stringToBigint = defineCoercion({
   input: 'string',
@@ -93,7 +93,7 @@ cx never merges past the array boundary — passing a registry is a
 Set once via the plugin (matches the per-form shape):
 
 ```ts
-createChemicalXForms({
+createDecant({
   defaults: { coerce: [...defaultCoercionRules, stringToBigint] },
 })
 ```

--- a/docs/recipes/custom-adapter.md
+++ b/docs/recipes/custom-adapter.md
@@ -1,6 +1,6 @@
 # Plug in your own schema library
 
-Chemical X is schema-agnostic. Zod is just one implementation of
+Decant is schema-agnostic. Zod is just one implementation of
 the internal `AbstractSchema` contract. If you're on Valibot,
 ArkType, Effect-Schema, or a hand-rolled validator, wire yours in
 without forking the library.
@@ -87,8 +87,8 @@ import type {
   SlimPrimitiveKind,
   ValidationError,
   ValidationResponse,
-} from '@chemical-x/forms'
-import type { DeepPartial, GenericForm } from '@chemical-x/forms'
+} from 'decant'
+import type { DeepPartial, GenericForm } from 'decant'
 
 // Permissive fallback used by `getSlimPrimitiveTypesAtPath` when the
 // schema doesn't declare a path. Adapter-specific — your library's
@@ -196,7 +196,7 @@ microtask and the caller's code works identically.
 
 ```ts
 // useForm.ts
-import { useForm as useAbstractForm } from '@chemical-x/forms'
+import { useForm as useAbstractForm } from 'decant'
 import { myLibAdapter } from './adapter'
 
 export function useForm<F extends GenericForm>(options: {

--- a/docs/recipes/devtools.md
+++ b/docs/recipes/devtools.md
@@ -17,7 +17,7 @@ That's it — the plugin auto-wires when the dep is present:
 ```ts
 // main.ts
 createApp(App)
-  .use(createChemicalXForms()) // devtools: true by default
+  .use(createDecant()) // devtools: true by default
   .mount('#app')
 ```
 
@@ -28,7 +28,7 @@ Supports DevTools v6 and v7 (`@vue/devtools-api` v6.6+).
 Skip the wiring in production, keep it in dev:
 
 ```ts
-import.meta.env.PROD ? createChemicalXForms({ devtools: false }) : createChemicalXForms()
+import.meta.env.PROD ? createDecant({ devtools: false }) : createDecant()
 ```
 
 If the peer dep isn't installed at runtime, nothing breaks — the
@@ -38,7 +38,7 @@ plugin silently skips setup.
 
 ### Inspector
 
-`Chemical X Forms` shows up alongside "Pinia", "Router", etc.
+`Decant` shows up alongside "Pinia", "Router", etc.
 Expand it to see one node per registered form (keyed by the form's
 `key`). Select a form to view:
 
@@ -52,7 +52,7 @@ Expand it to see one node per registered form (keyed by the form's
 
 ### Timeline
 
-A "Chemical X Forms" timeline layer logs:
+A "Decant" timeline layer logs:
 
 | Event            | Fires on                                                                  |
 | ---------------- | ------------------------------------------------------------------------- |

--- a/docs/recipes/dynamic-field-arrays.md
+++ b/docs/recipes/dynamic-field-arrays.md
@@ -8,7 +8,7 @@ path.
 
 ```ts
 import { z } from 'zod'
-import { useForm } from '@chemical-x/forms/zod'
+import { useForm } from 'decant/zod'
 
 const schema = z.object({
   tags: z.array(z.string()),
@@ -46,7 +46,7 @@ Out-of-range behaviour:
 
 ```vue
 <script setup lang="ts">
-  import { useForm } from '@chemical-x/forms/zod'
+  import { useForm } from 'decant/zod'
   import { z } from 'zod'
 
   const schema = z.object({

--- a/docs/recipes/focus-on-error.md
+++ b/docs/recipes/focus-on-error.md
@@ -35,7 +35,7 @@ directly:
 
 ```vue
 <script setup lang="ts">
-  import { useForm, parseApiErrors } from '@chemical-x/forms'
+  import { useForm, parseApiErrors } from 'decant'
 
   const form = useForm({ schema, key: 'signup' })
   const { handleSubmit, setFieldErrors, scrollToFirstError, focusFirstError } = form

--- a/docs/recipes/form-context.md
+++ b/docs/recipes/form-context.md
@@ -11,7 +11,7 @@ Parent owns the form:
 ```vue
 <!-- SignupForm.vue -->
 <script setup lang="ts">
-  import { useForm } from '@chemical-x/forms/zod'
+  import { useForm } from 'decant/zod'
   import { z } from 'zod'
 
   interface Form {
@@ -46,7 +46,7 @@ Any descendant grabs the same form:
 ```vue
 <!-- EmailRow.vue -->
 <script setup lang="ts">
-  import { injectForm } from '@chemical-x/forms/zod'
+  import { injectForm } from 'decant/zod'
 
   interface Form {
     email: string
@@ -78,7 +78,7 @@ different branch of the component tree:
 ```vue
 <!-- FloatingSaveButton.vue (anywhere in the app) -->
 <script setup lang="ts">
-  import { injectForm } from '@chemical-x/forms/zod'
+  import { injectForm } from 'decant/zod'
 
   interface Form {
     /* … */

--- a/docs/recipes/persistence.md
+++ b/docs/recipes/persistence.md
@@ -210,7 +210,7 @@ for the IndexedDB code.
 ```ts
 persist: {
   storage: 'local' | 'session' | 'indexeddb' | FormStorage,
-  key?: string,                     // default: chemical-x-forms:${formKey}
+  key?: string,                     // default: decant:${formKey}
                                     // (the resolved storage key adds a :${fingerprint} suffix automatically)
   debounceMs?: number,              // default 300
   include?: 'form' | 'form+errors', // default 'form'
@@ -235,7 +235,7 @@ The persisted payload contains only opted-in paths:
 // register('phone', { persist: true })
 // register('cvv')                     ← no opt-in
 
-// Persisted payload, written under key chemical-x-forms:signup:${fingerprint}
+// Persisted payload, written under key decant:signup:${fingerprint}
 {
   v: 4,                                          // cx-internal envelope version
   data: { form: { email: '…', phone: '…' } }     // no `cvv`
@@ -276,7 +276,7 @@ rehydration.
 Storage keys carry the schema's structural fingerprint:
 
 ```text
-chemical-x-forms:signup:7c3a0b   ← key on disk
+decant:signup:7c3a0b   ← key on disk
                        └────┘
                        fingerprint of the current schema
 ```
@@ -284,11 +284,11 @@ chemical-x-forms:signup:7c3a0b   ← key on disk
 When the schema changes shape — adding / removing / renaming a
 field, changing a leaf type, restructuring nested objects — the
 fingerprint changes. New writes go to a new key
-(`chemical-x-forms:signup:9d2b1f`); the old key
-(`chemical-x-forms:signup:7c3a0b`) becomes unreachable.
+(`decant:signup:9d2b1f`); the old key
+(`decant:signup:7c3a0b`) becomes unreachable.
 
 On the next mount, the orphan-cleanup pass enumerates keys under
-`chemical-x-forms:signup` (via `FormStorage.listKeys`), keeps the
+`decant:signup` (via `FormStorage.listKeys`), keeps the
 current-fingerprint entry, and removes the rest. No manual `version`
 bump, no possibility of forgetting it, no draft drops when only
 refinement logic changed (refinements collapse to opaque sentinels
@@ -342,7 +342,7 @@ Configuring a custom adapter still sweeps all three standard
 backends — the dev might have migrated away from any of them.
 
 The cleanup runs once at mount, only touches the `key` prefix your
-form resolves to (default `chemical-x-forms:${formKey}`), and never
+form resolves to (default `decant:${formKey}`), and never
 touches keys outside that prefix. Entries other forms wrote to the
 same backend under different keys are untouched. The exact-or-`:`-
 prefix match prevents collision with sibling forms whose keys share
@@ -356,7 +356,7 @@ the form's default key whenever `useForm()` is called without a
 `persist:` option, so a deployment that disables persistence (for
 compliance, simplification, whatever) actually clears the on-disk
 artifact instead of leaving a stale entry under
-`chemical-x-forms:${formKey}` indefinitely.
+`decant:${formKey}` indefinitely.
 
 Caveat: only the default key is reachable. If a previous deployment
 used a custom `persist.key`, that's an explicit migration on the
@@ -374,7 +374,7 @@ The escape hatch — implement the four-method contract and pass the
 object directly:
 
 ```ts
-import type { FormStorage } from '@chemical-x/forms'
+import type { FormStorage } from 'decant'
 
 const encryptedStorage: FormStorage = {
   async getItem(key) {
@@ -549,7 +549,7 @@ child's setup and re-bind v-register onto an inner native element:
 ```vue
 <!-- StyledInput.vue -->
 <script setup lang="ts">
-  import { useRegister } from '@chemical-x/forms'
+  import { useRegister } from 'decant'
   const register = useRegister()
 </script>
 
@@ -587,7 +587,7 @@ with its own `street`, `city`, `zip` inputs), use the existing
 ```vue
 <!-- AddressBlock.vue -->
 <script setup lang="ts">
-  import { injectForm } from '@chemical-x/forms'
+  import { injectForm } from 'decant'
   type SignupForm = { address: { street: string; city: string; zip: string } }
   const ctx = injectForm<SignupForm>('signup')
 </script>
@@ -613,7 +613,7 @@ components) or unusual binding targets, install the assigner
 directly on the element:
 
 ```ts
-import { assignKey } from '@chemical-x/forms'
+import { assignKey } from 'decant'
 elRef.value[assignKey] = (newValue) => emit('update:modelValue', newValue)
 ```
 

--- a/docs/recipes/server-errors.md
+++ b/docs/recipes/server-errors.md
@@ -10,7 +10,7 @@ as `errors` via a two-step pattern: parse the payload with
 
 ```vue
 <script setup lang="ts">
-  import { useForm, parseApiErrors } from '@chemical-x/forms'
+  import { useForm, parseApiErrors } from 'decant'
   import { z } from 'zod'
 
   const schema = z.object({
@@ -145,7 +145,7 @@ Legacy string entries (`{ email: 'taken' }`), entries missing
 ## Branching on `code`
 
 ```ts
-import { CxErrorCode } from '@chemical-x/forms'
+import { CxErrorCode } from 'decant'
 
 for (const err of form.errors.email ?? []) {
   if (err.code === 'api:duplicate-email') {

--- a/docs/recipes/ssr-hydration.md
+++ b/docs/recipes/ssr-hydration.md
@@ -16,7 +16,7 @@ Install the module and call `useForm` normally:
 ```ts
 // nuxt.config.ts
 export default defineNuxtConfig({
-  modules: ['@chemical-x/forms/nuxt'],
+  modules: ['decant/nuxt'],
 })
 ```
 
@@ -29,7 +29,7 @@ export default defineNuxtConfig({
 Values, errors, and touched / focused / blurred flags survive the
 server → client round-trip through `nuxtApp.payload`. Need to peek?
 Open the rendered HTML and look for your Nuxt payload `<script>`;
-`chemicalX` is a top-level key.
+`decant` is a top-level key.
 
 ## Bare Vue — two functions
 
@@ -38,24 +38,20 @@ Open the rendered HTML and look for your Nuxt payload `<script>`;
 ```ts
 import { createSSRApp } from 'vue'
 import { renderToString } from '@vue/server-renderer'
-import {
-  createChemicalXForms,
-  escapeForInlineScript,
-  renderChemicalXState,
-} from '@chemical-x/forms'
+import { createDecant, escapeForInlineScript, renderDecantState } from 'decant'
 import App from './App.vue'
 
 export async function render(url: string) {
   const app = createSSRApp(App)
-  app.use(createChemicalXForms())
+  app.use(createDecant())
 
   const html = await renderToString(app)
 
-  const chemicalXState = renderChemicalXState(app)
+  const decantState = renderDecantState(app)
   // escapeForInlineScript keeps `</script>` and U+2028 / U+2029
   // separators out of the inline payload so it can't break out of
   // the <script> tag.
-  const payload = escapeForInlineScript(JSON.stringify(chemicalXState))
+  const payload = escapeForInlineScript(JSON.stringify(decantState))
 
   return { html, payload }
 }
@@ -67,7 +63,7 @@ export async function render(url: string) {
 <body>
   <div id="app"><!--ssr-outlet--></div>
   <script>
-    window.__CHEMICAL_X_STATE__ = {{{ payload }}};
+    window.__DECANT_STATE__ = {{{ payload }}};
   </script>
   <script type="module" src="/src/entry-client.ts"></script>
 </body>
@@ -77,16 +73,16 @@ export async function render(url: string) {
 
 ```ts
 import { createSSRApp } from 'vue'
-import { createChemicalXForms, hydrateChemicalXState } from '@chemical-x/forms'
+import { createDecant, hydrateDecantState } from 'decant'
 import App from './App.vue'
 
 const app = createSSRApp(App)
-app.use(createChemicalXForms())
+app.use(createDecant())
 
 // Replay the server's form state BEFORE mounting — forms read from
 // the hydration bag during setup.
-const serialized = (window as any).__CHEMICAL_X_STATE__
-if (serialized !== undefined) hydrateChemicalXState(app, serialized)
+const serialized = (window as any).__DECANT_STATE__
+if (serialized !== undefined) hydrateDecantState(app, serialized)
 
 app.mount('#app')
 ```
@@ -105,7 +101,7 @@ values the server rendered.
 
 **"The form is empty on the client even though the server rendered values."**
 
-- Did you call `hydrateChemicalXState(app, payload)` before
+- Did you call `hydrateDecantState(app, payload)` before
   `app.mount(...)`? It has to land before `setup` runs.
 - Does the form's `key` match between server and client? Hard-code
   it as a string literal. `uuidv4()` or `Math.random()` produces a

--- a/docs/recipes/transforms.md
+++ b/docs/recipes/transforms.md
@@ -8,7 +8,7 @@ no matter how the user typed.
 ## Basic example
 
 ```ts
-import type { RegisterTransform } from '@chemical-x/forms'
+import type { RegisterTransform } from 'decant'
 
 const trim: RegisterTransform = (v) => (typeof v === 'string' ? v.trim() : v)
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -23,7 +23,7 @@ when the position is an array index.
 
 ## "Hydration mismatch after SSR"
 
-**Did you call `hydrateChemicalXState(app, payload)` before
+**Did you call `hydrateDecantState(app, payload)` before
 `app.mount(...)`?** It has to land before setup runs. See the
 [SSR recipe](./recipes/ssr-hydration.md).
 
@@ -58,7 +58,7 @@ In dev, a collision whose schemas disagree on shape surfaces as
 a `console.warn`:
 
 ```
-[@chemical-x/forms] Two useForm() calls with key "signup" use
+[decant] Two useForm() calls with key "signup" use
 structurally-different schemas. Only the first caller wires the
 form; the second caller's schema is silently ignored (shared
 "last-write" semantics). …
@@ -93,9 +93,9 @@ The schema generic couldn't be inferred. Two likely causes:
 - Your schema is typed as bare `ZodObject` without its concrete
   shape. Use the literal (`z.object({ email: z.string() })`) or
   give the variable a precise type.
-- You imported `useForm` from `@chemical-x/forms` (the abstract
+- You imported `useForm` from `decant` (the abstract
   entry) but passed a zod schema directly. Import from
-  `@chemical-x/forms/zod` or `/zod-v3` instead.
+  `decant/zod` or `/zod-v3` instead.
 
 See the [0.7 → 0.8 migration](./migration/0.7-to-0.8.md) for the
 subpath split and required-`key` contract.
@@ -134,7 +134,7 @@ v-register onto an inner native element:
 ```vue
 <!-- StyledInput.vue -->
 <script setup lang="ts">
-  import { useRegister } from '@chemical-x/forms'
+  import { useRegister } from 'decant'
   const register = useRegister()
 </script>
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@chemical-x/forms",
+  "name": "decant",
   "version": "0.13.0",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/cubicforms/chemical-x-forms"
+    "url": "https://github.com/decantjs/forms"
   },
   "scripts": {
     "dev": "nuxi dev playground",
@@ -45,10 +45,10 @@
     "version": "node scripts/promote-changelog.mjs && (node scripts/generate-release-notes.mjs || echo '[version] release-notes step failed; continuing') && git add CHANGELOG.md RELEASES.md",
     "prepare": "husky"
   },
-  "description": "A fully type-safe, schema-driven form library that gives you superpowers. Chemical X included.",
+  "description": "A fully type-safe, schema-driven form library for Vue 3 that gives you superpowers.",
   "author": "Oswald Chisala",
   "bugs": {
-    "url": "https://github.com/cubicforms/chemical-x-forms/issues"
+    "url": "https://github.com/decantjs/forms/issues"
   },
   "exports": {
     ".": {
@@ -98,8 +98,7 @@
     "composable",
     "field-array",
     "reactive",
-    "cubic forms",
-    "chemical x"
+    "decant"
   ],
   "license": "MIT",
   "packageManager": "pnpm@9.7.0",

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-  import { parseApiErrors } from '@chemical-x/forms'
-  import { useForm } from '@chemical-x/forms/zod'
+  import { parseApiErrors } from 'decant'
+  import { useForm } from 'decant/zod'
   import z from 'zod'
 
   // 1. Basic register + form.values across multiple inputs binding to the same path.
@@ -75,7 +75,7 @@
 
 <template>
   <div style="font-family: system-ui; max-width: 720px; margin: 2rem auto; padding: 0 1rem">
-    <h1>chemical-x-forms playground</h1>
+    <h1>decant playground</h1>
 
     <h2>1. Multiple inputs, one path</h2>
     <p>current fruit: '{{ fruitForm.values.fruit }}'</p>

--- a/playground/components/Grandchild.vue
+++ b/playground/components/Grandchild.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useFormContext } from '@chemical-x/forms'
+  import { useFormContext } from 'decant'
 
   const ctx = useFormContext()
   const value = ctx?.getValue()

--- a/playground/components/base-select.vue
+++ b/playground/components/base-select.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import type { RegisterValue } from '@chemical-x/forms/types'
+  import type { RegisterValue } from 'decant/types'
 
   // const registerValue = defineRegisterValue()
   const { registerValue } = defineProps<{ registerValue: RegisterValue }>()

--- a/playground/components/deeper-sfc.vue
+++ b/playground/components/deeper-sfc.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from '@chemical-x/forms/zod'
+  import { useForm } from 'decant/zod'
   import { z } from 'zod'
 
   const schema = z.object({ fruit: z.string() })

--- a/playground/components/root-component.vue
+++ b/playground/components/root-component.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import type { RegisterValue } from '@chemical-x/forms/types'
+  import type { RegisterValue } from 'decant/types'
 
   const { selectValue } = defineProps<{ selectValue: RegisterValue }>()
 </script>

--- a/playground/components/root-input.vue
+++ b/playground/components/root-input.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import type { RegisterValue } from '@chemical-x/forms/types'
+  import type { RegisterValue } from 'decant/types'
 
   const { fruit: fruitRegisterValue } = defineProps<{ fruit: RegisterValue }>()
 </script>

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -4,16 +4,16 @@ export default defineNuxtConfig({
   modules: ['../src/nuxt'],
   devtools: { enabled: true },
   alias: {
-    '@chemical-x/forms/types': '../src/runtime/types/types-api.ts',
+    'decant/types': '../src/runtime/types/types-api.ts',
     // Playground imports the zod-typed useForm directly so the form
     // composable picks up the zod-v4 schema types rather than the Nuxt
     // auto-imported abstract useForm.
-    '@chemical-x/forms/zod': '../src/zod.ts',
+    'decant/zod': '../src/zod.ts',
     // Bare-path import for the schema-agnostic surface (parseApiErrors,
     // useFormContext, etc). Without this, vite-node fails to resolve
-    // `@chemical-x/forms` and the SSR worker crashes with
+    // `decant` and the SSR worker crashes with
     // "IPC connection closed".
-    '@chemical-x/forms': '../src/index.ts',
+    decant: '../src/index.ts',
   },
   compatibilityDate: '2025-01-28',
 }) as DefineNuxtConfig

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "chemical-x-forms-playground",
+  "name": "decant-playground",
   "type": "module",
   "scripts": {
     "dev": "nuxi dev",

--- a/scripts/generate-release-notes.mjs
+++ b/scripts/generate-release-notes.mjs
@@ -112,7 +112,7 @@ function main() {
     log('no previous v-tag found — seeding first entry')
   }
 
-  const repo = process.env.GITHUB_REPOSITORY ?? 'cubicforms/chemical-x-forms'
+  const repo = process.env.GITHUB_REPOSITORY ?? 'decantjs/forms'
   const args = [
     'api',
     `repos/${repo}/releases/generate-notes`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,13 @@
 /**
- * `@chemical-x/forms` — framework-agnostic core entry.
+ * `decant` — framework-agnostic core entry.
  *
  * Consumers under bare Vue 3:
  *
  *   import { createApp } from 'vue'
- *   import { createChemicalXForms, useForm } from '@chemical-x/forms'
- *   import { chemicalXForms as chemicalXVite } from '@chemical-x/forms/vite'
+ *   import { createDecant, useForm } from 'decant'
+ *   import { decant as decantVite } from 'decant/vite'
  *
- *   createApp(App).use(createChemicalXForms()).mount('#app')
+ *   createApp(App).use(createDecant()).mount('#app')
  *
  * Consumers under Nuxt don't touch this file — the Nuxt module (`./nuxt`
  * subpath) installs everything automatically.
@@ -15,21 +15,21 @@
  * For schema-library integrations (Zod v3 today; Valibot / ArkType /
  * custom later), import from the matching subpath:
  *
- *   import { useForm, zodAdapter } from '@chemical-x/forms/zod-v3'
+ *   import { useForm, zodAdapter } from 'decant/zod-v3'
  */
 
 // The plugin, registry, serialization helpers
-export { createChemicalXForms } from './runtime/core/plugin'
-export type { ChemicalXFormsPluginOptions } from './runtime/core/plugin'
+export { createDecant } from './runtime/core/plugin'
+export type { DecantPluginOptions } from './runtime/core/plugin'
 export {
   createRegistry,
   getRegistryFromApp,
-  kChemicalXRegistry,
+  kDecantRegistry,
   useRegistry,
 } from './runtime/core/registry'
-export type { ChemicalXRegistry, SerializedFormData } from './runtime/core/registry'
-export { hydrateChemicalXState, renderChemicalXState } from './runtime/core/serialize'
-export type { SerializedChemicalXState } from './runtime/core/serialize'
+export type { DecantRegistry, SerializedFormData } from './runtime/core/registry'
+export { hydrateDecantState, renderDecantState } from './runtime/core/serialize'
+export type { SerializedDecantState } from './runtime/core/serialize'
 export { escapeForInlineScript } from './runtime/core/serialize-script'
 
 // The abstract useForm — works against any AbstractSchema implementation.
@@ -50,7 +50,7 @@ export { injectForm } from './runtime/composables/use-form-context'
 // `injectForm`.
 export { useRegister } from './runtime/composables/use-register'
 
-// The v-register directive (registered automatically by createChemicalXForms,
+// The v-register directive (registered automatically by createDecant,
 // but exported for advanced consumers who install directives themselves).
 export { vRegister, isRegisterValue, assignKey } from './runtime/core/directive'
 export { defaultCoercionRules, defineCoercion } from './runtime/core/schema-coerce'
@@ -74,7 +74,7 @@ export type {
   ApiErrorDetails,
   ApiErrorEntry,
   ApiErrorEnvelope,
-  ChemicalXFormsDefaults,
+  DecantDefaults,
   CoercionEntry,
   CoercionRegistry,
   CoercionResult,

--- a/src/nuxt.ts
+++ b/src/nuxt.ts
@@ -5,17 +5,17 @@ import { inputTextAreaNodeTransform } from './runtime/lib/core/transforms/input-
 import { selectNodeTransform } from './runtime/lib/core/transforms/select-transform'
 import { vRegisterHintTransform } from './runtime/lib/core/transforms/v-register-hint-transform'
 import { vRegisterPreambleTransform } from './runtime/lib/core/transforms/v-register-preamble-transform'
-import type { ChemicalXFormsDefaults } from './runtime/types/types-api'
+import type { DecantDefaults } from './runtime/types/types-api'
 
 /**
- * Options accepted by `@chemical-x/forms/nuxt` under the `chemicalX`
+ * Options accepted by `decant/nuxt` under the `decant`
  * config key.
  *
  * ```ts
  * // nuxt.config.ts
  * export default defineNuxtConfig({
- *   modules: ['@chemical-x/forms/nuxt'],
- *   chemicalX: {
+ *   modules: ['decant/nuxt'],
+ *   decant: {
  *     defaults: { debounceMs: 100 },
  *   },
  * })
@@ -24,45 +24,45 @@ import type { ChemicalXFormsDefaults } from './runtime/types/types-api'
 export interface CXModuleOptions {
   /**
    * App-level defaults applied to every `useForm` call. Per-form
-   * options always win. See `ChemicalXFormsDefaults` for the
+   * options always win. See `DecantDefaults` for the
    * supported option set and merge rules.
    */
-  defaults?: ChemicalXFormsDefaults
+  defaults?: DecantDefaults
 }
 
 /**
  * Shape of the Nuxt public runtime-config slot the module populates.
- * Reach it via `useRuntimeConfig().public.chemicalX` if you need to
+ * Reach it via `useRuntimeConfig().public.decant` if you need to
  * read the configured defaults outside the form library itself.
  */
 export type CXRuntimeConfig = {
-  defaults: ChemicalXFormsDefaults
+  defaults: DecantDefaults
 }
 
 /**
  * Whether `specifier` is resolvable using ESM resolution from either the
- * consumer's project root or chemical-x's own module location. Returning
+ * consumer's project root or decant's own module location. Returning
  * true matches what Vite's resolver would do for `optimizeDeps.include`,
  * so a true here means Vite will pre-bundle the dep without warning.
  *
  * Why two probe locations:
  *   - Consumer-rootDir probe finds direct deps + their declared peers
  *     (the standard pnpm strict-isolation visibility).
- *   - Chemical-x-module probe finds peers chemical-x itself declares —
+ *   - decant-module probe finds peers decant itself declares —
  *     specifically the optional `@vue/devtools-api`, which lands in
- *     chemical-x's own node_modules tree (or pnpm virtual store) when
+ *     decant's own node_modules tree (or pnpm virtual store) when
  *     installed, even if the consumer never references it directly.
  *
  * Why ESM resolution (`import.meta.resolve`) rather than CJS
  * (`createRequire(...).resolve`):
- *   - chemical-x's exports map declares only `import` conditions for
+ *   - decant's exports map declares only `import` conditions for
  *     non-`/nuxt` entries. CJS resolve hits ERR_PACKAGE_PATH_NOT_EXPORTED
- *     for `@chemical-x/forms` and its sub-entries.
+ *     for `decant` and its sub-entries.
  *   - pnpm strict isolation hides hoisted transitives behind the
  *     virtual store. CJS resolve walks the bare node_modules chain and
  *     misses them; ESM resolve follows pnpm's symlinks correctly.
  *   - `import.meta.resolve(spec, parentURL)` is sync and stable in
- *     Node 20.6+, which chemical-x already requires (engines.node).
+ *     Node 20.6+, which decant already requires (engines.node).
  */
 function isResolvableForVite(specifier: string, consumerRootDir: string): boolean {
   const consumerURL = pathToFileURL(join(consumerRootDir, 'package.json')).href
@@ -80,8 +80,8 @@ function canResolve(specifier: string, fromURL: string): boolean {
 
 export default defineNuxtModule<CXModuleOptions>({
   meta: {
-    name: 'chemical-x-forms',
-    configKey: 'chemicalX',
+    name: 'decant',
+    configKey: 'decant',
     compatibility: {
       nuxt: '>=3.0.0',
     },
@@ -103,11 +103,11 @@ export default defineNuxtModule<CXModuleOptions>({
     // by default — the plugin's merge code reads this slot directly
     // without a `?? {}` guard at every call site.
     const runtimePublic = nuxt.options.runtimeConfig.public as Record<string, unknown>
-    runtimePublic['chemicalX'] = {
+    runtimePublic['decant'] = {
       defaults: _options.defaults ?? {},
     } satisfies CXRuntimeConfig
 
-    // Force-include chemical-x's own peers that Vite's startup crawl
+    // Force-include decant's own peers that Vite's startup crawl
     // tends to miss for Nuxt projects. Vite scans `index.html` + the
     // statically-known entry points but doesn't deeply follow into
     // pages that get loaded via Nuxt's dynamic router; deps imported
@@ -118,14 +118,14 @@ export default defineNuxtModule<CXModuleOptions>({
     // later." Vite's own "discovered new dependencies at runtime"
     // warning recommends exactly this remediation.
     //
-    // We declare here only deps chemical-x itself owns the relationship
-    // with — `@vue/devtools-api` (chemical-x's DevTools integration
+    // We declare here only deps decant itself owns the relationship
+    // with — `@vue/devtools-api` (decant's DevTools integration
     // peer) and `zod` (the `/zod` and `/zod-v3` adapter peer). Consumer-
     // side deps (vue-query, immer, etc.) are the consumer's
     // responsibility — they declare them in their own
     // `vite.optimizeDeps.include`. Each push is gated on the spec
-    // being resolvable from the consumer's project (or chemical-x's
-    // own module context for chemical-x's optional peers like
+    // being resolvable from the consumer's project (or decant's
+    // own module context for decant's optional peers like
     // devtools-api), so consumers without the optional peer don't see
     // a "failed to resolve" warning at boot.
     nuxt.options.vite.optimizeDeps ??= {}
@@ -139,9 +139,9 @@ export default defineNuxtModule<CXModuleOptions>({
     const resolver = createResolver(import.meta.url)
 
     // Auto-import `useForm` — the framework-agnostic core composable (same
-    // binding as `@chemical-x/forms`'s top-level `useForm` export, which
+    // binding as `decant`'s top-level `useForm` export, which
     // is the abstract form composable). Consumers who want the zod-typed
-    // wrapper must import from `@chemical-x/forms/zod` or `/zod-v3`
+    // wrapper must import from `decant/zod` or `/zod-v3`
     // explicitly.
     //
     // We point at the public package entry rather than a relative
@@ -149,19 +149,19 @@ export default defineNuxtModule<CXModuleOptions>({
     // `src/runtime/composables/use-abstract-form` path has no matching
     // `dist/runtime/…` file (build.config's entries don't include it),
     // so a `resolver.resolve(...)` would raise ENOENT at Nuxt's auto-
-    // import step. Importing from `@chemical-x/forms` resolves through
-    // the shared chunk, identical to what `@chemical-x/forms/zod`
+    // import step. Importing from `decant` resolves through
+    // the shared chunk, identical to what `decant/zod`
     // consumers bundle — single registry instance across both import
     // surfaces.
-    addImports([{ name: 'useForm', from: '@chemical-x/forms' }])
+    addImports([{ name: 'useForm', from: 'decant' }])
 
-    // Plugin that installs `createChemicalXForms()` on the Vue app and
+    // Plugin that installs `createDecant()` on the Vue app and
     // wires the payload serialize/hydrate bridge. Uses a physical
-    // `src/runtime/plugins/chemical-x.ts` file (shipped to
-    // `dist/runtime/plugins/chemical-x.mjs` via an explicit entry in
+    // `src/runtime/plugins/decant.ts` file (shipped to
+    // `dist/runtime/plugins/decant.mjs` via an explicit entry in
     // build.config.ts) rather than an inline plugin template, because a
-    // template's `import { createChemicalXForms } from '@chemical-x/forms'`
-    // resolves through the `@chemical-x/forms` package entry — which in
+    // template's `import { createDecant } from 'decant'`
+    // resolves through the `decant` package entry — which in
     // local dev (`unbuild --stub`) is a jiti runtime transpiler whose
     // `node:module`/`createRequire` imports Nitro's Rollup build cannot
     // bundle. A physical file lets Nitro follow its imports directly
@@ -176,18 +176,18 @@ export default defineNuxtModule<CXModuleOptions>({
     // they guarantee the registry is installed (and SSR payload staged
     // into `pendingHydration`) before any `useForm` call runs.
     addPlugin({
-      src: resolver.resolve('./runtime/plugins/chemical-x'),
+      src: resolver.resolve('./runtime/plugins/decant'),
     })
 
     // v-register directive type. The directive itself is globally
-    // registered by `createChemicalXForms().install(app)` in the plugin
+    // registered by `createDecant().install(app)` in the plugin
     // above; this template only publishes the type so that
     // `<input v-register="…">` type-checks in consumer SFCs.
     addTypeTemplate({
       filename: 'types/v-register.d.ts',
-      getContents: () => `// Generated by @chemical-x/forms
+      getContents: () => `// Generated by decant
 import type { ObjectDirective } from "vue"
-import type { RegisterDirective } from "@chemical-x/forms/types"
+import type { RegisterDirective } from "decant/types"
 
 declare module "vue" {
   interface GlobalDirectives {

--- a/src/runtime/adapters/zod-v3/assert-supported.ts
+++ b/src/runtime/adapters/zod-v3/assert-supported.ts
@@ -45,7 +45,7 @@ export function assertSupportedKinds(
   const typeName = getTypeName(schema)
   if (typeName !== undefined && UNSUPPORTED_TYPE_NAMES.has(typeName)) {
     throw new UnsupportedSchemaError(
-      `[@chemical-x/forms/zod-v3] unsupported kind '${typeName}' at '${labelPath(path)}'`
+      `[decant/zod-v3] unsupported kind '${typeName}' at '${labelPath(path)}'`
     )
   }
 
@@ -130,9 +130,7 @@ export function assertSupportedKinds(
   if (isZodSchemaType(schema, 'ZodLazy')) {
     const getter = (schema._def as { getter?: () => z.ZodTypeAny }).getter
     if (getter !== undefined && lazyGetters.includes(getter)) {
-      throw new UnsupportedSchemaError(
-        `[@chemical-x/forms/zod-v3] Recursive z.lazy() at '${labelPath(path)}'`
-      )
+      throw new UnsupportedSchemaError(`[decant/zod-v3] Recursive z.lazy() at '${labelPath(path)}'`)
     }
     const inner = getter?.()
     if (inner !== undefined) {

--- a/src/runtime/adapters/zod-v3/index.ts
+++ b/src/runtime/adapters/zod-v3/index.ts
@@ -1,7 +1,7 @@
 import { cloneDeep, isFunction, merge, set } from 'lodash-es'
 // Imports zod v3 via the pnpm alias defined in devDependencies; the
 // published bundle rewrites this specifier back to 'zod' via the build
-// step (see build.config.ts). Consumers of `@chemical-x/forms/zod-v3`
+// step (see build.config.ts). Consumers of `decant/zod-v3`
 // install zod@3 themselves and the resolved import works.
 import { z } from 'zod-v3'
 import type {
@@ -68,7 +68,7 @@ let warnedZodCodeMissing = false
  * Wrap a Zod v3 `ZodObject` schema in an `AbstractSchema` factory.
  *
  * Most consumers never call this directly — `useForm` from
- * `@chemical-x/forms/zod-v3` does the wrapping automatically. Reach
+ * `decant/zod-v3` does the wrapping automatically. Reach
  * for it only when integrating with a custom code path that needs
  * the adapter outside of `useForm`.
  *
@@ -195,7 +195,7 @@ export function zodAdapter<
             const path = coercePathSegments(issue.path)
             if (!schemasAtPath.length) {
               console.error(
-                `[@chemical-x/forms] zod-v3 adapter: no schema at path ` +
+                `[decant] zod-v3 adapter: no schema at path ` +
                   `'${path.join(PATH_SEPARATOR)}' for key '${_formKey}'. ` +
                   `Skipping the issue. (This is a library-internal invariant — please file a bug.)`
               )
@@ -578,7 +578,7 @@ function zodIssuesToValidationErrors(issues: z.ZodIssue[], formKey: FormKey): Va
       if (__DEV__ && !warnedZodCodeMissing) {
         warnedZodCodeMissing = true
         console.warn(
-          '[@chemical-x/forms] zod-v3 adapter received an issue with no string `code`; ' +
+          '[decant] zod-v3 adapter received an issue with no string `code`; ' +
             "stamping `'zod:unknown'`. This usually means a custom Zod plugin emitted " +
             'an issue without the standard code field.'
         )
@@ -1342,7 +1342,7 @@ function getDefaultValuesFromZodSchema<
     }
 
     console.warn(
-      `[@chemical-x/forms] zod-v3 adapter: unsupported schema kind ` +
+      `[decant] zod-v3 adapter: unsupported schema kind ` +
         `'${schema.constructor.name}' on form '${formKey}'. Defaulting the field to null. ` +
         `Use a supported zod kind (object/array/record/string/number/etc.) at this path.`
     )

--- a/src/runtime/adapters/zod-v4/adapter.ts
+++ b/src/runtime/adapters/zod-v4/adapter.ts
@@ -184,7 +184,7 @@ function isLeafRequired(schema: z.ZodType, depth = 0): boolean {
  * Wrap a Zod v4 `ZodObject` schema in an `AbstractSchema` factory.
  *
  * Most consumers never call this directly — `useForm` from
- * `@chemical-x/forms/zod` does the wrapping automatically. Reach for
+ * `decant/zod` does the wrapping automatically. Reach for
  * it when you need an adapter outside of `useForm` (e.g. validating
  * data with the same library used elsewhere in the form runtime, or
  * exposing the adapter to a custom integration).

--- a/src/runtime/adapters/zod-v4/assert-supported.ts
+++ b/src/runtime/adapters/zod-v4/assert-supported.ts
@@ -51,7 +51,7 @@ export function assertSupportedKinds(
 
   if (UNSUPPORTED.includes(kind)) {
     throw new UnsupportedSchemaError(
-      `[@chemical-x/forms/zod] unsupported kind '${kind}' at '${labelPath(path)}'`
+      `[decant/zod] unsupported kind '${kind}' at '${labelPath(path)}'`
     )
   }
 
@@ -104,9 +104,7 @@ export function assertSupportedKinds(
     case 'lazy': {
       const getter = getLazyGetter(schema)
       if (getter !== undefined && lazyGetters.includes(getter)) {
-        throw new UnsupportedSchemaError(
-          `[@chemical-x/forms/zod] Recursive z.lazy() at '${labelPath(path)}'`
-        )
+        throw new UnsupportedSchemaError(`[decant/zod] Recursive z.lazy() at '${labelPath(path)}'`)
       }
       const inner = unwrapLazy(schema)
       if (inner !== undefined) {

--- a/src/runtime/adapters/zod-v4/errors.ts
+++ b/src/runtime/adapters/zod-v4/errors.ts
@@ -29,7 +29,7 @@ export function zodIssuesToValidationErrors(
       if (__DEV__ && !warnedZodCodeMissing) {
         warnedZodCodeMissing = true
         console.warn(
-          '[@chemical-x/forms] zod-v4 adapter received an issue with no string `code`; ' +
+          '[decant] zod-v4 adapter received an issue with no string `code`; ' +
             "stamping `'zod:unknown'`. This usually means a custom Zod plugin emitted " +
             'an issue without the standard code field.'
         )

--- a/src/runtime/adapters/zod-v4/index.ts
+++ b/src/runtime/adapters/zod-v4/index.ts
@@ -24,7 +24,7 @@ export type { ZodKind } from './introspect'
  * Create a form bound to a Zod v4 schema.
  *
  * ```ts
- * import { useForm } from '@chemical-x/forms/zod'
+ * import { useForm } from 'decant/zod'
  * import { z } from 'zod'
  *
  * const form = useForm({
@@ -41,7 +41,7 @@ export type { ZodKind } from './introspect'
  * helpers, and more. See `UseFormReturnType` for the full
  * surface.
  *
- * For Zod v3, import from `@chemical-x/forms/zod-v3` instead.
+ * For Zod v3, import from `decant/zod-v3` instead.
  */
 export function useForm<Schema extends z.ZodObject>(
   configuration: Omit<

--- a/src/runtime/adapters/zod-v4/introspect.ts
+++ b/src/runtime/adapters/zod-v4/introspect.ts
@@ -315,7 +315,7 @@ export function getDiscriminatedOptions(schema: z.ZodType): readonly z.ZodObject
 
 /**
  * Verify a schema is Zod v4. Throws a clear error if it's a v3
- * schema mistakenly imported through `@chemical-x/forms/zod`.
+ * schema mistakenly imported through `decant/zod`.
  *
  * Most consumers never call this directly — the v4 adapter calls it
  * internally on every schema. Reach for it only when wiring a custom
@@ -324,7 +324,7 @@ export function getDiscriminatedOptions(schema: z.ZodType): readonly z.ZodObject
 export function assertZodVersion(schema: unknown): void {
   const def = readDef(schema)
   if (def?.type === undefined) {
-    throw new Error('[@chemical-x/forms/zod] schema is not zod v4. Install zod@^4 or use /zod-v3.')
+    throw new Error('[decant/zod] schema is not zod v4. Install zod@^4 or use /zod-v3.')
   }
 }
 

--- a/src/runtime/composables/use-abstract-form.ts
+++ b/src/runtime/composables/use-abstract-form.ts
@@ -37,7 +37,7 @@ import { kFormContext, kFormInstanceId, useRegistry } from '../core/registry'
 import { walkUnsetSentinels } from '../core/unset-walker'
 import type {
   AbstractSchema,
-  ChemicalXFormsDefaults,
+  DecantDefaults,
   FormKey,
   PersistConfigOptions,
   UseFormReturnType,
@@ -52,7 +52,7 @@ import type { DeepPartial, DefaultValuesShape, GenericForm, WriteShape } from '.
  * adapter or a third-party validation library.
  *
  * ```ts
- * import { useForm } from '@chemical-x/forms'
+ * import { useForm } from 'decant'
  *
  * const form = useForm({
  *   schema: myCustomAdapter,
@@ -61,7 +61,7 @@ import type { DeepPartial, DefaultValuesShape, GenericForm, WriteShape } from '.
  * ```
  *
  * Most consumers prefer a typed entry point — e.g.
- * `@chemical-x/forms/zod` (v4) or `@chemical-x/forms/zod-v3` —
+ * `decant/zod` (v4) or `decant/zod-v3` —
  * which wrap the underlying library's schema with the matching
  * adapter automatically.
  *
@@ -266,7 +266,7 @@ export function useAbstractForm<
  * configuration. Per-form values always win for scalars; `validateOn`
  * and `debounceMs` resolve independently so a default like
  * `{ debounceMs: 100 }` carries through even when the per-form call
- * passes `{ validateOn: 'blur' }`. See `ChemicalXFormsDefaults` for the
+ * passes `{ validateOn: 'blur' }`. See `DecantDefaults` for the
  * full merge contract.
  */
 function mergeWithDefaults<
@@ -275,7 +275,7 @@ function mergeWithDefaults<
   Schema extends AbstractSchema<Form, GetValueFormType>,
   Defaults extends DeepPartial<DefaultValuesShape<Form>>,
 >(
-  defaults: ChemicalXFormsDefaults,
+  defaults: DecantDefaults,
   configuration: UseFormConfiguration<Form, GetValueFormType, Schema, Defaults>
 ): UseFormConfiguration<Form, GetValueFormType, Schema, Defaults> {
   // exactOptionalPropertyTypes rejects explicit `undefined` on optional
@@ -507,15 +507,12 @@ function warnOnSchemaFingerprintMismatch(
     existingFp = existing.fingerprint()
     incomingFp = incoming.fingerprint()
   } catch (error) {
-    console.error(
-      `[@chemical-x/forms] fingerprint() threw for key "${key}"; skipping mismatch check.`,
-      error
-    )
+    console.error(`[decant] fingerprint() threw for key "${key}"; skipping mismatch check.`, error)
     return
   }
   if (existingFp === incomingFp) return
   console.warn(
-    `[@chemical-x/forms] useForm() calls with key "${key}" use different schemas; first wins, second is ignored. Use identical schemas or unique keys.\n  existing: ${existingFp}\n  incoming: ${incomingFp}`
+    `[decant] useForm() calls with key "${key}" use different schemas; first wins, second is ignored. Use identical schemas or unique keys.\n  existing: ${existingFp}\n  incoming: ${incomingFp}`
   )
 }
 
@@ -972,7 +969,7 @@ function enforceAnonPersistRule(formKey: string, isSSR: boolean): boolean {
   if (!isSSR && !warnedAnonPersistKeys.has(formKey)) {
     warnedAnonPersistKeys.add(formKey)
     console.warn(
-      "[@chemical-x/forms] persist: ignored — anonymous useForm() can't safely persist " +
+      "[decant] persist: ignored — anonymous useForm() can't safely persist " +
         '(key drift + cross-form collision risk).\n' +
         '  Persistence is disabled for this form; the app keeps working.\n' +
         "  Fix: useForm({ schema, key: 'login', persist: '...' })"

--- a/src/runtime/composables/use-form-context.ts
+++ b/src/runtime/composables/use-form-context.ts
@@ -4,12 +4,7 @@ import type { FormStore } from '../core/create-form-store'
 import { __DEV__ } from '../core/dev'
 import { captureUserCallSite } from '../core/dev-stack-trace'
 import type { HistoryModule } from '../core/history'
-import {
-  kFormContext,
-  kFormInstanceId,
-  useRegistry,
-  type ChemicalXRegistry,
-} from '../core/registry'
+import { kFormContext, kFormInstanceId, useRegistry, type DecantRegistry } from '../core/registry'
 import type { FormKey, UseFormReturnType } from '../types/types-api'
 import type { GenericForm } from '../types/types-core'
 import { ambientProvideHistory } from './use-abstract-form'
@@ -121,7 +116,7 @@ export function injectForm<Form extends GenericForm, GetValueFormType extends Ge
  */
 function resolveState<Form extends GenericForm>(
   key: FormKey | undefined,
-  registry: ChemicalXRegistry
+  registry: DecantRegistry
 ): FormStore<Form> | null {
   if (key !== undefined) {
     const stored = registry.forms.get(key) as FormStore<Form> | undefined
@@ -152,8 +147,7 @@ function warnMiss(detail: string, isSSR: boolean): void {
   if (!__DEV__ || isSSR) return
   const frame = captureUserCallSite()
   console.warn(
-    `[@chemical-x/forms] injectForm: ${detail}. Returning null.` +
-      (frame !== undefined ? ` ${frame}` : '')
+    `[decant] injectForm: ${detail}. Returning null.` + (frame !== undefined ? ` ${frame}` : '')
   )
 }
 
@@ -185,7 +179,7 @@ function warnIfAmbientProviderHadDuplicates(): void {
       if (history.length > 1) {
         const lines = history.map((entry) => `  - ${entry.source ?? '<unknown location>'}`)
         console.warn(
-          '[@chemical-x/forms] injectForm<F>() (no key) resolved against ' +
+          '[decant] injectForm<F>() (no key) resolved against ' +
             'an ancestor with multiple anonymous useForm() calls; descendants ' +
             'only see the last-provided form. Anonymous useForm() calls were:\n' +
             lines.join('\n') +

--- a/src/runtime/composables/use-form.ts
+++ b/src/runtime/composables/use-form.ts
@@ -13,14 +13,14 @@ import { useAbstractForm } from './use-abstract-form'
  * Create a form bound to a custom `AbstractSchema` adapter.
  *
  * ```ts
- * import { useForm } from '@chemical-x/forms/zod-v3'
+ * import { useForm } from 'decant/zod-v3'
  *
  * const form = useForm({ schema: myAdapter, defaultValues: { … } })
  * ```
  *
  * For Zod schemas, prefer the overload that accepts a `ZodObject`
  * directly — it wraps the adapter automatically. For Zod v4, import
- * from `@chemical-x/forms/zod` instead.
+ * from `decant/zod` instead.
  */
 export function useForm<Form extends GenericForm, GetValueFormType extends GenericForm = Form>(
   configuration: UseFormConfiguration<
@@ -34,7 +34,7 @@ export function useForm<Form extends GenericForm, GetValueFormType extends Gener
  * Create a form bound to a Zod v3 `ZodObject` schema.
  *
  * ```ts
- * import { useForm } from '@chemical-x/forms/zod-v3'
+ * import { useForm } from 'decant/zod-v3'
  * import { z } from 'zod'
  *
  * const form = useForm({
@@ -52,7 +52,7 @@ export function useForm<Form extends GenericForm, GetValueFormType extends Gener
  * helpers, and more. See `UseFormReturnType` for the full
  * surface.
  *
- * For Zod v4, import from `@chemical-x/forms/zod` instead.
+ * For Zod v4, import from `decant/zod` instead.
  */
 export function useForm<
   Schema extends z.ZodObject<z.ZodRawShape>,
@@ -96,7 +96,7 @@ export function useForm<
   // intentionally NOT re-listed — the spread carries them through, and
   // writing `strict: configuration.strict ?? true` here would
   // short-circuit the registry's app-level defaults
-  // (`createChemicalXForms({ defaults: { strict: false } })`).
+  // (`createDecant({ defaults: { strict: false } })`).
   // The library-level fallback to `true` lives downstream in
   // `createFormStore`, where it can apply *after* the registry merge.
   return useAbstractForm<Form, GetValueFormType>({

--- a/src/runtime/composables/use-register.ts
+++ b/src/runtime/composables/use-register.ts
@@ -10,7 +10,7 @@
  *
  * <!-- MyInput.vue -->
  * <script setup lang="ts">
- *   import { useRegister } from '@chemical-x/forms'
+ *   import { useRegister } from 'decant'
  *   const register = useRegister()
  * </script>
  *
@@ -60,16 +60,14 @@ import type { RegisterValue } from '../types/types-api'
  * an inner v-register.
  *
  * `Symbol.for(...)` so the marker round-trips across duplicate copies
- * of chemical-x — see `assignKey` in core/directive.ts for the same
+ * of decant — see `assignKey` in core/directive.ts for the same
  * reasoning. `useRegister` and the directive are typically loaded
  * from the same module copy, but a consumer importing from
- * `@chemical-x/forms/zod` (Vite-optimized bundle) and the Nuxt
+ * `decant/zod` (Vite-optimized bundle) and the Nuxt
  * plugin's relative-path import (live ESM) can land on different
  * copies; a global symbol means the marker check still works.
  */
-export const REGISTER_OWNER_MARKER: unique symbol = Symbol.for(
-  'chemical-x-forms:register-owner-marker'
-)
+export const REGISTER_OWNER_MARKER: unique symbol = Symbol.for('decant:register-owner-marker')
 
 const warnedNoParentRV: WeakSet<object> | null = __DEV__ ? new WeakSet<object>() : null
 let warnedOutsideSetup = false
@@ -178,7 +176,7 @@ function warnOutsideSetup(): void {
   warnedOutsideSetup = true
   const frame = captureUserCallSite()
   console.warn(
-    `[@chemical-x/forms] useRegister() called outside a component setup; returning ComputedRef<undefined>. ` +
+    `[decant] useRegister() called outside a component setup; returning ComputedRef<undefined>. ` +
       `Fix: call it inside <script setup> or a setup() function — not from an event handler ` +
       `or async callback.` +
       (frame !== undefined ? ` ${frame}` : '')
@@ -191,7 +189,7 @@ function warnNoParentRV(instance: object): void {
   warnedNoParentRV.add(instance)
   const frame = captureUserCallSite()
   console.warn(
-    `[@chemical-x/forms] useRegister: no parent registerValue prop; returning ComputedRef<undefined>. ` +
+    `[decant] useRegister: no parent registerValue prop; returning ComputedRef<undefined>. ` +
       `Pass v-register on the parent: \`<YourComponent v-register="form.register('field')" />\`.` +
       (frame !== undefined ? ` ${frame}` : '')
   )

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -86,7 +86,7 @@ function isHydratedValidationErrorArray(value: unknown): value is ValidationErro
 function warnMalformedHydration(formKey: FormKey, kind: string, rawKey: string): void {
   if (!__DEV__) return
   console.warn(
-    `[@chemical-x/forms] hydration: skipping malformed ${kind} entry at key '${rawKey}' on form '${formKey}'. ` +
+    `[decant] hydration: skipping malformed ${kind} entry at key '${rawKey}' on form '${formKey}'. ` +
       `This usually means the SSR bundle is on a different version than the client (rolling deploy / stale cache).`
   )
 }
@@ -460,7 +460,7 @@ export type FormStore<F extends GenericForm, G extends GenericForm = F> = {
 
   /**
    * Resolved schema-coercion index — the merged config from
-   * `createChemicalXForms({ defaults: { coerce } })` ∪ `useForm({ coerce })`,
+   * `createDecant({ defaults: { coerce } })` ∪ `useForm({ coerce })`,
    * keyed by `${input}->${output}` for O(1) per-keystroke dispatch.
    * Empty Map when coercion is disabled. Read at `register()` time
    * by `buildCoerceFn` to bake the per-path coerce closure on
@@ -922,7 +922,7 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
       try {
         listener(next, meta)
       } catch (err) {
-        console.error('[@chemical-x/forms] onFormChange threw:', err)
+        console.error('[decant] onFormChange threw:', err)
       }
     }
   }
@@ -1341,7 +1341,7 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
       try {
         listener()
       } catch (err) {
-        console.error('[@chemical-x/forms] onSubmitSuccess threw:', err)
+        console.error('[decant] onSubmitSuccess threw:', err)
       }
     }
   }
@@ -1373,7 +1373,7 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
       try {
         hook()
       } catch (err) {
-        console.error('[@chemical-x/forms] cleanup threw:', err)
+        console.error('[decant] cleanup threw:', err)
       }
     }
     cleanupHooks.length = 0
@@ -1702,7 +1702,7 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
       try {
         listener()
       } catch (err) {
-        console.error('[@chemical-x/forms] onReset threw:', err)
+        console.error('[decant] onReset threw:', err)
       }
     }
   }
@@ -1739,7 +1739,7 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
         // guarantees primitive-correctness. A rejected reset write
         // signals an invariant violation upstream.
         console.error(
-          `[@chemical-x/forms] resetField: leaf write rejected for path '${targetKey}' — ` +
+          `[decant] resetField: leaf write rejected for path '${targetKey}' — ` +
             `originals contain a value that doesn't satisfy the slim primitive shape. ` +
             `This is a bug in the construction pipeline.`
         )
@@ -1779,7 +1779,7 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     const wroteSubtree = setValueAtPath(targetSegments, subtree)
     if (!wroteSubtree) {
       console.error(
-        `[@chemical-x/forms] resetField: subtree write rejected at path '${targetKey}' — ` +
+        `[decant] resetField: subtree write rejected at path '${targetKey}' — ` +
           `originals contain values that don't satisfy the slim primitive shape. ` +
           `This is a bug in the construction pipeline.`
       )

--- a/src/runtime/core/defaults.ts
+++ b/src/runtime/core/defaults.ts
@@ -7,7 +7,7 @@
  * timing/policy defaults.
  *
  * Per-form `useForm({ ... })` options always win over these. App-level
- * `createChemicalXForms({ defaults: ... })` options sit between the
+ * `createDecant({ defaults: ... })` options sit between the
  * two: per-form > app-level > library default.
  */
 
@@ -61,7 +61,7 @@ export const DEFAULT_HISTORY_MAX_SNAPSHOTS = 50
  * constant so multi-tenant deployments can audit or reserve their
  * own prefix without grepping for the literal.
  */
-export const PERSISTENCE_KEY_PREFIX = 'chemical-x-forms:'
+export const PERSISTENCE_KEY_PREFIX = 'decant:'
 
 /**
  * Reserved namespace for the library's internal synthetic keys

--- a/src/runtime/core/dev-stack-trace.ts
+++ b/src/runtime/core/dev-stack-trace.ts
@@ -1,7 +1,7 @@
 /**
  * Dev-only call-site capture for warnings that want to point the
  * reader at the offending line of their code (not at a cx-internal
- * frame). Walks the stack past `@chemical-x/forms` frames, picks the
+ * frame). Walks the stack past `decant` frames, picks the
  * first frame that looks like user code, then strips the dev-server
  * scheme + host + Vite/Nuxt's `/_nuxt/` prefix so the warning doesn't
  * carry a wall of `https://localhost:3000/_nuxt/...` noise.
@@ -17,8 +17,8 @@
  * and short paths read better there than full URLs.
  *
  * The cx-frame regex matches both the published path
- * (`@chemical-x/forms/...`) and the linked / source path
- * (`chemical-x-forms/...`) so local dev via `make link-cx` surfaces
+ * (`decant/...`) and the linked / source path
+ * (`decant/...`) so local dev via `make link-cx` surfaces
  * the same trimmed frames.
  *
  * Dev-only; callers should gate on `__DEV__` before invoking.
@@ -31,7 +31,7 @@ export function captureUserCallSite(): string | undefined {
   for (let i = 1; i < lines.length; i++) {
     const frame = lines[i]
     if (frame === undefined) continue
-    if (/chemical-x[/-]forms?/i.test(frame)) continue
+    if (/decant[/-]forms?/i.test(frame)) continue
     if (/\bforms\.[A-Za-z0-9_-]+\.m?js\b/.test(frame)) continue
     const trimmed = frame.trim()
     if (trimmed.length === 0) continue

--- a/src/runtime/core/devtools.ts
+++ b/src/runtime/core/devtools.ts
@@ -1,14 +1,14 @@
 import type { App } from 'vue'
 import type { FormStore } from './create-form-store'
-import type { ChemicalXRegistry } from './registry'
+import type { DecantRegistry } from './registry'
 import type { GenericForm } from '../types/types-core'
 import type { FormKey } from '../types/types-api'
 import { canonicalizePath } from './paths'
 import { isSensitivePath } from './persistence/sensitive-names'
 
 /**
- * Vue DevTools plugin wiring for @chemical-x/forms. Lazy-imported by
- * `createChemicalXForms` under dev-mode guards so the production
+ * Vue DevTools plugin wiring for decant. Lazy-imported by
+ * `createDecant` under dev-mode guards so the production
  * bundle tree-shakes it out entirely.
  *
  * Registers:
@@ -20,13 +20,13 @@ import { isSensitivePath } from './persistence/sensitive-names'
  *    pushes through `state.setValueAtPath`, mutating the form.
  *
  * Tolerant of missing `@vue/devtools-api` — the peer dep is marked
- * optional. If the import fails, `setupChemicalXDevtools` silently
+ * optional. If the import fails, `setupDecantDevtools` silently
  * no-ops so production builds / users without DevTools installed
  * don't see errors.
  */
 
-const INSPECTOR_ID = 'chemical-x-forms'
-const TIMELINE_LAYER_ID = 'chemical-x-forms:events'
+const INSPECTOR_ID = 'decant'
+const TIMELINE_LAYER_ID = 'decant:events'
 
 const REDACTED = '[redacted]'
 
@@ -131,10 +131,7 @@ type SetupDevtoolsPluginFn = (
  * DevTools was wired successfully, `false` otherwise — useful for
  * tests.
  */
-export async function setupChemicalXDevtools(
-  app: App,
-  registry: ChemicalXRegistry
-): Promise<boolean> {
+export async function setupDecantDevtools(app: App, registry: DecantRegistry): Promise<boolean> {
   let mod: { setupDevtoolsPlugin?: SetupDevtoolsPluginFn }
   try {
     mod = (await import('@vue/devtools-api')) as {
@@ -152,25 +149,25 @@ export async function setupChemicalXDevtools(
   setupDevtoolsPlugin(
     {
       id: INSPECTOR_ID,
-      label: 'Chemical X Forms',
-      packageName: '@chemical-x/forms',
-      homepage: 'https://github.com/cubicforms/chemical-x-forms',
+      label: 'Decant',
+      packageName: 'decant',
+      homepage: 'https://github.com/decantjs/forms',
       app,
-      componentStateTypes: ['Chemical X form'],
+      componentStateTypes: ['Decant form'],
     },
     (api) => wire(api, app, registry)
   )
   return true
 }
 
-function wire(api: UnsafeDevtoolsApi, app: App, registry: ChemicalXRegistry): void {
+function wire(api: UnsafeDevtoolsApi, app: App, registry: DecantRegistry): void {
   // Per-form subscriber bookkeeping — we keep the unsubscribers so
   // the registry's eviction path can detach them when a form is
   // disposed. Using a Map keyed by FormKey mirrors the registry.
   const subscriberUnsubs = new Map<FormKey, () => void>()
 
-  api.addInspector({ id: INSPECTOR_ID, label: 'Chemical X Forms', app })
-  api.addTimelineLayer({ id: TIMELINE_LAYER_ID, label: 'Chemical X Forms', color: 0x5b8def })
+  api.addInspector({ id: INSPECTOR_ID, label: 'Decant', app })
+  api.addTimelineLayer({ id: TIMELINE_LAYER_ID, label: 'Decant', color: 0x5b8def })
 
   function refreshTree(): void {
     api.sendInspectorTree(INSPECTOR_ID)

--- a/src/runtime/core/directive.ts
+++ b/src/runtime/core/directive.ts
@@ -9,7 +9,7 @@
  * <input v-register="form.register('email')" />
  * ```
  *
- * Installed automatically by `createChemicalXForms()`; the export is
+ * Installed automatically by `createDecant()`; the export is
  * for advanced consumers who install directives manually. Works
  * identically under Nuxt, bare Vue CSR, and bare Vue +
  * `@vue/server-renderer` — Vue skips directive lifecycle hooks during
@@ -49,7 +49,7 @@ import { enforceSensitiveCheck } from './persistence/sensitive-names'
  * when a DOM event fires:
  *
  * ```ts
- * import { assignKey } from '@chemical-x/forms'
+ * import { assignKey } from 'decant'
  * el[assignKey] = (value) => myCustomWriter(value)
  * ```
  *
@@ -57,14 +57,14 @@ import { enforceSensitiveCheck } from './persistence/sensitive-names'
  * default assigners for text inputs, checkboxes, radios, and selects.
  */
 // `Symbol.for(...)` so `el[assignKey] = ...` round-trips across
-// duplicate copies of chemical-x. The directive (which writes the
+// duplicate copies of decant. The directive (which writes the
 // default assigner) and the consumer-side composables/utilities (which
 // may read or override it) must agree on the key, or the directive
 // stops recognising consumer-installed assigners after the page is
 // served from a Vite-optimised copy that's distinct from the one the
 // directive registration came from. Same reasoning for `listenersKey`
 // and `DEFAULT_ASSIGNER_TAG` below.
-export const assignKey: unique symbol = Symbol.for('chemical-x-forms:assign-key')
+export const assignKey: unique symbol = Symbol.for('decant:assign-key')
 
 /**
  * Per-element bag of listener tuples added by the active directive
@@ -72,7 +72,7 @@ export const assignKey: unique symbol = Symbol.for('chemical-x-forms:assign-key'
  * so reused elements (KeepAlive, v-show) don't accumulate orphaned
  * handlers across activation cycles.
  */
-const listenersKey: unique symbol = Symbol.for('chemical-x-forms:directive-listeners')
+const listenersKey: unique symbol = Symbol.for('decant:directive-listeners')
 
 type TrackedListener = {
   event: string
@@ -163,7 +163,7 @@ function computePersistMeta(el: HTMLElement, registerValue: RegisterValue): Writ
  * has explicitly opted into reading whatever the listener captures,
  * so the bail doesn't apply.
  */
-const DEFAULT_ASSIGNER_TAG: unique symbol = Symbol.for('chemical-x-forms:default-assigner-tag')
+const DEFAULT_ASSIGNER_TAG: unique symbol = Symbol.for('decant:default-assigner-tag')
 
 type DefaultAssignerCarrier = { [DEFAULT_ASSIGNER_TAG]?: boolean }
 
@@ -259,14 +259,14 @@ function logTransformFailure(
   if (__DEV__) {
     const namePart = fn.name !== '' ? `, '${fn.name}'` : ''
     console.error(
-      `[@chemical-x/forms] transform threw for path '${path}' (index ${index}${namePart}) — ` +
+      `[decant] transform threw for path '${path}' (index ${index}${namePart}) — ` +
         `write aborted. Transforms must not throw; wrap your own try/catch if the throw is recoverable. ` +
         `Original error:`,
       err
     )
   } else {
     console.error(
-      `[@chemical-x/forms] transform error — write aborted (set NODE_ENV=development for details).`
+      `[decant] transform error — write aborted (set NODE_ENV=development for details).`
     )
   }
 }
@@ -303,13 +303,13 @@ function applyElementCoerce(value: unknown, registerValue: RegisterValue): unkno
 function logTransformAsync(path: PathKey): void {
   if (__DEV__) {
     console.error(
-      `[@chemical-x/forms] transform pipeline for path '${path}' returned a Promise — ` +
+      `[decant] transform pipeline for path '${path}' returned a Promise — ` +
         `transforms must be sync. Use async field validation for canonicalize-before-write patterns. ` +
         `Write aborted.`
     )
   } else {
     console.error(
-      `[@chemical-x/forms] transform error — write aborted (set NODE_ENV=development for details).`
+      `[decant] transform error — write aborted (set NODE_ENV=development for details).`
     )
   }
 }
@@ -1327,7 +1327,7 @@ const vRegisterDynamic: RegisterModelDynamicCustomDirective = {
         if (hasMarker || hasUserAssigner) return
         warnedUnsupportedElements.add(el)
         warn(
-          `[@chemical-x/forms] v-register on <${el.tagName.toLowerCase()}> is a no-op — ` +
+          `[decant] v-register on <${el.tagName.toLowerCase()}> is a no-op — ` +
             `non-input roots aren't bound to text-input semantics. For custom components: ` +
             `call \`useRegister()\` in the child's setup and re-bind v-register to an inner ` +
             `native element. Lower-level: install a custom assigner via the \`assignKey\` ` +
@@ -1395,7 +1395,7 @@ const vRegisterFileNoop: RegisterModelDynamicCustomDirective = {
     value.registerElement(el)
     if (__DEV__) {
       warn(
-        '[@chemical-x/forms] v-register on <input type="file"> is not supported. ' +
+        '[decant] v-register on <input type="file"> is not supported. ' +
           'Handle uploads with a manual @change listener.'
       )
     }
@@ -1457,7 +1457,7 @@ export type VXCustomDirective =
  *
  * The directive picks the right binding strategy automatically based
  * on the element's `tagName` and `type`. Registered globally by
- * `createChemicalXForms()` — most consumers never import it
+ * `createDecant()` — most consumers never import it
  * directly, but it's exposed for advanced integrations that wire
  * directives manually.
  */

--- a/src/runtime/core/errors.ts
+++ b/src/runtime/core/errors.ts
@@ -11,7 +11,7 @@
  */
 
 /**
- * Base for every error class thrown by `@chemical-x/forms`. Sets
+ * Base for every error class thrown by `decant`. Sets
  * `this.name` from the constructor's `new.target.name`, so subclasses
  * don't have to redeclare their own name override.
  */
@@ -40,14 +40,12 @@ export class SubmitErrorHandlerError extends CxError {}
  * Thrown by `useForm` / `injectForm` when the form library's
  * plugin hasn't been installed on the current Vue app.
  *
- * Fix: add `app.use(createChemicalXForms())` to your app entry
- * (or `@chemical-x/forms/nuxt` for Nuxt projects).
+ * Fix: add `app.use(createDecant())` to your app entry
+ * (or `decant/nuxt` for Nuxt projects).
  */
 export class RegistryNotInstalledError extends CxError {
   constructor() {
-    super(
-      '[@chemical-x/forms] Registry not found. Install the plugin via `app.use(createChemicalXForms())`.'
-    )
+    super('[decant] Registry not found. Install the plugin via `app.use(createDecant())`.')
   }
 }
 
@@ -62,7 +60,7 @@ export class RegistryNotInstalledError extends CxError {
 export class OutsideSetupError extends CxError {
   constructor() {
     super(
-      '[@chemical-x/forms] useForm / injectForm called outside Vue setup(). ' +
+      '[decant] useForm / injectForm called outside Vue setup(). ' +
         'Move into setup or mount a child component to trigger from an event.'
     )
   }
@@ -77,7 +75,7 @@ export class OutsideSetupError extends CxError {
 export class ReservedFormKeyError extends CxError {
   constructor(key: string) {
     super(
-      `[@chemical-x/forms] Form key "${key}" uses the reserved "__cx:" namespace. ` +
+      `[decant] Form key "${key}" uses the reserved "__cx:" namespace. ` +
         `Use a different prefix — "__cx:" is for library-internal synthetic keys ` +
         `(anonymous useForm() calls without an explicit key).`
     )
@@ -120,7 +118,7 @@ export class SensitivePersistFieldError extends CxError {
   constructor(path: ReadonlyArray<string | number> | string) {
     const display = Array.isArray(path) ? path.join('.') : String(path)
     super(
-      `[@chemical-x/forms] Refusing to persist "${display}" — this path matches a ` +
+      `[decant] Refusing to persist "${display}" — this path matches a ` +
         `sensitive-name pattern (password / cvv / ssn / token / etc.). Storing sensitive ` +
         `data in client-side storage is a compliance risk (HIPAA / PII / PCI-DSS / SOC2). ` +
         `Fix: persist this server-side, OR pass \`acknowledgeSensitive: true\` to register() ` +
@@ -183,5 +181,5 @@ function formatAnonPersistMessage(opts: {
       ? ` Fix: add \`key: '<stable-id>'\` to useForm().`
       : ` Fix: add \`persist: 'session'\` (or 'local') and \`key:\` to useForm(), or remove \`{ persist: true }\` from this register() call.`
   const where = opts.callSite !== undefined ? ` ${opts.callSite}` : ''
-  return `[@chemical-x/forms] ${head}${fields}${fix}${where}`
+  return `[decant] ${head}${fields}${fix}${where}`
 }

--- a/src/runtime/core/hash.ts
+++ b/src/runtime/core/hash.ts
@@ -1,8 +1,8 @@
 /**
  * Deterministic non-cryptographic string hash. Used to compact long
  * structural-fingerprint strings into bounded-size storage-key tokens
- * (`chemical-x-forms:formKey:<hash>` instead of
- * `chemical-x-forms:formKey:object{"a":string,"b":number,...}`).
+ * (`decant:formKey:<hash>` instead of
+ * `decant:formKey:object{"a":string,"b":number,...}`).
  *
  * Output: 11-char base36 string with leading zeros padded —
  * stable size regardless of input. ~53 bits of entropy (base of the

--- a/src/runtime/core/persistence/index.ts
+++ b/src/runtime/core/persistence/index.ts
@@ -173,7 +173,7 @@ function warnVersionMismatch(observedVersion: number): void {
   if (warnedVersions.has(observedVersion)) return
   warnedVersions.add(observedVersion)
   console.warn(
-    `[@chemical-x/forms] Dropping persisted draft — envelope v=${observedVersion}, ` +
+    `[decant] Dropping persisted draft — envelope v=${observedVersion}, ` +
       `but this version of the library expects v=${PERSISTED_ENVELOPE_VERSION}. ` +
       `The persisted shape changed across releases; older drafts can't be restored. ` +
       `New drafts saved this session will use the current envelope.`
@@ -277,7 +277,7 @@ export function createDebouncedWriter(
 
 /**
  * Resolve the per-form storage KEY BASE. Default is
- * `chemical-x-forms:${formKey}` — consumers who want a different
+ * `decant:${formKey}` — consumers who want a different
  * namespace (multi-tenant app, per-user prefix) pass `persist.key`.
  *
  * The full storage key is `${base}:${fingerprint}` (see

--- a/src/runtime/core/persistence/indexeddb.ts
+++ b/src/runtime/core/persistence/indexeddb.ts
@@ -3,7 +3,7 @@ import type { FormStorage } from '../../types/types-api'
 
 /**
  * Zero-dependency IndexedDB adapter. A single shared DB
- * (`chemical-x-forms`) with a single object store (`kv`). Entries are
+ * (`decant`) with a single object store (`kv`). Entries are
  * structured-cloned on write, so `Date` / `Map` / `Set` / typed
  * arrays / nested arrays round-trip without JSON flattening.
  *
@@ -17,7 +17,7 @@ import type { FormStorage } from '../../types/types-api'
  * the degradation so the developer notices.
  */
 
-const DB_NAME = 'chemical-x-forms'
+const DB_NAME = 'decant'
 const STORE_NAME = 'kv'
 const DB_VERSION = 1
 
@@ -51,7 +51,7 @@ function openDb(): Promise<IDBDatabase | null> {
       if (__DEV__ && !warnedOnOpenFailure) {
         warnedOnOpenFailure = true
         console.warn(
-          '[@chemical-x/forms] IndexedDB open failed; persistence disabled. ' +
+          '[decant] IndexedDB open failed; persistence disabled. ' +
             'Common causes: private-mode disabled IDB, browser quota policy.',
           request.error
         )
@@ -62,7 +62,7 @@ function openDb(): Promise<IDBDatabase | null> {
       if (__DEV__ && !warnedOnOpenFailure) {
         warnedOnOpenFailure = true
         console.warn(
-          '[@chemical-x/forms] IndexedDB open blocked (another tab holds an older version); persistence disabled until the conflict resolves.'
+          '[decant] IndexedDB open blocked (another tab holds an older version); persistence disabled until the conflict resolves.'
         )
       }
       // `onblocked` is transient — the holding tab can close at any
@@ -136,7 +136,7 @@ function runWriteOp(fn: (store: IDBObjectStore) => void): Promise<void> {
           if (__DEV__ && !warnedOnWriteFailure) {
             warnedOnWriteFailure = true
             console.warn(
-              '[@chemical-x/forms] IndexedDB transaction aborted; subsequent writes will silently no-op. ' +
+              '[decant] IndexedDB transaction aborted; subsequent writes will silently no-op. ' +
                 'Common cause: storage quota exceeded.',
               tx.error
             )

--- a/src/runtime/core/persistence/local-storage.ts
+++ b/src/runtime/core/persistence/local-storage.ts
@@ -53,7 +53,7 @@ export function createLocalStorageAdapter(): FormStorage {
         if (__DEV__ && !warnedOnFailure) {
           warnedOnFailure = true
           console.warn(
-            '[@chemical-x/forms] localStorage write failed; subsequent writes will silently no-op for this form. ' +
+            '[decant] localStorage write failed; subsequent writes will silently no-op for this form. ' +
               'Common causes: quota exceeded, private-mode storage lock. ' +
               'Switch to `persist: "indexeddb"` for larger payloads.',
             err

--- a/src/runtime/core/persistence/session-storage.ts
+++ b/src/runtime/core/persistence/session-storage.ts
@@ -32,7 +32,7 @@ export function createSessionStorageAdapter(): FormStorage {
         if (__DEV__ && !warnedOnFailure) {
           warnedOnFailure = true
           console.warn(
-            '[@chemical-x/forms] sessionStorage write failed; subsequent writes will silently no-op for this form. ' +
+            '[decant] sessionStorage write failed; subsequent writes will silently no-op for this form. ' +
               'Common causes: quota exceeded, private-mode storage lock.',
             err
           )

--- a/src/runtime/core/plugin.ts
+++ b/src/runtime/core/plugin.ts
@@ -3,12 +3,12 @@ import { __DEV__ } from './dev'
 import { attachRegistryToApp, createRegistry } from './registry'
 import { vRegister } from './directive'
 import type { SSRDetectOptions } from './ssr'
-import type { ChemicalXFormsDefaults } from '../types/types-api'
+import type { DecantDefaults } from '../types/types-api'
 
 /**
- * Options for `createChemicalXForms()`.
+ * Options for `createDecant()`.
  */
-export type ChemicalXFormsPluginOptions = SSRDetectOptions & {
+export type DecantPluginOptions = SSRDetectOptions & {
   /**
    * Whether to install the Vue DevTools integration. Default `true`.
    * The DevTools peer dependency is loaded lazily — in production
@@ -19,18 +19,18 @@ export type ChemicalXFormsPluginOptions = SSRDetectOptions & {
   devtools?: boolean
   /**
    * App-level defaults applied to every `useForm` call in this app.
-   * Per-form options always win. See `ChemicalXFormsDefaults` for
+   * Per-form options always win. See `DecantDefaults` for
    * the supported option set and the merge rules.
    *
    * ```ts
    * app.use(
-   *   createChemicalXForms({
+   *   createDecant({
    *     defaults: { debounceMs: 100 },
    *   })
    * )
    * ```
    */
-  defaults?: ChemicalXFormsDefaults
+  defaults?: DecantDefaults
 }
 
 /**
@@ -39,35 +39,35 @@ export type ChemicalXFormsPluginOptions = SSRDetectOptions & {
  *
  * ```ts
  * import { createApp } from 'vue'
- * import { createChemicalXForms } from '@chemical-x/forms'
+ * import { createDecant } from 'decant'
  *
  * createApp(App)
- *   .use(createChemicalXForms())
+ *   .use(createDecant())
  *   .mount('#app')
  * ```
  *
  * Under SSR with bare Vue 3, pass `{ ssr: true }` from your server
- * entry. Under Nuxt, install via `@chemical-x/forms/nuxt` instead —
+ * entry. Under Nuxt, install via `decant/nuxt` instead —
  * the Nuxt module wires both server and client automatically.
  *
  * Installing more than once on the same app is a no-op (the second
  * call logs a dev-mode warning).
  */
-export function createChemicalXForms(options: ChemicalXFormsPluginOptions = {}): Plugin {
+export function createDecant(options: DecantPluginOptions = {}): Plugin {
   const plugin: Plugin = {
     install(app: App) {
-      // Idempotent install: a second `app.use(createChemicalXForms())`
+      // Idempotent install: a second `app.use(createDecant())`
       // (e.g. accidentally registered twice in vite.config + nuxt
       // module, or by a higher-order plugin that installs us alongside
       // a consumer's own install) would otherwise overwrite the
       // existing registry — orphaning every FormStore the previous
-      // instance had built. Detect via the `_chemicalX` slot
+      // instance had built. Detect via the `_decant` slot
       // `attachRegistryToApp` writes; bail with a dev warning so the
       // duplicate is visible during development.
-      if (app._chemicalX !== undefined) {
+      if (app._decant !== undefined) {
         if (__DEV__) {
           console.warn(
-            '[@chemical-x/forms] createChemicalXForms() install was called twice on the same app; ' +
+            '[decant] createDecant() install was called twice on the same app; ' +
               'the second call is a no-op. ' +
               'Likely cause: registering the plugin via both the Nuxt module AND a manual `app.use(...)`.'
           )
@@ -81,8 +81,8 @@ export function createChemicalXForms(options: ChemicalXFormsPluginOptions = {}):
       if (options.devtools !== false && !registry.isSSR) {
         void (async () => {
           try {
-            const { setupChemicalXDevtools } = await import('./devtools')
-            await setupChemicalXDevtools(app, registry)
+            const { setupDecantDevtools } = await import('./devtools')
+            await setupDecantDevtools(app, registry)
           } catch {
             // Missing peer dep / DevTools not attached — silently
             // skip. The form runtime works without DevTools; this is

--- a/src/runtime/core/process-form.ts
+++ b/src/runtime/core/process-form.ts
@@ -139,7 +139,7 @@ export function buildProcessForm<F extends GenericForm>(
     ) {
       warnedNoScopeStores.add(state as FormStore<GenericForm>)
       console.warn(
-        '[@chemical-x/forms] validate() called outside a Vue effect scope; ' +
+        '[decant] validate() called outside a Vue effect scope; ' +
           'its reactive watcher will leak until the form is garbage-collected. ' +
           'Fix: call validate() inside setup() / a child component, ' +
           'or wrap the call in `effectScope().run(...)`.'

--- a/src/runtime/core/register-api.ts
+++ b/src/runtime/core/register-api.ts
@@ -39,10 +39,10 @@ const EMPTY_TRANSFORMS: ReadonlyArray<RegisterTransform> = Object.freeze([])
 
 const INTERACTIVE_TAG_NAMES = new Set(['INPUT', 'SELECT', 'TEXTAREA'])
 
-// `Symbol.for(...)` so duplicate copies of chemical-x agree on the
+// `Symbol.for(...)` so duplicate copies of decant agree on the
 // element-property key for stashed focus/blur handlers — see
 // `assignKey` in core/directive.ts for the same reasoning.
-const cxListenersSymbol: unique symbol = Symbol.for('chemical-x-forms:focus-listeners')
+const cxListenersSymbol: unique symbol = Symbol.for('decant:focus-listeners')
 
 type ElementWithListeners = HTMLElement & {
   [cxListenersSymbol]?: {

--- a/src/runtime/core/registry.ts
+++ b/src/runtime/core/registry.ts
@@ -1,6 +1,6 @@
 import type { App, InjectionKey } from 'vue'
 import { getCurrentInstance, inject, shallowReactive } from 'vue'
-import type { ChemicalXFormsDefaults, FormKey } from '../types/types-api'
+import type { DecantDefaults, FormKey } from '../types/types-api'
 import type { GenericForm } from '../types/types-core'
 import type { FormStore } from './create-form-store'
 import { OutsideSetupError, RegistryNotInstalledError } from './errors'
@@ -8,7 +8,7 @@ import { detectSSR, type SSRDetectOptions } from './ssr'
 
 /**
  * Per-Vue-app container for all form state instances. Each
- * `app.use(createChemicalXForms())` call gets its own registry,
+ * `app.use(createDecant())` call gets its own registry,
  * so the library runs under bare Vue 3 + SSR (via
  * `@vue/server-renderer`) and Nuxt with the same code path.
  *
@@ -20,8 +20,8 @@ import { detectSSR, type SSRDetectOptions } from './ssr'
 
 /**
  * Serialised snapshot of one form's state, captured by
- * `renderChemicalXState` for SSR and replayed by
- * `hydrateChemicalXState` on the client. Round-trips through
+ * `renderDecantState` for SSR and replayed by
+ * `hydrateDecantState` on the client. Round-trips through
  * JSON-safe tuples; field references are intentionally omitted
  * (DOM nodes don't survive serialisation).
  */
@@ -57,28 +57,28 @@ export type SerializedFormData = {
 export type PendingHydration = Map<FormKey, SerializedFormData>
 
 /**
- * The library's per-Vue-app container. One `ChemicalXRegistry` is
- * created per `app.use(createChemicalXForms())` call.
+ * The library's per-Vue-app container. One `DecantRegistry` is
+ * created per `app.use(createDecant())` call.
  *
  * Most consumers never touch this directly — `useForm` and
  * `injectForm` reach the registry on your behalf. Access it
  * explicitly only when wiring SSR or a custom plugin integration.
  */
-export type ChemicalXRegistry = {
+export type DecantRegistry = {
   /**
    * Live forms keyed by `FormKey`.
    * @internal
    */
   readonly forms: Map<FormKey, FormStore<GenericForm>>
   /**
-   * Snapshots staged by `hydrateChemicalXState` waiting to be consumed by the next `useForm` call.
+   * Snapshots staged by `hydrateDecantState` waiting to be consumed by the next `useForm` call.
    * @internal
    */
   readonly pendingHydration: PendingHydration
   /** `true` while running on the server during SSR; `false` on the client. */
   readonly isSSR: boolean
   /** App-level defaults applied to every `useForm` call. */
-  readonly defaults: ChemicalXFormsDefaults
+  readonly defaults: DecantDefaults
   /**
    * Track a consumer of `key`. Returns a dispose function — call it
    * when the consumer unmounts. The form is evicted automatically
@@ -102,18 +102,16 @@ export type ChemicalXRegistry = {
  * `injectForm` resolve the registry automatically.
  */
 // `Symbol.for(...)` so the key survives module duplication. If Vite's
-// dep optimizer ends up serving chemical-x as two separate copies (one
+// dep optimizer ends up serving decant as two separate copies (one
 // live-ESM, one pre-bundled — the standard hazard for linked-source
 // installs that opt into `optimizeDeps.include`), each copy still
 // resolves the same global symbol from the well-known string. Plugin
-// install's `app.provide(kChemicalXRegistry, ...)` and the page's
-// `inject(kChemicalXRegistry, null)` agree on the key, so `useForm`
+// install's `app.provide(kDecantRegistry, ...)` and the page's
+// `inject(kDecantRegistry, null)` agree on the key, so `useForm`
 // finds its registry regardless of which copy did the provide. The
-// `chemical-x-forms:` prefix namespaces the key safely. Same reasoning
+// `decant:` prefix namespaces the key safely. Same reasoning
 // for `kFormContext` and `kFormInstanceId` below.
-export const kChemicalXRegistry: InjectionKey<ChemicalXRegistry> = Symbol.for(
-  'chemical-x-forms:registry'
-)
+export const kDecantRegistry: InjectionKey<DecantRegistry> = Symbol.for('decant:registry')
 
 /**
  * Provides the current form's FormStore to descendants. Installed by
@@ -124,9 +122,7 @@ export const kChemicalXRegistry: InjectionKey<ChemicalXRegistry> = Symbol.for(
  * shape must supply its own `Form` generic, because Vue's InjectionKey
  * erases the generic at the provide/inject boundary.
  */
-export const kFormContext: InjectionKey<FormStore<GenericForm>> = Symbol.for(
-  'chemical-x-forms:form-context'
-)
+export const kFormContext: InjectionKey<FormStore<GenericForm>> = Symbol.for('decant:form-context')
 
 /**
  * Provide / inject key for the per-`useForm()`-call instance ID. Provided
@@ -140,12 +136,12 @@ export const kFormContext: InjectionKey<FormStore<GenericForm>> = Symbol.for(
  * ID; descendants of each branch inherit the branch's ID. Two ID spaces
  * stay isolated even when the underlying FormStore is shared.
  */
-export const kFormInstanceId: InjectionKey<string> = Symbol.for('chemical-x-forms:form-instance-id')
+export const kFormInstanceId: InjectionKey<string> = Symbol.for('decant:form-instance-id')
 
 declare module 'vue' {
   interface App {
     /** @internal */
-    _chemicalX?: ChemicalXRegistry
+    _decant?: DecantRegistry
   }
 }
 
@@ -155,24 +151,24 @@ export type CreateRegistryOptions = SSRDetectOptions & {
    * App-level defaults applied to every `useForm` call. Per-form
    * options always win. Omitted is equivalent to `{}`.
    */
-  defaults?: ChemicalXFormsDefaults
+  defaults?: DecantDefaults
 }
 
 /**
- * Create a fresh `ChemicalXRegistry`. `createChemicalXForms()` calls
+ * Create a fresh `DecantRegistry`. `createDecant()` calls
  * this internally — most consumers never need to call it directly.
  * Use it when building a custom plugin that doesn't want the
- * `createChemicalXForms` plugin's auto-install behaviour (e.g. test
+ * `createDecant` plugin's auto-install behaviour (e.g. test
  * harnesses, embedded apps).
  */
-export function createRegistry(options: CreateRegistryOptions = {}): ChemicalXRegistry {
+export function createRegistry(options: CreateRegistryOptions = {}): DecantRegistry {
   const isSSR = detectSSR(options)
   // Frozen so accidental writes downstream throw in dev. Public surface
-  // (`createChemicalXForms({ defaults })`) treats this as data, not as
+  // (`createDecant({ defaults })`) treats this as data, not as
   // a mutation point — there's no public API to update defaults after
   // install, and adding one would invite race conditions with already-
   // mounted forms.
-  const defaults: ChemicalXFormsDefaults = Object.freeze({ ...(options.defaults ?? {}) })
+  const defaults: DecantDefaults = Object.freeze({ ...(options.defaults ?? {}) })
   // The outer object is plain (it holds references we never rebind); inner
   // Maps are reactive via Vue's collection handlers so per-key reads track
   // per-key. `shallowReactive` avoids Vue's deep Ref-unwrapping, which would
@@ -253,14 +249,14 @@ export function createRegistry(options: CreateRegistryOptions = {}): ChemicalXRe
  *   into setup, or trigger it from a child component.
  * - `RegistryNotInstalledError` when called inside setup but the
  *   plugin wasn't installed. Add
- *   `app.use(createChemicalXForms())` to your app entry.
+ *   `app.use(createDecant())` to your app entry.
  */
-export function useRegistry(): ChemicalXRegistry {
+export function useRegistry(): DecantRegistry {
   const instance = getCurrentInstance()
   if (instance === null) {
     throw new OutsideSetupError()
   }
-  const registry = inject(kChemicalXRegistry, null)
+  const registry = inject(kDecantRegistry, null)
   if (registry === null) {
     throw new RegistryNotInstalledError()
   }
@@ -269,21 +265,21 @@ export function useRegistry(): ChemicalXRegistry {
 
 /**
  * Look up a Vue app's registry by `App` reference. Used by
- * SSR helpers (`renderChemicalXState`, `hydrateChemicalXState`) that
+ * SSR helpers (`renderDecantState`, `hydrateDecantState`) that
  * run outside a component setup context.
  *
  * Throws `RegistryNotInstalledError` when the app hasn't been wired
- * with `createChemicalXForms()`.
+ * with `createDecant()`.
  */
-export function getRegistryFromApp(app: App): ChemicalXRegistry {
-  const registry = app._chemicalX
+export function getRegistryFromApp(app: App): DecantRegistry {
+  const registry = app._decant
   if (registry === undefined) {
     throw new RegistryNotInstalledError()
   }
   return registry
 }
 
-export function attachRegistryToApp(app: App, registry: ChemicalXRegistry): void {
-  app.provide(kChemicalXRegistry, registry)
-  app._chemicalX = registry
+export function attachRegistryToApp(app: App, registry: DecantRegistry): void {
+  app.provide(kDecantRegistry, registry)
+  app._decant = registry
 }

--- a/src/runtime/core/schema-coerce.ts
+++ b/src/runtime/core/schema-coerce.ts
@@ -133,13 +133,13 @@ function indexRules(rules: CoercionRegistry): CoercionIndex {
       typeof (candidate as { transform?: unknown }).transform !== 'function'
     ) {
       if (__DEV__) {
-        console.warn('[@chemical-x/forms] coercion entry missing or invalid `transform` — skipped.')
+        console.warn('[decant] coercion entry missing or invalid `transform` — skipped.')
       }
       continue
     }
     const key = `${entry.input}->${entry.output}` as const
     if (idx.has(key) && __DEV__) {
-      console.warn(`[@chemical-x/forms] duplicate coercion rule for '${key}' — last entry wins.`)
+      console.warn(`[decant] duplicate coercion rule for '${key}' — last entry wins.`)
     }
     idx.set(key, entry)
   }
@@ -250,7 +250,7 @@ function coerceScalar(
   } catch (err) {
     if (__DEV__ && shouldWarnOnce(`${entry.input}->${entry.output}::throw`)) {
       console.warn(
-        `[@chemical-x/forms] coercion '${entry.input}->${entry.output}' threw — write passes through.`,
+        `[decant] coercion '${entry.input}->${entry.output}' threw — write passes through.`,
         err
       )
     }
@@ -264,7 +264,7 @@ function coerceScalar(
   if (returnedKind !== entry.output) {
     if (__DEV__ && shouldWarnOnce(`${entry.input}->${entry.output}::wrong-kind:${returnedKind}`)) {
       console.warn(
-        `[@chemical-x/forms] coercion '${entry.input}->${entry.output}' produced a ${returnedKind} — write passes through.`
+        `[decant] coercion '${entry.input}->${entry.output}' produced a ${returnedKind} — write passes through.`
       )
     }
     return value
@@ -272,7 +272,7 @@ function coerceScalar(
   if (entry.output === 'number' && !Number.isFinite(result.value as number)) {
     if (__DEV__ && shouldWarnOnce(`${entry.input}->${entry.output}::nan`)) {
       console.warn(
-        `[@chemical-x/forms] coercion '${entry.input}->${entry.output}' produced a non-finite number — write passes through.`
+        `[decant] coercion '${entry.input}->${entry.output}' produced a non-finite number — write passes through.`
       )
     }
     return value

--- a/src/runtime/core/serialize-script.ts
+++ b/src/runtime/core/serialize-script.ts
@@ -5,7 +5,7 @@
  * break out of the script tag.
  *
  * ```ts
- * const payload = escapeForInlineScript(JSON.stringify(renderChemicalXState(app)))
+ * const payload = escapeForInlineScript(JSON.stringify(renderDecantState(app)))
  * // `<script>window.__CX_STATE__ = ${payload}</script>` is safe.
  * ```
  *

--- a/src/runtime/core/serialize.ts
+++ b/src/runtime/core/serialize.ts
@@ -4,12 +4,12 @@ import { getRegistryFromApp, type SerializedFormData } from './registry'
 
 /**
  * Serialised snapshot of every form in a Vue app, produced by
- * `renderChemicalXState` and consumed by `hydrateChemicalXState`.
+ * `renderDecantState` and consumed by `hydrateDecantState`.
  *
  * JSON-safe — pass to `JSON.stringify`, `devalue`, or any other
  * serialiser before embedding in your SSR payload.
  */
-export type SerializedChemicalXState = {
+export type SerializedDecantState = {
   /** Tuples of `[formKey, snapshot]` for every form in the app. */
   readonly forms: ReadonlyArray<readonly [FormKey, SerializedFormData]>
 }
@@ -20,10 +20,10 @@ export type SerializedChemicalXState = {
  *
  * ```ts
  * import { renderToString } from '@vue/server-renderer'
- * import { renderChemicalXState, escapeForInlineScript } from '@chemical-x/forms'
+ * import { renderDecantState, escapeForInlineScript } from 'decant'
  *
  * const html = await renderToString(app)
- * const state = renderChemicalXState(app)
+ * const state = renderDecantState(app)
  * const payload = escapeForInlineScript(JSON.stringify(state))
  *
  * return `
@@ -32,11 +32,11 @@ export type SerializedChemicalXState = {
  * `
  * ```
  *
- * Pair with `hydrateChemicalXState` on the client to restore the
+ * Pair with `hydrateDecantState` on the client to restore the
  * forms in their server-rendered state. Nuxt users don't need this —
- * `@chemical-x/forms/nuxt` wires SSR automatically.
+ * `decant/nuxt` wires SSR automatically.
  */
-export function renderChemicalXState(app: App): SerializedChemicalXState {
+export function renderDecantState(app: App): SerializedDecantState {
   const registry = getRegistryFromApp(app)
   const forms: Array<readonly [FormKey, SerializedFormData]> = []
   for (const [key, state] of registry.forms) {
@@ -65,17 +65,17 @@ export function renderChemicalXState(app: App): SerializedChemicalXState {
  *
  * ```ts
  * import { createApp } from 'vue'
- * import { createChemicalXForms, hydrateChemicalXState } from '@chemical-x/forms'
+ * import { createDecant, hydrateDecantState } from 'decant'
  *
- * const app = createApp(App).use(createChemicalXForms())
- * hydrateChemicalXState(app, window.__CX_STATE__)
+ * const app = createApp(App).use(createDecant())
+ * hydrateDecantState(app, window.__CX_STATE__)
  * app.mount('#app')
  * ```
  *
  * The next `useForm({ key })` call for each serialised form picks up
  * the snapshot transparently — no further action is required.
  */
-export function hydrateChemicalXState(app: App, payload: SerializedChemicalXState): void {
+export function hydrateDecantState(app: App, payload: SerializedDecantState): void {
   const registry = getRegistryFromApp(app)
   for (const [key, data] of payload.forms) {
     registry.pendingHydration.set(key, data)

--- a/src/runtime/core/slim-primitive-gate.ts
+++ b/src/runtime/core/slim-primitive-gate.ts
@@ -178,7 +178,7 @@ function reportRejection(
   // enough that they don't deserve top billing.
   if (accepted.size === 0) {
     console.warn(
-      `[@chemical-x/forms] Cannot write to '${dotted}' — this path is not in your schema.\n` +
+      `[decant] Cannot write to '${dotted}' — this path is not in your schema.\n` +
         `  Fix: check for a typo in register('${dotted}'); it should match a leaf key in your schema.\n` +
         `  (If the path resolves to a never-typed schema, it explicitly admits no values — relax the schema if intentional.)\n` +
         `  The write was a no-op.`
@@ -194,7 +194,7 @@ function reportRejection(
   // so the dev can copy-paste rather than parse "slim primitive set".
   if (kind === 'string' && accepted.has('number')) {
     console.warn(
-      `[@chemical-x/forms] Cannot write a string to '${dotted}' — the schema expects ${expected}.\n` +
+      `[decant] Cannot write a string to '${dotted}' — the schema expects ${expected}.\n` +
         `  Fix: add type="number" to the input, OR use the .number modifier on v-register:\n` +
         `    <input type="number" v-register="register('${dotted}')" />\n` +
         `    <input v-register.number="register('${dotted}')" />\n` +
@@ -205,7 +205,7 @@ function reportRejection(
 
   // Generic kind mismatch — no built-in DOM coercion path to suggest.
   console.warn(
-    `[@chemical-x/forms] Cannot write a ${kind} to '${dotted}' — the schema expects ${expected}.\n` +
+    `[decant] Cannot write a ${kind} to '${dotted}' — the schema expects ${expected}.\n` +
       `  The write was a no-op.`
   )
 }

--- a/src/runtime/core/ssr.ts
+++ b/src/runtime/core/ssr.ts
@@ -4,7 +4,7 @@
  * of truth instead of sniffing `import.meta.*` (bundler-specific) at each
  * call site.
  *
- * Consumers can override explicitly via `createChemicalXForms({ ssr: true })`;
+ * Consumers can override explicitly via `createDecant({ ssr: true })`;
  * the default heuristic handles the common Node-vs-browser split without
  * relying on any bundler-injected flag.
  */

--- a/src/runtime/core/unset-walker.ts
+++ b/src/runtime/core/unset-walker.ts
@@ -209,7 +209,7 @@ function warnNonPrimitiveLeaf(segments: Segment[], slim: unknown): void {
   warnedNonPrimitivePaths.add(dotted)
   const slimType = slim === null ? 'null' : slim instanceof Date ? 'Date' : typeof slim
   console.warn(
-    `[@chemical-x/forms] \`unset\` at "${dotted || '<root>'}" is a no-op — ` +
+    `[decant] \`unset\` at "${dotted || '<root>'}" is a no-op — ` +
       `unset only works at primitive leaves (string / number / boolean / bigint, ` +
       `plus their optional / nullable variants), got "${slimType}". ` +
       `The slim default was written but the path is NOT marked blank. ` +

--- a/src/runtime/core/unset.ts
+++ b/src/runtime/core/unset.ts
@@ -43,7 +43,7 @@ export type Unset = typeof _unsetBrand
  * @see {@link isUnset} — type guard that narrows a value back to {@link Unset}.
  * @see `docs/blank.md` — the conceptual model behind blank-aware fields.
  */
-export const unset: Unset = Symbol.for('@chemical-x/forms/unset') as Unset
+export const unset: Unset = Symbol.for('decant/unset') as Unset
 
 /**
  * Type guard — `true` when `value` is the `unset` sentinel.

--- a/src/runtime/core/values-proxy.ts
+++ b/src/runtime/core/values-proxy.ts
@@ -111,16 +111,14 @@ export function buildValuesProxy<F extends GenericForm>(form: Ref<F>): ValuesPro
     set(_, key) {
       if (__DEV__) {
         console.warn(
-          `[@chemical-x/forms] form.values is read-only — write to "${String(key)}" was ignored. Use form.setValue / the directive / field-array helpers instead.`
+          `[decant] form.values is read-only — write to "${String(key)}" was ignored. Use form.setValue / the directive / field-array helpers instead.`
         )
       }
       return true
     },
     deleteProperty(_, key) {
       if (__DEV__) {
-        console.warn(
-          `[@chemical-x/forms] form.values is read-only — delete of "${String(key)}" was ignored.`
-        )
+        console.warn(`[decant] form.values is read-only — delete of "${String(key)}" was ignored.`)
       }
       return true
     },

--- a/src/runtime/lib/core/transforms/input-text-area-transform.ts
+++ b/src/runtime/lib/core/transforms/input-text-area-transform.ts
@@ -187,8 +187,8 @@ function couldResolveToFileType(value: SummarizedProp['value']): boolean {
  * `<textarea v-register>`. Injects the `:value` / `:checked`
  * bindings required for SSR-correct initial render.
  *
- * Wired automatically by `@chemical-x/forms/vite` and
- * `@chemical-x/forms/nuxt`. Use directly only when integrating with
+ * Wired automatically by `decant/vite` and
+ * `decant/nuxt`. Use directly only when integrating with
  * a custom bundler.
  */
 export const inputTextAreaNodeTransform: NodeTransform = (node) => {
@@ -363,6 +363,6 @@ export const inputTextAreaNodeTransform: NodeTransform = (node) => {
     // alone handles value binding (via mounted/beforeUpdate), so the only
     // cost is a one-frame flash on SSR initial render.
 
-    console.error('[@chemical-x/forms] input/textarea transform failed, skipping:', err)
+    console.error('[decant] input/textarea transform failed, skipping:', err)
   }
 }

--- a/src/runtime/lib/core/transforms/select-transform.ts
+++ b/src/runtime/lib/core/transforms/select-transform.ts
@@ -291,8 +291,8 @@ function inferOptionValueFromChildren(node: TemplateChildNode | RootNode): strin
  * `:registerValue` bridge bindings the runtime directive needs to
  * pre-mark selected options at SSR time.
  *
- * Wired automatically by `@chemical-x/forms/vite` and
- * `@chemical-x/forms/nuxt`. Use directly only when integrating with
+ * Wired automatically by `decant/vite` and
+ * `decant/nuxt`. Use directly only when integrating with
  * a custom bundler.
  */
 export const selectNodeTransform: NodeTransform = (node, context) => {
@@ -499,7 +499,7 @@ export const selectNodeTransform: NodeTransform = (node, context) => {
         outputExp = processExpression(simpleExpression, { ...context, prefixIdentifiers: false })
       } catch (err) {
         console.error(
-          '[@chemical-x/forms] select transform: processExpression failed; falling back to the unprocessed expression.',
+          '[decant] select transform: processExpression failed; falling back to the unprocessed expression.',
           err
         )
         outputExp = simpleExpression
@@ -571,6 +571,6 @@ export const selectNodeTransform: NodeTransform = (node, context) => {
       target.splice(0, target.length, ...snapshot)
     }
 
-    console.error('[@chemical-x/forms] select transform failed, skipping:', err)
+    console.error('[decant] select transform failed, skipping:', err)
   }
 }

--- a/src/runtime/lib/core/transforms/v-register-hint-transform.ts
+++ b/src/runtime/lib/core/transforms/v-register-hint-transform.ts
@@ -57,7 +57,7 @@ const HINT_SUFFIX = `)`
  * `getFieldState(path).isConnected` after hydration.
  *
  * Must run after `vRegisterPreambleTransform`. Wired automatically
- * by `@chemical-x/forms/vite` and `@chemical-x/forms/nuxt`.
+ * by `decant/vite` and `decant/nuxt`.
  */
 export const vRegisterHintTransform: NodeTransform = (node) => {
   try {
@@ -74,7 +74,7 @@ export const vRegisterHintTransform: NodeTransform = (node) => {
     // directive: skip this transform entirely. The runtime mark is
     // fail-safe — without the wrapper, we just get the existing
     // false→true flicker on first paint, never an incorrect render.
-    console.error('[@chemical-x/forms] v-register hint transform failed, skipping:', err)
+    console.error('[decant] v-register hint transform failed, skipping:', err)
   }
 }
 

--- a/src/runtime/lib/core/transforms/v-register-preamble-transform.ts
+++ b/src/runtime/lib/core/transforms/v-register-preamble-transform.ts
@@ -94,7 +94,7 @@ const PREAMBLE_ATTR = 'data-cx-pre-mark'
  * correct value during the server's single-pass render.
  *
  * Must run before `vRegisterHintTransform`. Wired automatically
- * by `@chemical-x/forms/vite` and `@chemical-x/forms/nuxt`.
+ * by `decant/vite` and `decant/nuxt`.
  */
 export const vRegisterPreambleTransform: NodeTransform = (node, context) => {
   try {
@@ -159,7 +159,7 @@ export const vRegisterPreambleTransform: NodeTransform = (node, context) => {
     // entirely. The per-element vRegisterHintTransform still covers
     // the common case (read at-or-after the input). Failure here only
     // affects the read-before-input edge.
-    console.error('[@chemical-x/forms] v-register preamble transform failed, skipping:', err)
+    console.error('[decant] v-register preamble transform failed, skipping:', err)
     return
   }
 }

--- a/src/runtime/plugins/decant.ts
+++ b/src/runtime/plugins/decant.ts
@@ -1,5 +1,5 @@
 /**
- * Nuxt plugin: installs the framework-agnostic createChemicalXForms Vue
+ * Nuxt plugin: installs the framework-agnostic createDecant Vue
  * plugin on nuxtApp.vueApp and wires the Nuxt payload mechanism to the
  * registry's SSR serialization helpers. Replaces the old split of
  * register.ts (client-only) + register-stub.ts (server-only).
@@ -9,10 +9,10 @@
  * without a stub.
  */
 import { defineNuxtPlugin, useRuntimeConfig } from 'nuxt/app'
-import { createChemicalXForms } from '../core/plugin'
-import { hydrateChemicalXState, renderChemicalXState } from '../core/serialize'
-import type { SerializedChemicalXState } from '../core/serialize'
-import type { ChemicalXFormsDefaults } from '../types/types-api'
+import { createDecant } from '../core/plugin'
+import { hydrateDecantState, renderDecantState } from '../core/serialize'
+import type { SerializedDecantState } from '../core/serialize'
+import type { DecantDefaults } from '../types/types-api'
 
 export default defineNuxtPlugin({
   // `enforce: 'pre'` makes the "we run before any component's setup" claim
@@ -27,27 +27,25 @@ export default defineNuxtPlugin({
     // Read app-level defaults from the Nuxt module's runtime-config slot
     // (populated in src/nuxt.ts). The module ships in the same package
     // as this plugin, so the slot is always present and well-typed.
-    const { defaults } = (
-      useRuntimeConfig().public as { chemicalX: { defaults: ChemicalXFormsDefaults } }
-    ).chemicalX
+    const { defaults } = (useRuntimeConfig().public as { decant: { defaults: DecantDefaults } })
+      .decant
 
-    nuxtApp.vueApp.use(createChemicalXForms({ override: isServer, defaults }))
+    nuxtApp.vueApp.use(createDecant({ override: isServer, defaults }))
 
     if (isServer) {
       // After the app renders, capture every FormStore into the Nuxt payload
       // so the client can hydrate with matching form values and errors.
       nuxtApp.hook('app:rendered', () => {
-        const state = renderChemicalXState(nuxtApp.vueApp)
-        ;(nuxtApp.payload as unknown as { chemicalX?: SerializedChemicalXState }).chemicalX = state
+        const state = renderDecantState(nuxtApp.vueApp)
+        ;(nuxtApp.payload as unknown as { decant?: SerializedDecantState }).decant = state
       })
     } else {
       // Stage the payload into pendingHydration so `useForm` finds it. The
       // `enforce: 'pre'` + `prepend: true` pair above is what makes it safe
       // to assume this runs before any user setup.
-      const serialized = (nuxtApp.payload as unknown as { chemicalX?: SerializedChemicalXState })
-        .chemicalX
+      const serialized = (nuxtApp.payload as unknown as { decant?: SerializedDecantState }).decant
       if (serialized !== undefined) {
-        hydrateChemicalXState(nuxtApp.vueApp, serialized)
+        hydrateDecantState(nuxtApp.vueApp, serialized)
       }
     }
   },

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -160,7 +160,7 @@ type GetDefaultValuesConfig<Form> = {
  * schema library.
  *
  * Most consumers never touch this type directly — the typed entry
- * points (e.g. `@chemical-x/forms/zod`, `@chemical-x/forms/zod-v3`)
+ * points (e.g. `decant/zod`, `decant/zod-v3`)
  * wire an adapter automatically. Implement this interface only when
  * adding support for a new schema library (Valibot, ArkType, custom).
  */
@@ -705,7 +705,7 @@ export type PersistConfigOptions = {
   storage: FormStorageKind | FormStorage
 
   /**
-   * Storage key namespace. Defaults to `chemical-x-forms:${formKey}`.
+   * Storage key namespace. Defaults to `decant:${formKey}`.
    * Override when you need a custom prefix (e.g. multi-tenant apps
    * where the same form key may exist per-tenant).
    */
@@ -786,7 +786,7 @@ export type UseFormConfiguration<
 > = {
   /**
    * The schema describing the form's shape and validation rules.
-   * Typed entry points like `@chemical-x/forms/zod` accept the
+   * Typed entry points like `decant/zod` accept the
    * underlying library's schema directly and wrap an adapter; the
    * abstract entry point accepts any object implementing
    * `AbstractSchema`.
@@ -947,7 +947,7 @@ export type UseFormConfiguration<
   /**
    * Schema-driven coercion of user-typed DOM values at the v-register
    * directive layer. Per-form override of the plugin-level
-   * `ChemicalXFormsDefaults.coerce`.
+   * `DecantDefaults.coerce`.
    *
    * - `true` / `undefined` — runs the built-in `defaultCoercionRules`.
    * - `false` — disables coercion; the slim gate rejects mismatches.
@@ -964,18 +964,18 @@ export type UseFormConfiguration<
 
 /**
  * App-level defaults applied to every `useForm` call. Set these once
- * per app via `createChemicalXForms({ defaults })` (bare Vue) or
- * `chemicalX.defaults` (Nuxt module).
+ * per app via `createDecant({ defaults })` (bare Vue) or
+ * `decant.defaults` (Nuxt module).
  *
  * Resolution order (per-form wins):
  *
- *   useForm({ ... })  >  createChemicalXForms({ defaults })  >  library default
+ *   useForm({ ... })  >  createDecant({ defaults })  >  library default
  *
  * `validateOn` and `debounceMs` resolve per-field — set the debounce
  * globally while still overriding the trigger per form:
  *
  * ```ts
- * createChemicalXForms({
+ * createDecant({
  *   defaults: { debounceMs: 100 },
  * })
  * // later
@@ -991,7 +991,7 @@ export type UseFormConfiguration<
  * `schema`, `key`, `defaultValues`, and `persist` are not configurable
  * here — they belong on the per-form call.
  */
-export type ChemicalXFormsDefaults = {
+export type DecantDefaults = {
   /** Default for `useForm({ strict })`. Default `true`. */
   strict?: boolean
   /** Default for `useForm({ onInvalidSubmit })`. */
@@ -1672,7 +1672,7 @@ export type RegisterModelDynamicCustomDirective = ObjectDirective<
  *
  * <!-- MyField.vue (root is <label>, not <input>) -->
  * <script setup>
- * import { useRegister } from '@chemical-x/forms'
+ * import { useRegister } from 'decant'
  * defineProps<{ label: string }>()
  * const register = useRegister()
  * </script>
@@ -1692,8 +1692,8 @@ export type RegisterModelDynamicCustomDirective = ObjectDirective<
  * See `RegisterTextModifier` / `RegisterSelectModifier` for
  * per-modifier semantics.
  *
- * Registered globally by `createChemicalXForms()` (and by the
- * `@chemical-x/forms/nuxt` module). Most consumers don't import the
+ * Registered globally by `createDecant()` (and by the
+ * `decant/nuxt` module). Most consumers don't import the
  * directive itself — it's exposed for integrations that install
  * directives manually.
  */

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -1,9 +1,9 @@
 /**
- * `@chemical-x/forms/transforms` — raw node-transform functions for
+ * `decant/transforms` — raw node-transform functions for
  * advanced bundler integrations.
  *
- * The Vite plugin at `@chemical-x/forms/vite` handles @vitejs/plugin-vue
- * automatically; the Nuxt module at `@chemical-x/forms/nuxt` pushes these
+ * The Vite plugin at `decant/vite` handles @vitejs/plugin-vue
+ * automatically; the Nuxt module at `decant/nuxt` pushes these
  * into `nuxt.options.vue.compilerOptions.nodeTransforms` for you.
  *
  * Use this subpath only when rolling your own bundler config (esbuild,
@@ -15,7 +15,7 @@
  *     inputTextAreaNodeTransform,
  *     vRegisterPreambleTransform,
  *     vRegisterHintTransform,
- *   } from '@chemical-x/forms/transforms'
+ *   } from 'decant/transforms'
  *
  * Order matters: `vRegisterPreambleTransform` MUST run before
  * `vRegisterHintTransform`. The preamble's pre-order captures each

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -1,15 +1,15 @@
 /**
- * `@chemical-x/forms/vite` — Vite plugin that registers the compile-time
+ * `decant/vite` — Vite plugin that registers the compile-time
  * node transforms with @vitejs/plugin-vue.
  *
  * Usage (bare Vue 3 consumers):
  *
  *   // vite.config.ts
  *   import vue from '@vitejs/plugin-vue'
- *   import { chemicalXForms } from '@chemical-x/forms/vite'
+ *   import { decant } from 'decant/vite'
  *
  *   export default defineConfig({
- *     plugins: [vue(), chemicalXForms()],
+ *     plugins: [vue(), decant()],
  *   })
  *
  * The transforms inject `:value`, `:checked`, and `:selected` bindings into
@@ -21,7 +21,7 @@
  * Implementation note: this plugin mutates @vitejs/plugin-vue's options via
  * the documented but somewhat informal `api.options` surface used by
  * VueUse, Vite PWA, and other Vue ecosystem plugins. If you're using a
- * custom Vue plugin wrapper, fall back to `@chemical-x/forms/transforms`
+ * custom Vue plugin wrapper, fall back to `decant/transforms`
  * and wire them yourself.
  */
 import type { Plugin } from 'vite'
@@ -30,8 +30,8 @@ import { selectNodeTransform } from './runtime/lib/core/transforms/select-transf
 import { vRegisterHintTransform } from './runtime/lib/core/transforms/v-register-hint-transform'
 import { vRegisterPreambleTransform } from './runtime/lib/core/transforms/v-register-preamble-transform'
 
-/** Options for `chemicalXForms()`. Reserved for future use; pass `{}` or omit. */
-export type ChemicalXVitePluginOptions = Record<string, never>
+/** Options for `decant()`. Reserved for future use; pass `{}` or omit. */
+export type DecantVitePluginOptions = Record<string, never>
 
 interface VitePluginVueApi {
   options?: {
@@ -51,21 +51,21 @@ interface VitePluginVueApi {
  * ```ts
  * // vite.config.ts
  * import vue from '@vitejs/plugin-vue'
- * import { chemicalXForms } from '@chemical-x/forms/vite'
+ * import { decant } from 'decant/vite'
  *
  * export default defineConfig({
- *   plugins: [vue(), chemicalXForms()],
+ *   plugins: [vue(), decant()],
  * })
  * ```
  *
  * Place the call after `vue()` in the plugins array. Nuxt projects
- * don't need this — `@chemical-x/forms/nuxt` handles it.
+ * don't need this — `decant/nuxt` handles it.
  */
-export function chemicalXForms(_options: ChemicalXVitePluginOptions = {}): Plugin {
+export function decant(_options: DecantVitePluginOptions = {}): Plugin {
   // Unused-var suppression until options exist.
   void _options
   return {
-    name: 'chemical-x-forms',
+    name: 'decant',
     enforce: 'pre',
     configResolved(resolved) {
       const vuePlugin = resolved.plugins.find((p) => p.name === 'vite:vue')
@@ -76,14 +76,14 @@ export function chemicalXForms(_options: ChemicalXVitePluginOptions = {}): Plugi
       //      version mismatch with @vitejs/plugin-vue
       if (vuePlugin === undefined) {
         throw new Error(
-          '[@chemical-x/forms/vite] @vitejs/plugin-vue is not installed (or not registered before chemicalXForms()). ' +
-            'Install @vitejs/plugin-vue and place `chemicalXForms()` after `vue()` in your plugins array.'
+          '[decant/vite] @vitejs/plugin-vue is not installed (or not registered before decant()). ' +
+            'Install @vitejs/plugin-vue and place `decant()` after `vue()` in your plugins array.'
         )
       }
       const api = (vuePlugin as unknown as { api?: VitePluginVueApi }).api
       if (api?.options === undefined) {
         throw new Error(
-          '[@chemical-x/forms/vite] Found @vitejs/plugin-vue but it does not expose `api.options`. ' +
+          '[decant/vite] Found @vitejs/plugin-vue but it does not expose `api.options`. ' +
             'This usually means a version-incompatible @vitejs/plugin-vue (or a wrapper plugin re-exporting it). ' +
             'Pin @vitejs/plugin-vue to a version compatible with the documented `api.options.template.compilerOptions.nodeTransforms` surface.'
         )
@@ -91,8 +91,8 @@ export function chemicalXForms(_options: ChemicalXVitePluginOptions = {}): Plugi
       api.options.template ??= {}
       api.options.template.compilerOptions ??= {}
       const existing = api.options.template.compilerOptions.nodeTransforms ?? []
-      // Idempotent install: if a previous chemicalXForms() invocation
-      // (vite + nuxt module + manual `plugins: [chemicalXForms()]`) has
+      // Idempotent install: if a previous decant() invocation
+      // (vite + nuxt module + manual `plugins: [decant()]`) has
       // already pushed our transforms, skip — re-pushing would double
       // every binding the AST emits, breaking the IIFE-wrapping
       // invariants downstream transforms depend on. We detect the

--- a/src/zod-v3.ts
+++ b/src/zod-v3.ts
@@ -1,8 +1,8 @@
 /**
- * `@chemical-x/forms/zod-v3` — Zod v3 adapter.
+ * `decant/zod-v3` — Zod v3 adapter.
  *
  * This subpath is considered legacy; new projects should use
- * `@chemical-x/forms/zod` (v4 adapter) once v4 support lands. The two
+ * `decant/zod` (v4 adapter) once v4 support lands. The two
  * adapters are physically isolated (separate directories, no cross-imports,
  * enforced by ESLint), so v3 can be removed in a future major without
  * touching v4 or the framework-agnostic core.
@@ -13,7 +13,7 @@
  *
  * Usage:
  *
- *   import { useForm } from '@chemical-x/forms/zod-v3'
+ *   import { useForm } from 'decant/zod-v3'
  *   import { z } from 'zod'
  *
  *   const { register, handleSubmit } = useForm({

--- a/src/zod.ts
+++ b/src/zod.ts
@@ -1,12 +1,12 @@
 /**
- * `@chemical-x/forms/zod` — Zod v4 adapter (recommended).
+ * `decant/zod` — Zod v4 adapter (recommended).
  *
  * Requires `zod@^4` in the consumer's project. If you're still on zod@3,
- * import from `@chemical-x/forms/zod-v3` instead.
+ * import from `decant/zod-v3` instead.
  *
  * Usage:
  *
- *   import { useForm } from '@chemical-x/forms/zod'
+ *   import { useForm } from 'decant/zod'
  *   import { z } from 'zod'
  *
  *   const { register, handleSubmit, errors } = useForm({

--- a/test/composables/anonymous-form.test.ts
+++ b/test/composables/anonymous-form.test.ts
@@ -5,7 +5,7 @@ import { renderToString } from '@vue/server-renderer'
 import { useForm, injectForm } from '../../src'
 import { ANONYMOUS_FORM_KEY_PREFIX, RESERVED_KEY_PREFIX } from '../../src/runtime/core/defaults'
 import { ReservedFormKeyError } from '../../src/runtime/core/errors'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 import { fakeSchema } from '../utils/fake-schema'
 
 /**
@@ -52,7 +52,7 @@ describe('anonymous useForm — independent state per setup call', () => {
       },
     })
 
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -89,7 +89,7 @@ describe('anonymous useForm — ambient injectForm access', () => {
       },
     })
 
-    const app = createApp(Parent).use(createChemicalXForms())
+    const app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -135,7 +135,7 @@ describe('anonymous useForm — ambient-overwrite dev warning', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -159,7 +159,7 @@ describe('anonymous useForm — ambient-overwrite dev warning', () => {
         return () => h('div', [h(Child)])
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -190,7 +190,7 @@ describe('anonymous useForm — ambient-overwrite dev warning', () => {
         return () => h('div', [h(Child)])
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -232,7 +232,7 @@ describe('anonymous useForm — ambient-overwrite dev warning', () => {
         return () => h('div', [h(Child)])
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -268,7 +268,7 @@ describe('anonymous useForm — ambient-overwrite dev warning', () => {
         return () => h('div', [h(Child)])
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -293,7 +293,7 @@ describe('anonymous useForm — ambient-overwrite dev warning', () => {
         return () => h('div', [h(Child)])
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -321,7 +321,7 @@ describe('anonymous useForm — ambient-overwrite dev warning', () => {
         return () => h('div', [h(ChildA), h(ChildB)])
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -351,12 +351,12 @@ describe('anonymous useForm — ambient-overwrite dev warning', () => {
     })
 
     const serverApp = createSSRApp(App)
-    serverApp.use(createChemicalXForms({ override: true }))
+    serverApp.use(createDecant({ override: true }))
     await renderToString(serverApp)
 
     expect(warnSpy).not.toHaveBeenCalled()
 
-    const clientApp = createApp(App).use(createChemicalXForms())
+    const clientApp = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     clientApp.mount(root)
@@ -384,7 +384,7 @@ describe('anonymous useForm — SSR determinism', () => {
 
     // Server-side render — useId() draws from Vue's SSR id allocator.
     const serverApp = createSSRApp(App((api) => (serverApi = api)))
-    serverApp.use(createChemicalXForms({ override: true }))
+    serverApp.use(createDecant({ override: true }))
     await renderToString(serverApp)
 
     // Client-side mount of the same tree shape — useId() must match
@@ -392,7 +392,7 @@ describe('anonymous useForm — SSR determinism', () => {
     // entry. We simulate the client by creating a fresh app (new
     // registry, fresh id allocator) and confirming the same position
     // resolves to the same id.
-    const clientApp = createApp(App((api) => (clientApi = api))).use(createChemicalXForms())
+    const clientApp = createApp(App((api) => (clientApi = api))).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     clientApp.mount(root)
@@ -419,7 +419,7 @@ describe('reserved key namespace', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms({ override: true }))
+    const app = createApp(App).use(createDecant({ override: true }))
     // The throw IS the test's signal — vitest captures it via
     // `.toThrow(...)`. Vue still emits a `[Vue warn]: Unhandled error
     // during execution of setup function` to stderr before re-throwing,

--- a/test/composables/app-defaults.test.ts
+++ b/test/composables/app-defaults.test.ts
@@ -4,13 +4,13 @@ import { createApp, defineComponent, h, nextTick, type App } from 'vue'
 import { z } from 'zod'
 import { useForm as useFormV3 } from '../../src/zod-v3'
 import { ANONYMOUS_FORM_KEY_PREFIX } from '../../src/runtime/core/defaults'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 import type { UseFormReturnType } from '../../src/runtime/types/types-api'
 import { useForm } from '../../src/zod'
 import { z as zV3 } from 'zod-v3'
 
 /**
- * App-level defaults: `createChemicalXForms({ defaults: ... })` lets
+ * App-level defaults: `createDecant({ defaults: ... })` lets
  * consumers configure cx-wide preferences once. Per-form options
  * always win.
  *
@@ -35,7 +35,7 @@ type Tight = z.infer<typeof tightSchema>
 type API = ReturnType<typeof useForm<typeof tightSchema>>
 
 function mountWithDefaults(
-  defaults: Parameters<typeof createChemicalXForms>[0] extends infer T
+  defaults: Parameters<typeof createDecant>[0] extends infer T
     ? T extends { defaults?: infer D }
       ? D
       : never
@@ -65,7 +65,7 @@ function mountWithDefaults(
     },
   })
   const app = createApp(App).use(
-    createChemicalXForms({
+    createDecant({
       override: true,
       ...(defaults !== undefined ? { defaults } : {}),
     })
@@ -222,9 +222,7 @@ describe('app-level defaults — anonymous + multi-form', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(
-      createChemicalXForms({ override: true, defaults: { strict: false } })
-    )
+    const app = createApp(App).use(createDecant({ override: true, defaults: { strict: false } }))
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -262,9 +260,7 @@ describe('app-level defaults — v3 wrapper regression', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(
-      createChemicalXForms({ override: true, defaults: { strict: false } })
-    )
+    const app = createApp(App).use(createDecant({ override: true, defaults: { strict: false } }))
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)

--- a/test/composables/async-validation.test.ts
+++ b/test/composables/async-validation.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, nextTick, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 
 /**
  * Phase 5.6 — async validation end-to-end.
@@ -49,7 +49,7 @@ function mountForm(onCreated: (form: ReturnType<typeof useForm<typeof signupSche
       return () => h('div')
     },
   })
-  const app = createApp(App).use(createChemicalXForms({ override: true }))
+  const app = createApp(App).use(createDecant({ override: true }))
   const root = document.createElement('div')
   document.body.appendChild(root)
   app.mount(root)

--- a/test/composables/blank-paths-order-stability.test.ts
+++ b/test/composables/blank-paths-order-stability.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, nextTick, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 import type { UseFormReturnType } from '../../src/runtime/types/types-api'
 
 /**
@@ -39,7 +39,7 @@ function mountForm<Schema extends z.ZodObject>(schema: Schema): { app: App; api:
       return () => h('div')
     },
   })
-  const app = createApp(App).use(createChemicalXForms({ override: true }))
+  const app = createApp(App).use(createDecant({ override: true }))
   app.config.warnHandler = () => {}
   app.config.errorHandler = () => {}
   app.mount(document.createElement('div'))

--- a/test/composables/blank-persistence.test.ts
+++ b/test/composables/blank-persistence.test.ts
@@ -8,7 +8,7 @@ import { CxErrorCode } from '../../src/runtime/core/error-codes'
 import { canonicalizePath } from '../../src/runtime/core/paths'
 import { fingerprintZodSchema } from '../../src/runtime/adapters/zod-v4/fingerprint'
 import { hashStableString } from '../../src/runtime/core/hash'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 
 /**
  * Round-trip coverage for blank across `localStorage`
@@ -106,7 +106,7 @@ describe('persistence — v=2 envelope rejection emits a one-time dev-warn', () 
           ])
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     apps.push(app)
     app.mount(document.createElement('div'))
 
@@ -164,7 +164,7 @@ describe('persistence — blank round-trips across mount', () => {
           )
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     apps.push(app)
     app.mount(document.createElement('div'))
 
@@ -205,7 +205,7 @@ describe('persistence — blank round-trips across mount', () => {
           )
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     apps.push(app)
     app.mount(root)
 
@@ -262,7 +262,7 @@ describe('persistence — blank round-trips across mount', () => {
           )
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     apps.push(app)
     app.mount(document.createElement('div'))
 

--- a/test/composables/checkbox-mid-click.test.ts
+++ b/test/composables/checkbox-mid-click.test.ts
@@ -15,7 +15,7 @@ import { createApp, defineComponent, h, nextTick, withDirectives, type App } fro
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
 import { vRegister } from '../../src/runtime/core/directive'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 
 const schema = z.object({
   items: z.array(z.string()),
@@ -73,7 +73,7 @@ describe('<input type="checkbox" v-register> — sibling re-render mid-click', (
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -158,7 +158,7 @@ describe('<input type="checkbox" v-register> — sibling re-render mid-click', (
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -231,7 +231,7 @@ describe('<input type="checkbox" v-register> — sibling re-render mid-click', (
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)

--- a/test/composables/checkbox.test.ts
+++ b/test/composables/checkbox.test.ts
@@ -4,7 +4,7 @@ import { createApp, defineComponent, h, nextTick, withDirectives, type App } fro
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
 import { vRegister } from '../../src/runtime/core/directive'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 
 /**
  * `<input type="checkbox" v-register>` end-to-end coverage.
@@ -61,7 +61,7 @@ describe('<input type="checkbox" v-register> — single boolean', () => {
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -103,7 +103,7 @@ describe('<input type="checkbox" v-register> — single boolean', () => {
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -146,7 +146,7 @@ describe('<input type="checkbox" v-register> — array group', () => {
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -208,7 +208,7 @@ describe('<input type="checkbox" v-register> — array group', () => {
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -243,7 +243,7 @@ describe('<input type="checkbox" v-register> — array group', () => {
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -282,7 +282,7 @@ describe('<input type="checkbox" v-register> — array group', () => {
         },
       })
 
-      app = createApp(Parent).use(createChemicalXForms())
+      app = createApp(Parent).use(createDecant())
       const root = document.createElement('div')
       document.body.appendChild(root)
       app.mount(root)
@@ -341,7 +341,7 @@ describe('<input type="checkbox" v-register> — Set group', () => {
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -410,7 +410,7 @@ describe('<input type="checkbox" v-register> — :true-value / :false-value', ()
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -458,7 +458,7 @@ describe('checkbox slim-primitive gate interactions', () => {
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -481,7 +481,7 @@ describe('checkbox slim-primitive gate interactions', () => {
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)

--- a/test/composables/coerce.test.ts
+++ b/test/composables/coerce.test.ts
@@ -16,7 +16,7 @@ import { createApp, defineComponent, h, nextTick, withDirectives, type App } fro
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
 import { vRegister, isRegisterValue, assignKey } from '../../src/runtime/core/directive'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 import { defineCoercion, defaultCoercionRules } from '../../src/runtime/core/schema-coerce'
 
 async function flush(): Promise<void> {
@@ -38,7 +38,7 @@ function mount<S extends z.ZodObject>(
   schema: S,
   defaultValues: z.infer<S>,
   body: (api: ReturnType<typeof useForm<S>>) => unknown,
-  pluginOpts?: Parameters<typeof createChemicalXForms>[0]
+  pluginOpts?: Parameters<typeof createDecant>[0]
 ): { api: ReturnType<typeof useForm<S>>; root: HTMLDivElement } {
   const handle: { api?: ReturnType<typeof useForm<S>> } = {}
   const Parent = defineComponent({
@@ -52,7 +52,7 @@ function mount<S extends z.ZodObject>(
       return () => body(api)
     },
   })
-  app = createApp(Parent).use(createChemicalXForms(pluginOpts))
+  app = createApp(Parent).use(createDecant(pluginOpts))
   const root = document.createElement('div')
   document.body.appendChild(root)
   app.mount(root)
@@ -504,7 +504,7 @@ describe('programmatic write bypass', () => {
 })
 
 describe('plugin-default off', () => {
-  it('createChemicalXForms({ defaults: { coerce: false } }) disables coerce globally', async () => {
+  it('createDecant({ defaults: { coerce: false } }) disables coerce globally', async () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {})
     const schema = z.object({ age: z.number() })
     const { api, root } = mount(
@@ -548,7 +548,7 @@ describe('per-form override beats plugin default (both directions)', () => {
           ])
       },
     })
-    app = createApp(Parent).use(createChemicalXForms({ defaults: { coerce: false } }))
+    app = createApp(Parent).use(createDecant({ defaults: { coerce: false } }))
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -581,7 +581,7 @@ describe('per-form override beats plugin default (both directions)', () => {
           ])
       },
     })
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -733,7 +733,7 @@ describe('consumer-extended registry — string->bigint', () => {
           ])
       },
     })
-    app = createApp(Parent).use(createChemicalXForms({ defaults: { coerce: customRules } }))
+    app = createApp(Parent).use(createDecant({ defaults: { coerce: customRules } }))
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)

--- a/test/composables/custom-defaults-e2e.test.ts
+++ b/test/composables/custom-defaults-e2e.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 
 /**
  * End-to-end coverage for explicit `.default(customValue)` flowing
@@ -44,7 +44,7 @@ function harness<S extends z.ZodObject>(
     },
   })
   const app = createApp(Probe)
-  app.use(createChemicalXForms())
+  app.use(createDecant())
   app.mount(document.createElement('div'))
   return { app, form: captured }
 }

--- a/test/composables/derived-blank-errors.test.ts
+++ b/test/composables/derived-blank-errors.test.ts
@@ -5,7 +5,7 @@ import { z } from 'zod'
 import { unset } from '../../src/zod'
 import { useForm } from '../../src/zod'
 import { CxErrorCode } from '../../src/runtime/core/error-codes'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 
 /**
  * Reactive `derivedBlankErrors` contract — `errors = f(schema, state)`.
@@ -45,7 +45,7 @@ function mountNumeric(): { app: App; api: NumericApi } {
       return () => h('div')
     },
   })
-  const app = createApp(App).use(createChemicalXForms({ override: true }))
+  const app = createApp(App).use(createDecant({ override: true }))
   const root = document.createElement('div')
   document.body.appendChild(root)
   app.mount(root)
@@ -140,7 +140,7 @@ describe('derivedBlankErrors — string / boolean leaves do NOT auto-mark', () =
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms({ override: true }))
+    const app = createApp(App).use(createDecant({ override: true }))
     app.mount(document.createElement('div'))
     apps.push(app)
 
@@ -159,7 +159,7 @@ describe('derivedBlankErrors — string / boolean leaves do NOT auto-mark', () =
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms({ override: true }))
+    const app = createApp(App).use(createDecant({ override: true }))
     app.mount(document.createElement('div'))
     apps.push(app)
 
@@ -178,7 +178,7 @@ describe('derivedBlankErrors — string / boolean leaves do NOT auto-mark', () =
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms({ override: true }))
+    const app = createApp(App).use(createDecant({ override: true }))
     app.mount(document.createElement('div'))
     apps.push(app)
 
@@ -213,7 +213,7 @@ describe('derivedBlankErrors — string / boolean leaves do NOT auto-mark', () =
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms({ override: true }))
+    const app = createApp(App).use(createDecant({ override: true }))
     app.mount(document.createElement('div'))
     apps.push(app)
 
@@ -235,7 +235,7 @@ describe('derivedBlankErrors — string / boolean leaves do NOT auto-mark', () =
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms({ override: true }))
+    const app = createApp(App).use(createDecant({ override: true }))
     app.mount(document.createElement('div'))
     apps.push(app)
 
@@ -253,7 +253,7 @@ describe('derivedBlankErrors — string / boolean leaves do NOT auto-mark', () =
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms({ override: true }))
+    const app = createApp(App).use(createDecant({ override: true }))
     app.mount(document.createElement('div'))
     apps.push(app)
 
@@ -282,7 +282,7 @@ describe('derivedBlankErrors — schema modifiers gate the synthesis', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms({ override: true }))
+    const app = createApp(App).use(createDecant({ override: true }))
     app.mount(document.createElement('div'))
     apps.push(app)
 
@@ -300,7 +300,7 @@ describe('derivedBlankErrors — schema modifiers gate the synthesis', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms({ override: true }))
+    const app = createApp(App).use(createDecant({ override: true }))
     app.mount(document.createElement('div'))
     apps.push(app)
 
@@ -318,7 +318,7 @@ describe('derivedBlankErrors — schema modifiers gate the synthesis', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms({ override: true }))
+    const app = createApp(App).use(createDecant({ override: true }))
     app.mount(document.createElement('div'))
     apps.push(app)
 
@@ -341,7 +341,7 @@ describe('derivedBlankErrors — schema modifiers gate the synthesis', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms({ override: true }))
+    const app = createApp(App).use(createDecant({ override: true }))
     app.mount(document.createElement('div'))
     apps.push(app)
 
@@ -410,7 +410,7 @@ describe('derivedBlankErrors — independent of imperative writers', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms({ override: true }))
+    const app = createApp(App).use(createDecant({ override: true }))
     app.mount(document.createElement('div'))
     apps.push(app)
 

--- a/test/composables/discriminated-union-variant-switch.test.ts
+++ b/test/composables/discriminated-union-variant-switch.test.ts
@@ -6,7 +6,7 @@ import { z as zV3 } from 'zod-v3'
 import { useForm } from '../../src/zod'
 import { useForm as useFormV3 } from '../../src/zod-v3'
 import { CxErrorCode } from '../../src/runtime/core/error-codes'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 import type { UseFormReturnType, ValidationError } from '../../src/runtime/types/types-api'
 
 /**
@@ -64,7 +64,7 @@ function mountProfile(): { app: App; api: ProfileApi } {
       return () => h('div')
     },
   })
-  const app = createApp(App).use(createChemicalXForms({ override: true }))
+  const app = createApp(App).use(createDecant({ override: true }))
   app.mount(document.createElement('div'))
   return { app, api: handle.api as ProfileApi }
 }
@@ -254,7 +254,7 @@ describe('discriminated-union variant switch — numeric variant blank auto-mark
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms({ override: true }))
+    const app = createApp(App).use(createDecant({ override: true }))
     app.mount(document.createElement('div'))
     apps.push(app)
     return handle.api as NumericApi
@@ -348,7 +348,7 @@ describe('discriminated-union variant switch — wrapped DU', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms({ override: true }))
+    const app = createApp(App).use(createDecant({ override: true }))
     app.mount(document.createElement('div'))
     apps.push(app)
     const api = handle.api as WrappedApi
@@ -399,7 +399,7 @@ describe('discriminated-union variant switch — DU inside an array', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms({ override: true }))
+    const app = createApp(App).use(createDecant({ override: true }))
     app.mount(document.createElement('div'))
     apps.push(app)
     const api = handle.api as ArrayApi
@@ -442,7 +442,7 @@ describe('discriminated-union variant switch — zod v3 adapter', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms({ override: true }))
+    const app = createApp(App).use(createDecant({ override: true }))
     app.mount(document.createElement('div'))
     apps.push(app)
     return handle.api as V3Api
@@ -510,7 +510,7 @@ function mountProfileWith(options: { rememberVariants?: boolean } = {}): {
       return () => h('div')
     },
   })
-  const app = createApp(App).use(createChemicalXForms({ override: true }))
+  const app = createApp(App).use(createDecant({ override: true }))
   app.mount(document.createElement('div'))
   return { app, api: handle.api as ProfileApi }
 }
@@ -573,7 +573,7 @@ describe('variant memory — round-trip preserves typed data', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms({ override: true }))
+    const app = createApp(App).use(createDecant({ override: true }))
     app.mount(document.createElement('div'))
     apps.push(app)
     const api = handle.api as TriApi
@@ -852,7 +852,7 @@ function mountFlow(): { app: App; api: FlowApi } {
       return () => h('div')
     },
   })
-  const app = createApp(App).use(createChemicalXForms({ override: true }))
+  const app = createApp(App).use(createDecant({ override: true }))
   app.mount(document.createElement('div'))
   return { app, api: handle.api as FlowApi }
 }
@@ -1084,7 +1084,7 @@ describe('variant memory — DU nested inside an array element', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms({ override: true }))
+    const app = createApp(App).use(createDecant({ override: true }))
     app.mount(document.createElement('div'))
     apps.push(app)
     return handle.api as ArrayApi
@@ -1209,7 +1209,7 @@ describe('variant memory — nested DUs (depth 3)', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms({ override: true }))
+    const app = createApp(App).use(createDecant({ override: true }))
     app.mount(document.createElement('div'))
     apps.push(app)
     return handle.api as WizardApi
@@ -1316,7 +1316,7 @@ describe('variant memory — history (undo/redo) interaction', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms({ override: true }))
+    const app = createApp(App).use(createDecant({ override: true }))
     app.mount(document.createElement('div'))
     apps.push(app)
     const api = handle.api as ProfileApi

--- a/test/composables/du-variant-error-flicker.test.ts
+++ b/test/composables/du-variant-error-flicker.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, nextTick, watchEffect, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 import type { UseFormReturnType, ValidationError } from '../../src/runtime/types/types-api'
 
 /**
@@ -62,7 +62,7 @@ function mountWithSnapshotter(): { app: App; api: ProfileApi; snapshots: string[
       return () => h('div')
     },
   })
-  const app = createApp(App).use(createChemicalXForms({ override: true }))
+  const app = createApp(App).use(createDecant({ override: true }))
   app.config.warnHandler = () => {}
   app.config.errorHandler = () => {}
   app.mount(document.createElement('div'))

--- a/test/composables/du-variant-error-regressions.test.ts
+++ b/test/composables/du-variant-error-regressions.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, nextTick, type App } from 'vue'
 import { z } from 'zod'
 import { unset, useForm } from '../../src/zod'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 import type { UseFormReturnType, ValidationError } from '../../src/runtime/types/types-api'
 
 /**
@@ -88,7 +88,7 @@ function mount(
       return () => h('div')
     },
   })
-  const app = createApp(App).use(createChemicalXForms({ override: true }))
+  const app = createApp(App).use(createDecant({ override: true }))
   app.config.warnHandler = (msg: string) => {
     warnings.push(msg)
   }

--- a/test/composables/du-variant-persistence.test.ts
+++ b/test/composables/du-variant-persistence.test.ts
@@ -4,7 +4,7 @@ import { createApp, defineComponent, h, nextTick, withDirectives, type App } fro
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
 import { vRegister } from '../../src/runtime/core/directive'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 import { fingerprintZodSchema } from '../../src/runtime/adapters/zod-v4/fingerprint'
 import { hashStableString } from '../../src/runtime/core/hash'
 import type { UseFormReturnType } from '../../src/runtime/types/types-api'
@@ -148,7 +148,7 @@ function mount(persistKey: string): {
         ])
     },
   })
-  const app = createApp(App).use(createChemicalXForms())
+  const app = createApp(App).use(createDecant())
   app.config.warnHandler = () => {}
   app.config.errorHandler = () => {}
   app.mount(document.createElement('div'))

--- a/test/composables/field-errors-view.test.ts
+++ b/test/composables/field-errors-view.test.ts
@@ -4,7 +4,7 @@ import { createApp, defineComponent, h, nextTick, type App } from 'vue'
 import { useForm } from '../../src/zod'
 import { z } from 'zod'
 import { parseApiErrors } from '../../src/runtime/core/parse-api-errors'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 
 /**
  * `form.errors` is a leaf-aware drillable callable Proxy. At leaf paths
@@ -36,7 +36,7 @@ function mount(): { app: App; api: Api } {
       return () => h('div')
     },
   })
-  const app = createApp(App).use(createChemicalXForms({ override: true }))
+  const app = createApp(App).use(createDecant({ override: true }))
   const root = document.createElement('div')
   document.body.appendChild(root)
   app.mount(root)
@@ -203,7 +203,7 @@ describe('form.errors — reactivity in render scope', () => {
         }
       },
     })
-    const app = createApp(Reader).use(createChemicalXForms({ override: true }))
+    const app = createApp(Reader).use(createDecant({ override: true }))
     apps.push(app)
     const root = document.createElement('div')
     document.body.appendChild(root)

--- a/test/composables/field-state-proxy.test.ts
+++ b/test/composables/field-state-proxy.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, nextTick, watch, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 
 /**
  * `form.fields` — Pinia-style nested reactive proxy. Each path
@@ -49,7 +49,7 @@ function mountForm(): {
       return () => h('div')
     },
   })
-  const app = createApp(App).use(createChemicalXForms())
+  const app = createApp(App).use(createDecant())
   const root = document.createElement('div')
   document.body.appendChild(root)
   app.mount(root)

--- a/test/composables/field-validation.test.ts
+++ b/test/composables/field-validation.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, nextTick, type App } from 'vue'
 import { useForm } from '../../src/zod'
 import { z } from 'zod'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 
 /**
  * Debounced field-level validation.
@@ -45,7 +45,7 @@ function mountWith(options: { validateOn?: 'change' | 'blur' | 'submit'; debounc
       return () => h('div')
     },
   })
-  const app = createApp(App).use(createChemicalXForms({ override: true }))
+  const app = createApp(App).use(createDecant({ override: true }))
   const root = document.createElement('div')
   document.body.appendChild(root)
   app.mount(root)

--- a/test/composables/focus-scroll.test.ts
+++ b/test/composables/focus-scroll.test.ts
@@ -4,7 +4,7 @@ import { createApp, defineComponent, h, nextTick, ref } from 'vue'
 import { useForm } from '../../src'
 import { injectForm } from '../../src/runtime/composables/use-form-context'
 import type { Path } from '../../src/runtime/core/paths'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 import { fakeSchema } from '../utils/fake-schema'
 
 type Form = {
@@ -93,7 +93,7 @@ function mountWith(options: {
     },
   })
 
-  const app = createApp(App).use(createChemicalXForms({ override: true }))
+  const app = createApp(App).use(createDecant({ override: true }))
   const root = document.createElement('div')
   document.body.appendChild(root)
   app.mount(root)
@@ -379,7 +379,7 @@ describe('focusFirstError — shared-key form isolation', () => {
       setup: () => () => h('div', [h(SidebarForm), h(MainForm)]),
     })
 
-    const app = createApp(App).use(createChemicalXForms({ override: true }))
+    const app = createApp(App).use(createDecant({ override: true }))
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -430,7 +430,7 @@ describe('focusFirstError — shared-key form isolation', () => {
     const App = defineComponent({
       setup: () => () => h('div', [h(FormA), h(FormB)]),
     })
-    const app = createApp(App).use(createChemicalXForms({ override: true }))
+    const app = createApp(App).use(createDecant({ override: true }))
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -521,7 +521,7 @@ describe('focusFirstError — sort cache invalidation', () => {
       },
     })
 
-    const app = createApp(App).use(createChemicalXForms({ override: true }))
+    const app = createApp(App).use(createDecant({ override: true }))
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -615,7 +615,7 @@ describe('focusFirstError — instanceId inheritance through injectForm', () => 
       },
     })
 
-    const app = createApp(Parent).use(createChemicalXForms({ override: true }))
+    const app = createApp(Parent).use(createDecant({ override: true }))
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -693,7 +693,7 @@ describe('focusFirstError — instanceId inheritance through injectForm', () => 
       },
     })
 
-    const app = createApp(Grandparent).use(createChemicalXForms({ override: true }))
+    const app = createApp(Grandparent).use(createDecant({ override: true }))
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)

--- a/test/composables/history.test.ts
+++ b/test/composables/history.test.ts
@@ -4,7 +4,7 @@ import { createApp, defineComponent, h, type App } from 'vue'
 import { z } from 'zod'
 import { unset, useForm } from '../../src/zod'
 import { canonicalizePath } from '../../src/runtime/core/paths'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 
 /**
  * Phase 5.9 — undo/redo.
@@ -37,7 +37,7 @@ function mountForm(history: Parameters<typeof useForm<typeof schema>>[0]['histor
       return () => h('div')
     },
   })
-  const app = createApp(App).use(createChemicalXForms())
+  const app = createApp(App).use(createDecant())
   const root = document.createElement('div')
   document.body.appendChild(root)
   app.mount(root)
@@ -193,7 +193,7 @@ describe('history — blankPaths preservation', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)

--- a/test/composables/initial-validation-seed.test.ts
+++ b/test/composables/initial-validation-seed.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, type App } from 'vue'
 import { z } from 'zod'
 import { createFormStore } from '../../src/runtime/core/create-form-store'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 import { canonicalizePath } from '../../src/runtime/core/paths'
 import { useForm } from '../../src/zod'
 import { fakeSchema } from '../utils/fake-schema'
@@ -46,7 +46,7 @@ function mountWithZod(options: { strict?: boolean; defaultValues?: Partial<Tight
       return () => h('div')
     },
   })
-  const app = createApp(App).use(createChemicalXForms({ override: true }))
+  const app = createApp(App).use(createDecant({ override: true }))
   const root = document.createElement('div')
   document.body.appendChild(root)
   app.mount(root)
@@ -88,7 +88,7 @@ describe('initial validation seed — strict mode', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms({ override: true }))
+    const app = createApp(App).use(createDecant({ override: true }))
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -183,7 +183,7 @@ describe('initial validation seed — async-refine schema', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -220,7 +220,7 @@ describe('initial validation seed — async-refine schema', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -258,10 +258,10 @@ describe('initial validation seed — async-refine schema', () => {
         return () => h('div')
       },
     })
-    // Override the registry to SSR mode — `createChemicalXForms({
+    // Override the registry to SSR mode — `createDecant({
     // override: true })` flips `detectSSR` to true, matching what
     // happens during a Nuxt server pass.
-    const app = createApp(App).use(createChemicalXForms({ override: true }))
+    const app = createApp(App).use(createDecant({ override: true }))
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -299,7 +299,7 @@ describe('initial validation seed — async-refine schema', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -339,7 +339,7 @@ describe('initial validation seed — async-refine schema', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)

--- a/test/composables/inject-form.test.ts
+++ b/test/composables/inject-form.test.ts
@@ -4,10 +4,10 @@ import { createApp, defineComponent, h } from 'vue'
 import { useForm } from '../../src'
 import { injectForm } from '../../src/runtime/composables/use-form-context'
 import { ANONYMOUS_FORM_KEY_PREFIX } from '../../src/runtime/core/defaults'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 import { fakeSchema } from '../utils/fake-schema'
 
-const NULL_WARN_MARKER = '[@chemical-x/forms] injectForm'
+const NULL_WARN_MARKER = '[decant] injectForm'
 
 type Form = {
   email: string
@@ -45,7 +45,7 @@ describe('injectForm — ambient provide/inject', () => {
       },
     })
 
-    const app = createApp(Parent).use(createChemicalXForms({ override: true }))
+    const app = createApp(Parent).use(createDecant({ override: true }))
     const root = document.createElement('div')
     app.mount(root)
 
@@ -79,7 +79,7 @@ describe('injectForm — ambient provide/inject', () => {
       },
     })
 
-    const app = createApp(Parent).use(createChemicalXForms({ override: true }))
+    const app = createApp(Parent).use(createDecant({ override: true }))
     app.mount(document.createElement('div'))
     expect(shared.parent).toBeDefined()
     expect(shared.parent?.startsWith(ANONYMOUS_FORM_KEY_PREFIX)).toBe(true)
@@ -114,7 +114,7 @@ describe('injectForm — ambient provide/inject', () => {
       // warnMiss in use-form-context.ts). JSDOM has `window`, so the
       // default detectSSR resolves to false and the warn fires as
       // intended for client-side coverage.
-      const app = createApp(Child).use(createChemicalXForms())
+      const app = createApp(Child).use(createDecant())
       app.mount(document.createElement('div'))
       expect(captured).toBeNull()
       const calls = matchingWarnCalls()
@@ -141,7 +141,7 @@ describe('injectForm — ambient provide/inject', () => {
           return () => h(Child)
         },
       })
-      const app = createApp(Parent).use(createChemicalXForms())
+      const app = createApp(Parent).use(createDecant())
       app.mount(document.createElement('div'))
       expect(captured).toBeNull()
       const calls = matchingWarnCalls()
@@ -158,7 +158,7 @@ describe('injectForm — ambient provide/inject', () => {
           return () => h('div')
         },
       })
-      const app = createApp(Orphan).use(createChemicalXForms())
+      const app = createApp(Orphan).use(createDecant())
       app.mount(document.createElement('div'))
       expect(captured).toBeNull()
       const calls = matchingWarnCalls()
@@ -172,7 +172,7 @@ describe('injectForm — ambient provide/inject', () => {
     // The warn embeds a `(<path>:<line>)` user call-site frame via
     // `captureUserCallSite()`. We don't unit-test that here: the
     // capture's regex deliberately skips any frame matching
-    // `/chemical-x[/-]forms?/i`, which includes this very test file
+    // `/decant[/-]forms?/i`, which includes this very test file
     // — there's no "user frame" outside the lib workspace to attach.
     // End-to-end verification lives in the cubic-forms spike, where
     // the warn renders as e.g. `(.../SpikeCxChild.vue:19)`.
@@ -197,7 +197,7 @@ describe('injectForm — ambient provide/inject', () => {
         return () => h(Child)
       },
     })
-    const app = createApp(Parent).use(createChemicalXForms({ override: true }))
+    const app = createApp(Parent).use(createDecant({ override: true }))
     app.mount(document.createElement('div'))
     expect(shared.childKey).toBeDefined()
     expect(shared.childKey?.startsWith(ANONYMOUS_FORM_KEY_PREFIX)).toBe(true)
@@ -238,7 +238,7 @@ describe('injectForm — ambient provide/inject', () => {
       },
     })
 
-    const app = createApp(Grandparent).use(createChemicalXForms({ override: true }))
+    const app = createApp(Grandparent).use(createDecant({ override: true }))
     app.mount(document.createElement('div'))
 
     // Grandchild resolves to the PARENT (closer), not the grandparent.
@@ -294,7 +294,7 @@ describe('injectForm — ambient provide/inject', () => {
       },
     })
 
-    const app = createApp(Grandparent).use(createChemicalXForms({ override: true }))
+    const app = createApp(Grandparent).use(createDecant({ override: true }))
     app.mount(document.createElement('div'))
 
     expect(shared.grandparent).toBeDefined()
@@ -351,7 +351,7 @@ describe('injectForm — ambient provide/inject', () => {
       setup: () => () => h('div', [h(LeftBranch), h(RightBranch)]),
     })
 
-    const app = createApp(Root).use(createChemicalXForms({ override: true }))
+    const app = createApp(Root).use(createDecant({ override: true }))
     app.mount(document.createElement('div'))
 
     expect(shared.leftParent?.key).not.toBe(shared.rightParent?.key)
@@ -393,7 +393,7 @@ describe('injectForm — explicit key resolution', () => {
       },
     })
 
-    const app = createApp(Root).use(createChemicalXForms({ override: true }))
+    const app = createApp(Root).use(createDecant({ override: true }))
     app.mount(document.createElement('div'))
 
     expect(shared.sibling).toBeDefined()
@@ -415,7 +415,7 @@ describe('injectForm — explicit key resolution', () => {
         return () => h('div')
       },
     })
-    const app = createApp(Orphan).use(createChemicalXForms())
+    const app = createApp(Orphan).use(createDecant())
     app.mount(document.createElement('div'))
     expect(captured).toBeNull()
     const matching = warnSpy.mock.calls.filter((args: readonly unknown[]) =>
@@ -452,16 +452,16 @@ describe('injectForm — consumer ref-counting', () => {
       },
     })
 
-    const app = createApp(Parent).use(createChemicalXForms({ override: true }))
+    const app = createApp(Parent).use(createDecant({ override: true }))
     const root = document.createElement('div')
     app.mount(root)
 
     // While mounted: the form is in the registry.
-    const registryApp = app as unknown as { _chemicalX: { forms: Map<string, unknown> } }
-    expect(registryApp._chemicalX.forms.has('lifetime-form')).toBe(true)
+    const registryApp = app as unknown as { _decant: { forms: Map<string, unknown> } }
+    expect(registryApp._decant.forms.has('lifetime-form')).toBe(true)
 
     app.unmount()
     // After unmount: eviction has run.
-    expect(registryApp._chemicalX.forms.has('lifetime-form')).toBe(false)
+    expect(registryApp._decant.forms.has('lifetime-form')).toBe(false)
   })
 })

--- a/test/composables/meta-errors-order-stability.test.ts
+++ b/test/composables/meta-errors-order-stability.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, nextTick, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 import type { UseFormReturnType } from '../../src/runtime/types/types-api'
 
 /**
@@ -49,7 +49,7 @@ function mountForm<Schema extends z.ZodObject>(
       return () => h('div')
     },
   })
-  const app = createApp(App).use(createChemicalXForms({ override: true }))
+  const app = createApp(App).use(createDecant({ override: true }))
   app.config.warnHandler = () => {}
   app.config.errorHandler = () => {}
   app.mount(document.createElement('div'))

--- a/test/composables/multi-select-cmd-click.test.ts
+++ b/test/composables/multi-select-cmd-click.test.ts
@@ -18,7 +18,7 @@ import { createApp, defineComponent, h, nextTick, withDirectives, type App } fro
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
 import { vRegister } from '../../src/runtime/core/directive'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 
 const schema = z.object({
   colors: z.array(z.string()),
@@ -78,7 +78,7 @@ describe('<select multiple v-register> — Cmd+click adds selection', () => {
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -190,7 +190,7 @@ describe('<select multiple v-register> — Cmd+click adds selection', () => {
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)

--- a/test/composables/multi-select-hydration.test.ts
+++ b/test/composables/multi-select-hydration.test.ts
@@ -16,7 +16,7 @@ import { renderToString } from '@vue/server-renderer'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
 import { vRegister } from '../../src/runtime/core/directive'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 
 const schema = z.object({ colors: z.array(z.string()) })
 
@@ -58,7 +58,7 @@ describe('<select multiple v-register> — SSR + hydration', () => {
   })
 
   it('SSR HTML output for the select', async () => {
-    const ssrApp = createSSRApp(Parent).use(createChemicalXForms({ override: true }))
+    const ssrApp = createSSRApp(Parent).use(createDecant({ override: true }))
     const html = await renderToString(ssrApp)
     // Surface the SSR HTML so we can see what attributes (if any) the
     // server emits on options. The user's browser snapshot showed
@@ -72,7 +72,7 @@ describe('<select multiple v-register> — SSR + hydration', () => {
 
   it('after hydration, red and blue options have selected=true on the IDL property', async () => {
     // SSR pass.
-    const ssrApp = createSSRApp(Parent).use(createChemicalXForms({ override: true }))
+    const ssrApp = createSSRApp(Parent).use(createDecant({ override: true }))
     const html = await renderToString(ssrApp)
 
     // Plant the SSR HTML in the document so the client can hydrate it.
@@ -93,7 +93,7 @@ describe('<select multiple v-register> — SSR + hydration', () => {
 
     // Client hydration. createSSRApp + mount on the populated container
     // performs hydration (vs createApp + mount which does a fresh render).
-    app = createSSRApp(Parent).use(createChemicalXForms())
+    app = createSSRApp(Parent).use(createDecant())
     app.mount(root)
     await flush()
 

--- a/test/composables/persist-hydration-validate.test.ts
+++ b/test/composables/persist-hydration-validate.test.ts
@@ -4,7 +4,7 @@ import { createApp, defineComponent, h, nextTick, type App } from 'vue'
 import { z } from 'zod'
 import { fingerprintZodSchema } from '../../src/runtime/adapters/zod-v4/fingerprint'
 import { hashStableString } from '../../src/runtime/core/hash'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 import { useForm } from '../../src/zod'
 
 /**
@@ -125,7 +125,7 @@ function mountAsyncForm(persistKey: string, strict: boolean = true): { app: App;
       return () => h('div')
     },
   })
-  const app = createApp(App).use(createChemicalXForms())
+  const app = createApp(App).use(createDecant())
   const root = document.createElement('div')
   document.body.appendChild(root)
   app.mount(root)
@@ -148,7 +148,7 @@ function mountSyncForm(persistKey: string): { app: App; api: SyncApi } {
       return () => h('div')
     },
   })
-  const app = createApp(App).use(createChemicalXForms())
+  const app = createApp(App).use(createDecant())
   const root = document.createElement('div')
   document.body.appendChild(root)
   app.mount(root)

--- a/test/composables/persistence.test.ts
+++ b/test/composables/persistence.test.ts
@@ -7,7 +7,7 @@ import { useForm } from '../../src/zod'
 import { vRegister } from '../../src/runtime/core/directive'
 import { AnonPersistError } from '../../src/runtime/core/errors'
 import { __resetIndexedDbForTests } from '../../src/runtime/core/persistence/indexeddb'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 import { fingerprintZodSchema } from '../../src/runtime/adapters/zod-v4/fingerprint'
 import { hashStableString } from '../../src/runtime/core/hash'
 
@@ -152,7 +152,7 @@ function mountForm(persist: Parameters<typeof useForm<typeof schema>>[0]['persis
         ])
     },
   })
-  const app = createApp(App).use(createChemicalXForms())
+  const app = createApp(App).use(createDecant())
   const root = document.createElement('div')
   document.body.appendChild(root)
   app.mount(root)
@@ -345,9 +345,9 @@ describe('persistence — non-opted-in blank paths survive hydration', () => {
     })
     const customFp = hashStableString(fingerprintZodSchema(customSchema))
     // Default `resolveStorageKeyBase`: `${PERSISTENCE_KEY_PREFIX}${formKey}`,
-    // and PERSISTENCE_KEY_PREFIX is 'chemical-x-forms:'. Then the full
+    // and PERSISTENCE_KEY_PREFIX is 'decant:'. Then the full
     // storage key appends `:${hashedFingerprint}`.
-    const customKey = `chemical-x-forms:test-non-optin-tep:${customFp}`
+    const customKey = `decant:test-non-optin-tep:${customFp}`
 
     // Pre-seed sessionStorage with a payload representing the state
     // after a user typed into the opted-in email field.
@@ -389,7 +389,7 @@ describe('persistence — non-opted-in blank paths survive hydration', () => {
           ])
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -491,7 +491,7 @@ describe('persistence — anonymous useForm() rejects persist (dev throw)', () =
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     apps.push(app)
     const root = document.createElement('div')
     document.body.appendChild(root)
@@ -686,7 +686,7 @@ describe('persistence — per-element opt-in', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -727,7 +727,7 @@ describe('persistence — per-element opt-in', () => {
           ])
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -781,7 +781,7 @@ describe('persistence — per-element opt-in', () => {
           ])
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -840,7 +840,7 @@ describe('persistence — sensitive-name heuristic', () => {
           ])
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     let captured: unknown
     app.config.errorHandler = (err): void => {
       captured = err
@@ -876,7 +876,7 @@ describe('persistence — sensitive-name heuristic', () => {
           ])
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     let captured: unknown
     app.config.errorHandler = (err): void => {
       captured = err
@@ -900,7 +900,7 @@ describe('persistence — sensitive-name heuristic', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -921,7 +921,7 @@ describe('persistence — sensitive-name heuristic', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -965,7 +965,7 @@ describe('persistence — form.persist / form.clearPersistedDraft', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -998,7 +998,7 @@ describe('persistence — form.persist / form.clearPersistedDraft', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -1033,7 +1033,7 @@ describe('persistence — form.persist / form.clearPersistedDraft', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -1061,7 +1061,7 @@ describe('persistence — form.persist / form.clearPersistedDraft', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -1141,7 +1141,7 @@ describe('persistence — reset wipes the persisted draft', () => {
           ])
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -1201,7 +1201,7 @@ describe('persistence — reset wipes the persisted draft', () => {
           return () => h('div')
         },
       })
-      const app = createApp(App).use(createChemicalXForms())
+      const app = createApp(App).use(createDecant())
       const root = document.createElement('div')
       document.body.appendChild(root)
       // Construct-time should NOT throw.
@@ -1210,7 +1210,7 @@ describe('persistence — reset wipes the persisted draft', () => {
       await drain()
       const warnCalls = warnSpy.mock.calls.map((args) => args.join(' '))
       const errorCalls = errorSpy.mock.calls.map((args) => args.join(' '))
-      const cxNoise = [...warnCalls, ...errorCalls].filter((m) => m.includes('[@chemical-x/forms]'))
+      const cxNoise = [...warnCalls, ...errorCalls].filter((m) => m.includes('[decant]'))
       expect(cxNoise).toEqual([])
     } finally {
       warnSpy.mockRestore()
@@ -1234,7 +1234,7 @@ describe('persistence — reset wipes the persisted draft', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
 
@@ -1267,7 +1267,7 @@ describe('persistence — reset wipes the persisted draft', () => {
           )
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
 
@@ -1348,7 +1348,7 @@ describe('persistence — shorthand config', () => {
   })
 
   it("persist: 'local' (string shorthand) writes to localStorage with default key", async () => {
-    // The default key is `chemical-x-forms:${formKey}` — mountForm
+    // The default key is `decant:${formKey}` — mountForm
     // generates a unique formKey, so the resolved storage key is unique
     // per test and we read back via the same scheme.
     const handle: { api?: ApiReturn; el?: HTMLInputElement } = {}
@@ -1372,7 +1372,7 @@ describe('persistence — shorthand config', () => {
           )
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -1382,7 +1382,7 @@ describe('persistence — shorthand config', () => {
     el.value = 'shorthand@example.com'
     el.dispatchEvent(new Event('input', { bubbles: true }))
     // Default debounceMs is 300 — allow 600 ms for the timer + adapter chain.
-    const expectedKey = `chemical-x-forms:${formKey}:${FP}`
+    const expectedKey = `decant:${formKey}:${FP}`
     const raw = await waitUntil(() => localStorage.getItem(expectedKey), 1000)
     expect(raw).not.toBeNull()
     const payload = JSON.parse(raw as string) as { v: number; data: { form: { email: string } } }
@@ -1423,7 +1423,7 @@ describe('persistence — shorthand config', () => {
           )
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -1434,7 +1434,7 @@ describe('persistence — shorthand config', () => {
     await waitUntil(() => (writes.length > 0 ? true : null), 1000)
     expect(writes.length).toBeGreaterThan(0)
     const [writtenKey, writtenValue] = writes[writes.length - 1]!
-    expect(writtenKey).toBe(`chemical-x-forms:${formKey}:${FP}`)
+    expect(writtenKey).toBe(`decant:${formKey}:${FP}`)
     const payload = writtenValue as { data: { form: { email: string } } }
     expect(payload.data.form.email).toBe('custom@example.com')
   })
@@ -1475,7 +1475,7 @@ describe('persistence — cross-store cleanup at mount', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -1536,7 +1536,7 @@ describe('persistence — cross-store cleanup at mount', () => {
     // The shorthand is normalised to { storage: 'local' } before the
     // sweep — same code path, same behaviour.
     const formKey = `shorthand-cleanup-${Math.random().toString(36).slice(2)}`
-    const expectedStorageKey = `chemical-x-forms:${formKey}`
+    const expectedStorageKey = `decant:${formKey}`
     sessionStorage.setItem(expectedStorageKey, JSON.stringify({ stale: 'session' }))
     const App = defineComponent({
       setup() {
@@ -1544,7 +1544,7 @@ describe('persistence — cross-store cleanup at mount', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -1572,7 +1572,7 @@ describe('persistence — cross-store cleanup at mount', () => {
     // The "I disabled persistence in this deployment" scenario.
     //
     // Deployment N had `useForm({ key: 'signup', persist: 'local' })` and
-    // wrote an entry under `chemical-x-forms:signup`. Deployment N+1
+    // wrote an entry under `decant:signup`. Deployment N+1
     // removed the `persist:` option entirely (compliance pivot,
     // simplification, whatever) but kept the same form `key`. On next
     // mount, the orphaned entry from deployment N must be wiped from
@@ -1583,7 +1583,7 @@ describe('persistence — cross-store cleanup at mount', () => {
     // This test simulates that gap directly: pre-seed a stale entry,
     // mount with NO persist option, expect the entry gone.
     const formKey = 'persist-removed'
-    const expectedStorageKey = `chemical-x-forms:${formKey}`
+    const expectedStorageKey = `decant:${formKey}`
     localStorage.setItem(
       expectedStorageKey,
       JSON.stringify({ v: 4, data: { form: { email: 'old@x.com' } } })
@@ -1603,7 +1603,7 @@ describe('persistence — cross-store cleanup at mount', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -1806,8 +1806,8 @@ describe('persistence — dispose race (B1)', () => {
     // Use the registry from app1 (any of them works — both share the
     // create-app pattern but have separate registries; we drain each
     // by calling its registry's shutdown).
-    const registry1 = app1._chemicalX
-    const registry2 = app2._chemicalX
+    const registry1 = app1._decant
+    const registry2 = app2._decant
     expect(registry1).toBeDefined()
     expect(registry2).toBeDefined()
     await Promise.all([registry1?.shutdown(), registry2?.shutdown()])

--- a/test/composables/radio-mid-click.test.ts
+++ b/test/composables/radio-mid-click.test.ts
@@ -14,7 +14,7 @@ import { createApp, defineComponent, h, nextTick, withDirectives, type App } fro
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
 import { vRegister } from '../../src/runtime/core/directive'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 
 const schema = z.object({
   flavor: z.string(),
@@ -69,7 +69,7 @@ describe('<input type="radio" v-register> — sibling re-render mid-click', () =
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -149,7 +149,7 @@ describe('<input type="radio" v-register> — sibling re-render mid-click', () =
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -217,7 +217,7 @@ describe('<input type="radio" v-register> — sibling re-render mid-click', () =
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)

--- a/test/composables/radio.test.ts
+++ b/test/composables/radio.test.ts
@@ -4,7 +4,7 @@ import { createApp, defineComponent, h, nextTick, withDirectives, type App } fro
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
 import { vRegister } from '../../src/runtime/core/directive'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 
 /**
  * `<input type="radio" v-register>` end-to-end coverage.
@@ -71,7 +71,7 @@ describe('<input type="radio" v-register> — single-group selection', () => {
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -135,7 +135,7 @@ describe('<input type="radio" v-register> — single-group selection', () => {
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -183,7 +183,7 @@ describe('<input type="radio" v-register> — single-group selection', () => {
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -231,7 +231,7 @@ describe('<input type="radio" v-register> — single-group selection', () => {
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -289,7 +289,7 @@ describe('<input type="radio" v-register> — hydration with static value attrib
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -342,7 +342,7 @@ describe('<input type="radio" v-register> — slim-gate interactions', () => {
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -372,7 +372,7 @@ describe('<input type="radio" v-register> — slim-gate interactions', () => {
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)

--- a/test/composables/schema-errors-edge-cases.test.ts
+++ b/test/composables/schema-errors-edge-cases.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, nextTick, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 import type { UseFormReturnType, ValidationError } from '../../src/runtime/types/types-api'
 
 /**
@@ -47,7 +47,7 @@ function mountForm<Schema extends z.ZodObject>(
       return () => h('div')
     },
   })
-  const app = createApp(App).use(createChemicalXForms({ override: true }))
+  const app = createApp(App).use(createDecant({ override: true }))
   app.config.warnHandler = () => {}
   app.config.errorHandler = () => {}
   app.mount(document.createElement('div'))

--- a/test/composables/schema-fingerprint-warning.test.ts
+++ b/test/composables/schema-fingerprint-warning.test.ts
@@ -4,7 +4,7 @@ import { createApp, defineComponent, h } from 'vue'
 import { z } from 'zod'
 import { useForm as useZodForm } from '../../src/zod'
 import { useForm } from '../../src'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 import { fakeSchema } from '../utils/fake-schema'
 
 /**
@@ -63,7 +63,7 @@ describe('schema-fingerprint shared-key warning', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -131,7 +131,7 @@ describe('schema-fingerprint shared-key warning', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)

--- a/test/composables/select-out-of-enum.test.ts
+++ b/test/composables/select-out-of-enum.test.ts
@@ -4,7 +4,7 @@ import { createApp, defineComponent, h, nextTick, withDirectives, type App } fro
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
 import { vRegister } from '../../src/runtime/core/directive'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 
 /**
  * `<select v-register>` against a `z.enum(...)` schema with an
@@ -71,7 +71,7 @@ describe('<select v-register> with out-of-enum option', () => {
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -109,7 +109,7 @@ describe('<select v-register> with out-of-enum option', () => {
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -151,7 +151,7 @@ describe('<select v-register> with out-of-enum option', () => {
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)

--- a/test/composables/set-value-schema-fill-regression.test.ts
+++ b/test/composables/set-value-schema-fill-regression.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 
 /**
  * Regression spec: every write through setValue must leave the form
@@ -60,7 +60,7 @@ function harness(initialPeople: Form['people']) {
     },
   })
   const app = createApp(Probe)
-  app.use(createChemicalXForms())
+  app.use(createDecant())
   app.mount(document.createElement('div'))
   return { app, form: captured }
 }
@@ -225,7 +225,7 @@ function profileHarness(initial: Partial<ProfileForm['user']>) {
     },
   })
   const app = createApp(Probe)
-  app.use(createChemicalXForms())
+  app.use(createDecant())
   app.mount(document.createElement('div'))
   return { app, form: captured }
 }
@@ -320,7 +320,7 @@ function addressHarness(initialPeople: AddressForm['address']['people']) {
     },
   })
   const app = createApp(Probe)
-  app.use(createChemicalXForms())
+  app.use(createDecant())
   app.mount(document.createElement('div'))
   return { app, form: captured }
 }
@@ -408,7 +408,7 @@ function cascadeHarness() {
     },
   })
   const app = createApp(Probe)
-  app.use(createChemicalXForms())
+  app.use(createDecant())
   app.mount(document.createElement('div'))
   return { app, form: captured }
 }
@@ -528,7 +528,7 @@ function tupleHarness(initial: TupleForm['coords']) {
     },
   })
   const app = createApp(Probe)
-  app.use(createChemicalXForms())
+  app.use(createDecant())
   app.mount(document.createElement('div'))
   return { app, form: captured }
 }

--- a/test/composables/slim-primitive-defaults.test.ts
+++ b/test/composables/slim-primitive-defaults.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, nextTick, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 
 /**
  * `useForm({ defaultValues })` aligns with the runtime write contract:
@@ -53,7 +53,7 @@ function mountWith<S extends z.ZodObject>(
       return () => h('div')
     },
   })
-  const app = createApp(App).use(createChemicalXForms())
+  const app = createApp(App).use(createDecant())
   const root = document.createElement('div')
   document.body.appendChild(root)
   app.mount(root)

--- a/test/composables/spike-modifier-bugs.test.ts
+++ b/test/composables/spike-modifier-bugs.test.ts
@@ -5,7 +5,7 @@ import { createApp, defineComponent, nextTick, type App } from 'vue'
 import * as VueRuntime from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 import { inputTextAreaNodeTransform } from '../../src/runtime/lib/core/transforms/input-text-area-transform'
 import { selectNodeTransform } from '../../src/runtime/lib/core/transforms/select-transform'
 import { vRegisterHintTransform } from '../../src/runtime/lib/core/transforms/v-register-hint-transform'
@@ -94,7 +94,7 @@ describe('regression: 16b — `<input v-register.trim>` spacebar after content',
     })
 
     app = createApp(App)
-    app.use(createChemicalXForms({ override: false }))
+    app.use(createDecant({ override: false }))
     app.mount(root)
     await flush()
 
@@ -143,7 +143,7 @@ describe('regression: 16b — `<input v-register.trim>` spacebar after content',
     })
 
     app = createApp(App)
-    app.use(createChemicalXForms({ override: false }))
+    app.use(createDecant({ override: false }))
     app.mount(root)
     await flush()
 
@@ -198,7 +198,7 @@ describe('regression: 16e — `<input type="number">` backspace-to-empty', () =>
     })
 
     app = createApp(App)
-    app.use(createChemicalXForms({ override: false }))
+    app.use(createDecant({ override: false }))
     app.mount(root)
     await flush()
 

--- a/test/composables/spike-no-debounce.test.ts
+++ b/test/composables/spike-no-debounce.test.ts
@@ -17,7 +17,7 @@ import { createApp, defineComponent, h, nextTick, withDirectives, type App } fro
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
 import { vRegister } from '../../src/runtime/core/directive'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 
 let app: App | undefined
 afterEach(() => {
@@ -72,7 +72,7 @@ describe('spike — debounceMs: 0 disables the debounce timer', () => {
           ])
       },
     })
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -111,7 +111,7 @@ describe('spike — debounceMs: 0 disables the debounce timer', () => {
           ])
       },
     })
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -147,7 +147,7 @@ describe('spike — debounceMs: 0 disables the debounce timer', () => {
           ])
       },
     })
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -234,7 +234,7 @@ describe('spike — persist.debounceMs: 0 writes immediately on every form chang
           ])
       },
     })
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -284,7 +284,7 @@ describe('spike — persist.debounceMs: 0 writes immediately on every form chang
           ])
       },
     })
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)

--- a/test/composables/surface-proxy.test.ts
+++ b/test/composables/surface-proxy.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, type App } from 'vue'
 import { z } from 'zod'
 import { unset, useForm } from '../../src/zod'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 
 /**
  * Coverage for the leaf-aware drillable callable Proxy machinery
@@ -36,7 +36,7 @@ function mount<Schema extends z.ZodObject>(
       return () => h('div')
     },
   })
-  const app = createApp(App).use(createChemicalXForms({ override: true }))
+  const app = createApp(App).use(createDecant({ override: true }))
   const root = document.createElement('div')
   document.body.appendChild(root)
   app.mount(root)

--- a/test/composables/transform-clamp-dom-sync.test.ts
+++ b/test/composables/transform-clamp-dom-sync.test.ts
@@ -27,7 +27,7 @@ import { createApp, defineComponent, h, nextTick, withDirectives, type App } fro
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
 import { vRegister } from '../../src/runtime/core/directive'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 
 async function flush(): Promise<void> {
   for (let i = 0; i < 6; i++) {
@@ -70,7 +70,7 @@ describe('spike 18c — `<input type="number">` + clamp transform DOM/storage pa
           ])
       },
     })
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -125,7 +125,7 @@ describe('spike 18c — `<input type="number">` + clamp transform DOM/storage pa
           ])
       },
     })
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -168,7 +168,7 @@ describe('spike 18c — `<input type="number">` + clamp transform DOM/storage pa
           ])
       },
     })
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)

--- a/test/composables/transform-no-op-write-dom-sync.test.ts
+++ b/test/composables/transform-no-op-write-dom-sync.test.ts
@@ -15,7 +15,7 @@ import { createApp, defineComponent, h, nextTick, withDirectives, type App } fro
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
 import { vRegister } from '../../src/runtime/core/directive'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 
 async function flush(): Promise<void> {
   for (let i = 0; i < 6; i++) {
@@ -59,7 +59,7 @@ describe('no-op-write DOM-sync bug class — probes for non-text directives', ()
           ])
       },
     })
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -106,7 +106,7 @@ describe('no-op-write DOM-sync bug class — probes for non-text directives', ()
           ])
       },
     })
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)

--- a/test/composables/transforms-all-elements.test.ts
+++ b/test/composables/transforms-all-elements.test.ts
@@ -11,7 +11,7 @@ import { createApp, defineComponent, h, nextTick, withDirectives, type App } fro
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
 import { vRegister } from '../../src/runtime/core/directive'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 
 async function flush(): Promise<void> {
   for (let i = 0; i < 4; i++) {
@@ -84,7 +84,7 @@ describe('register({ transforms }) — applies to all four element variants', ()
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)

--- a/test/composables/transforms-prod-log.test.ts
+++ b/test/composables/transforms-prod-log.test.ts
@@ -22,7 +22,7 @@ import { createApp, defineComponent, h, nextTick, withDirectives, type App } fro
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
 import { vRegister } from '../../src/runtime/core/directive'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 
 async function flush(): Promise<void> {
   for (let i = 0; i < 4; i++) {
@@ -63,7 +63,7 @@ describe('register({ transforms }) — prod log shape (information-leak guard)',
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -112,7 +112,7 @@ describe('register({ transforms }) — prod log shape (information-leak guard)',
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)

--- a/test/composables/use-abstract-form.test.ts
+++ b/test/composables/use-abstract-form.test.ts
@@ -4,7 +4,7 @@ import { createApp, createSSRApp, defineComponent, h, nextTick, ref } from 'vue'
 import { renderToString } from '@vue/server-renderer'
 import { useForm } from '../../src'
 import { ANONYMOUS_FORM_KEY_PREFIX } from '../../src/runtime/core/defaults'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 import { injectForm } from '../../src/runtime/composables/use-form-context'
 import { fakeSchema } from '../utils/fake-schema'
 
@@ -37,7 +37,7 @@ function mountWith(config: { keyValue?: unknown; provideKey: boolean }): Promise
       },
     })
     const app = createSSRApp(App)
-    app.use(createChemicalXForms({ override: true }))
+    app.use(createDecant({ override: true }))
     void renderToString(app)
   })
 }
@@ -112,7 +112,7 @@ describe('useForm — key is captured once at setup', () => {
       },
     })
     const app = createApp(App)
-    app.use(createChemicalXForms({ override: false }))
+    app.use(createDecant({ override: false }))
     app.mount(root)
 
     if (captured === undefined) throw new Error('unreachable')
@@ -156,7 +156,7 @@ describe('useForm — key is captured once at setup', () => {
     })
 
     const app = createApp(Owner)
-    app.use(createChemicalXForms({ override: false }))
+    app.use(createDecant({ override: false }))
     app.mount(root)
 
     // The owner's useForm bound to 'form-original'.
@@ -201,7 +201,7 @@ describe('useForm — key is captured once at setup', () => {
     })
 
     const app = createApp(Parent)
-    app.use(createChemicalXForms({ override: false }))
+    app.use(createDecant({ override: false }))
     app.mount(root)
 
     expect(apiHistory).toEqual([{ key: 'form-a' }])

--- a/test/composables/use-form-v3-forwarding.test.ts
+++ b/test/composables/use-form-v3-forwarding.test.ts
@@ -4,7 +4,7 @@ import { createApp, defineComponent, h, nextTick, withDirectives, type App } fro
 import { z } from 'zod-v3'
 import type { FormStorage, UseFormReturnType } from '../../src/runtime/types/types-api'
 import { vRegister } from '../../src/runtime/core/directive'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 import { useForm } from '../../src/zod-v3'
 import { fingerprintZodSchema } from '../../src/runtime/adapters/zod-v3/fingerprint'
 import { hashStableString } from '../../src/runtime/core/hash'
@@ -34,7 +34,7 @@ function mount(options: AnyUseFormOptions): { app: App; api: ApiReturn } {
       return () => h('div')
     },
   })
-  const app = createApp(App).use(createChemicalXForms())
+  const app = createApp(App).use(createDecant())
   const root = document.createElement('div')
   document.body.appendChild(root)
   app.mount(root)
@@ -118,7 +118,7 @@ describe('v3 useForm forwards opt-in options to useAbstractForm', () => {
           ])
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -137,7 +137,7 @@ describe('v3 useForm forwards opt-in options to useAbstractForm', () => {
     expect(setItem).toHaveBeenCalled()
     const [key, payload] = setItem.mock.calls[0] ?? []
     const fp = hashStableString(fingerprintZodSchema(schema))
-    expect(key).toBe(`chemical-x-forms:v3-persist:${fp}`)
+    expect(key).toBe(`decant:v3-persist:${fp}`)
     expect(payload).toMatchObject({
       v: 4,
       data: { form: { email: 'alice@example.com' } },

--- a/test/composables/use-register-template.test.ts
+++ b/test/composables/use-register-template.test.ts
@@ -7,7 +7,7 @@ import { z } from 'zod'
 import { useForm } from '../../src/zod'
 import { useRegister } from '../../src/runtime/composables/use-register'
 import { vRegister } from '../../src/runtime/core/directive'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 import { inputTextAreaNodeTransform } from '../../src/runtime/lib/core/transforms/input-text-area-transform'
 import { selectNodeTransform } from '../../src/runtime/lib/core/transforms/select-transform'
 import { vRegisterHintTransform } from '../../src/runtime/lib/core/transforms/v-register-hint-transform'
@@ -32,7 +32,7 @@ import { vRegisterPreambleTransform } from '../../src/runtime/lib/core/transform
  *   4. vRegisterHintTransform — hints / dev-warns
  *
  * The directive itself is registered globally by
- * `createChemicalXForms()` (the app plugin), matching what consumer
+ * `createDecant()` (the app plugin), matching what consumer
  * apps do.
  */
 
@@ -83,7 +83,7 @@ describe('useRegister — template-compiled v-register reaches inner input', () 
     // Child SFC equivalent: <label><input v-register="register" /></label>.
     // After compilation, the `v-register` directive on the inner input
     // is resolved against the globally-registered `register` directive
-    // (see createChemicalXForms()). The render function reads
+    // (see createDecant()). The render function reads
     // `register` from setup return.
     const Child = defineComponent({
       name: 'Child',
@@ -112,7 +112,7 @@ describe('useRegister — template-compiled v-register reaches inner input', () 
       render: compileTemplateToRender(`<Child v-register="form.register('email')" />`),
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -165,7 +165,7 @@ describe('useRegister — template-compiled v-register reaches inner input', () 
       render: compileTemplateToRender(`<Child v-register="form.register('email')" />`),
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -193,7 +193,7 @@ describe('useRegister — template-compiled v-register reaches inner input', () 
   // started silently no-op'ing.
   it('the globally-registered v-register directive is the same vRegister this lib exports', () => {
     const probe = createApp({ render: () => null })
-    probe.use(createChemicalXForms())
+    probe.use(createDecant())
     expect(probe._context.directives['register']).toBe(vRegister)
   })
 })

--- a/test/composables/use-register.test.ts
+++ b/test/composables/use-register.test.ts
@@ -5,7 +5,7 @@ import { z } from 'zod'
 import { useForm } from '../../src/zod'
 import { useRegister } from '../../src/runtime/composables/use-register'
 import { vRegister } from '../../src/runtime/core/directive'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 
 /**
  * Unit tests for the `useRegister()` composable. The composable's
@@ -100,7 +100,7 @@ describe('useRegister — inside child setup', () => {
       warnings.push(args.map((a) => String(a)).join(' '))
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -137,7 +137,7 @@ describe('useRegister — inside child setup', () => {
       warnings.push(args.map((a) => String(a)).join(' '))
     })
 
-    app = createApp(defineComponent({ render: () => h(Child) })).use(createChemicalXForms())
+    app = createApp(defineComponent({ render: () => h(Child) })).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -196,7 +196,7 @@ describe('useRegister — inside child setup', () => {
       warnings.push(args.map((a) => String(a)).join(' '))
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -243,7 +243,7 @@ describe('useRegister — inside child setup', () => {
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -281,7 +281,7 @@ describe('useRegister — inside child setup', () => {
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -357,7 +357,7 @@ describe('useRegister — sentinel suppresses parent-directive warn', () => {
       warnings.push(args.map((a) => String(a)).join(' '))
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -405,7 +405,7 @@ describe('useRegister — sentinel suppresses parent-directive warn', () => {
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -468,7 +468,7 @@ describe('useRegister — inner v-register receives full directive lifecycle', (
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -534,7 +534,7 @@ describe('useRegister — strips bridge keys from attrs (no inheritAttrs needed)
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -576,7 +576,7 @@ describe('useRegister — strips bridge keys from attrs (no inheritAttrs needed)
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -619,7 +619,7 @@ describe('useRegister — strips bridge keys from attrs (no inheritAttrs needed)
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)

--- a/test/composables/v-register-component-runtime.test.ts
+++ b/test/composables/v-register-component-runtime.test.ts
@@ -4,7 +4,7 @@ import { createApp, defineComponent, h, nextTick, ref, withDirectives, type App 
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
 import { assignKey, vRegister } from '../../src/runtime/core/directive'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 import { useRegister } from '../../src/runtime/composables/use-register'
 import type { RegisterValue } from '../../src/runtime/types/types-api'
 
@@ -95,7 +95,7 @@ async function mountWithChild(
     },
   })
 
-  const app = createApp(Parent).use(createChemicalXForms())
+  const app = createApp(Parent).use(createDecant())
   const root = document.createElement('div')
   document.body.appendChild(root)
   app.mount(root)
@@ -344,7 +344,7 @@ describe('pattern 4: v-register on a non-form root WITH assignKey (kept-current 
       },
     })
 
-    const app = createApp(Parent).use(createChemicalXForms())
+    const app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -471,7 +471,7 @@ describe('pattern 3: @update:registerValue prop on a component', () => {
           )
       },
     })
-    const localApp = createApp(Parent).use(createChemicalXForms())
+    const localApp = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     localApp.mount(root)
@@ -662,7 +662,7 @@ describe('register({ transforms: [...] }) — sync user-input pipeline', () => {
           ])
       },
     })
-    const localApp = createApp(Parent).use(createChemicalXForms())
+    const localApp = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     localApp.mount(root)
@@ -707,7 +707,7 @@ describe('register({ transforms: [...] }) — sync user-input pipeline', () => {
           ])
       },
     })
-    const localApp = createApp(Parent).use(createChemicalXForms())
+    const localApp = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     localApp.mount(root)
@@ -773,7 +773,7 @@ describe('v-register="undefined" is a graceful no-op (invariant 4)', () => {
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -829,7 +829,7 @@ describe('v-register="undefined" is a graceful no-op (invariant 4)', () => {
       },
     })
 
-    app = createApp(Parent).use(createChemicalXForms())
+    app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -974,7 +974,7 @@ describe("multi-root component — directive lands on Vue's placeholder ⚠", ()
       },
     })
 
-    const app = createApp(Parent).use(createChemicalXForms())
+    const app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -1012,7 +1012,7 @@ describe('component re-render with prop change does NOT leak listeners (works �
           withDirectives(h(ChildInput, { hint: hint.value, registerValue: rv }), [[vRegister, rv]])
       },
     })
-    const app = createApp(Parent).use(createChemicalXForms())
+    const app = createApp(Parent).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)

--- a/test/composables/values-proxy.test.ts
+++ b/test/composables/values-proxy.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, isReactive, isReadonly, isRef, nextTick, watch } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 
 /**
  * `form.values` — Pinia-style reactive readonly proxy over the form
@@ -51,7 +51,7 @@ function mountForm(): {
       return () => h('div')
     },
   })
-  const app = createApp(App).use(createChemicalXForms())
+  const app = createApp(App).use(createDecant())
   const root = document.createElement('div')
   document.body.appendChild(root)
   app.mount(root)

--- a/test/core/directive-modifiers.test.ts
+++ b/test/core/directive-modifiers.test.ts
@@ -13,7 +13,7 @@ import type { RegisterValue } from '../../src/runtime/types/types-api'
  * Modifier coverage for `v-register` (`.lazy`, `.trim`, `.number`).
  * The runtime is ported from Vue's `vModelText` / `vModelSelect`;
  * Vue tests its own modifier semantics in its own suite, but the
- * port has additional chemical-x guards (`shouldBailListener`, the
+ * port has additional decant guards (`shouldBailListener`, the
  * slim-primitive gate, value-swap migration) that intersect with
  * the modifier paths and need direct coverage here.
  *
@@ -735,10 +735,10 @@ describe('vRegisterText.beforeUpdate — escape hatches under focus', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────
-// chemical-x-specific interactions
+// decant-specific interactions
 // ─────────────────────────────────────────────────────────────────
 
-describe('chemical-x interactions: `.number` × slim-primitive gate', () => {
+describe('decant interactions: `.number` × slim-primitive gate', () => {
   beforeEach(() => {
     document.body.innerHTML = ''
   })
@@ -769,7 +769,7 @@ describe('chemical-x interactions: `.number` × slim-primitive gate', () => {
   })
 })
 
-describe('chemical-x interactions: `.lazy` × value-swap', () => {
+describe('decant interactions: `.lazy` × value-swap', () => {
   beforeEach(() => {
     document.body.innerHTML = ''
   })

--- a/test/core/errors.test.ts
+++ b/test/core/errors.test.ts
@@ -48,9 +48,9 @@ describe('error classes', () => {
   })
 
   describe('RegistryNotInstalledError', () => {
-    it('has a helpful default message pointing at createChemicalXForms', () => {
+    it('has a helpful default message pointing at createDecant', () => {
       const err = new RegistryNotInstalledError()
-      expect(err.message).toContain('createChemicalXForms')
+      expect(err.message).toContain('createDecant')
       expect(err.name).toBe('RegistryNotInstalledError')
     })
   })

--- a/test/core/plugin.test.ts
+++ b/test/core/plugin.test.ts
@@ -1,19 +1,19 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi } from 'vitest'
 import { createApp } from 'vue'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 import { getRegistryFromApp } from '../../src/runtime/core/registry'
 
-describe('createChemicalXForms', () => {
+describe('createDecant', () => {
   it('installs a registry on the Vue app', () => {
     const app = createApp({ render: () => null })
-    app.use(createChemicalXForms())
+    app.use(createDecant())
     expect(getRegistryFromApp(app)).toBeDefined()
   })
 
   it('registers the v-register directive on the app', () => {
     const app = createApp({ render: () => null })
-    app.use(createChemicalXForms())
+    app.use(createDecant())
     // Vue exposes directive lookup via app._context.directives (stable internal).
     // Mount a throwaway root so _context is populated.
     const host = document.createElement('div')
@@ -33,38 +33,38 @@ describe('createChemicalXForms', () => {
 
   it('passes the ssr option through to the registry', () => {
     const app = createApp({ render: () => null })
-    app.use(createChemicalXForms({ override: true }))
+    app.use(createDecant({ override: true }))
     expect(getRegistryFromApp(app).isSSR).toBe(true)
   })
 
   it('multiple apps in the same process get independent registries', () => {
     // Bare Vue + SSR ships one module across many requests. This test proves
-    // that `createChemicalXForms()` does not rely on module-scoped state.
+    // that `createDecant()` does not rely on module-scoped state.
     const a = createApp({ render: () => null })
     const b = createApp({ render: () => null })
-    a.use(createChemicalXForms())
-    b.use(createChemicalXForms())
+    a.use(createDecant())
+    b.use(createDecant())
     expect(getRegistryFromApp(a)).not.toBe(getRegistryFromApp(b))
   })
 
   // D1 — installing twice on the same app is a no-op (idempotent).
-  // Pre-fix, the second install overwrote `app._chemicalX`, orphaning
+  // Pre-fix, the second install overwrote `app._decant`, orphaning
   // every form the first registry had built.
   it('a second install on the same app is a no-op and warns in dev', () => {
     const app = createApp({ render: () => null })
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     try {
-      app.use(createChemicalXForms())
+      app.use(createDecant())
       const firstRegistry = getRegistryFromApp(app)
       // Second install with a fresh factory call (Vue's Plugin dedupe
       // only catches identical plugin objects).
-      app.use(createChemicalXForms())
+      app.use(createDecant())
       const secondRegistry = getRegistryFromApp(app)
       // Same registry — no overwrite.
       expect(secondRegistry).toBe(firstRegistry)
       // Single dev warning fired.
       const matched = warnSpy.mock.calls.filter((c: unknown[]) =>
-        String(c[0]).includes('createChemicalXForms() install was called twice')
+        String(c[0]).includes('createDecant() install was called twice')
       )
       expect(matched.length).toBe(1)
     } finally {

--- a/test/core/registry.test.ts
+++ b/test/core/registry.test.ts
@@ -45,7 +45,7 @@ describe('useRegistry', () => {
 
   it('throws RegistryNotInstalledError when called inside setup but no plugin attached', () => {
     // Inside setup, `getCurrentInstance()` resolves — but the `inject`
-    // for `kChemicalXRegistry` returns null because `app.use(...)` was
+    // for `kDecantRegistry` returns null because `app.use(...)` was
     // never called. Different cause, different fix from the case above.
     let captured: unknown
     const Probe = defineComponent({
@@ -96,7 +96,7 @@ describe('useRegistry', () => {
 })
 
 describe('getRegistryFromApp / attachRegistryToApp', () => {
-  it('round-trips via the app._chemicalX escape hatch', () => {
+  it('round-trips via the app._decant escape hatch', () => {
     const registry = createRegistry()
     const app = createApp({ render: () => null })
     attachRegistryToApp(app, registry)

--- a/test/core/serialize.test.ts
+++ b/test/core/serialize.test.ts
@@ -3,16 +3,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp } from 'vue'
 import { createFormStore } from '../../src/runtime/core/create-form-store'
 import { canonicalizePath } from '../../src/runtime/core/paths'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 import { getRegistryFromApp, type SerializedFormData } from '../../src/runtime/core/registry'
-import { hydrateChemicalXState, renderChemicalXState } from '../../src/runtime/core/serialize'
+import { hydrateDecantState, renderDecantState } from '../../src/runtime/core/serialize'
 import { fakeSchema } from '../utils/fake-schema'
 
 type Signup = { email: string; password: string }
 
 function seedServerApp(formKey: string, initialEmail: string) {
   const app = createApp({ render: () => null })
-  app.use(createChemicalXForms({ override: true }))
+  app.use(createDecant({ override: true }))
   const registry = getRegistryFromApp(app)
   const state = createFormStore<Signup>({
     formKey,
@@ -22,7 +22,7 @@ function seedServerApp(formKey: string, initialEmail: string) {
   return { app, state }
 }
 
-describe('renderChemicalXState', () => {
+describe('renderDecantState', () => {
   it('extracts form data and source-segregated errors for every registered form', () => {
     const { app, state } = seedServerApp('signup', 'a@a')
     // Schema validation populates the schema-error store directly via
@@ -35,7 +35,7 @@ describe('renderChemicalXState', () => {
     state.setAllUserErrors([
       { message: 'banned-domain', path: ['email'], formKey: 'signup', code: 'api:validation' },
     ])
-    const payload = renderChemicalXState(app)
+    const payload = renderDecantState(app)
     expect(payload.forms).toHaveLength(1)
     const entry = payload.forms[0]
     expect(entry).toBeDefined()
@@ -49,7 +49,7 @@ describe('renderChemicalXState', () => {
 
   it('does not include originals or elements in the payload', () => {
     const { app } = seedServerApp('x', 'y')
-    const payload = renderChemicalXState(app)
+    const payload = renderDecantState(app)
     const firstEntry = payload.forms[0]
     expect(firstEntry).toBeDefined()
     if (firstEntry === undefined) return
@@ -63,9 +63,9 @@ describe('renderChemicalXState', () => {
 
   it('is round-trippable through JSON.stringify', () => {
     const { app } = seedServerApp('rt', 'z@z')
-    const payload = renderChemicalXState(app)
+    const payload = renderDecantState(app)
     const serialised = JSON.stringify(payload)
-    const restored = JSON.parse(serialised) as ReturnType<typeof renderChemicalXState>
+    const restored = JSON.parse(serialised) as ReturnType<typeof renderDecantState>
     expect(restored.forms).toHaveLength(1)
     const entry = restored.forms[0]
     expect(entry).toBeDefined()
@@ -76,15 +76,15 @@ describe('renderChemicalXState', () => {
   })
 })
 
-describe('hydrateChemicalXState', () => {
+describe('hydrateDecantState', () => {
   it('stages entries into pendingHydration for later consumption', () => {
     const { app } = seedServerApp('stage', 'a@a')
-    const payload = renderChemicalXState(app)
+    const payload = renderDecantState(app)
 
     // Simulate the client: fresh app, same plugin, then hydrate.
     const clientApp = createApp({ render: () => null })
-    clientApp.use(createChemicalXForms())
-    hydrateChemicalXState(clientApp, payload)
+    clientApp.use(createDecant())
+    hydrateDecantState(clientApp, payload)
     const registry = getRegistryFromApp(clientApp)
     expect(registry.pendingHydration.has('stage')).toBe(true)
   })
@@ -92,11 +92,11 @@ describe('hydrateChemicalXState', () => {
   it('reconstructs an equivalent FormStore when the client creates a form with hydration', () => {
     const { app, state } = seedServerApp('rt2', 'server@x')
     state.setValueAtPath(['email'], 'server-edited@x')
-    const payload = renderChemicalXState(app)
+    const payload = renderDecantState(app)
 
     const clientApp = createApp({ render: () => null })
-    clientApp.use(createChemicalXForms())
-    hydrateChemicalXState(clientApp, payload)
+    clientApp.use(createDecant())
+    hydrateDecantState(clientApp, payload)
     const clientRegistry = getRegistryFromApp(clientApp)
 
     const pending = clientRegistry.pendingHydration.get('rt2')

--- a/test/core/unset.test.ts
+++ b/test/core/unset.test.ts
@@ -4,7 +4,7 @@ import { isUnset, unset } from '../../src/runtime/core/unset'
 describe('unset symbol', () => {
   it('is a registry-keyed symbol so cross-realm equality holds', () => {
     expect(typeof unset).toBe('symbol')
-    expect(unset).toBe(Symbol.for('@chemical-x/forms/unset'))
+    expect(unset).toBe(Symbol.for('decant/unset'))
   })
 
   it('is a stable reference — two reads return the same value', () => {

--- a/test/devtools/plugin.test.ts
+++ b/test/devtools/plugin.test.ts
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, type App } from 'vue'
 import { z } from 'zod'
-import { setupChemicalXDevtools } from '../../src/runtime/core/devtools'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { setupDecantDevtools } from '../../src/runtime/core/devtools'
+import { createDecant } from '../../src/runtime/core/plugin'
 import { createRegistry, attachRegistryToApp } from '../../src/runtime/core/registry'
 import { useForm } from '../../src/zod'
 
@@ -125,13 +125,13 @@ describe('DevTools plugin — inspector + timeline wiring', () => {
     const app = createApp(defineComponent({ setup: () => () => h('div') }))
     const registry = createRegistry({})
     attachRegistryToApp(app, registry)
-    const ok = await setupChemicalXDevtools(app, registry)
+    const ok = await setupDecantDevtools(app, registry)
     expect(ok).toBe(true)
     expect(currentMock.api!.addInspector).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'chemical-x-forms' })
+      expect.objectContaining({ id: 'decant' })
     )
     expect(currentMock.api!.addTimelineLayer).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'chemical-x-forms:events' })
+      expect.objectContaining({ id: 'decant:events' })
     )
   })
 
@@ -150,10 +150,10 @@ describe('DevTools plugin — inspector + timeline wiring', () => {
     })
     registry.forms.set('dev-tree', state)
 
-    await setupChemicalXDevtools(regApp, registry)
+    await setupDecantDevtools(regApp, registry)
 
     const payload = {
-      inspectorId: 'chemical-x-forms',
+      inspectorId: 'decant',
       filter: '',
       rootNodes: [] as Array<{ id: string; label: string }>,
     }
@@ -177,7 +177,7 @@ describe('DevTools plugin — inspector + timeline wiring', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms({ devtools: false }))
+    const app = createApp(App).use(createDecant({ devtools: false }))
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -186,7 +186,7 @@ describe('DevTools plugin — inspector + timeline wiring', () => {
     // Register the devtools against the app's own registry.
     const { getRegistryFromApp } = await import('../../src/runtime/core/registry')
     const registry = getRegistryFromApp(app)
-    await setupChemicalXDevtools(app, registry)
+    await setupDecantDevtools(app, registry)
     // Drain microtasks so the devtools subscriber has subscribed.
     await Promise.resolve()
     await Promise.resolve()
@@ -233,10 +233,10 @@ describe('DevTools plugin — sensitive-name redaction (B5)', () => {
     })
     registry.forms.set('redact-form', state)
 
-    await setupChemicalXDevtools(regApp, registry)
+    await setupDecantDevtools(regApp, registry)
 
     const payload = {
-      inspectorId: 'chemical-x-forms',
+      inspectorId: 'decant',
       nodeId: 'form:redact-form',
       state: {} as Record<string, Array<{ key: string; value: unknown; editable?: boolean }>>,
     }
@@ -266,7 +266,7 @@ describe('DevTools plugin — sensitive-name redaction (B5)', () => {
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms({ devtools: false }))
+    const app = createApp(App).use(createDecant({ devtools: false }))
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)
@@ -274,7 +274,7 @@ describe('DevTools plugin — sensitive-name redaction (B5)', () => {
 
     const { getRegistryFromApp } = await import('../../src/runtime/core/registry')
     const registry = getRegistryFromApp(app)
-    await setupChemicalXDevtools(app, registry)
+    await setupDecantDevtools(app, registry)
     await Promise.resolve()
 
     handle.api!.setValue('password', 'super-secret')
@@ -303,10 +303,10 @@ describe('DevTools plugin — sensitive-name redaction (B5)', () => {
     state.applyFormReplacement({ password: 'original' })
     registry.forms.set('edit-block', state)
 
-    await setupChemicalXDevtools(regApp, registry)
+    await setupDecantDevtools(regApp, registry)
 
     currentMock.api!._handlers.editInspectorState!({
-      inspectorId: 'chemical-x-forms',
+      inspectorId: 'decant',
       nodeId: 'form:edit-block',
       // path = ['Form value', 'form', 'password']
       path: ['Form value', 'form', 'password'],

--- a/test/packaging/vite-plugin.test.ts
+++ b/test/packaging/vite-plugin.test.ts
@@ -1,12 +1,12 @@
 import vue from '@vitejs/plugin-vue'
 import { describe, expect, it } from 'vitest'
 import { resolveConfig, type Plugin, type ResolvedConfig } from 'vite'
-import { chemicalXForms } from '../../src/vite'
+import { decant } from '../../src/vite'
 import { inputTextAreaNodeTransform } from '../../src/runtime/lib/core/transforms/input-text-area-transform'
 import { selectNodeTransform } from '../../src/runtime/lib/core/transforms/select-transform'
 
 /**
- * Integration coverage for `@chemical-x/forms/vite`. The plugin mutates
+ * Integration coverage for `decant/vite`. The plugin mutates
  * @vitejs/plugin-vue's options via the (informal) `api.options` surface;
  * if Vite's plugin resolution order or @vitejs/plugin-vue's api shape
  * changes, we want the build to break loudly, not at render time in a
@@ -35,9 +35,9 @@ function getVueApi(config: ResolvedConfig): VuePluginApi | undefined {
   return (vuePlugin as unknown as { api?: VuePluginApi } | undefined)?.api
 }
 
-describe('@chemical-x/forms/vite — plugin registration', () => {
+describe('decant/vite — plugin registration', () => {
   it('registers both node transforms with @vitejs/plugin-vue', async () => {
-    const config = await resolveWith([vue(), chemicalXForms()])
+    const config = await resolveWith([vue(), decant()])
     const api = getVueApi(config)
     const nodeTransforms = api?.options?.template?.compilerOptions?.nodeTransforms ?? []
 
@@ -62,7 +62,7 @@ describe('@chemical-x/forms/vite — plugin registration', () => {
         transforms.push(sentinel as unknown as (...args: unknown[]) => unknown)
       },
     }
-    const config = await resolveWith([vue(), earlierPlugin, chemicalXForms()])
+    const config = await resolveWith([vue(), earlierPlugin, decant()])
     const api = getVueApi(config)
     const nodeTransforms = api?.options?.template?.compilerOptions?.nodeTransforms ?? []
     expect(nodeTransforms).toContain(sentinel)
@@ -73,16 +73,14 @@ describe('@chemical-x/forms/vite — plugin registration', () => {
   it('throws a helpful install-hint error when @vitejs/plugin-vue is missing', async () => {
     // The error message changed in E2 to differentiate "not installed"
     // from "found but version-incompatible". Match the new wording.
-    await expect(resolveWith([chemicalXForms()])).rejects.toThrow(
-      /@vitejs\/plugin-vue is not installed/
-    )
+    await expect(resolveWith([decant()])).rejects.toThrow(/@vitejs\/plugin-vue is not installed/)
   })
 
-  // E2 — second registration of chemicalXForms() must NOT double-push
+  // E2 — second registration of decant() must NOT double-push
   // transforms. Pre-fix, two registrations stacked the transforms array
   // twice, double-injecting every binding the AST emits.
   it('is idempotent on duplicate registration', async () => {
-    const config = await resolveWith([vue(), chemicalXForms(), chemicalXForms()])
+    const config = await resolveWith([vue(), decant(), decant()])
     const api = getVueApi(config)
     const nodeTransforms = api?.options?.template?.compilerOptions?.nodeTransforms ?? []
     const selectCount = nodeTransforms.filter((t) => t === selectNodeTransform).length
@@ -92,10 +90,10 @@ describe('@chemical-x/forms/vite — plugin registration', () => {
   })
 })
 
-describe('@chemical-x/forms/vite — plugin order', () => {
+describe('decant/vite — plugin order', () => {
   it('runs with enforce:"pre" so it is not downstream of other transforms', async () => {
-    const config = await resolveWith([vue(), chemicalXForms()])
-    const cxPlugin = config.plugins.find((p) => p.name === 'chemical-x-forms')
+    const config = await resolveWith([vue(), decant()])
+    const cxPlugin = config.plugins.find((p) => p.name === 'decant')
     expect(cxPlugin).toBeDefined()
     expect(cxPlugin?.enforce).toBe('pre')
   })

--- a/test/ssr-bare-vue/optimistic-is-connected.test.ts
+++ b/test/ssr-bare-vue/optimistic-is-connected.test.ts
@@ -4,9 +4,9 @@ import { describe, expect, it } from 'vitest'
 import * as Vue from 'vue'
 import { createSSRApp, defineComponent } from 'vue'
 import { useForm } from '../../src'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 import { getRegistryFromApp } from '../../src/runtime/core/registry'
-import { renderChemicalXState } from '../../src/runtime/core/serialize'
+import { renderDecantState } from '../../src/runtime/core/serialize'
 import { vRegisterHintTransform } from '../../src/runtime/lib/core/transforms/v-register-hint-transform'
 import { vRegisterPreambleTransform } from '../../src/runtime/lib/core/transforms/v-register-preamble-transform'
 import { fakeSchema } from '../utils/fake-schema'
@@ -69,7 +69,7 @@ function makeAppWithTemplate(template: string, mode: CxTransformMode) {
     render,
   })
   const app = createSSRApp(App)
-  app.use(createChemicalXForms({ override: true /* SSR */ }))
+  app.use(createDecant({ override: true /* SSR */ }))
   return app
 }
 
@@ -124,7 +124,7 @@ describe('SSR isConnected via vRegisterHintTransform', () => {
       },
     })
     const app = createSSRApp(App)
-    app.use(createChemicalXForms({ override: true }))
+    app.use(createDecant({ override: true }))
     await renderToString(app)
     const registry = getRegistryFromApp(app)
     const state = registry.forms.get('setup-only')
@@ -140,7 +140,7 @@ describe('SSR isConnected via vRegisterHintTransform', () => {
       'hint-only'
     )
     await renderToString(app)
-    const payload = renderChemicalXState(app)
+    const payload = renderDecantState(app)
     const serialised = JSON.parse(JSON.stringify(payload)) as typeof payload
     const formEntry = serialised.forms.find(([k]) => k === 'connected-test')
     expect(formEntry).toBeDefined()
@@ -320,7 +320,7 @@ describe('SSR isConnected — cross-component sync via shared form key', () => {
       render: compileTemplate(`<div><Writer /><Reader /></div>`, 'preamble+hint'),
     })
     const app = createSSRApp(Parent)
-    app.use(createChemicalXForms({ override: true }))
+    app.use(createDecant({ override: true }))
 
     const html = await renderToString(app)
     // Reader's div serialises the email field state. Both forms are
@@ -412,7 +412,7 @@ describe('SSR isConnected — cross-component sync via shared form key', () => {
       render: compileTemplate(`<div><Binder /><SetupOnlyReader /></div>`, 'preamble+hint'),
     })
     const app = createSSRApp(Parent)
-    app.use(createChemicalXForms({ override: true }))
+    app.use(createDecant({ override: true }))
 
     const html = await renderToString(app)
     const readerMatch = html.match(/<div class="setup-only-reader">([\s\S]*?)<\/div>/)
@@ -491,7 +491,7 @@ describe('SSR isConnected — cross-component sync via shared form key', () => {
       render: compileTemplate(`<div><SetupOnlyA /><SetupOnlyB /><Reader /></div>`, 'preamble+hint'),
     })
     const app = createSSRApp(Parent)
-    app.use(createChemicalXForms({ override: true }))
+    app.use(createDecant({ override: true }))
 
     const html = await renderToString(app)
     const readerMatch = html.match(/<div class="case-b-reader">([\s\S]*?)<\/div>/)

--- a/test/ssr-bare-vue/preamble-null-context.test.ts
+++ b/test/ssr-bare-vue/preamble-null-context.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as Vue from 'vue'
 import { createSSRApp, defineComponent } from 'vue'
 import { injectForm } from '../../src'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 import { vRegisterHintTransform } from '../../src/runtime/lib/core/transforms/v-register-hint-transform'
 import { vRegisterPreambleTransform } from '../../src/runtime/lib/core/transforms/v-register-preamble-transform'
 
@@ -71,7 +71,7 @@ describe('SSR preamble null-safety', () => {
       render,
     })
     const app = createSSRApp(App)
-    app.use(createChemicalXForms({ override: true }))
+    app.use(createDecant({ override: true }))
 
     // The catchable failure mode pre-fix was an unhandled rejection
     // bubbling out of `_sfc_ssrRender`. If that ever returns, this
@@ -118,7 +118,7 @@ describe('SSR preamble null-safety', () => {
       render,
     })
     const app = createSSRApp(App)
-    app.use(createChemicalXForms({ override: true }))
+    app.use(createDecant({ override: true }))
 
     const html = await renderToString(app)
     expect(html).toContain('<input')

--- a/test/ssr-bare-vue/round-trip.test.ts
+++ b/test/ssr-bare-vue/round-trip.test.ts
@@ -2,13 +2,13 @@ import { renderToString } from '@vue/server-renderer'
 import { describe, expect, it } from 'vitest'
 import { createSSRApp, defineComponent, h } from 'vue'
 import { useForm } from '../../src'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 import { getRegistryFromApp } from '../../src/runtime/core/registry'
-import { hydrateChemicalXState, renderChemicalXState } from '../../src/runtime/core/serialize'
+import { hydrateDecantState, renderDecantState } from '../../src/runtime/core/serialize'
 import { fakeSchema } from '../utils/fake-schema'
 
 /*
- * End-to-end proof that `@chemical-x/forms` works under bare Vue 3 + SSR
+ * End-to-end proof that `decant` works under bare Vue 3 + SSR
  * via `@vue/server-renderer` — no Nuxt involved. Exercises the full round
  * trip: server creates app, useForm sets some state, render HTML,
  * serialize, hydrate on a fresh "client" app, confirm the reconstructed
@@ -32,7 +32,7 @@ function makeApp(opts: { ssr: boolean; initialEmail?: string }) {
     },
   })
   const app = createSSRApp(App)
-  app.use(createChemicalXForms({ override: opts.ssr }))
+  app.use(createDecant({ override: opts.ssr }))
   return app
 }
 
@@ -54,15 +54,12 @@ describe('bare-Vue SSR round-trip', () => {
     state.setValueAtPath(['email'], 'server-edited@x')
 
     // Serialize
-    const payload = renderChemicalXState(serverApp)
+    const payload = renderDecantState(serverApp)
     const serialised = JSON.stringify(payload)
 
     // Client: fresh app, fresh registry, hydrate from payload
     const clientApp = makeApp({ ssr: false })
-    hydrateChemicalXState(
-      clientApp,
-      JSON.parse(serialised) as ReturnType<typeof renderChemicalXState>
-    )
+    hydrateDecantState(clientApp, JSON.parse(serialised) as ReturnType<typeof renderDecantState>)
 
     // Render the client app — during setup, useForm should pick up the
     // hydrated state rather than re-initialising from schema defaults.
@@ -85,7 +82,7 @@ describe('bare-Vue SSR round-trip', () => {
   it('serialization payload is JSON-safe for direct transport', async () => {
     const app = makeApp({ ssr: true, initialEmail: 'user@x' })
     await renderToString(app)
-    const payload = renderChemicalXState(app)
+    const payload = renderDecantState(app)
     // Any attempt to stringify the full payload must succeed; nothing in
     // the structure should carry a symbol, function, or non-serialisable
     // reference.

--- a/test/ssr-bare-vue/use-register-ssr.test.ts
+++ b/test/ssr-bare-vue/use-register-ssr.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as Vue from 'vue'
 import { createSSRApp, defineComponent } from 'vue'
 import { useForm, useRegister } from '../../src'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 import { selectNodeTransform } from '../../src/runtime/lib/core/transforms/select-transform'
 import { vRegisterHintTransform } from '../../src/runtime/lib/core/transforms/v-register-hint-transform'
 import { vRegisterPreambleTransform } from '../../src/runtime/lib/core/transforms/v-register-preamble-transform'
@@ -92,7 +92,7 @@ function makeAppWithParentChildTemplate(parentTemplate: string) {
     render: compileWithCxTransforms(parentTemplate),
   })
   const app = createSSRApp(Parent)
-  app.use(createChemicalXForms({ override: true /* SSR */ }))
+  app.use(createDecant({ override: true /* SSR */ }))
   return app
 }
 
@@ -187,7 +187,7 @@ describe('useRegister — SSR (renderToString)', () => {
       },
     })
     const app = createSSRApp(Parent)
-    app.use(createChemicalXForms({ override: true }))
+    app.use(createDecant({ override: true }))
     await renderToString(app)
 
     const noParentRvWarns = warnings.filter((w) =>

--- a/test/ssr.test.ts
+++ b/test/ssr.test.ts
@@ -74,7 +74,7 @@ describe('SSR behavior of useForm', async () => {
           const option = options[0]
           expect(option?.value).toBe('chess')
 
-          // this is false in the test fixture (Chemical X should set this to true)
+          // this is false in the test fixture (Decant should set this to true)
           expect(option?.selected).toBe(true)
         })
         it('should find a match in an arbitrarily nested <option> within the <select> DOM tree', async () => {
@@ -94,7 +94,7 @@ describe('SSR behavior of useForm', async () => {
           expect(option?.value).toBe('chess')
           expect(option?.textContent).toBe('Chess Option Nested')
 
-          // Chemical X finds deeply nested options, even if the are NOT inside an <optgroup>
+          // Decant finds deeply nested options, even if the are NOT inside an <optgroup>
           // This does not satisfy the HTML5 spec, but is more permissive so things don't feel broken
           expect(option?.selected).toBe(true)
         })

--- a/test/utils/form-harness.ts
+++ b/test/utils/form-harness.ts
@@ -8,7 +8,7 @@
  * own typed import without the harness coupling to either zod major.
  */
 import { createApp, defineComponent, h, nextTick, type App } from 'vue'
-import { createChemicalXForms } from '../../src/runtime/core/plugin'
+import { createDecant } from '../../src/runtime/core/plugin'
 
 /**
  * Drain microtasks + Vue's queue four times. Four is empirical —
@@ -56,7 +56,7 @@ export function makeMounter<S>(
         return () => h('div')
       },
     })
-    const app = createApp(App).use(createChemicalXForms())
+    const app = createApp(App).use(createDecant())
     const root = document.createElement('div')
     document.body.appendChild(root)
     app.mount(root)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,10 +25,10 @@
     "pretty": true,
     "paths": {
       "@runtime/*": ["./src/runtime/*"],
-      "@chemical-x/forms": ["./src/index.ts"],
-      "@chemical-x/forms/types": ["./src/runtime/types/types-api.ts"],
-      "@chemical-x/forms/zod": ["./src/zod.ts"],
-      "@chemical-x/forms/zod-v3": ["./src/zod-v3.ts"]
+      "decant": ["./src/index.ts"],
+      "decant/types": ["./src/runtime/types/types-api.ts"],
+      "decant/zod": ["./src/zod.ts"],
+      "decant/zod-v3": ["./src/zod-v3.ts"]
     },
     "removeComments": false,
     "stripInternal": true,


### PR DESCRIPTION
## Summary

Pre-1.0 rebrand: the npm package becomes `decant` (bare, no scope), the GitHub home is now `decantjs/forms` (already transferred). Three commits, scoped for review:

1. **`refactor!: rename @chemical-x/forms → decant (code, identifiers, symbols)`** — 123 files, the load-bearing change. All public/internal identifiers, Symbol.for keys, persistence prefix, Nuxt configKey, devtools labels, error message prefixes, file rename, package.json/tsconfig/build.config.
2. **`docs: rebrand README, CONTRIBUTING, recipes, migration guides for decant`** — 22 docs files. Prose-only.
3. **`ci: rename CI step display names from @chemical-x/forms → decant`** — 3 workflow files. Display-only.

`CHANGELOG.md` and `RELEASES.md` are intentionally untouched — they document historical releases under the old name; GitHub's repo-rename redirect keeps the `cubicforms/chemical-x-forms` URLs they contain resolvable.

## Public API renames

| Old | New |
|---|---|
| `createChemicalXForms()` | `createDecant()` |
| `ChemicalXFormsPluginOptions` | `DecantPluginOptions` |
| `ChemicalXFormsDefaults` | `DecantDefaults` |
| `ChemicalXRegistry` | `DecantRegistry` |
| `ChemicalXVitePluginOptions` | `DecantVitePluginOptions` |
| `SerializedChemicalXState` | `SerializedDecantState` |
| `hydrateChemicalXState()` | `hydrateDecantState()` |
| `renderChemicalXState()` | `renderDecantState()` |
| `setupChemicalXDevtools()` | `setupDecantDevtools()` |
| `kChemicalXRegistry` (InjectionKey) | `kDecantRegistry` |
| `app._chemicalX` | `app._decant` |
| `chemicalXForms()` (Vite plugin function) | `decant()` |
| Nuxt `configKey: 'chemicalX'` | `'decant'` |
| `useRuntimeConfig().public.chemicalX` | `.public.decant` |
| `window.__CHEMICAL_X_STATE__` | `window.__DECANT_STATE__` |

## Internal contract changes (also breaking)

- `Symbol.for('chemical-x-forms:*')` → `Symbol.for('decant:*')` (10 sites; affects module-deduplication safety in some monorepos)
- `Symbol.for('@chemical-x/forms/unset')` → `Symbol.for('decant/unset')`
- `PERSISTENCE_KEY_PREFIX = 'chemical-x-forms:'` → `'decant:'` — **anyone with persisted form data under the old prefix loses it on next load**
- Error-message prefix `'[@chemical-x/forms] '` → `'[decant] '`
- Devtools labels `'Chemical X Forms'` / `'Chemical X form'` → `'Decant'` / `'Decant form'`

No backward-compat shims (per project policy: aggressive simplification, no compat hacks). Acceptable because there are no real npm consumers today.

## File rename

`src/runtime/plugins/chemical-x.ts` → `src/runtime/plugins/decant.ts` (via `git mv`, preserves blame). `build.config.ts` updated.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm vitest run` — 1839 tests pass (no skip count change)
- [x] `pnpm lint:fix` applied; `pnpm format:check` clean
- [x] `pnpm check` (full gate: lint + typecheck + test + size + bench + coverage) green
- [x] Repo-wide `rg -i 'chemical[ _-]?x'` returns zero hits outside `CHANGELOG.md` / `RELEASES.md` / `pnpm-lock.yaml` / `node_modules/` / `dist/`

## Action required after merge (manual, by maintainer)

1. Publish the next release as `decant@X.Y.Z` from this repo (CI handles the version bump on next release).
2. From the old npm account: `npm deprecate "@chemical-x/forms@*" "Renamed to decant — please run: npm install decant"`.
3. (Optional cleanup) Delete the empty `mochijs` GitHub org left over from earlier in the rebrand exploration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)