### PR TITLE
perf: hot-path optimizations (S/A tier perf review findings)

### DIFF
--- a/bench/errors-materialization.bench.ts
+++ b/bench/errors-materialization.bench.ts
@@ -1,0 +1,90 @@
+/**
+ * Phase 5.2 baseline: errors-materialization inner loop.
+ *
+ * `JSON.stringify(form.errors.<container>)` triggers `materializeErrors`
+ * (errors-proxy.ts), which walks all three reactive error stores and
+ * recovers the structured `Segment[]` per entry. Pre-5.2 used
+ * `JSON.parse(pathKey)` per entry (300 parses for a 100-error form
+ * across schema/blank/user stores). Post-5.2 reads the canonical
+ * segments through the inverse cache populated by `canonicalizePath`.
+ *
+ * This bench isolates the iteration + parse/lookup cost so the gate
+ * tracks the JSON.parse elimination directly. The actual proxy
+ * machinery (containerSegments comparison, hasAtPath active-path
+ * filter, placeAt tree write) is identical between branches and
+ * shared by both implementations under test — only the parse/lookup
+ * step differs.
+ */
+
+import { bench, describe } from 'vitest'
+import {
+  canonicalizePath,
+  segmentsForPathKey,
+  type PathKey,
+  type Segment,
+} from '../src/runtime/core/paths'
+
+type ErrorEntry = { message: string; path: readonly Segment[]; code: string }
+
+// 100 errors across 10 groups × 10 fields, mirroring the keystroke
+// fixture's shape so the bench results compose with paths.bench.ts.
+function makeErrorStore(): Map<PathKey, ErrorEntry[]> {
+  const m = new Map<PathKey, ErrorEntry[]>()
+  for (let i = 0; i < 100; i++) {
+    const dotted = `group${Math.floor(i / 10)}.field${i % 10}`
+    const { key, segments } = canonicalizePath(dotted)
+    m.set(key, [{ message: `bad ${i}`, path: segments, code: 'cx:test' }])
+  }
+  return m
+}
+
+function makeUncachedKeysFromOldStore(store: Map<PathKey, ErrorEntry[]>): PathKey[] {
+  // Pre-5.2 baseline: PathKey strings without the inverse cache
+  // populated. We can't actually un-warm the cache from outside it,
+  // but the old branch below uses raw `JSON.parse` and so doesn't
+  // touch the cache anyway — the keys are functionally cold relative
+  // to that code path.
+  return [...store.keys()]
+}
+
+const errorStore = makeErrorStore()
+const errorKeys = makeUncachedKeysFromOldStore(errorStore)
+
+describe('materializeErrors inner loop: 100-entry error store', () => {
+  // Worst-case container scope: root container with no descendant
+  // filter. Both branches walk every entry.
+  const containerSegments: readonly Segment[] = []
+
+  bench('old: JSON.parse(pathKey) per entry', () => {
+    let collected = 0
+    entries: for (const [pathKey, errors] of errorStore) {
+      if (errors.length === 0) continue
+      const fullPath = JSON.parse(pathKey) as Segment[]
+      if (fullPath.length <= containerSegments.length) continue
+      for (let i = 0; i < containerSegments.length; i++) {
+        if (fullPath[i] !== containerSegments[i]) continue entries
+      }
+      collected += errors.length
+    }
+    if (collected === 0) throw new Error('fixture invariant: 100 errors expected')
+  })
+
+  bench('new: segmentsForPathKey via inverse cache', () => {
+    let collected = 0
+    entries: for (const [pathKey, errors] of errorStore) {
+      if (errors.length === 0) continue
+      const fullPath = segmentsForPathKey(pathKey)
+      if (fullPath === null) continue
+      if (fullPath.length <= containerSegments.length) continue
+      for (let i = 0; i < containerSegments.length; i++) {
+        if (fullPath[i] !== containerSegments[i]) continue entries
+      }
+      collected += errors.length
+    }
+    if (collected === 0) throw new Error('fixture invariant: 100 errors expected')
+  })
+
+  // Ensure the keys array is referenced so the constructor isn't
+  // tree-shaken out of the bench fixture.
+  if (errorKeys.length !== 100) throw new Error('fixture invariant: 100 keys expected')
+})

--- a/src/runtime/adapters/zod-v3/index.ts
+++ b/src/runtime/adapters/zod-v3/index.ts
@@ -339,6 +339,29 @@ export function zodAdapter<
         const peeled = unwrapStructuralLeafV3(leaf)
         return getDefaultValuesFromZodSchema(peeled as z.ZodSchema, true, _formKey)
       },
