### PR TITLE
refactor(test): centralise wait/waitUntil + convert fixed-time waits

### DIFF
--- a/test/composables/du-variant-persistence.test.ts
+++ b/test/composables/du-variant-persistence.test.ts
@@ -8,6 +8,7 @@ import { createAttaform } from '../../src/runtime/core/plugin'
 import { fingerprintZodSchema } from '../../src/runtime/adapters/zod-v4/fingerprint'
 import { hashStableString } from '../../src/runtime/core/hash'
 import type { UseFormReturnType } from '../../src/runtime/types/types-api'
+import { wait, waitUntil } from '../utils/form-harness'
 
 /**
  * Variant memory × persistence interaction. The contract under test:
@@ -173,29 +174,11 @@ function mount(persistKey: string): {
   return { app, api: handle.api as Api, setAddress, setNumber, setChannel }
 }
 
-async function wait(ms: number): Promise<void> {
-  await new Promise<void>((r) => setTimeout(r, ms))
-}
-
 async function drain(rounds = 8): Promise<void> {
   for (let i = 0; i < rounds; i++) {
     await Promise.resolve()
     await nextTick()
   }
-}
-
-async function waitUntil<T>(
-  predicate: () => T | null | undefined,
-  timeoutMs = 500,
-  intervalMs = 10
-): Promise<T> {
-  const start = Date.now()
-  while (Date.now() - start < timeoutMs) {
-    const v = predicate()
-    if (v !== null && v !== undefined) return v
-    await wait(intervalMs)
-  }
-  throw new Error('waitUntil: predicate never resolved')
 }
 
 describe('rememberVariants × persistence — refresh-survives contract', () => {

--- a/test/composables/persist-hydration-validate.test.ts
+++ b/test/composables/persist-hydration-validate.test.ts
@@ -6,6 +6,7 @@ import { fingerprintZodSchema } from '../../src/runtime/adapters/zod-v4/fingerpr
 import { hashStableString } from '../../src/runtime/core/hash'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import { useForm } from '../../src/zod'
+import { waitUntil } from '../utils/form-harness'
 
 /**
  * Persistence hydration must run validation to completion against the
@@ -89,24 +90,6 @@ type SyncForm = z.infer<typeof syncSchema>
 
 const ASYNC_FP = hashStableString(fingerprintZodSchema(asyncSchema))
 const SYNC_FP = hashStableString(fingerprintZodSchema(syncSchema))
-
-async function wait(ms: number): Promise<void> {
-  await new Promise((r) => setTimeout(r, ms))
-}
-
-async function waitUntil<T>(
-  predicate: () => T | null | undefined,
-  timeoutMs = 2000,
-  intervalMs = 5
-): Promise<T | null> {
-  const deadline = Date.now() + timeoutMs
-  for (;;) {
-    const v = predicate()
-    if (v !== null && v !== undefined) return v
-    if (Date.now() >= deadline) return null
-    await wait(intervalMs)
-  }
-}
 
 type AsyncApi = ReturnType<typeof useForm<typeof asyncSchema>>
 type SyncApi = ReturnType<typeof useForm<typeof syncSchema>>

--- a/test/composables/persistence.test.ts
+++ b/test/composables/persistence.test.ts
@@ -10,6 +10,7 @@ import { __resetIndexedDbForTests } from '../../src/runtime/core/persistence/ind
 import { createAttaform } from '../../src/runtime/core/plugin'
 import { fingerprintZodSchema } from '../../src/runtime/adapters/zod-v4/fingerprint'
 import { hashStableString } from '../../src/runtime/core/hash'
+import { wait, waitUntil } from '../utils/form-harness'
 
 /**
  * Node 25's native `localStorage` (behind `--experimental-webstorage`)
@@ -169,34 +170,6 @@ async function drain(rounds = 8): Promise<void> {
   for (let i = 0; i < rounds; i++) {
     await Promise.resolve()
     await nextTick()
-  }
-}
-
-async function wait(ms: number): Promise<void> {
-  await new Promise((r) => setTimeout(r, ms))
-}
-
-/**
- * Poll `predicate` until it returns a non-null / non-undefined value or
- * the timeout elapses. Avoids the classic `await wait(40)` flake: the
- * debounced writer + adapter chain (dynamic-imported + Promise.then →
- * adapter.setItem) can exceed a fixed sleep on a loaded CI runner,
- * even for an expected 20 ms debounce window. Polling converges as
- * soon as the write lands, with a generous ceiling (default 500 ms)
- * so a genuinely broken write still fails the assertion instead of
- * hanging the suite.
- */
-async function waitUntil<T>(
-  predicate: () => T | null | undefined,
-  timeoutMs = 500,
-  intervalMs = 5
-): Promise<T | null> {
-  const deadline = Date.now() + timeoutMs
-  for (;;) {
-    const v = predicate()
-    if (v !== null && v !== undefined) return v
-    if (Date.now() >= deadline) return null
-    await wait(intervalMs)
   }
 }
 

