### PR TITLE
perf: drop LRU bump in canonicalizePath; FIFO at this cap

### DIFF
--- a/src/runtime/core/paths.ts
+++ b/src/runtime/core/paths.ts
@@ -69,20 +69,27 @@ export function parseDottedPath(path: string): Segment[] {
 }
 
 /**
- * Bounded LRU cache for canonicalizePath on dotted-string inputs. Real forms
- * issue many repeat canonicalizations for a small working-set of paths as
- * the user types, registers fields, and validates — so an LRU amortises the
- * parse + stringify cost across repeat calls without pinning memory as apps
+ * Bounded FIFO cache for canonicalizePath on dotted-string inputs.
+ * Real forms re-canonicalise a small working-set of paths thousands
+ * of times per session (every keystroke on a registered field, every
+ * validate, every getValue), so a small cache amortises the parse +
+ * stringify cost across repeat calls without pinning memory as apps
  * accumulate fields.
  *
- * Array inputs are not cached: they're already structured, so `.map` +
- * `JSON.stringify` on a short array is cheaper than two Map touches.
+ * Eviction is FIFO (oldest insertion wins), not LRU. The 128-entry
+ * cap is generous relative to a typical form's working set
+ * (playground: ~15 paths; the entire test suite: 45 unique register
+ * patterns) — overflow doesn't fire in practice. On the rare overflow
+ * a re-canonicalisation hit is still O(segments) and lands back in
+ * the cache. Bumping recency on every hit (`delete` + `set`) costs
+ * two Map operations per cache hit, in the hottest read-side loop in
+ * the library, with no observable benefit at this cap — so we don't.
  *
- * LRU is implemented as a plain `Map<string, entry>`: Map preserves insertion
- * order, so on a cache hit we re-insert to move the entry to the end, and on
- * overflow we delete the oldest (Map's first-in-iteration key). The cap is
- * 128 — well above a typical form's working set but small enough that the
- * Map itself stays cheap to scan on eviction.
+ * Array inputs are not cached: callers in the runtime (unset-walker's
+ * recursive `[...segments, i]`, devtools' inspector `payload.path.slice(...)`)
+ * overwhelmingly pass freshly-allocated arrays per call, so a
+ * WeakMap-keyed cache would miss on every call and pay the
+ * lookup-then-set cost without benefit.
  */
 const CANONICAL_STRING_CACHE_MAX = 128
 const canonicalStringCache = new Map<string, { segments: readonly Segment[]; key: PathKey }>()
@@ -109,13 +116,7 @@ export function canonicalizePath(input: string | Path): {
 } {
   if (typeof input === 'string') {
     const cached = canonicalStringCache.get(input)
-    if (cached !== undefined) {
-      // Move to end so frequently-touched paths survive eviction; `delete`
-      // + `set` is the canonical JS-Map LRU bump pattern.
-      canonicalStringCache.delete(input)
-      canonicalStringCache.set(input, cached)
-      return cached
-    }
+    if (cached !== undefined) return cached
     // `parseDottedPath` already normalises each segment; the previous
     // `.map(normalizeSegment)` second pass was a no-op. We drop it here.
     const segments: readonly Segment[] = parseDottedPath(input)


### PR DESCRIPTION
## Summary

- The dotted-string cache in `canonicalizePath` was bumping recency on every cache hit (`Map.delete` + `Map.set`), paying two Map operations on every keystroke / register / setValue / validate. Worth it iff eviction actually fires — but real working sets are tiny (playground: ~15 distinct paths; entire `test/` suite: 45 unique `register(...)` patterns) against a 128-entry cap.
- This is **Tier B1** from the 2026-05-02 perf audit. **B2** (array-form `WeakMap` cache) was re-investigated and **dropped from scope** — call-site audit showed array-form callers overwhelmingly pass freshly-allocated arrays per call (`unset-walker`'s recursive `[...segments, i]`, devtools' inspector `payload.path.slice(...)`), so a WeakMap would miss on every call. Documented in the file's comment block to spare the next perf pass.
- No public API change — cache is module-private.

Independent of #164. Branched from `main`; rebases trivially after #164 merges (the bump lines are unchanged in #164).

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm vitest run` — 1839 pass
- [x] `pnpm check:bench` — gate green; canonicalizePath bench: **9.48× over uncached baseline**, comfortably above the 3× floor; ratio widens vs pre-change with-bump number as expected
- [x] `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)