+      arrayShapeAtPath(path) {
+        if (path.length === 0) return undefined
+        const leaf = walkV3ToLeafSchema(_zodSchema, path)
+        if (!leaf) return undefined
+        // Peel transparent wrappers down to the underlying shape.
+        // peelV3Wrappers handles optional / nullable / default /
+        // effects / pipeline / readonly / branded. ZodCatch is left
+        // by that helper for default-value reasons — peel it here
+        // since arrayShapeAtPath only needs the structural kind.
+        let peeled = peelV3Wrappers(leaf)
+        for (let i = 0; i < MAX_UNWRAP_STEPS; i++) {
+          if (!isZodSchemaType(peeled, 'ZodCatch')) break
+          const inner = (peeled._def as { innerType?: z.ZodTypeAny }).innerType
+          if (!inner) break
+          peeled = peelV3Wrappers(inner)
+        }
+        if (isZodSchemaType(peeled, 'ZodTuple')) {
+          const items = (peeled._def as { items?: readonly z.ZodTypeAny[] }).items
+          return Array.isArray(items) ? items.length : undefined
+        }
+        if (isZodSchemaType(peeled, 'ZodArray')) return null
+        return undefined
+      },
       getSchemasAtPath(path) {
         const [strippedSchema] = stripRootSchema(_zodSchema, {
           stripDefaultValues: true,

--- a/src/runtime/adapters/zod-v4/adapter.ts
+++ b/src/runtime/adapters/zod-v4/adapter.ts
@@ -24,6 +24,7 @@ import {
   getIntersectionRight,
   getLiteralValues,
   getObjectShape,
+  getTupleItems,
   getUnionOptions,
   kindOf,
   unwrapInner,
@@ -81,6 +82,43 @@ function unwrapStructuralWrappers(schema: z.ZodType): z.ZodType {
     const inner = unwrapInner(current)
     if (inner === undefined) return current
     if (!isStructuralKind(kindOf(inner))) break
+    current = inner
+  }
+  return current
+}
+
+/**
+ * Peel every transparent wrapper (optional / nullable / default /
+ * readonly / catch / pipe / lazy) off `schema`. Stops on the first
+ * non-wrapper kind. Used by `arrayShapeAtPath` for shape
+ * introspection where we want the inner kind regardless of what the
+ * default-value semantic is — different from
+ * `unwrapStructuralWrappers`, which preserves `.default()` so the
+ * runtime fill returns the explicit default.
+ *
+ * Bounded iteration cap as a runaway guard for pathological wrappers.
+ */
+function peelAllWrappers(schema: z.ZodType): z.ZodType {
+  let current: z.ZodType = schema
+  for (let i = 0; i < 64; i++) {
+    const k = kindOf(current)
+    let inner: z.ZodType | undefined
+    if (
+      k === 'optional' ||
+      k === 'nullable' ||
+      k === 'default' ||
+      k === 'readonly' ||
+      k === 'catch'
+    ) {
+      inner = unwrapInner(current)
+    } else if (k === 'pipe') {
+      inner = unwrapPipe(current)
+    } else if (k === 'lazy') {
+      inner = unwrapLazy(current)
+    } else {
+      return current
+    }
+    if (inner === undefined) return current
     current = inner
   }
   return current
@@ -283,6 +321,17 @@ export function zodV4Adapter<FormSchema extends z.ZodObject, Form extends z.infe
         // and getDefaultValuesFromZodSchema's line-256 first-candidate
         // behavior.
         return deriveDefault(unwrapStructuralWrappers(first), true)
+      },
+
+      arrayShapeAtPath(path) {
+        if (path.length === 0) return undefined
+        const [first] = getNestedZodSchemasAtPath(rootSchema, path)
+        if (first === undefined) return undefined
+        const peeled = peelAllWrappers(first)
+        const kind = kindOf(peeled)
+        if (kind === 'tuple') return getTupleItems(peeled).length
+        if (kind === 'array') return null
+        return undefined
       },
 
       getSchemasAtPath(path) {

--- a/src/runtime/core/build-form-api.ts
+++ b/src/runtime/core/build-form-api.ts
@@ -17,7 +17,7 @@ import { buildFieldArrayApi } from './field-arrays'
 import { buildFieldStateProxy } from './field-state-proxy'
 import type { HistoryModule } from './history'
 import { getAtPath } from './path-walker'
-import { canonicalizePath, type Path, type PathKey } from './paths'
+import { canonicalizePath, segmentsForPathKey, type Path, type PathKey } from './paths'
 import { PERSISTENCE_MODULE_KEY, type PersistenceModule } from './persistence'
 import { enforceSensitiveCheck } from './persistence/sensitive-names'
 import { buildProcessForm } from './process-form'
@@ -135,7 +135,8 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
       // have removed any prior blank entries for the paths
       // we just touched — re-add them now.
       for (const pathKey of walked.paths) {
-        const segments = JSON.parse(pathKey) as Path
+        const segments = segmentsForPathKey(pathKey)
+        if (segments === null) continue
         state.setValueAtPath(segments, state.schema.getDefaultAtPath(segments), {
           blank: true,
         })
@@ -372,7 +373,8 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
       // here is safe.
       state.reset(walked.cleanedValues as DeepPartial<unknown> as Parameters<typeof state.reset>[0])
       for (const pathKey of walked.paths) {
-        const segments = JSON.parse(pathKey) as Path
+        const segments = segmentsForPathKey(pathKey)
+        if (segments === null) continue
         state.setValueAtPath(segments, state.schema.getDefaultAtPath(segments), {
           blank: true,
         })

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -12,7 +12,13 @@ import type { DeepPartial, GenericForm, WriteShape } from '../types/types-core'
 import { DEFAULT_FIELD_VALIDATION_DEBOUNCE_MS } from './defaults'
 import { diffAndApply } from './diff-apply'
 import { CxErrorCode } from './error-codes'
-import { canonicalizePath, type Path, type PathKey, type Segment } from './paths'
+import {
+  canonicalizePath,
+  segmentsForPathKey,
+  type Path,
+  type PathKey,
+  type Segment,
+} from './paths'
 import {
   getAtPath,
   isPlainRecord,
@@ -560,12 +566,8 @@ export type CreateFormStoreOptions<F extends GenericForm, G extends GenericForm 
  * variant's effective shape.
  */
 function isPathKeyUnder(existingKey: PathKey, parentPath: Path): boolean {
-  let parsed: Segment[]
-  try {
-    parsed = JSON.parse(existingKey) as Segment[]
-  } catch {
-    return false
-  }
+  const parsed = segmentsForPathKey(existingKey)
+  if (parsed === null) return false
   if (parsed.length <= parentPath.length) return false
   for (let i = 0; i < parentPath.length; i++) {
     if (parsed[i] !== parentPath[i]) return false
@@ -755,7 +757,8 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     const result = new Map<PathKey, ValidationError[]>()
     if (blankPaths.size === 0) return result
     for (const pathKey of blankPaths) {
-      const segments = JSON.parse(pathKey) as Segment[]
+      const segments = segmentsForPathKey(pathKey)
+      if (segments === null) continue
       if (!schema.isRequiredAtPath(segments)) continue
       result.set(pathKey, [
         {
@@ -1719,12 +1722,8 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     // is intentionally preserved — the snapshot self-corrects on the
     // next switch-out.
     for (const memKey of [...variantMemory.keys()]) {
-      let memSegments: Segment[]
-      try {
-        memSegments = JSON.parse(memKey) as Segment[]
-      } catch {
-        continue
-      }
+      const memSegments = segmentsForPathKey(memKey)
+      if (memSegments === null) continue
       if (isPathPrefix(targetSegments, memSegments)) {
         variantMemory.delete(memKey)
       }

--- a/src/runtime/core/devtools.ts
+++ b/src/runtime/core/devtools.ts
@@ -4,7 +4,7 @@ import type { DecantRegistry } from './registry'
 import type { GenericForm } from '../types/types-core'
 import type { FormKey } from '../types/types-api'
 import { canonicalizePath } from './paths'
-import { isSensitivePath } from './persistence/sensitive-names'
+import { isSensitivePath, segmentMatchesSensitive } from './persistence/sensitive-names'
 
 /**
  * Vue DevTools plugin wiring for decant. Lazy-imported by
@@ -46,27 +46,43 @@ const REDACTED = '[redacted]'
  * `acknowledgeSensitive: true` on persistence does NOT bypass this —
  * if the consumer opted into persisting the value, they still
  * shouldn't see it in DevTools timelines that grow unbounded.
+ *
+ * Implementation note: tracks an `inSensitiveSubtree` flag through
+ * the recursion instead of allocating a fresh path array per node
+ * + calling `isSensitivePath` per leaf. Once any ancestor segment
+ * matches the heuristic, the flag stays set for every descendant —
+ * the leaf simply returns `REDACTED` without re-scanning the path.
+ * For a 100-leaf form: ~100 path allocations + ~100 full-path regex
+ * sweeps → 0 path allocations + ~100 single-segment regex sweeps,
+ * with whole-subtree short-circuit when sensitive ancestors are
+ * found early.
  */
-function redactSensitiveLeaves(
-  value: unknown,
-  pathSoFar: ReadonlyArray<string | number> = []
-): unknown {
+function redactSensitiveLeaves(value: unknown): unknown {
+  return redactImpl(value, false)
+}
+
+function redactImpl(value: unknown, inSensitiveSubtree: boolean): unknown {
   if (value === null || value === undefined) return value
   if (typeof value !== 'object') {
-    // Primitive leaf — redact if the enclosing path is sensitive.
-    return isSensitivePath([...pathSoFar]) ? REDACTED : value
+    return inSensitiveSubtree ? REDACTED : value
   }
   if (Array.isArray(value)) {
-    return value.map((item, idx) => redactSensitiveLeaves(item, [...pathSoFar, idx]))
+    // Numeric segments never match the sensitive-name heuristic
+    // (segmentMatchesSensitive rejects non-string segments), so the
+    // flag passes through unchanged when descending into arrays.
+    return value.map((item) => redactImpl(item, inSensitiveSubtree))
   }
-  // Plain object (Map / Set / Date / etc. fall through to "treat as
-  // primitive" — DevTools rendering of those is already heuristic).
+  // Non-plain object (Map / Set / Date / class instance) — redact
+  // wholesale if we're already in a sensitive subtree; otherwise pass
+  // through. DevTools rendering of these is already heuristic, so we
+  // don't try to descend into them.
   if (Object.getPrototypeOf(value) !== Object.prototype && Object.getPrototypeOf(value) !== null) {
-    return isSensitivePath([...pathSoFar]) ? REDACTED : value
+    return inSensitiveSubtree ? REDACTED : value
   }
   const out: Record<string, unknown> = {}
   for (const key of Object.keys(value as Record<string, unknown>)) {
-    out[key] = redactSensitiveLeaves((value as Record<string, unknown>)[key], [...pathSoFar, key])
+    const childSensitive = inSensitiveSubtree || segmentMatchesSensitive(key)
+    out[key] = redactImpl((value as Record<string, unknown>)[key], childSensitive)
   }
   return out
 }

--- a/src/runtime/core/errors-proxy.ts
+++ b/src/runtime/core/errors-proxy.ts
@@ -2,7 +2,13 @@ import type { ValidationError } from '../types/types-api'
 import type { GenericForm } from '../types/types-core'
 import type { FormStore } from './create-form-store'
 import { getAtPath, hasAtPath } from './path-walker'
-import { canonicalizePath, type PathKey, type Path, type Segment } from './paths'
+import {
+  canonicalizePath,
+  segmentsForPathKey,
+  type PathKey,
+  type Path,
+  type Segment,
+} from './paths'
 import { buildSurfaceProxy, type SurfaceProxy } from './surface-proxy'
 
 /**
@@ -93,7 +99,11 @@ function materializeErrors<F extends GenericForm>(
   const collect = (store: ReadonlyMap<PathKey, ValidationError[]>): void => {
     entries: for (const [pathKey, errors] of store) {
       if (errors.length === 0) continue
-      const fullPath = JSON.parse(pathKey) as Segment[]
+      // Cache hit on every keystroke — the store's PathKeys are
+      // produced through `canonicalizePath`, which warms the inverse
+      // cache. Cold path (corrupt key) returns null and we skip.
+      const fullPath = segmentsForPathKey(pathKey)
+      if (fullPath === null) continue
       // Skip paths that aren't strict descendants of the container —
       // a path equal to or shorter than the container has no leaf-keyed
       // contribution at this view (errors at the exact container path

--- a/src/runtime/core/path-walker.ts
+++ b/src/runtime/core/path-walker.ts
@@ -9,6 +9,13 @@ import type { Path, Segment } from './paths'
  */
 export type SchemaForFill = {
   getDefaultAtPath(path: Path): unknown
+  /**
+   * Distinguish tuple (number — structural length) from unbounded
+   * array (null) at `path`. `undefined` signals "fall back to the
+   * legacy index-probe loop" for adapters that can't introspect.
+   * See `AbstractSchema.arrayShapeAtPath` for the full contract.
+   */
+  arrayShapeAtPath(path: Path): number | null | undefined
 }
 
 /**
@@ -187,6 +194,41 @@ function deleteAtPathOffset(root: unknown, path: Path, offset: number): unknown 
  * relative to defaults the function returns `consumer` by reference,
  * so common-case writes (consumer already complete) allocate nothing.
  */
+/**
+ * Resolve the array shape at `scratch`. Returns the tuple's
+ * structural length, `null` for unbounded arrays, or `undefined`
+ * if the adapter doesn't support `arrayShapeAtPath` (signalling
+ * the legacy probe loop).
+ *
+ * The fallback path matches the pre-5.2 semantic: probe at index
+ * `1_000_000` (tuple → `undefined`; array → element default), then
+ * probe sequentially up to the cap to discover the tuple length.
+ * Built-in zod adapters return a definitive shape so this never
+ * fires for them; the fallback exists for third-party adapters
+ * that haven't implemented the new method.
+ */
+function resolveArrayShape(schema: SchemaForFill, scratch: Segment[]): number | null | undefined {
+  const shape = schema.arrayShapeAtPath(scratch)
+  if (shape !== undefined) return shape
+  // Legacy probe: high-index lookup distinguishes tuple from array.
+  const TUPLE_PROBE_INDEX = 1_000_000
+  scratch.push(TUPLE_PROBE_INDEX)
+  const probe = schema.getDefaultAtPath(scratch)
+  scratch.pop()
+  if (probe !== undefined) return null // unbounded array
+  // Tuple-like: walk forward to find the structural length. Cap at
+  // 1024 to protect against pathological recursive lazies.
+  let n = 0
+  while (n < 1024) {
+    scratch.push(n)
+    const v = schema.getDefaultAtPath(scratch)
+    scratch.pop()
+    if (v === undefined) break
+    n++
+  }
+  return n
+}
+
 export function mergeStructural(
   schema: SchemaForFill,
   path: Path,
@@ -221,34 +263,33 @@ function mergeStructuralImpl(
   if (consumer === null) return null
 
   // Array branch: distinguish tuple-like (fixed length) from array
-  // (unbounded). Probe at a high index — tuples return `undefined`,
-  // arrays return the element default. For tuple-like, pad consumer
-  // up to the structural length; for arrays, length tracks consumer.
+  // (unbounded) via `arrayShapeAtPath`. Tuples pad consumer to the
+  // structural length; unbounded arrays follow the consumer's length
+  // and reuse one element default across positions.
   if (Array.isArray(consumer)) {
-    const TUPLE_PROBE_INDEX = 1_000_000
-    scratch.push(TUPLE_PROBE_INDEX)
-    const probe = schema.getDefaultAtPath(scratch)
-    scratch.pop()
-    let targetLen = consumer.length
-    if (probe === undefined) {
-      // Tuple-like: find structural length via sequential probe. Cap
-      // protects against pathological recursive lazies.
-      let n = consumer.length
-      while (n < 1024) {
-        scratch.push(n)
-        const v = schema.getDefaultAtPath(scratch)
-        scratch.pop()
-        if (v === undefined) break
-        n++
-      }
-      targetLen = n
-    }
+    const shape = resolveArrayShape(schema, scratch)
+    const isTuple = typeof shape === 'number'
+    const targetLen = isTuple ? shape : consumer.length
+    // Unbounded array: every position resolves to the same element
+    // default — query once and reuse. Tuples query per-position
+    // since each slot carries its own default.
+    let cachedElementDefault: unknown
+    let cachedElementDefaultRead = false
     let mutated = targetLen > consumer.length
     const out = consumer.slice() as unknown[]
     while (out.length < targetLen) out.push(undefined)
     for (let i = 0; i < targetLen; i++) {
       scratch.push(i)
-      const elemDefault = schema.getDefaultAtPath(scratch)
+      let elemDefault: unknown
+      if (isTuple) {
+        elemDefault = schema.getDefaultAtPath(scratch)
+      } else {
+        if (!cachedElementDefaultRead) {
+          cachedElementDefault = schema.getDefaultAtPath(scratch)
+          cachedElementDefaultRead = true
+        }
+        elemDefault = cachedElementDefault
+      }
       const consumerElem = i < consumer.length ? consumer[i] : undefined
       const merged = mergeStructuralImpl(schema, scratch, consumerElem, elemDefault)
       scratch.pop()
@@ -357,16 +398,27 @@ function setAtPathWithSchemaFillImpl(
     // of objects (each call yields a fresh object, identity differs)
     // AND for tuples of identical primitives (Object.is(0, 0) === true).
     if (arr.length < head) {
-      const TUPLE_PROBE_INDEX = 1_000_000
-      const probe = schema.getDefaultAtPath([...prefix, TUPLE_PROBE_INDEX])
-      const tupleLike = probe === undefined
+      const scratch: Segment[] = prefix.slice() as Segment[]
+      const shape = resolveArrayShape(schema, scratch)
+      const tupleLike = typeof shape === 'number'
       // For unbounded arrays, every position resolves to the same
       // element default — cache the lookup once. For tuples, query
       // per-position so each slot's default lands at its own index.
-      const cachedArrayDefault = tupleLike ? undefined : schema.getDefaultAtPath([...prefix, 0])
+      let cachedArrayDefault: unknown
+      if (!tupleLike) {
+        scratch.push(0)
+        cachedArrayDefault = schema.getDefaultAtPath(scratch)
+        scratch.pop()
+      }
       while (arr.length < head) {
         const idx = arr.length
-        arr.push(tupleLike ? schema.getDefaultAtPath([...prefix, idx]) : cachedArrayDefault)
+        if (tupleLike) {
+          scratch.push(idx)
+          arr.push(schema.getDefaultAtPath(scratch))
+          scratch.pop()
+        } else {
+          arr.push(cachedArrayDefault)
+        }
       }
     }
 

--- a/src/runtime/core/path-walker.ts
+++ b/src/runtime/core/path-walker.ts
@@ -88,21 +88,25 @@ export function isPlainRecord(value: unknown): value is Record<string, unknown> 
 }
 
 export function setAtPath(root: unknown, path: Path, value: unknown): unknown {
-  if (path.length === 0) return value
+  return setAtPathOffset(root, path, value, 0)
+}
 
-  const head = path[0] as Segment
-  const rest = path.slice(1)
+function setAtPathOffset(root: unknown, path: Path, value: unknown, offset: number): unknown {
+  if (offset >= path.length) return value
+
+  const head = path[offset] as Segment
+  const nextOffset = offset + 1
 
   if (typeof head === 'number') {
     const arr = Array.isArray(root) ? [...root] : []
     // Extend sparse arrays with undefined slots up to the target index.
     while (arr.length <= head) arr.push(undefined)
-    arr[head] = setAtPath(arr[head], rest, value)
+    arr[head] = setAtPathOffset(arr[head], path, value, nextOffset)
     return arr
   }
 
   const rec: Record<string, unknown> = isPlainRecord(root) ? { ...root } : {}
-  rec[head] = setAtPath(rec[head], rest, value)
+  rec[head] = setAtPathOffset(rec[head], path, value, nextOffset)
   return rec
 }
 
@@ -121,33 +125,38 @@ export function setAtPath(root: unknown, path: Path, value: unknown): unknown {
  * paths the user might have opted in.
  */
 export function deleteAtPath(root: unknown, path: Path): unknown {
-  if (path.length === 0) return undefined
+  return deleteAtPathOffset(root, path, 0)
+}
 
-  const head = path[0] as Segment
-  const rest = path.slice(1)
+function deleteAtPathOffset(root: unknown, path: Path, offset: number): unknown {
+  if (offset >= path.length) return undefined
+
+  const head = path[offset] as Segment
+  const isLeafStep = offset === path.length - 1
+  const nextOffset = offset + 1
 
   if (typeof head === 'number') {
     if (!Array.isArray(root)) return root
     if (head < 0 || head >= root.length) return root
-    if (rest.length === 0) {
+    if (isLeafStep) {
       const arr = [...root]
       arr.splice(head, 1)
       return arr
     }
     const arr = [...root]
-    arr[head] = deleteAtPath(arr[head], rest)
+    arr[head] = deleteAtPathOffset(arr[head], path, nextOffset)
     return arr
   }
 
   if (!isPlainRecord(root)) return root
-  if (rest.length === 0) {
+  if (isLeafStep) {
     const rec: Record<string, unknown> = { ...root }
     delete rec[head]
     return rec
   }
   if (!(head in root)) return root
   const rec: Record<string, unknown> = { ...root }
-  rec[head] = deleteAtPath(rec[head], rest)
+  rec[head] = deleteAtPathOffset(rec[head], path, nextOffset)
   return rec
 }
 
@@ -184,6 +193,24 @@ export function mergeStructural(
   consumer: unknown,
   defaultValue: unknown = schema.getDefaultAtPath(path)
 ): unknown {
+  // Internal recursion uses a single mutable scratch path: each level
+  // pushes its segment before descending and pops on return. Eliminates
+  // the per-recursion `[...path, key]` / `[...path, i]` allocation
+  // that previously fired on every object key + every array element.
+  // Schema adapters (zod / standard-schema) read `getDefaultAtPath`
+  // synchronously and don't retain the path, so passing the live
+  // scratch is safe; if a future adapter needed retention, snapshot
+  // inside that adapter rather than allocating per-call here.
+  const scratch: Segment[] = path.slice()
+  return mergeStructuralImpl(schema, scratch, consumer, defaultValue)
+}
+
+function mergeStructuralImpl(
+  schema: SchemaForFill,
+  scratch: Segment[],
+  consumer: unknown,
+  defaultValue: unknown
+): unknown {
   // Consumer is missing — fall back to the schema default. When the
   // schema default itself is `undefined` (path doesn't exist in the
   // schema), the result is `undefined` and we don't fight it.
@@ -199,22 +226,32 @@ export function mergeStructural(
   // up to the structural length; for arrays, length tracks consumer.
   if (Array.isArray(consumer)) {
     const TUPLE_PROBE_INDEX = 1_000_000
-    const probe = schema.getDefaultAtPath([...path, TUPLE_PROBE_INDEX])
+    scratch.push(TUPLE_PROBE_INDEX)
+    const probe = schema.getDefaultAtPath(scratch)
+    scratch.pop()
     let targetLen = consumer.length
     if (probe === undefined) {
       // Tuple-like: find structural length via sequential probe. Cap
       // protects against pathological recursive lazies.
       let n = consumer.length
-      while (n < 1024 && schema.getDefaultAtPath([...path, n]) !== undefined) n++
+      while (n < 1024) {
+        scratch.push(n)
+        const v = schema.getDefaultAtPath(scratch)
+        scratch.pop()
+        if (v === undefined) break
+        n++
+      }
       targetLen = n
     }
     let mutated = targetLen > consumer.length
     const out = consumer.slice() as unknown[]
     while (out.length < targetLen) out.push(undefined)
     for (let i = 0; i < targetLen; i++) {
-      const elemDefault = schema.getDefaultAtPath([...path, i])
+      scratch.push(i)
+      const elemDefault = schema.getDefaultAtPath(scratch)
       const consumerElem = i < consumer.length ? consumer[i] : undefined
-      const merged = mergeStructural(schema, [...path, i], consumerElem, elemDefault)
+      const merged = mergeStructuralImpl(schema, scratch, consumerElem, elemDefault)
+      scratch.pop()
       if (merged !== consumerElem) {
         out[i] = merged
         mutated = true
@@ -241,7 +278,9 @@ export function mergeStructural(
         // Recurse so that filling produces a structurally-complete
         // sub-tree (covers nested-object defaults that themselves
         // contain wrappers / unions).
-        const filled = mergeStructural(schema, [...path, key], undefined, defAtKey)
+        scratch.push(key)
+        const filled = mergeStructuralImpl(schema, scratch, undefined, defAtKey)
+        scratch.pop()
         if (filled !== undefined) {
           out[key] = filled
           mutated = true
@@ -250,7 +289,9 @@ export function mergeStructural(
     }
     // Recurse into consumer-supplied keys to catch nested gaps.
     for (const key of Object.keys(consumer)) {
-      const merged = mergeStructural(schema, [...path, key], consumer[key], defaultValue[key])
+      scratch.push(key)
+      const merged = mergeStructuralImpl(schema, scratch, consumer[key], defaultValue[key])
+      scratch.pop()
       if (merged !== consumer[key]) {
         out[key] = merged
         mutated = true

--- a/src/runtime/core/paths.ts
+++ b/src/runtime/core/paths.ts
@@ -88,6 +88,68 @@ const CANONICAL_STRING_CACHE_MAX = 128
 const canonicalStringCache = new Map<string, { segments: readonly Segment[]; key: PathKey }>()
 
 /**
+ * Inverse cache: PathKey → segments. Populated by `canonicalizePath`
+ * (string and array branches) so any consumer holding a PathKey
+ * produced through the canonical pipeline can recover its structured
+ * segments without `JSON.parse`. Callers reach this through
+ * `segmentsForPathKey` below.
+ *
+ * The store-side data structures keyed by PathKey (form-store error
+ * maps, blank-paths set, variant-memory map, persistence opt-in
+ * registry) all source their keys from `canonicalizePath`, so reads
+ * are dominantly cache hits. Cold paths (PathKeys round-tripped from
+ * a persisted payload that came from disk) still hit a single
+ * `JSON.parse` on first lookup, then warm the cache.
+ *
+ * Bounded FIFO at 4096 entries — generous relative to a typical form's
+ * working set (~tens to ~hundreds of paths per form) but small enough
+ * that long-running multi-form apps don't accumulate unbounded
+ * references. Eviction only fires on net-new entries; idempotent
+ * overwrites (same key, same segments) don't count toward the cap.
+ */
+const PATHKEY_TO_SEGMENTS_MAX = 4096
+const pathKeyToSegments = new Map<PathKey, readonly Segment[]>()
+
+function rememberSegmentsForPathKey(key: PathKey, segments: readonly Segment[]): void {
+  if (!pathKeyToSegments.has(key) && pathKeyToSegments.size >= PATHKEY_TO_SEGMENTS_MAX) {
+    const oldest = pathKeyToSegments.keys().next().value
+    if (oldest !== undefined) pathKeyToSegments.delete(oldest)
+  }
+  pathKeyToSegments.set(key, segments)
+}
+
+/**
+ * Recover the structured `Segment[]` for a `PathKey` produced by
+ * `canonicalizePath`. O(1) on the hot path (cache hit); cold keys
+ * fall back to `JSON.parse(key)` plus segment normalization, then
+ * warm the cache so subsequent lookups hit.
+ *
+ * Returns `null` for malformed PathKeys (non-JSON, non-array, or
+ * containing values that aren't strings/numbers). Keys produced by
+ * `canonicalizePath` never trip this — corrupt persistence payloads
+ * (or test fixtures crafting raw strings) are the only realistic
+ * sources.
+ */
+export function segmentsForPathKey(key: PathKey): readonly Segment[] | null {
+  const cached = pathKeyToSegments.get(key)
+  if (cached !== undefined) return cached
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(key)
+  } catch {
+    return null
+  }
+  if (!Array.isArray(parsed)) return null
+  const segments: Segment[] = []
+  for (const raw of parsed) {
+    if (typeof raw !== 'string' && typeof raw !== 'number') return null
+    segments.push(normalizeSegment(raw))
+  }
+  rememberSegmentsForPathKey(key, segments)
+  return segments
+}
+
+/**
  * Canonicalise a path into structured segments plus a stable string
  * key. Accepts either dotted-string or array form; integer-looking
  * segments normalise to numbers.
@@ -126,10 +188,12 @@ export function canonicalizePath(input: string | Path): {
       if (oldest !== undefined) canonicalStringCache.delete(oldest)
     }
     canonicalStringCache.set(input, entry)
+    rememberSegmentsForPathKey(key, segments)
     return entry
   }
   const segments = Array.from(input).map(normalizeSegment)
   const key = JSON.stringify(segments) as PathKey
+  rememberSegmentsForPathKey(key, segments)
   return { segments, key }
 }
 

--- a/src/runtime/core/persistence/index.ts
+++ b/src/runtime/core/persistence/index.ts
@@ -9,7 +9,7 @@ import type {
 import { PERSISTENCE_KEY_PREFIX } from '../defaults'
 import { __DEV__ } from '../dev'
 import { isPlainRecord, setAtPath, getAtPath } from '../path-walker'
-import type { Path, PathKey, Segment } from '../paths'
+import { segmentsForPathKey, type Path, type PathKey, type Segment } from '../paths'
 
 /**
  * Public-ish handle returned by `wirePersistence`. Lives on
@@ -477,7 +477,11 @@ export async function sweepNonConfiguredStandardStoresForOrphans(
 export function pluckPaths(form: unknown, pathKeys: Iterable<PathKey>): unknown {
   let sparse: unknown = undefined
   for (const pathKey of pathKeys) {
-    const segments = parsePathKey(pathKey)
+    // PathKeys arrive from the opt-in registry (canonical) — cache hit
+    // every iteration. The null branch covers persistence payloads
+    // round-tripped from disk that were corrupted before reaching the
+    // restoration code.
+    const segments = segmentsForPathKey(pathKey)
     if (segments === null) continue
     const value = getAtPath(form, segments)
     if (value === undefined) continue
@@ -574,14 +578,4 @@ function mergeDeep(
     out[key] = mergeDeep(out[key], (source as Record<string, unknown>)[key], [...path, key], schema)
   }
   return out
-}
-
-function parsePathKey(pathKey: PathKey): readonly Segment[] | null {
-  try {
-    const parsed = JSON.parse(pathKey) as unknown
-    if (!Array.isArray(parsed)) return null
-    return parsed as readonly Segment[]
-  } catch {
-    return null
-  }
 }

--- a/src/runtime/core/persistence/sensitive-names.ts
+++ b/src/runtime/core/persistence/sensitive-names.ts
@@ -81,7 +81,15 @@ export const SENSITIVE_NAME_PATTERNS: readonly RegExp[] = [
   /backup[_\s-]?code/i,
 ] as const
 
-function segmentMatchesSensitive(segment: Segment): boolean {
+/**
+ * True iff `segment` itself matches a sensitive-name pattern. Numeric
+ * segments are never sensitive (array indices carry no semantic
+ * weight). Used by `isSensitivePath` AND by the devtools redact
+ * walk, which short-circuits whole subtrees the moment any ancestor
+ * segment matches — saving an O(leaves × ancestors) regex sweep
+ * per timeline event.
+ */
+export function segmentMatchesSensitive(segment: Segment): boolean {
   if (typeof segment !== 'string') return false
   for (const pattern of SENSITIVE_NAME_PATTERNS) {
     if (pattern.test(segment)) return true

--- a/src/runtime/core/process-form.ts
+++ b/src/runtime/core/process-form.ts
@@ -15,7 +15,7 @@ import type { FormStore } from './create-form-store'
 import { __DEV__ } from './dev'
 import { CxErrorCode } from './error-codes'
 import { SubmitErrorHandlerError } from './errors'
-import { canonicalizePath, type Path, type Segment } from './paths'
+import { canonicalizePath, segmentsForPathKey, type Path } from './paths'
 
 /**
  * Tracks FormStores for which we've already emitted the
@@ -396,12 +396,13 @@ function collectScopedBlankErrors<F extends GenericForm>(
   const errors: ValidationError[] = []
   for (const [pathKey, entries] of derived) {
     if (scope !== undefined) {
-      // PathKey is `JSON.stringify(segments)` per `canonicalizePath`, so
-      // recovering the structured segments is `JSON.parse(...)`. Don't
-      // round-trip through `canonicalizePath(pathKey)` — that would treat
-      // the JSON-encoded string as a NEW dotted path and produce a single
-      // segment containing the literal JSON.
-      const segments = JSON.parse(pathKey) as Segment[]
+      // Cache hit on canonical PathKeys; cold (corrupt) keys return
+      // null and we skip. Don't round-trip through
+      // `canonicalizePath(pathKey)` — that would treat the JSON-encoded
+      // string as a NEW dotted path and produce a single segment
+      // containing the literal JSON.
+      const segments = segmentsForPathKey(pathKey)
+      if (segments === null) continue
       if (!pathStartsWith(segments, scope)) continue
     }
     errors.push(...entries)

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -225,6 +225,29 @@ export type AbstractSchema<Form, GetValueFormType> = {
    */
   getDefaultAtPath(path: Path): unknown
   /**
+   * Distinguish a tuple (fixed-length, position-typed) from an
+   * unbounded array at `path`. The runtime calls this on every
+   * `mergeStructural` / `setAtPathWithSchemaFill` write that descends
+   * into an array branch — caching the answer at the schema level
+   * replaces the per-write 1M-index probe + sequential probe loop
+   * (up to 1024 schema lookups) the runtime previously used.
+   *
+   * Return values:
+   * - `number` → tuple of this structural length. The runtime pads
+   *   the consumer to this length and recurses position-by-position.
+   * - `null` → unbounded array. The runtime uses the consumer's
+   *   length and reuses one element default for every position.
+   * - `undefined` → the path doesn't resolve to an array OR the
+   *   adapter can't determine the shape. The runtime falls back to
+   *   the legacy probe loop in this case (defensive — every built-in
+   *   adapter returns `number` or `null`).
+   *
+   * Wrappers (optional / nullable / default / readonly / catch /
+   * pipe / lazy) are peeled transparently before the type check, so
+   * `optional(z.tuple([...]))` reports its tuple length.
+   */
+  arrayShapeAtPath(path: Path): number | null | undefined
+  /**
    * Return every sub-schema that could resolve at the given structured
    * path. Multiple results are only expected for discriminated / union
    * branches where the adapter can't decide a single winner until the

--- a/test/core/merge-structural.test.ts
+++ b/test/core/merge-structural.test.ts
@@ -73,6 +73,20 @@ function buildSchema(
       }
       return current
     },
+    arrayShapeAtPath(path: Path): number | null | undefined {
+      // Tuple keys configured via `options.tupleAt` resolve to that
+      // position's count; an `arr` key with `arrayElementDefault`
+      // configured is an unbounded array. Anything else falls back
+      // to the legacy probe in mergeStructural's resolver.
+      if (path.length === 1 && typeof path[0] === 'string') {
+        const key = path[0]
+        if (options?.tupleAt?.[key] !== undefined) {
+          return options.tupleAt[key].length
+        }
+        if (key === 'arr' && options?.arrayElementDefault !== undefined) return null
+      }
+      return undefined
+    },
   }
 }
 

--- a/test/utils/fake-schema.ts
+++ b/test/utils/fake-schema.ts
@@ -74,6 +74,14 @@ export function fakeSchema<F extends GenericForm>(
       }
       return current
     },
+    arrayShapeAtPath(path) {
+      // fakeSchema can't model element schemas — return `undefined` so
+      // the runtime falls back to the legacy probe loop, matching the
+      // old behaviour. Tests needing tuple/array shape semantics
+      // override this on the returned object.
+      void path
+      return undefined
+    },
     getSchemasAtPath(path) {
       void path
       return []


### PR DESCRIPTION
## Summary

Surgical hot-path perf push from the codebase audit (2026-05-02). Four atomic commits, no API breakage for consumers — only `AbstractSchema` gains one new method (`arrayShapeAtPath`) that built-in adapters implement.

## Commits

### `perf: cache PathKey→segments mapping; drop JSON.parse from hot loops`
Module-level `Map<PathKey, readonly Segment[]>` populated inside `canonicalizePath` (string + array branches); `segmentsForPathKey()` exported for callers holding a PathKey. Replaces `JSON.parse(pathKey)` at **8 hot sites** (errors-proxy, persistence pluckPaths, build-form-api ×2, process-form, create-form-store ×3). New `bench/errors-materialization.bench.ts` shows **5.3× speedup** on the materialize-errors inner loop (100-error store, root container scope).

### `perf: path-walker uses offset / scratch path; drops per-recursion slice + spread`
`setAtPath` / `deleteAtPath` thread the immutable Path through recursion via an integer offset instead of `path.slice(1)` per level. `mergeStructural` keeps the immutable signature on its public entry but seeds an internal scratch path (push before recurse, pop on return), eliminating `[...path, key]` per object-key + per array-element. Per-call savings: O(depth) path allocations dropped on writes; ~110 path allocations per merge of a 100-leaf form with half-missing consumer. Direct micro-bench was ~1.4× (COW spread cost dominates wall-clock); kept the change for the cleaner pattern + Commit 3 builds on the scratch primitive.

### `perf: schema-cached tuple-vs-array detection; cache unbounded-array element default`
New `AbstractSchema.arrayShapeAtPath(path)`: number for tuples, null for unbounded arrays, undefined to signal the legacy probe loop (defensive for third-party adapters). Implemented in **zod-v4** and **zod-v3** via existing introspection helpers. Two wins per array merge:

1. Tuple detection in O(1) — replaces probe-at-1_000_000 + sequential probe-to-1024 (was ~1025 schema lookups for a tuple write; now 1).
2. Cached element default for unbounded arrays — `mergeStructural` now queries once and reuses across positions (matches `setAtPathWithSchemaFillImpl`'s existing cache). For 100-element array merges, ~100 lookups → 1.

Direct micro-bench was ~1.9×; real-world zod adapter walks are more expensive than the bench stub so the savings are larger in practice.

### `perf: redactSensitiveLeaves tracks sensitive-subtree flag, drops per-node path allocation`
Devtools redact walk: instead of allocating `[...pathSoFar, idx]` at every node + scanning the full path against every sensitive-name regex on each leaf, threads an `inSensitiveSubtree` boolean. Once any ancestor segment matches, the flag stays set for every descendant — leaves return `REDACTED` without re-scanning, and whole sensitive subtrees short-circuit the regex sweep. Exports `segmentMatchesSensitive` from `persistence/sensitive-names.ts` (previously private). Devtools-only.

## Skipped from the audit

- **B1 (`opt-in-registry.ts:87-92` inverse index)** — defer; impact too small for the change cost.
- **B2 / Commit 5 (LRU-bump drop, array-form cache)** — measurement showed the array-form caching has only one literal call site in `src/` (a doc example), and the `delete+set` LRU bump on cache hits is sub-µs per keystroke and invisible in the keystroke benches. The simpler code didn't justify the commit churn.
- **`scripts/check-bench.mjs` `RATIO_FLOOR` 3.0 → 2.5** — separate PR (decided in earlier session).

## Bench gate

All scenarios within 3× floor:

```
bench/errors-materialization.bench.ts > materializeErrors inner loop  5.55× ✓
bench/keystroke.bench.ts > keystroke: 100-leaf form                   5.37× ✓
bench/keystroke.bench.ts > keystroke: 500-leaf form                  10.12× ✓
bench/paths.bench.ts > canonicalizePath: repeated dotted input        4.41× ✓
bench/paths.bench.ts > isDirty: 100-leaf pristine form                3.71× ✓
```

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm vitest run` — 1839 / 1839 pass
- [x] `pnpm check:bench` — all scenarios within 3× floor (fresh run on top of Commit 4)
- [ ] Spot-check on a real form with persistence + a tuple field (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)