--- a/test/composables/spike-no-debounce.test.ts
+++ b/test/composables/spike-no-debounce.test.ts
@@ -18,6 +18,7 @@ import { z } from 'zod'
 import { useForm } from '../../src/zod'
 import { vRegister } from '../../src/runtime/core/directive'
 import { createAttaform } from '../../src/runtime/core/plugin'
+import { waitUntil } from '../utils/form-harness'
 
 let app: App | undefined
 afterEach(() => {
@@ -36,11 +37,6 @@ async function microtaskFlush(): Promise<void> {
     await Promise.resolve()
     await nextTick()
   }
-}
-
-async function timerFlush(ms: number): Promise<void> {
-  await new Promise((r) => setTimeout(r, ms))
-  await nextTick()
 }
 
 describe('spike — debounceMs: 0 disables the debounce timer', () => {
@@ -88,8 +84,11 @@ describe('spike — debounceMs: 0 disables the debounce timer', () => {
     await microtaskFlush()
     expect(handle.api?.errors.email).toBeUndefined()
 
-    // Wait long enough for the 125 ms timer to fire, then errors land.
-    await timerFlush(150)
+    // Wait for the 125 ms timer + revalidation chain to land. Polled
+    // rather than fixed-time-pumped so a contended CI doesn't flake.
+    await waitUntil(() =>
+      handle.api?.errors.email?.[0]?.message === 'Enter a valid email.' ? true : null
+    )
     expect(handle.api?.errors.email?.[0]?.message).toBe('Enter a valid email.')
   })
 
@@ -248,8 +247,10 @@ describe('spike — persist.debounceMs: 0 writes immediately on every form chang
     await microtaskFlush()
     expect(writes.length).toBe(0)
 
-    // After the timer, exactly one coalesced write lands.
-    await timerFlush(350)
+    // After the debounce timer fires, exactly one coalesced write
+    // lands. Poll on the side-effect rather than time-pumping so a
+    // contended CI doesn't flake before the timer has a chance.
+    await waitUntil(() => (writes.length >= 1 ? true : null))
     expect(writes.length).toBe(1)
   })
 

--- a/test/composables/use-form-v3-forwarding.test.ts
+++ b/test/composables/use-form-v3-forwarding.test.ts
@@ -8,6 +8,7 @@ import { createAttaform } from '../../src/runtime/core/plugin'
 import { useForm } from '../../src/zod-v3'
 import { fingerprintZodSchema } from '../../src/runtime/adapters/zod-v3/fingerprint'
 import { hashStableString } from '../../src/runtime/core/hash'
+import { waitUntil } from '../utils/form-harness'
 
 /**
  * Regression pin: the zod v3 `useForm` wrapper used to hand-pick the
@@ -48,10 +49,6 @@ async function drain(rounds = 8): Promise<void> {
   }
 }
 
-async function wait(ms: number): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, ms))
-}
-
 describe('v3 useForm forwards opt-in options to useAbstractForm', () => {
   const apps: App[] = []
   afterEach(() => {
@@ -76,7 +73,7 @@ describe('v3 useForm forwards opt-in options to useAbstractForm', () => {
     // reached useAbstractForm — populates fieldErrors within the
     // debounce window.
     api.setValue('email', 'nope')
-    await wait(60)
+    await waitUntil(() => (api.errors.email?.[0]?.message === 'bad email' ? true : null))
     await drain()
 
     expect(api.errors.email?.[0]?.message).toBe('bad email')
@@ -131,7 +128,7 @@ describe('v3 useForm forwards opt-in options to useAbstractForm', () => {
     if (input === undefined) throw new Error('email input not mounted')
     input.value = 'alice@example.com'
     input.dispatchEvent(new Event('input', { bubbles: true }))
-    await wait(50)
+    await waitUntil(() => (setItem.mock.calls.length > 0 ? true : null))
     await drain()
 
     expect(setItem).toHaveBeenCalled()

--- a/test/utils/form-harness.ts
+++ b/test/utils/form-harness.ts
@@ -23,6 +23,51 @@ export async function flush(): Promise<void> {
   }
 }
 
+/**
+ * Sleep for `ms` real-time milliseconds. Thin wrapper over
+ * `setTimeout` for ergonomic use inside `waitUntil`'s polling loop
+ * and for the rare test that legitimately needs a wall-clock pause.
+ *
+ * Prefer `waitUntil(predicate)` over `wait(N)` followed by an
+ * assertion — a fixed-time pump can blow past its budget on a
+ * contended CI runner (dynamic-imported adapters, debounced writes,
+ * async refinement chains), producing flakes that pass locally and
+ * fail intermittently on CI.
+ */
+export async function wait(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * Poll `predicate` until it returns a non-null / non-undefined value
+ * or the timeout elapses. Returns the resolved value, or `null` if
+ * the deadline passed.
+ *
+ * Use this for any wait-then-assert pattern that depends on async
+ * I/O — debounced storage writes, dynamic-imported persistence
+ * adapters, async Zod refinements. The classic alternative
+ * (`await wait(40); expect(...)`) silently flakes when the chain
+ * exceeds the fixed budget under CI contention.
+ *
+ * The default 1000 ms timeout covers in-process work, dynamic-imported
+ * adapters, and short async-refinement chains. Raise it for tests
+ * that wait on a debounce window plus an external mock with its own
+ * latency budget.
+ */
+export async function waitUntil<T>(
+  predicate: () => T | null | undefined,
+  timeoutMs = 1000,
+  intervalMs = 5
+): Promise<T | null> {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    const v = predicate()
+    if (v !== null && v !== undefined) return v
+    if (Date.now() >= deadline) return null
+    await wait(intervalMs)
+  }
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyUseForm = (opts: any) => any
 


### PR DESCRIPTION
## Summary

Consolidates the test suite's async-wait helpers and converts the remaining fixed-time-wait + assert sites surfaced by the audit. Independent of [#173](https://github.com/attaform/Attaform/pull/173) (which fixes the v=2 envelope flake in \`blank-persistence.test.ts\`); the two PRs touch disjoint files and can merge in any order.

### What's centralised

Adds \`wait\` and \`waitUntil\` to \`test/utils/form-harness.ts\`. Drops three ad-hoc copies of \`waitUntil\` (one of which threw on timeout — now nullable like the other two for consistency) and three ad-hoc \`wait\` helpers. Default \`timeoutMs\` bumped from 500ms → 1000ms to cover async-refinement chains comfortably.

### What's converted

Two remaining wait-then-assert sites that depended on a fixed-time pump:

| File | Before | After |
|---|---|---|
| \`use-form-v3-forwarding.test.ts\` | \`await wait(60)\` then assert on debounced field error | \`await waitUntil(predicate)\` |
| \`use-form-v3-forwarding.test.ts\` | \`await wait(50)\` then assert \`setItem\` was called | \`await waitUntil(predicate)\` |
| \`spike-no-debounce.test.ts\` | \`await timerFlush(150)\` then assert error message | \`await waitUntil(predicate)\` |
| \`spike-no-debounce.test.ts\` | \`await timerFlush(350)\` then assert \`writes.length\` | \`await waitUntil(predicate)\` |

The spike tests intentionally exercise debounce timers; the polled wait still proves the timer fired without baking in a fixed sleep budget.

### What's NOT touched

The ~24 microtask-only \`flush()\` helpers across the suite — they wait out **synchronous** Vue reactive work (no async I/O dependency), so they're not the same antipattern. Left alone for scope discipline.

\`blank-persistence.test.ts\` is also left alone (covered by #173).

## Test plan

- [x] \`pnpm test\` — 2042/2042 ✓
- [x] \`pnpm lint\` — clean ✓
- [x] \`pnpm typecheck\` — clean ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)