### PR TITLE
fix(site): ship REPL types in prod + clean up build noise

### DIFF
--- a/apps/site/nuxt.config.ts
+++ b/apps/site/nuxt.config.ts
@@ -276,11 +276,24 @@ export default defineNuxtConfig({
       // same resolver (single vue copy across the @vue/repl tree).
       exclude: ['@vue/repl', '@vue/repl/monaco-editor'],
     },
-    // Production sourcemaps are pure overhead for a docs site —
-    // every chunk would ship a .map sidecar, and several plugins in
-    // the build chain (Tailwind v4's vite plugin, the
-    // module-preload-polyfill) don't emit accurate maps anyway.
-    build: { sourcemap: false },
+    build: {
+      // Production sourcemaps are pure overhead for a docs site —
+      // every chunk would ship a .map sidecar, and several plugins
+      // in the build chain (Tailwind v4's vite plugin, the
+      // module-preload-polyfill) don't emit accurate maps anyway.
+      sourcemap: false,
+      // The @vue/repl Monaco preset bundles Monaco + the Vue/TS
+      // language services into one chunk weighing ~5.4 MB minified
+      // (~1.3 MB gzipped). Vite's default 500 KB threshold flags it
+      // every build with no actionable remediation — the chunk is
+      // already dynamically loaded behind `<DemoReplEditor>` (a
+      // `.client.vue` component) so it never blocks first paint, and
+      // splitting it further isn't possible without forking
+      // @vue/repl. Bumping the threshold to 6000 (6 MB) silences
+      // the existing warning while still catching any unrelated
+      // chunk that grows past Monaco's size.
+      chunkSizeWarningLimit: 6000,
+    },
   },
   hooks: {
     // Strip the Shiki/Twoslash transformers from public runtimeConfig

--- a/apps/site/nuxt.config.ts
+++ b/apps/site/nuxt.config.ts
@@ -1,8 +1,43 @@
 import tailwindcss from '@tailwindcss/vite'
 import { rendererRich, transformerTwoslash } from '@shikijs/twoslash'
+import type { Logger, LogOptions } from 'vite'
 import attaformPkg from '../../package.json'
 import vuePkg from 'vue/package.json'
 import zodPkg from 'zod/package.json'
+
+// Two warning families fire on every build, are not ours to fix,
+// and add nothing actionable for a maintainer reading the logs:
+//
+//   1. "Sourcemap is likely to be incorrect: a plugin (…) was used
+//      to transform files, but didn't generate a sourcemap for the
+//      transformation."
+//      — Tailwind v4's vite plugin and Nuxt's module-preload-polyfill
+//      transform without emitting sourcemaps. Rollup walks the chain
+//      and warns ~17×/build that the resulting maps would be lossy.
+//      We've disabled sourcemap output anyway (vite.build.sourcemap
+//      = false), so the maps don't ship — the warnings are stale.
+//
+//   2. "new URL(\"assets/(editor|vue).worker-…\", import.meta.url)
+//      doesn't exist at build time, it will remain unchanged to be
+//      resolved at runtime."
+//      — @vue/repl's Monaco preset constructs its worker URLs via
+//      dynamic strings; Vite's static analyser can't resolve them
+//      and warns. That warning is exactly the trigger condition for
+//      the Worker-constructor Proxy in DemoReplEditor.client.vue,
+//      which intercepts the runtime resolution and reroutes to
+//      /lib/repl-workers/* (the static copies bundle:repl emits).
+//      Filtered narrowly to the editor + vue worker filenames; any
+//      other "URL doesn't exist at build time" warning still surfaces.
+function isFilteredBuildWarning(msg: string): boolean {
+  if (msg.includes('Sourcemap is likely to be incorrect')) return true
+  if (
+    msg.includes("doesn't exist at build time") &&
+    /\bassets\/(editor|vue)\.worker-[A-Za-z0-9_-]+\.js\b/.test(msg)
+  ) {
+    return true
+  }
+  return false
+}
 
 export default defineNuxtConfig({
   modules: ['@nuxt/content', '@nuxt/fonts', '@nuxtjs/color-mode'],
@@ -195,29 +230,6 @@ export default defineNuxtConfig({
       },
     ],
   },
-  hooks: {
-    // Strip the Shiki transformers from public runtimeConfig before
-    // Nitro's serializer runs over it. @nuxt/content copies the whole
-    // `content.build.markdown.highlight` block into
-    // `runtimeConfig.public.mdc` so client-side MDC rendering can read
-    // it — but our Twoslash transformer carries function callbacks
-    // (`preprocess`, `tokens`, `pre`, `code`) that don't survive JSON
-    // serialization, producing four "may not be able to be serialized"
-    // warnings on every dev start.
-    //
-    // Build-time markdown parsing reads transformers directly from
-    // `nuxt.options.content` (not from runtimeConfig), so removing
-    // them here doesn't affect the rendered output — it just keeps
-    // the functions out of the client-bound config payload, where
-    // they'd be useless anyway since Twoslash runs only at parse time.
-    'nitro:config'(nitroConfig) {
-      const mdc = (nitroConfig.runtimeConfig as { public?: { mdc?: unknown } } | undefined)?.public
-        ?.mdc as { highlight?: { transformers?: unknown[] } } | undefined
-      if (mdc?.highlight?.transformers) {
-        delete mdc.highlight.transformers
-      }
-    },
-  },
   vite: {
     plugins: [tailwindcss()],
     // Mirror Nuxt's devServer.host into Vite's server.host so
@@ -263,6 +275,77 @@ export default defineNuxtConfig({
       // node_modules paths (assets/ neighbors resolve) and through the
       // same resolver (single vue copy across the @vue/repl tree).
       exclude: ['@vue/repl', '@vue/repl/monaco-editor'],
+    },
+    // Production sourcemaps are pure overhead for a docs site —
+    // every chunk would ship a .map sidecar, and several plugins in
+    // the build chain (Tailwind v4's vite plugin, the
+    // module-preload-polyfill) don't emit accurate maps anyway.
+    build: { sourcemap: false },
+  },
+  hooks: {
+    // Strip the Shiki/Twoslash transformers from public runtimeConfig
+    // before Nitro's serializer runs. @nuxt/content copies the whole
+    // `content.build.markdown.highlight` block into
+    // `runtimeConfig.public.mdc` so client-side MDC rendering can
+    // read it — but the Twoslash transformer carries function
+    // callbacks (`preprocess`, `tokens`, `pre`, `code`) that don't
+    // survive JSON serialization, producing "may not be able to be
+    // serialized" warnings during build. Build-time markdown parsing
+    // reads transformers directly from `nuxt.options.content` (not
+    // from runtimeConfig), so removing them here is harmless — the
+    // functions only run during prerender anyway.
+    'nitro:config'(nitroConfig) {
+      const mdc = (nitroConfig.runtimeConfig as { public?: { mdc?: unknown } } | undefined)?.public
+        ?.mdc as { highlight?: { transformers?: unknown[] } } | undefined
+      if (mdc?.highlight?.transformers) {
+        delete mdc.highlight.transformers
+      }
+
+      // Allow `.d.ts` / `.d.cts` / `.d.mts` files in public/ to ship
+      // in the static output. Nuxt's `@nuxt/schema` ships
+      // `**/*.d.{cts,mts,ts}` in the default `ignore` array on the
+      // assumption that declaration files aren't meant for the
+      // browser; Nitro inherits this and applies it to the
+      // public-assets globby pass, stripping our REPL type bundles
+      // from `.output/public/lib/types/`. Without those files, Volar
+      // (via @vue/repl's `pkgFileTextUrl` callback) 404s on
+      // `attaform`/`attaform/zod`/`vue`/`zod` declaration fetches and
+      // intellisense degrades to "any" in production.
+      //
+      // We strip the .d.ts ignore pattern from Nitro's options only.
+      // Nuxt's own component / layout scanners read from
+      // `nuxt.options.ignore` directly (not `nitroConfig.ignore`), so
+      // their behaviour is unaffected — they keep skipping ambient
+      // `.d.ts` files outside `public/` exactly as before.
+      const declRe = /\bd\.\{?(cts|mts|ts|c|m)/
+      if (Array.isArray(nitroConfig.ignore)) {
+        nitroConfig.ignore = nitroConfig.ignore.filter(
+          (p): p is string => typeof p === 'string' && !declRe.test(p)
+        )
+      }
+    },
+    // Wrap Vite's logger to filter the two warning families documented
+    // at the top of the file. Nuxt's vite-builder installs its own
+    // `customLogger` (which forwards to Consola); user-supplied
+    // `vite.customLogger` gets clobbered during the Nuxt config
+    // merge. By the time `vite:configResolved` fires, Nuxt's logger
+    // is on the resolved config as `customLogger` — wrap its `warn` /
+    // `warnOnce` in place so every Vite-emitted warning passes
+    // through our filter before reaching Consola. Fires twice (once
+    // per Vite build: client + server); both loggers get wrapped.
+    'vite:configResolved'(config) {
+      const lg = (config as { customLogger?: Logger }).customLogger
+      if (!lg) return
+      const origWarn = lg.warn.bind(lg)
+      const origWarnOnce = lg.warnOnce.bind(lg)
+      lg.warn = (msg: string, opts?: LogOptions) => {
+        if (isFilteredBuildWarning(msg)) return
+        origWarn(msg, opts)
+      }
+      lg.warnOnce = (msg: string, opts?: LogOptions) => {
+        if (isFilteredBuildWarning(msg)) return
+        origWarnOnce(msg, opts)
+      }
     },
   },
   css: ['@shikijs/twoslash/style-rich.css', '~/assets/css/tailwind.css'],

--- a/apps/site/scripts/bundle-repl-deps.mjs
+++ b/apps/site/scripts/bundle-repl-deps.mjs
@@ -60,6 +60,15 @@ await mkdir(typesDir, { recursive: true })
 
 const watch = process.argv.includes('--watch')
 
+// `tsconfig` is set explicitly to the workspace-root config. Without
+// this, esbuild auto-discovers `apps/site/tsconfig.json` (the cwd this
+// script runs in), which extends `./.nuxt/tsconfig.json` — and `.nuxt/`
+// hasn't been generated yet at this point in the build pipeline
+// (bundle:repl runs BEFORE nuxi build). The auto-discovery path then
+// emits "Cannot find base config file './.nuxt/tsconfig.json'" three
+// times per build. Pointing at the library's own tsconfig sidesteps
+// the unresolved extends and gives esbuild the right `paths` aliases
+// for `attaform` / `attaform/zod` resolution against `src/`.
 const sharedEsbuildOpts = {
   bundle: true,
   format: 'esm',
@@ -67,6 +76,7 @@ const sharedEsbuildOpts = {
   target: 'es2020',
   sourcemap: 'linked',
   outdir: outDir,
+  tsconfig: resolve(repoRoot, 'tsconfig.json'),
 }
 
 const ctxs = await Promise.all([


### PR DESCRIPTION
## Summary

Branched off `main` after #168 merged. Fixes one real production bug and clears the build log of noise — answering Oswald's question "are you suppressing warnings or fixing issues?" with: a fix where one was available, and a narrow filter where none was.

## Real fix: REPL intellisense was broken in production

The live REPL's Volar language service fetches `attaform` / `attaform/zod` / `vue` / `zod` declaration files via `@vue/repl`'s `pkgFileTextUrl` callback, which resolves to `/lib/types/<pkg>/index.d.ts`. The `bundle:repl` script writes those `.d.ts` files to `apps/site/public/lib/types/` at build time.

**In dev they served fine. In prod they were missing** — Nuxt 4's `@nuxt/schema` ships `**/*.d.{cts,mts,ts}` in the default `options.ignore` array (treating declaration files as TS artifacts not meant for the browser), and Nitro's public-asset copy honours that list, stripping our type bundles from `.output/public/lib/types/`. Volar 404s on the missing files, intellisense degrades to "any" — emails aren't type-checked, `useForm` doesn't autocomplete, hover tooltips empty.

Strip the `.d.ts` ignore patterns from Nitro's options only, inside the existing `nitro:config` hook. Nuxt's own component / layout scanners read from `nuxt.options.ignore` directly (not `nitroConfig.ignore`), so they keep ignoring ambient `.d.ts` files outside `public/` exactly as before.

## Smaller real fix: tsconfig discovery in `bundle:repl`

esbuild's auto-discovery picked up `apps/site/tsconfig.json` (the cwd it runs in), which extends `./.nuxt/tsconfig.json` — but `.nuxt/` doesn't exist yet at that point in the build pipeline (`bundle:repl` runs BEFORE `nuxi build`). esbuild emitted "Cannot find base config file" three times per build. Passing the workspace-root tsconfig explicitly resolves both the warning and the unresolved `paths` aliases.

## Filtered (not fixable from our side)

- **Sourcemap chain warnings** (~17×/build) — Tailwind v4's vite plugin and Nuxt's `module-preload-polyfill` don't emit sourcemaps for their transformations. Both are upstream issues. `vite.build.sourcemap: false` disables map output but Rollup still walks the chain and warns.
- **`new URL("assets/(editor|vue).worker-…").js" doesn't exist at build time`** — exactly the trigger condition for the `Worker`-constructor Proxy in `DemoReplEditor.client.vue` that intercepts the runtime resolution and reroutes to `/lib/repl-workers/`. The warning's own remediation (`/* @vite-ignore */`) lives in `@vue/repl`'s compiled output, not ours.

Both filtered narrowly via a wrapper installed on Vite's `customLogger` inside `vite:configResolved` — user-supplied `vite.customLogger` doesn't survive Nuxt's config merge step.

## Verified

- Clean rebuild inside the dev container: zero meaningful build warnings.
- `find apps/site/.output/public/lib/types -name "*.d.ts"` → all four files present (attaform 3298 lines, zod 5172 lines — real declarations, not stubs).
- Pagefind still indexes 33 pages, prerender still emits 35 HTML files.
- `pnpm typecheck` clean.

## Test plan

- [ ] After Vercel auto-deploys: open `https://attaform.com/play`, hover `useForm` — popover shows the full signature.
- [ ] On `/`, edit the demo schema in the REPL — `form.errors.email?.[0]?.message` autocompletes.
- [ ] Open `https://attaform.com/lib/types/attaform/index.d.ts` directly — should serve the .d.ts (was 404 before).
- [ ] Vercel build log shows no `Cannot find base config file`, no `Sourcemap is likely to be incorrect`, no Monaco worker URL warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)