### PR TITLE
refactor(site): editorial polish on docs landing + homepage v-register flag

### DIFF
--- a/apps/site/pages/docs/index.vue
+++ b/apps/site/pages/docs/index.vue
@@ -20,13 +20,13 @@
     },
     {
       title: 'Recipes',
-      body: 'Task-oriented walkthroughs: persistence, transforms, async validation, focus-on-error.',
-      to: '/docs/recipes/transforms',
+      body: 'Task-oriented walkthroughs: persistence, dynamic field arrays, async validation, focus-on-error.',
+      to: '/docs/recipes/persistence',
       icon: BookOpen,
     },
     {
       title: 'Troubleshooting',
-      body: 'Common gotchas, hydration mismatches, slim-primitive write errors.',
+      body: 'Common gotchas: type-inference failures, SSR hydration mismatches, v-register on the wrong root.',
       to: '/docs/troubleshooting',
       icon: Wrench,
     },

--- a/apps/site/pages/index.vue
+++ b/apps/site/pages/index.vue
@@ -194,7 +194,10 @@
             </h2>
             <p class="mt-4 text-lg text-fg-muted">
               Edit the schema, edit the template, watch it run. No backend, no build step — every
-              change re-renders live.
+              change re-renders live. Inputs stay native —
+              <code class="font-mono">v-register</code> is a Vue directive, not a wrapper component,
+              so there's no field-component overhead between your
+              <code class="font-mono">&lt;input&gt;</code> and the form.
             </p>
           </div>
           <UiButton to="/play" variant="link">


### PR DESCRIPTION
## Summary

Three small editorial fixes off external review feedback:

1. **Recipes card** — repointed `/docs/recipes/transforms` → `/docs/recipes/persistence`. Persistence is the most-developed recipe corner (walkthrough + policy + backends + edge cases) and the use case readers most often reach Recipes for. Card body now leads with persistence + dynamic field arrays as representative tasks rather than the alphabetical-by-accident default.

2. **Troubleshooting card body** — dropped the jargon "slim-primitive write errors" (means nothing without the doc page already open). Replaced with concrete reader-facing gotchas: "type-inference failures, SSR hydration mismatches, v-register on the wrong root."

3. **Homepage `v-register` flag** — `v-register` is a distinctive design choice (Vue directive rather than a field-component wrapper) and the docs/quickstart introduced it casually. Added one sentence to the homepage Live editor section's lede: "Inputs stay native — `v-register` is a Vue directive, not a wrapper component, so there's no field-component overhead between your `<input>` and the form." Lands directly under the demo embed where readers first encounter it.

## Test plan

- [ ] `/docs` landing — Recipes card body now mentions persistence first; clicking it lands on `/docs/recipes/persistence` (was `/docs/recipes/transforms`).
- [ ] `/docs` landing — Troubleshooting card body reads cleanly (no "slim-primitive" jargon).
- [ ] `/` homepage — Live editor section's lede now ends with the v-register sentence; `v-register` and `<input>` render as inline `<code>` styled correctly.
- [ ] `pnpm typecheck` from `apps/site` clean.
- [ ] After Vercel deploys: same three checks on attaform.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)