### PR TITLE
feat: Vite + useForm DX overhaul

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -11,13 +11,33 @@ on:
     branches: ['main']
   workflow_dispatch:
 
+# Cancel superseded runs on the same ref. When a follow-up commit
+# lands while CI is still running, the older run is killed — only
+# the latest commit's status matters for review. Saves wasted
+# compute on force-push / rapid push cycles.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Job topology — designed for parallelism, no redundant work:
+#   - Version-agnostic checks (lint, typecheck, size, bench, coverage,
+#     build-site) each run ONCE on a single Node version, in parallel.
+#     They have no Node-version sensitivity — running them on a matrix
+#     would 3× the compute for no signal.
+#   - Cross-Node coverage lives in the `test` matrix: it runs ONLY
+#     `pnpm test`, on the load-bearing Node majors (20.x as the
+#     engines minimum, 22.x as the current LTS).
+#
+# Wall-clock time = max(slowest single-Node job, slowest matrix
+# shard). The previous `pnpm check` matrix had each Node version
+# re-running every step (including the Node-version-agnostic ones),
+# pushing the critical path to ~5min. Splitting brings it to ~2min.
+#
+# When adding a new check to `pnpm check`, ALSO add a corresponding
+# job here. `pnpm check` stays the single source-of-truth command
+# for local dev; CI fans the same set out into independent jobs.
+
 jobs:
-  # Dedicated lint job — runs in parallel with the test matrix so a lint-only
-  # regression flips the PR red within ~30s instead of waiting on the full
-  # gate (typecheck + tests + size + bench + coverage). The matrix's
-  # `pnpm check` still runs lint + format:check too; the duplication is
-  # intentional (cheap, and keeps `pnpm check` as the single source-of-truth
-  # command for local dev).
   lint:
     name: Lint and format
     runs-on: ubuntu-latest
@@ -51,9 +71,7 @@ jobs:
 
       # Generate apps/site/.nuxt/imports.d.ts so the eslint config can
       # parse Nuxt's auto-imports (`computed`, `useState`, etc.) and
-      # `no-undef` doesn't false-fail on auto-imported names. The full
-      # `test` job below also runs this before `pnpm check`; mirroring
-      # the same step here keeps the dedicated lint job self-contained.
+      # `no-undef` doesn't false-fail on auto-imported names.
       - name: Prepare Nuxt auto-imports
         run: pnpm dev:prepare
 
@@ -63,8 +81,45 @@ jobs:
       - name: Prettier
         run: pnpm format:check
 
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Stub attaform (Nuxt + site types)
+        run: pnpm dev:prepare
+
+      - name: Typecheck
+        run: pnpm typecheck
+
   test:
-    name: Full check on Node.js ${{ matrix.node-version }}
+    name: Test (Node.js ${{ matrix.node-version }})
     runs-on: ubuntu-latest
 
     strategy:
@@ -72,7 +127,12 @@ jobs:
         # Node 18 dropped after its 2025-04-30 EOL — several transitive
         # dependencies (Nuxt 4's nuxi → @clack/core) now call
         # `node:util.styleText`, which ships in Node 20.12+ only.
-        node-version: [20.x, 22.x, 'lts/*']
+        #
+        # Pinning explicit majors (rather than `lts/*` aliases): 20.x
+        # is the engines lower bound; 22.x is the current LTS. `lts/*`
+        # was previously listed too, but it currently resolves to 22.x
+        # — the same row twice was pure waste.
+        node-version: [20.x, 22.x]
       fail-fast: false
 
     steps:
@@ -106,28 +166,133 @@ jobs:
       - name: Stub attaform (Nuxt + site types)
         run: pnpm dev:prepare
 
-      # `pnpm check` runs the full gate: lint → format:check → typecheck →
-      # test → check:size → check:bench → check:coverage. Running it on the
-      # full Node matrix catches compat regressions (a new syntax, a changed
-      # Buffer API, a bundler quirk on LTS vs current) at PR time rather
-      # than on release.
-      - name: Full pnpm check
-        run: pnpm check
+      - name: Run tests
+        run: pnpm test
 
-      # Build the docs site so a regression in apps/site (broken link in
-      # markdown, malformed Vue template, REPL bundler choke on src/ change)
-      # fails the PR. Runs after pnpm check so the lib gate signal isn't
-      # masked by site issues.
+  size:
+    name: Bundle size
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      # `pnpm check:size` runs `pnpm prepack` (unbuild) before
+      # invoking size-limit, so we don't need a separate prepack
+      # step here.
+      - name: Check bundle size
+        run: pnpm check:size
+
+  bench:
+    name: Performance benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Stub attaform
+        run: pnpm dev:prepare
+
+      - name: Run benchmarks
+        run: pnpm check:bench
+
+  build-site:
+    name: Build docs site
+    runs-on: ubuntu-latest
+    # The docs site is a downstream consumer of attaform — building
+    # it catches site-level regressions (broken markdown link, REPL
+    # bundler choke on a src/ change) at PR time. Node-version
+    # agnostic: a single LTS run is enough; the test matrix covers
+    # the cross-version surface.
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Stub attaform (Nuxt + site types)
+        run: pnpm dev:prepare
+
       - name: Build docs site
         run: pnpm build:site
 
   coverage-artifact:
     name: Publish coverage HTML artifact
     runs-on: ubuntu-latest
-    # Independent of the matrix job — this exists so PR reviewers can open
-    # the coverage report in a browser without checking out the branch and
-    # running the suite locally. Fails only if coverage thresholds fail
-    # (matrix job would already be red in that case).
+    # Independent of the test matrix — this exists so PR reviewers
+    # can open the coverage report in a browser without checking out
+    # the branch and running the suite locally. Uses
+    # `pnpm check:coverage` (vitest with coverage instrumentation),
+    # which also fails the job if coverage thresholds drop.
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -128,11 +128,14 @@ jobs:
         # dependencies (Nuxt 4's nuxi → @clack/core) now call
         # `node:util.styleText`, which ships in Node 20.12+ only.
         #
-        # Pinning explicit majors (rather than `lts/*` aliases): 20.x
-        # is the engines lower bound; 22.x is the current LTS. `lts/*`
-        # was previously listed too, but it currently resolves to 22.x
-        # — the same row twice was pure waste.
-        node-version: [20.x, 22.x]
+        # Two-row matrix: 20.x is the engines lower bound (pinned —
+        # never auto-rotates), and `lts/*` is the auto-rotating
+        # current-LTS canary (today 22.x; when Node 24 ships LTS the
+        # canary jumps with no config change). Listing 22.x explicitly
+        # alongside `lts/*` would be redundant today and would freeze
+        # us at "previous LTS" the moment a new one ships — neither
+        # outcome is what we want.
+        node-version: [20.x, 'lts/*']
       fail-fast: false
 
     steps:

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -171,7 +171,36 @@ export default [
     // withMeta clone-on-write + getFieldMetaAtPath resolver + path-
     // walker tree traversal for shared-schema disambiguation).
     // Measured at 29.20 KB.
-    limit: '30 KB',
+    //
+    // Raised 30 → 45 KB on the unified-attaform/zod-entry branch.
+    // `attaform/zod` is no longer a single-adapter subpath — it's
+    // the runtime-dispatch unified entry that pulls in BOTH the
+    // Zod 3 wrapper and the Zod 4 adapter so it can route on schema
+    // shape at call time. The build-time alias in `attaform/vite`
+    // rewrites `attaform/zod` imports to the matching explicit
+    // subpath (`/zod-v3` or `/zod-v4`), so Vite consumers DON'T
+    // ship this file in their bundle. The size cap covers the
+    // "no Vite plugin" fallback path. Explicit-subpath consumers
+    // (other bundlers) still get a lean ~30 KB v3 or v4 bundle.
+    // Measured at 40.55 KB; 4.45 KB headroom.
+    limit: '45 KB',
+    gzip: true,
+    ignore: ['zod'],
+    modifyEsbuildConfig: asEsm,
+  },
+  {
+    path: 'dist/zod-v4.mjs',
+    // Explicit Zod 4 subpath. Mirrors what `attaform/zod` used to be
+    // before the unified-entry rework: a single-adapter bundle with
+    // strict typing. The Vite plugin rewrites `attaform/zod` to this
+    // path at build time when zod@^4 is detected, so most Vite
+    // consumers ship this regardless of which import they wrote.
+    //
+    // Cap at 36 KB to match zod-v3.mjs — unbuild's chunker pulls
+    // unified-entry shared code into v4's closure on this branch,
+    // adding ~5 KB over the pre-rework single-adapter baseline.
+    // Measured at 34.89 KB.
+    limit: '36 KB',
     gzip: true,
     ignore: ['zod'],
     modifyEsbuildConfig: asEsm,
@@ -210,7 +239,14 @@ export default [
     // bump (same shared core chunk + v3 fieldMeta WeakMap shim +
     // withMeta clone via constructor+_def + v3 getFieldMetaAtPath
     // resolver). Measured at 29.05 KB.
-    limit: '30 KB',
+    //
+    // Raised 30 → 36 KB on the unified-attaform/zod-entry branch:
+    // unbuild's chunker now shares more code between zod-v3.mjs and
+    // the unified zod.mjs (which imports from both v3 and v4). The
+    // shared chunk pulls extra symbols into v3's closure that
+    // weren't there when zod.mjs was a single-adapter v4 bundle.
+    // Measured at 34.49 KB; 1.51 KB headroom.
+    limit: '36 KB',
     gzip: true,
     ignore: ['zod', 'lodash-es'],
     modifyEsbuildConfig: asEsm,
@@ -224,7 +260,14 @@ export default [
   },
   {
     path: 'dist/vite.mjs',
-    limit: '4 KB',
+    // Raised 4 → 5 KB on the unified-attaform/zod-entry branch: the
+    // plugin gained a `resolveId` hook + Zod-major detection
+    // (`detectZodMajor` reads the consumer's `zod/package.json` via
+    // `import.meta.resolve`) + the `resolveZodAlias` opt-out + the
+    // associated diagnostic copy (missing-zod throw, unparseable-
+    // version warn). Measured at 4.19 KB; ~0.8 KB headroom for the
+    // follow-up docs / test commit.
+    limit: '5 KB',
     gzip: true,
     ignore: ['vite'],
     modifyEsbuildConfig: asEsmNode,

--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ A type-safe, schema-driven form library for Vue 3 and Nuxt with first-class Zod 
 npm install attaform zod
 ```
 
-**Nuxt 3 / 4** — install the module:
+That's it for client-side rendering. Forms render and validate the moment you call `useForm` — the registry self-installs on first use.
+
+### Going further
+
+**Nuxt 3 / 4** — add the module:
 
 ```ts
 // nuxt.config.ts
@@ -23,15 +27,7 @@ export default defineNuxtConfig({
 })
 ```
 
-**Bare Vue 3** — install the plugin and the Vite plugin:
-
-```ts
-// main.ts
-import { createApp } from 'vue'
-import { createAttaform } from 'attaform'
-
-createApp(App).use(createAttaform()).mount('#app')
-```
+**Bare Vue + SSR** — add the Vite plugin so server-rendered HTML matches the hydrated client (the plugin injects `:value` / `:checked` bindings at compile time):
 
 ```ts
 // vite.config.ts
@@ -41,6 +37,20 @@ import { attaform } from 'attaform/vite'
 export default defineConfig({
   plugins: [vue(), attaform()],
 })
+```
+
+The Vite plugin also rewrites `attaform/zod` imports at build time to `attaform/zod-v3` or `attaform/zod-v4` — your bundle ships only the adapter you actually use.
+
+**App-wide options** — install the Vue plugin if you want to set defaults or disable devtools:
+
+```ts
+// main.ts
+import { createApp } from 'vue'
+import { createAttaform } from 'attaform'
+
+createApp(App)
+  .use(createAttaform({ defaults: { debounceMs: 100 } }))
+  .mount('#app')
 ```
 
 ### Recommended tsconfig
@@ -63,7 +73,7 @@ It catches stale `form.values.contacts[N]` reads at compile time. Nuxt 3 / 4 set
 ```vue
 <script setup lang="ts">
   import { z } from 'zod'
-  import { useForm } from 'attaform/zod' // zod v4; use /zod-v3 for v3
+  import { useForm } from 'attaform/zod' // auto-detects Zod major
 
   const schema = z.object({
     email: z.email(),

--- a/apps/site/composables/useDocsNavigation.ts
+++ b/apps/site/composables/useDocsNavigation.ts
@@ -30,6 +30,7 @@ export const docsNavigation: DocsSection[] = [
       { title: 'useForm return value', to: '/docs/api/use-form-return' },
       { title: 'attaform/zod', to: '/docs/api/zod' },
       { title: 'attaform/zod-v3', to: '/docs/api/zod-v3' },
+      { title: 'attaform/zod-v4', to: '/docs/api/zod-v4' },
       { title: 'attaform/nuxt', to: '/docs/api/nuxt' },
       { title: 'attaform/vite', to: '/docs/api/vite' },
       { title: 'attaform/transforms', to: '/docs/api/transforms' },

--- a/apps/site/nuxt.config.ts
+++ b/apps/site/nuxt.config.ts
@@ -129,11 +129,11 @@ export default defineNuxtConfig({
   },
   // nuxt-og-image renders Vue components to 1200×630 PNGs at build
   // time via Satori. We're on the generic Nitro `static` preset
-  // (rather than the platform-specific `vercel-static`), and the
-  // module logs a one-time "Unknown Nitro preset" warning at config
-  // time about that — it's informational, the prerender path falls
-  // through to node-server compatibility which is correct for our
-  // SSG flow.
+  // (rather than the platform-specific `vercel-static`) for
+  // portability — the resulting `dist/` is servable anywhere. The
+  // og-image module reads `nitro.static` (set in the `nitro:` block
+  // below) to detect SSG and route to its `nitro-prerender`
+  // compatibility profile.
   //
   // `ogImage.fonts` is pinned to Inter explicitly so Satori only
   // tries to load fonts it can actually serve. Without this, the
@@ -340,6 +340,15 @@ export default defineNuxtConfig({
     // those are real bugs too, and catching them in CI beats finding
     // them in production from a user filing an issue.
     preset: 'static',
+    // `static: true` is the SSG flag a few modules read to detect
+    // "this build emits HTML at prerender time, no runtime server."
+    // nuxt-og-image specifically uses it (its `resolveOgImagePreset`
+    // returns `'nitro-prerender'` for `nitro.static`), which puts it
+    // on a known preset and silences the "Unknown Nitro preset
+    // 'static'" warning. Setting `preset: 'static'` alone doesn't
+    // flip this flag — Nitro's `static` preset and the `static`
+    // boolean are sibling concerns rather than one-implies-the-other.
+    static: true,
     prerender: {
       crawlLinks: true,
       routes: ['/', '/docs', '/play'],

--- a/apps/site/nuxt.config.ts
+++ b/apps/site/nuxt.config.ts
@@ -133,10 +133,21 @@ export default defineNuxtConfig({
   // module logs a one-time "Unknown Nitro preset" warning at config
   // time about that — it's informational, the prerender path falls
   // through to node-server compatibility which is correct for our
-  // SSG flow. Inter (the site's primary font) is already pulled in
-  // by @nuxt/fonts; nuxt-og-image picks it up automatically — no
-  // explicit fonts config needed at this layer.
+  // SSG flow.
   //
+  // `ogImage.fonts` is pinned to Inter explicitly so Satori only
+  // tries to load fonts it can actually serve. Without this, the
+  // module discovers font names from the global stack
+  // (`--font-sans` in tailwind.css includes 'Helvetica Neue',
+  // Arial, … as system-font fallbacks) and warns at every dev
+  // start that it can't resolve Arial through Google / Bunny /
+  // Fontsource — Satori needs real woff2 bytes, system fallbacks
+  // aren't fetchable. The OG cards themselves only ever use Inter
+  // (see components/OgImage/Default.satori.vue), so this constrains
+  // resolution to what's actually rendered.
+  ogImage: {
+    fonts: ['Inter:400', 'Inter:600', 'Inter:700'],
+  },
   // nuxt-link-checker walks every prerendered HTML page and probes
   // each <a> + canonical / og:url for resolvability. With
   // `failOnError: true`, a broken internal link exits the build

--- a/build.config.ts
+++ b/build.config.ts
@@ -21,6 +21,7 @@ export default defineBuildConfig({
     'src/transforms',
     'src/zod',
     'src/zod-v3',
+    'src/zod-v4',
     'src/runtime/plugins/attaform',
   ],
   externals: [

--- a/docs/api/vite.md
+++ b/docs/api/vite.md
@@ -1,14 +1,14 @@
 ---
 title: 'attaform/vite — Vite plugin'
-description: "Attaform's Vite plugin applies v-register transforms at compile time so Vue 3 forms stay tree-shakable and zero-cost in your production bundle."
+description: "Attaform's Vite plugin: injects the v-register transforms into @vitejs/plugin-vue and rewrites attaform/zod imports to the matching Zod-major adapter at build time so your bundle ships exactly one adapter."
 ---
 
 # `attaform/vite`
 
-A Vite plugin that injects the `v-register` node transforms into
-`@vitejs/plugin-vue`. Required under bare Vue + Vite for SSR-
-correct `v-register` bindings on `<input>`, `<textarea>`, and
-`<select>`.
+A Vite plugin that does two things:
+
+1. **Injects the `v-register` node transforms** into `@vitejs/plugin-vue` — required under bare Vue + Vite for SSR-correct bindings on `<input>`, `<textarea>`, and `<select>`.
+2. **Rewrites `attaform/zod` imports at build time** to either [`attaform/zod-v3`](/docs/api/zod-v3) or [`attaform/zod-v4`](/docs/api/zod-v4) based on the consumer's installed Zod major. The bundle ships exactly one adapter — no manual subpath choice.
 
 ```ts
 // vite.config.ts
@@ -19,3 +19,41 @@ export default defineConfig({
   plugins: [vue(), attaform()],
 })
 ```
+
+Place the call after `vue()` in the plugins array. Nuxt projects don't need this — [`attaform/nuxt`](/docs/api/nuxt) installs it for you.
+
+## Options
+
+### `resolveZodAlias`
+
+```ts
+attaform({ resolveZodAlias: true | false })
+```
+
+Default `true`. When enabled, the plugin reads the consumer's `zod/package.json` at build time, parses the major version, and registers a `resolveId` hook that rewrites every `attaform/zod` import to the matching subpath:
+
+- `zod@^4` → `attaform/zod-v4`
+- `zod@^3` → `attaform/zod-v3`
+
+`attaform/zod-v3`, `attaform/zod-v4`, and the root `attaform` import are NEVER rewritten — power users who want to pin a specific subpath, or who want the runtime-dispatch behavior of `attaform/zod`, still get it.
+
+Pass `resolveZodAlias: false` when:
+
+- your project intentionally has both `zod` and `zod-v3` (or another aliased pair) installed and the schema-shape dispatch is the right behavior;
+- your monorepo's Zod resolution is non-standard and the plugin's detection (`import.meta.resolve('zod/package.json')`) lands on the wrong copy;
+- you want to rely on the unified entry's runtime dispatch for any other reason.
+
+The opt-out also short-circuits the "zod is not installed" build-time error, so a consumer who hasn't installed Zod yet doesn't see that check fire.
+
+## Build-time errors
+
+When `resolveZodAlias` is on (default):
+
+- **Zod is not installed.** Throws `[attaform/vite] zod is not installed.` at `configResolved`. Install `zod@^3` or `zod@^4`, OR pass `resolveZodAlias: false` to bypass the check (and consume the runtime-dispatch unified entry).
+- **Zod's `version` field is unparseable** (corrupt package.json, monorepo edge case). Logs a one-time `console.warn` and falls through to runtime dispatch — the build still succeeds, the consumer just ships both adapters.
+
+## See also
+
+- [`attaform/zod`](/docs/api/zod) — the unified entry the plugin's alias hook rewrites.
+- [`attaform/nuxt`](/docs/api/nuxt) — the Nuxt module that installs this plugin and the SSR payload bridge in one step.
+- [`attaform/transforms`](/docs/api/transforms) — the bare node transforms, for non-Vite bundlers.

--- a/docs/api/zod-v3.md
+++ b/docs/api/zod-v3.md
@@ -5,8 +5,11 @@ description: 'Use Attaform with Zod 3 schemas: full API parity with the Zod 4 ad
 
 # `attaform/zod-v3`
 
-Zod v3 adapter. Requires `zod@^3`. New projects should use [`/zod`](/docs/api/zod)
-(v4).
+Explicit Zod v3 adapter subpath. Use this when you want to pin v3 regardless of what your bundler resolves — handy for non-Vite bundlers (webpack, esbuild standalone, Rollup) where you'd otherwise pay for both adapters via the unified [`attaform/zod`](/docs/api/zod) entry's runtime fallback.
+
+Most Vite consumers should import from `attaform/zod` instead — the [`attaform/vite`](/docs/api/vite) plugin rewrites that import to this subpath at build time when `zod@^3` is detected, so the same lean bundle ships with less ceremony.
+
+Requires `zod@^3`.
 
 ```ts
 import { useForm, zodAdapter, isZodSchemaType, fieldMeta, withMeta } from 'attaform/zod-v3'

--- a/docs/api/zod-v4.md
+++ b/docs/api/zod-v4.md
@@ -1,0 +1,209 @@
+---
+title: 'attaform/zod-v4 — explicit Zod 4 subpath'
+description: 'The explicit Zod 4 subpath for Attaform — pin the v4 adapter regardless of bundler-side resolution. Same surface as the unified attaform/zod entry, with a guaranteed lean bundle.'
+---
+
+# `attaform/zod-v4`
+
+Explicit Zod v4 adapter subpath. Use this when you want to pin v4 regardless of what your bundler resolves — handy for non-Vite bundlers (webpack, esbuild standalone, Rollup) where you'd otherwise pay for both adapters via the unified [`attaform/zod`](/docs/api/zod) entry's runtime fallback.
+
+Most Vite consumers should import from `attaform/zod` instead — the [`attaform/vite`](/docs/api/vite) plugin rewrites that import to this subpath at build time when `zod@^4` is detected, so the same lean bundle ships with less ceremony.
+
+Requires `zod@^4`. Importing this subpath against `zod@3` throws a clear version-mismatch error from the adapter at the first schema parse.
+
+```ts
+import { useForm, zodAdapter, fieldMeta, withMeta, kindOf, assertZodVersion } from 'attaform/zod-v4'
+import type { FieldMetaPayload, ZodKind } from 'attaform/zod-v4'
+```
+
+## `useForm<Schema>(options)`
+
+The primary entry point. Returns a typed reactive surface; see
+[The useForm return value](/docs/api/use-form-return).
+
+```ts
+const schema = z.object({ email: z.email() })
+const form = useForm({ schema, key: 'signup' })
+```
+
+Options:
+
+| Field              | Type                                                                                                | Required | Description                                                                                                                                    |
+| ------------------ | --------------------------------------------------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `schema`           | `z.ZodType`                                                                                         | yes      | The Zod schema describing the form shape.                                                                                                      |
+| `key`              | `string`                                                                                            | no       | Form identity for `injectForm(key)`, shared state, persistence keys, or DevTools labels. See [Keys](#keys).                                    |
+| `defaultValues`    | `DeepPartial<DefaultValuesShape<Form>>`                                                             | no       | Constraints applied over schema defaults. Each leaf may be the `unset` sentinel. See [Default values](#default-values).                        |
+| `strict`           | `boolean`                                                                                           | no       | Default `true` — defaults that fail the schema seed `schemaErrors` at construction. `false` opts out (multi-step wizards, placeholder rows).   |
+| `onInvalidSubmit`  | `'none'` \| `'focus-first-error'` \| `'scroll-to-first-error'` \| `'both'`                          | no       | Behaviour on failed submit. See [recipe](/docs/recipes/focus-on-error).                                                                        |
+| `validateOn`       | `'change'` \| `'blur'` \| `'submit'`                                                                | no       | When per-field validation runs. Default `'change'`. See [recipe](/docs/recipes/field-level-validation).                                        |
+| `debounceMs`       | `number`                                                                                            | no       | Wait after the last write before re-validating. Default `0`. Only valid with `validateOn: 'change'`.                                           |
+| `coerce`           | `boolean` \| `CoercionRegistry`                                                                     | no       | DOM-input coercion. Default `true` (`string→number`, `string→boolean`). See [recipe](/docs/recipes/coerce).                                    |
+| `rememberVariants` | `boolean`                                                                                           | no       | Default `true` — switching back to a discriminated-union variant restores its prior subtree. See [recipe](/docs/recipes/discriminated-unions). |
+| `persist`          | `FormStorageKind \| FormStorage \| { storage, key?, debounceMs?, include?, clearOnSubmitSuccess? }` | no       | Persistence config. Per-field opt-in lives at `register()`. See [Persistence config](#persistence-config).                                     |
+| `history`          | `true` \| `{ max?: number }`                                                                        | no       | Enable undo/redo. See [recipe](/docs/recipes/undo-redo).                                                                                       |
+
+### Keys
+
+Omit for one-off forms — the runtime allocates a synthetic
+`__atta:anon:<id>` via `useId()`. Pass a string when you need
+cross-component lookup via `injectForm(key)`, shared state across
+call-sites, a stable `persist` storage-key default, or a
+recognisable DevTools label.
+
+Keys starting with `__atta:` are reserved for the library's
+internal synthetic-key namespace; passing one throws
+`ReservedFormKeyError`.
+
+### Default values
+
+Refinement-invalid leaves that satisfy the slim primitive type at
+their path (e.g. `'teal'` against `z.enum(['red','green','blue'])`,
+a 4-character string against `z.string().min(8)`) pass through
+unchanged so SSR / autosave rehydration can land partial-but-saved
+state as-is. Wrong-primitive leaves (a number where a string is
+expected) are still replaced by the schema default.
+
+Each primitive leaf may be the `unset` sentinel to mark the path
+displayed-empty at construction.
+
+### Persistence config
+
+The form-level option is operational only — backend, key,
+debounce, error inclusion. Per-field opt-in lives at every
+`register('foo', { persist: true })` call site; this config alone
+never causes any field to persist.
+
+Three input forms: a string shorthand (`'local'` / `'session'` /
+`'indexeddb'`), a custom `FormStorage` adapter passed directly, or
+the full options bag.
+
+Storage keys carry the schema's fingerprint
+(`${base}:${fingerprint}`) so schema changes auto-invalidate old
+drafts. The orphan-cleanup pass on mount sweeps stale-fingerprint
+entries on the configured backend AND wipes any matching keys on
+the non-configured standard backends. Malformed payloads are wiped
+on read.
+
+See [persistence recipe](/docs/recipes/persistence) for the full pattern.
+
+## Schema-attached metadata
+
+Attach labels, descriptions, and placeholders directly to schema
+fields. Read them off `form.fields(path).label` / `.description` /
+`.placeholder` / `.meta` — same surface for leaves and containers.
+
+```ts
+import { z } from 'zod'
+import { fieldMeta, withMeta } from 'attaform/zod-v4'
+
+// Native Zod 4 chain
+const A = z.object({
+  email: z.email().register(fieldMeta, {
+    label: 'Email',
+    placeholder: 'you@example.com',
+  }),
+})
+
+// Helper (works on v3 and v4)
+const B = z.object({
+  email: withMeta(z.email(), {
+    label: 'Email',
+    placeholder: 'you@example.com',
+  }),
+})
+```
+
+Both forms write to the same `fieldMeta` registry; pick whichever
+reads naturally. Container schemas register the same way:
+`z.object({...}).register(fieldMeta, { label: 'Pickup address' })`.
+
+**Resolution order** for each field on `form.fields(path)`:
+
+| Field         | Sources                                                                                                                            |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `label`       | registered `label` → `humanize(lastSegment)` (camelCase / snake_case / kebab-case → Title Case; numeric segments collapse to `''`) |
+| `description` | registered `description` → `schema.description` (Zod's `.describe(...)`) → `undefined`                                             |
+| `placeholder` | registered `placeholder` → `undefined`                                                                                             |
+| `meta`        | the full registered payload, frozen — empty object when nothing has been registered                                                |
+
+Setting both `.describe('...')` and `.register(fieldMeta, { description: '...' })` is fine — the registered description wins,
+and `.describe()` stays readable for unrelated tooling (JSON-Schema
+export, etc.).
+
+**Custom payload keys.** `FieldMetaPayload` is an `interface` — extend
+it via TypeScript module augmentation:
+
+```ts
+declare module 'attaform/zod-v4' {
+  interface FieldMetaPayload {
+    tooltip?: string
+    icon?: string
+  }
+}
+
+const schema = z.object({
+  email: z.email().register(fieldMeta, { label: 'Email', tooltip: 'For login' }),
+})
+
+// template: {{ form.fields.email.meta.tooltip }} → 'For login'
+```
+
+The single `fieldMeta` registry holds the augmented shape — no
+fragmentation across consumers.
+
+**Reusing a sub-schema at multiple paths.** Both registration styles
+are safe. Zod's registry keys on the schema reference, but the
+adapter walks the form's schema tree at first lookup and pairs each
+path with its intended payload — registration order (object literal
+left-to-right) matches walk order, so the two patterns below both
+resolve as you'd expect:
+
+```ts
+const addressSchema = z.object({ line1: z.string(), city: z.string() })
+
+// Native chain — adapter disambiguates by tree-walk order
+const form = z.object({
+  pickup: addressSchema.register(fieldMeta, { label: 'Pickup address' }),
+  delivery: addressSchema.register(fieldMeta, { label: 'Delivery address' }),
+})
+// form.fields('pickup').label   → 'Pickup address'
+// form.fields('delivery').label → 'Delivery address'
+
+// Helper — clones the schema first so each call gets distinct identity
+const form2 = z.object({
+  pickup: withMeta(addressSchema, { label: 'Pickup address' }),
+  delivery: withMeta(addressSchema, { label: 'Delivery address' }),
+})
+```
+
+Sharing a schema with IDENTICAL metadata is also fine — common for
+array elements (every line item shares one `lineItemSchema` instance
+and inherits the same per-leaf labels).
+
+## `zodAdapter(schema)`
+
+Lower-level. Returns an `AbstractSchema<Form, Form>` that wraps a
+Zod schema. Reach for it only when composing your own `useForm`-like
+hook.
+
+## `kindOf(schema)`
+
+Returns the zod kind (`'string'`, `'number'`, `'object'`,
+`'discriminated-union'`, etc.) for a Zod 4 schema. For advanced
+adapter work — wrapping `register`, building per-kind UI, branching
+on schema shape.
+
+## `assertZodVersion(schema)`
+
+Throws if the installed `zod` major doesn't match the adapter. Use
+when wiring custom adapter code that introspects schema internals
+and would silently misbehave under the wrong version.
+
+## `type ZodKind`
+
+Union of the strings returned by `kindOf` — `'string' | 'number' | 'boolean' | 'object' | 'array' | 'tuple' | 'discriminated-union' | 'union' | …`.
+
+## See also
+
+- [`attaform/zod`](/docs/api/zod) — unified entry that auto-detects the consumer's Zod major.
+- [`attaform/zod-v3`](/docs/api/zod-v3) — explicit Zod 3 subpath.

--- a/docs/api/zod.md
+++ b/docs/api/zod.md
@@ -1,200 +1,82 @@
 ---
-title: 'attaform/zod — Zod 4 adapter'
-description: 'The recommended Zod 4 adapter for Attaform — useForm with Zod schemas, withMeta for schema-attached labels, and the fieldMeta registry helpers.'
+title: 'attaform/zod — unified Zod entry'
+description: 'The unified Zod entry for Attaform. Auto-detects the installed Zod major and routes to the matching adapter — `attaform/zod` for the recommended hello-world path, with build-time alias when the Vite plugin is active and runtime dispatch as a graceful fallback.'
 ---
 
 # `attaform/zod`
 
-Zod v4 adapter. Requires `zod@^4`.
+The unified Zod entry. Same import for Zod 3 and Zod 4 projects — the runtime checks the schema's shape and routes to the matching adapter.
 
 ```ts
-import { useForm, zodAdapter, fieldMeta, withMeta, kindOf, assertZodVersion } from 'attaform/zod'
-import type { FieldMetaPayload, ZodKind } from 'attaform/zod'
+import { useForm, fieldMeta, withMeta } from 'attaform/zod'
+import { z } from 'zod'
+
+const form = useForm({ schema: z.object({ email: z.email() }) })
 ```
 
-## `useForm<Schema>(options)`
+This is THE recommended import for new projects. Use it whenever you don't have a specific reason to pin one Zod major.
 
-The primary entry point. Returns a typed reactive surface; see
-[The useForm return value](/docs/api/use-form-return).
+## How resolution works
+
+Three tiers, picked in order:
+
+1. **Build-time alias (preferred).** When the [`attaform/vite`](/docs/api/vite) plugin is installed, it reads your `zod/package.json` at build time and rewrites every `attaform/zod` import to either [`attaform/zod-v3`](/docs/api/zod-v3) or [`attaform/zod-v4`](/docs/api/zod-v4). Your bundle ships exactly one adapter — same DX, smaller payload. Nuxt projects get this automatically via `attaform/nuxt`.
+2. **Runtime dispatch (fallback).** Without the Vite plugin (other bundlers, plain ESM consumption), `useForm` checks `schema.def?.type` (Zod 4) or `schema._def?.typeName` (Zod 3) at call time and routes to the matching adapter. The bundle ships both adapters; the size cost is modest but real.
+3. **Explicit subpath (escape hatch).** Import directly from [`attaform/zod-v3`](/docs/api/zod-v3) or [`attaform/zod-v4`](/docs/api/zod-v4) when you want a guaranteed lean bundle on a non-Vite bundler, or when you intentionally run both Zod majors side by side.
+
+The Vite plugin's [`resolveZodAlias: false`](/docs/api/vite#resolvezodalias) opts out of step 1 if you need the dispatch fallback even with Vite.
+
+## What this entry exports
 
 ```ts
-const schema = z.object({ email: z.email() })
-const form = useForm({ schema, key: 'signup' })
+import {
+  useForm,
+  injectForm,
+  useRegister,
+  fieldMeta,
+  withMeta,
+  unset,
+  isUnset,
+  AttaformErrorCode,
+} from 'attaform/zod'
+import type { FieldMetaPayload, Unset } from 'attaform/zod'
 ```
 
-Options:
+| Export                                      | What it does                                                                            |
+| ------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `useForm`                                   | Runtime-dispatching wrapper. Type signature targets Zod 4. See [usage](#useform).       |
+| `injectForm`, `useRegister`                 | Schema-agnostic — identical across the two adapters.                                    |
+| `fieldMeta`, `withMeta`, `FieldMetaPayload` | Re-exported from the v4 adapter; see [Caveats](#caveats) for the runtime-dispatch case. |
+| `unset`, `isUnset`, `Unset`                 | Sentinel for "displayed empty"; identical across adapters.                              |
+| `AttaformErrorCode`                         | Library-emitted error-code enum (`atta:*`).                                             |
 
-| Field              | Type                                                                                                | Required | Description                                                                                                                                    |
-| ------------------ | --------------------------------------------------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `schema`           | `z.ZodType`                                                                                         | yes      | The Zod schema describing the form shape.                                                                                                      |
-| `key`              | `string`                                                                                            | no       | Form identity for `injectForm(key)`, shared state, persistence keys, or DevTools labels. See [Keys](#keys).                                    |
-| `defaultValues`    | `DeepPartial<DefaultValuesShape<Form>>`                                                             | no       | Constraints applied over schema defaults. Each leaf may be the `unset` sentinel. See [Default values](#default-values).                        |
-| `strict`           | `boolean`                                                                                           | no       | Default `true` — defaults that fail the schema seed `schemaErrors` at construction. `false` opts out (multi-step wizards, placeholder rows).   |
-| `onInvalidSubmit`  | `'none'` \| `'focus-first-error'` \| `'scroll-to-first-error'` \| `'both'`                          | no       | Behaviour on failed submit. See [recipe](/docs/recipes/focus-on-error).                                                                        |
-| `validateOn`       | `'change'` \| `'blur'` \| `'submit'`                                                                | no       | When per-field validation runs. Default `'change'`. See [recipe](/docs/recipes/field-level-validation).                                        |
-| `debounceMs`       | `number`                                                                                            | no       | Wait after the last write before re-validating. Default `0`. Only valid with `validateOn: 'change'`.                                           |
-| `coerce`           | `boolean` \| `CoercionRegistry`                                                                     | no       | DOM-input coercion. Default `true` (`string→number`, `string→boolean`). See [recipe](/docs/recipes/coerce).                                    |
-| `rememberVariants` | `boolean`                                                                                           | no       | Default `true` — switching back to a discriminated-union variant restores its prior subtree. See [recipe](/docs/recipes/discriminated-unions). |
-| `persist`          | `FormStorageKind \| FormStorage \| { storage, key?, debounceMs?, include?, clearOnSubmitSuccess? }` | no       | Persistence config. Per-field opt-in lives at `register()`. See [Persistence config](#persistence-config).                                     |
-| `history`          | `true` \| `{ max?: number }`                                                                        | no       | Enable undo/redo. See [recipe](/docs/recipes/undo-redo).                                                                                       |
+For `zodAdapter`, `kindOf`, `assertZodVersion`, `ZodKind`, and `UnsupportedSchemaError` — the surfaces that diverge between v3 and v4 — use the [`attaform/zod-v3`](/docs/api/zod-v3) or [`attaform/zod-v4`](/docs/api/zod-v4) explicit subpath.
 
-### Keys
+## `useForm`
 
-Omit for one-off forms — the runtime allocates a synthetic
-`__atta:anon:<id>` via `useId()`. Pass a string when you need
-cross-component lookup via `injectForm(key)`, shared state across
-call-sites, a stable `persist` storage-key default, or a
-recognisable DevTools label.
+Same surface as the per-major adapters. See [The useForm return value](/docs/api/use-form-return) for the full return shape, and the [`attaform/zod-v4`](/docs/api/zod-v4#useformschemaoptions) page for the option table — the unified entry's signature targets Zod 4.
 
-Keys starting with `__atta:` are reserved for the library's
-internal synthetic-key namespace; passing one throws
-`ReservedFormKeyError`.
+```ts
+const form = useForm({
+  schema: z.object({ email: z.email() }),
+  key: 'signup',
+})
+```
 
-### Default values
-
-Refinement-invalid leaves that satisfy the slim primitive type at
-their path (e.g. `'teal'` against `z.enum(['red','green','blue'])`,
-a 4-character string against `z.string().min(8)`) pass through
-unchanged so SSR / autosave rehydration can land partial-but-saved
-state as-is. Wrong-primitive leaves (a number where a string is
-expected) are still replaced by the schema default.
-
-Each primitive leaf may be the `unset` sentinel to mark the path
-displayed-empty at construction.
-
-### Persistence config
-
-The form-level option is operational only — backend, key,
-debounce, error inclusion. Per-field opt-in lives at every
-`register('foo', { persist: true })` call site; this config alone
-never causes any field to persist.
-
-Three input forms: a string shorthand (`'local'` / `'session'` /
-`'indexeddb'`), a custom `FormStorage` adapter passed directly, or
-the full options bag.
-
-Storage keys carry the schema's fingerprint
-(`${base}:${fingerprint}`) so schema changes auto-invalidate old
-drafts. The orphan-cleanup pass on mount sweeps stale-fingerprint
-entries on the configured backend AND wipes any matching keys on
-the non-configured standard backends. Malformed payloads are wiped
-on read.
-
-See [persistence recipe](/docs/recipes/persistence) for the full pattern.
+When the build-time alias is in play, the consumer's bundled code resolves to the explicit subpath's full-strength types. Without the alias, TypeScript inference comes from the Zod 4 typings — a Zod 3 consumer gets correct runtime behavior but slightly weaker inference.
 
 ## Schema-attached metadata
 
-Attach labels, descriptions, and placeholders directly to schema
-fields. Read them off `form.fields(path).label` / `.description` /
-`.placeholder` / `.meta` — same surface for leaves and containers.
+`fieldMeta` and `withMeta` are re-exported from the v4 adapter. Same surface as documented in [`attaform/zod-v4` § Schema-attached metadata](/docs/api/zod-v4#schema-attached-metadata).
 
-```ts
-import { z } from 'zod'
-import { fieldMeta, withMeta } from 'attaform/zod'
+## Caveats
 
-// Native Zod 4 chain
-const A = z.object({
-  email: z.email().register(fieldMeta, {
-    label: 'Email',
-    placeholder: 'you@example.com',
-  }),
-})
+- **`fieldMeta` shape on Zod 3 without the Vite plugin.** Without the build-time alias, the unified entry exports the v4 `fieldMeta` registry. The v4 registry's `getFieldMetaList` helper isn't available on Zod 3. If you're on Zod 3 and not using Vite, import `fieldMeta` from [`attaform/zod-v3`](/docs/api/zod-v3) directly.
+- **Both Zod versions installed.** Aliasing both `zod` and `zod-v3` (or similar) bypasses the Vite plugin's detection — pass `attaform({ resolveZodAlias: false })` and consume the runtime dispatch, or import the explicit subpath at every call site.
+- **TypeScript inference.** The unified entry's `useForm` signature targets Zod 4. With the build-time alias, the consumer's code is rewritten to the explicit subpath, so post-build inference is exact. Without it, Zod 3 consumers should reach for [`attaform/zod-v3`](/docs/api/zod-v3) for the strongest inference.
 
-// Helper (works on v3 and v4)
-const B = z.object({
-  email: withMeta(z.email(), {
-    label: 'Email',
-    placeholder: 'you@example.com',
-  }),
-})
-```
+## See also
 
-Both forms write to the same `fieldMeta` registry; pick whichever
-reads naturally. Container schemas register the same way:
-`z.object({...}).register(fieldMeta, { label: 'Pickup address' })`.
-
-**Resolution order** for each field on `form.fields(path)`:
-
-| Field         | Sources                                                                                                                            |
-| ------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `label`       | registered `label` → `humanize(lastSegment)` (camelCase / snake_case / kebab-case → Title Case; numeric segments collapse to `''`) |
-| `description` | registered `description` → `schema.description` (Zod's `.describe(...)`) → `undefined`                                             |
-| `placeholder` | registered `placeholder` → `undefined`                                                                                             |
-| `meta`        | the full registered payload, frozen — empty object when nothing has been registered                                                |
-
-Setting both `.describe('...')` and `.register(fieldMeta, { description: '...' })` is fine — the registered description wins,
-and `.describe()` stays readable for unrelated tooling (JSON-Schema
-export, etc.).
-
-**Custom payload keys.** `FieldMetaPayload` is an `interface` — extend
-it via TypeScript module augmentation:
-
-```ts
-declare module 'attaform/zod' {
-  interface FieldMetaPayload {
-    tooltip?: string
-    icon?: string
-  }
-}
-
-const schema = z.object({
-  email: z.email().register(fieldMeta, { label: 'Email', tooltip: 'For login' }),
-})
-
-// template: {{ form.fields.email.meta.tooltip }} → 'For login'
-```
-
-The single `fieldMeta` registry holds the augmented shape — no
-fragmentation across consumers.
-
-**Reusing a sub-schema at multiple paths.** Both registration styles
-are safe. Zod's registry keys on the schema reference, but the
-adapter walks the form's schema tree at first lookup and pairs each
-path with its intended payload — registration order (object literal
-left-to-right) matches walk order, so the two patterns below both
-resolve as you'd expect:
-
-```ts
-const addressSchema = z.object({ line1: z.string(), city: z.string() })
-
-// Native chain — adapter disambiguates by tree-walk order
-const form = z.object({
-  pickup: addressSchema.register(fieldMeta, { label: 'Pickup address' }),
-  delivery: addressSchema.register(fieldMeta, { label: 'Delivery address' }),
-})
-// form.fields('pickup').label   → 'Pickup address'
-// form.fields('delivery').label → 'Delivery address'
-
-// Helper — clones the schema first so each call gets distinct identity
-const form2 = z.object({
-  pickup: withMeta(addressSchema, { label: 'Pickup address' }),
-  delivery: withMeta(addressSchema, { label: 'Delivery address' }),
-})
-```
-
-Sharing a schema with IDENTICAL metadata is also fine — common for
-array elements (every line item shares one `lineItemSchema` instance
-and inherits the same per-leaf labels).
-
-## `zodAdapter(schema)`
-
-Lower-level. Returns an `AbstractSchema<Form, Form>` that wraps a
-Zod schema. Reach for it only when composing your own `useForm`-like
-hook.
-
-## `kindOf(schema)`
-
-Returns the zod kind (`'string'`, `'number'`, `'object'`,
-`'discriminated-union'`, etc.) for a Zod 4 schema. For advanced
-adapter work — wrapping `register`, building per-kind UI, branching
-on schema shape.
-
-## `assertZodVersion(schema)`
-
-Throws if the installed `zod` major doesn't match the adapter. Use
-when wiring custom adapter code that introspects schema internals
-and would silently misbehave under the wrong version.
-
-## `type ZodKind`
-
-Union of the strings returned by `kindOf` — `'string' | 'number' | 'boolean' | 'object' | 'array' | 'tuple' | 'discriminated-union' | 'union' | …`.
+- [`attaform/zod-v3`](/docs/api/zod-v3) — explicit Zod 3 subpath. Pin v3, ship a single adapter on any bundler.
+- [`attaform/zod-v4`](/docs/api/zod-v4) — explicit Zod 4 subpath. Pin v4, ship a single adapter on any bundler.
+- [`attaform/vite`](/docs/api/vite) — the Vite plugin that drives the build-time alias.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,74 +4,25 @@ description: 'Five minutes from pnpm install to a working Vue 3 form: write a Zo
 
 # Quick start
 
-Get a working Attaform form on screen in under five minutes. The
-mainline path is Nuxt — bare-Vue + Vite is one section down.
+Get a working Attaform form on screen in under five minutes.
 
 ## 1. Install
 
 ::ui-install-command{:show-quick-start="false"}
 ::
 
-`zod` is a peer dependency. Requires Vue 3 and Zod 4 — for Zod v3,
-swap the import for [`attaform/zod-v3`](/docs/api/zod-v3) (same
-surface, separate adapter).
+`zod` is a peer dependency. Both Zod 3 and Zod 4 are supported — `attaform/zod` auto-detects the version you have installed.
 
-## 2. Wire it up
-
-### Nuxt 3 / 4
-
-Add the module to `nuxt.config.ts`:
-
-```ts
-export default defineNuxtConfig({
-  modules: ['attaform/nuxt'],
-})
-```
-
-That's everything. The module installs the plugin, registers the
-`v-register` directive, and auto-imports `useForm` so you can call
-it without an explicit import.
-
-### Bare Vue + Vite
-
-```ts
-// vite.config.ts
-import { defineConfig } from 'vite'
-import vue from '@vitejs/plugin-vue'
-import { attaform } from 'attaform/vite'
-
-export default defineConfig({
-  plugins: [vue(), attaform()],
-})
-```
-
-```ts
-// main.ts
-import { createApp } from 'vue'
-import { createAttaform } from 'attaform'
-import App from './App.vue'
-
-createApp(App).use(createAttaform()).mount('#app')
-```
-
-The Vite plugin is required for SSR-correct `v-register` bindings.
-For other bundlers, see [`attaform/transforms`](/docs/api/transforms).
-
-## 3. Your first form
+## 2. Your first form
 
 ```vue
 <script setup lang="ts">
   import { z } from 'zod'
-  import { useForm, fieldMeta } from 'attaform/zod' // or auto-imported under Nuxt
+  import { useForm } from 'attaform/zod'
 
   const schema = z.object({
-    email: z.email().register(fieldMeta, {
-      label: 'Email',
-      placeholder: 'you@example.com',
-    }),
-    password: z.string().min(8, 'At least 8 characters').register(fieldMeta, {
-      label: 'Password',
-    }),
+    email: z.email(),
+    password: z.string().min(8, 'At least 8 characters'),
   })
 
   const form = useForm({ schema, key: 'signup' })
@@ -85,17 +36,13 @@ For other bundlers, see [`attaform/transforms`](/docs/api/transforms).
 <template>
   <form @submit.prevent="onSubmit">
     <label>
-      {{ form.fields.email.label }}
-      <input
-        v-register="form.register('email')"
-        type="email"
-        :placeholder="form.fields.email.placeholder"
-      />
+      Email
+      <input v-register="form.register('email')" type="email" />
       <small>{{ form.errors.email?.[0]?.message }}</small>
     </label>
 
     <label>
-      {{ form.fields.password.label }}
+      Password
       <input v-register="form.register('password')" type="password" />
       <small>{{ form.errors.password?.[0]?.message }}</small>
     </label>
@@ -107,22 +54,96 @@ For other bundlers, see [`attaform/transforms`](/docs/api/transforms).
 </template>
 ```
 
-This shows four things:
+That's the whole library in one screen:
 
-- **`v-register`** binds a native input directly to a path on the form.
-  No two-way wiring, no manual `v-model` plumbing.
-- **`fieldMeta`** attaches labels and placeholders to schema fields.
-  Read them off `form.fields.<path>.label` / `.placeholder` — schema is the
-  single source of truth for both shape and presentation.
-- **`form.errors`** is a reactive proxy. Refinement errors surface as
-  the user types; required-field "no value supplied" errors fire on
-  submit.
-- **`form.meta.valid`** and `form.meta.submitting` gate the
-  submit button — submit auto-runs validation first, so the callback
-  receives strictly-typed values.
+- **`v-register`** binds a native input directly to a path on the form. No two-way wiring, no manual `v-model` plumbing.
+- **`form.errors`** is a reactive proxy. Refinement errors surface as the user types; required-field "no value supplied" errors fire on submit.
+- **`form.meta.valid`** and `form.meta.submitting` gate the submit button — submit auto-runs validation first, so the callback receives strictly-typed values.
 
-Open the [live playground](/play) to edit this exact example without
-leaving the browser.
+You don't need to call `app.use(createAttaform())` or add a Vite plugin to get this working — `useForm` auto-installs the registry the first time you call it.
+
+Open the [live playground](/play) to edit this exact example without leaving the browser.
+
+## 3. Going further
+
+Each section below opts in to a layered capability. None are required for the example above.
+
+### Adding labels and placeholders
+
+Attach metadata to fields so the schema stays the single source of truth for both shape and presentation:
+
+```vue
+<script setup lang="ts">
+  import { z } from 'zod'
+  import { useForm, fieldMeta } from 'attaform/zod'
+
+  const schema = z.object({
+    email: z.email().register(fieldMeta, {
+      label: 'Email',
+      placeholder: 'you@example.com',
+    }),
+    password: z.string().min(8).register(fieldMeta, { label: 'Password' }),
+  })
+
+  const form = useForm({ schema, key: 'signup' })
+</script>
+
+<template>
+  <label>
+    {{ form.fields.email.label }}
+    <input
+      v-register="form.register('email')"
+      type="email"
+      :placeholder="form.fields.email.placeholder"
+    />
+  </label>
+</template>
+```
+
+Read `form.fields.<path>.label` / `.placeholder` (and any custom metadata you attach) directly in the template. See [Schema-attached metadata](/docs/api/zod#schema-attached-metadata) for the full surface.
+
+### Bare Vue + SSR
+
+For server-rendered pages, install the Vite plugin so `:value` / `:checked` / `:selected` bindings appear in the SSR HTML — without it, the first render is correct but `v-register`-bound elements briefly flash blank during hydration.
+
+```ts
+// vite.config.ts
+import vue from '@vitejs/plugin-vue'
+import { attaform } from 'attaform/vite'
+
+export default defineConfig({
+  plugins: [vue(), attaform()],
+})
+```
+
+The Vite plugin also rewrites `attaform/zod` imports at build time to either `attaform/zod-v3` or `attaform/zod-v4` based on the Zod major you installed — your bundle ships exactly one adapter. Pass `attaform({ resolveZodAlias: false })` to opt out (e.g. when intentionally running both Zod versions side by side).
+
+For [SSR payload round-tripping](/docs/recipes/ssr-hydration) (`renderAttaformState` / `hydrateAttaformState`), install the Vue plugin explicitly on your server entry — auto-install only covers the component-setup path.
+
+### Nuxt
+
+Add the module — it wires the Vite plugin (transforms + build-time alias), the SSR payload bridge, and `useForm` auto-imports in one step:
+
+```ts
+// nuxt.config.ts
+export default defineNuxtConfig({
+  modules: ['attaform/nuxt'],
+})
+```
+
+### App-wide options
+
+If you want to set defaults across every `useForm` call (or disable devtools), install the Vue plugin explicitly. Auto-install always runs with default options; `createAttaform({ ... })` must run before the first `useForm`:
+
+```ts
+// main.ts
+import { createApp } from 'vue'
+import { createAttaform } from 'attaform'
+
+createApp(App)
+  .use(createAttaform({ defaults: { debounceMs: 100 } }))
+  .mount('#app')
+```
 
 ## 4. Where to next
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -298,6 +298,25 @@ the full contract including `isRequiredAtPath` (used by the blank
 validation augmentation) and `getSlimPrimitiveTypesAtPath` (used
 by the slim-primitive write gate).
 
+## "Which Zod entry should I import — `attaform/zod`, `/zod-v3`, or `/zod-v4`?"
+
+Default to **`attaform/zod`** for new code. It auto-detects the installed Zod major and routes to the matching adapter. With the [`attaform/vite`](./api/vite.md) plugin (or `attaform/nuxt`) installed, the import is rewritten at build time to either `attaform/zod-v3` or `attaform/zod-v4`, so your bundle ships exactly one adapter — same DX, no decision required at the call site.
+
+Reach for the explicit subpaths when:
+
+- **You're not using Vite (and want a lean bundle).** `attaform/zod` without the build-time alias falls back to runtime dispatch and ships both adapters. Importing [`attaform/zod-v3`](./api/zod-v3.md) or [`attaform/zod-v4`](./api/zod-v4.md) directly gives you a single-adapter bundle on webpack, esbuild, Rollup, and friends.
+- **You intentionally have both Zod versions installed** (e.g. via `pnpm add zod zod-v3`). Pin each import site to the version you mean.
+- **You hit a Zod 3 type-inference edge case under the unified entry.** The unified entry's TypeScript signature targets Zod 4; importing from `attaform/zod-v3` gives Zod 3 consumers the strongest inference.
+
+## "My bundle ships both Zod adapters — how do I trim it?"
+
+Two paths:
+
+- **Vite consumers:** install [`attaform/vite`](./api/vite.md) (or use the [Nuxt module](./api/nuxt.md), which installs it for you). The plugin rewrites `attaform/zod` to the matching subpath at build time. No code changes required.
+- **Other bundlers:** swap `import { useForm } from 'attaform/zod'` for the explicit subpath — `attaform/zod-v3` or `attaform/zod-v4` — at every call site. The unified entry's runtime dispatch is the only path that pulls in both adapters.
+
+The Vite plugin can also be opted out via `attaform({ resolveZodAlias: false })` — useful when your project intentionally mixes Zod versions and the runtime dispatch is the right behavior.
+
 ## "Dev warnings don't fire — am I in production?"
 
 The library uses a `__DEV__` flag that resolves from

--- a/package.json
+++ b/package.json
@@ -118,7 +118,15 @@
   "pnpm": {
     "overrides": {
       "@nuxt/devtools": "3.2.4"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "@parcel/watcher",
+      "better-sqlite3",
+      "esbuild",
+      "sharp",
+      "unrs-resolver",
+      "vue-demi"
+    ]
   },
   "devDependencies": {
     "@commitlint/cli": "^20.5.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,10 @@
       "types": "./dist/zod-v3.d.mts",
       "import": "./dist/zod-v3.mjs"
     },
+    "./zod-v4": {
+      "types": "./dist/zod-v4.d.mts",
+      "import": "./dist/zod-v4.mjs"
+    },
     "./types": {
       "types": "./dist/index.d.mts"
     }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "sideEffects": false,
   "engines": {
-    "node": ">=20.12.0",
+    "node": ">=20.12.0 <27",
     "pnpm": ">=9.0.0"
   },
   "publishConfig": {
@@ -107,7 +107,7 @@
     "attaform"
   ],
   "license": "MIT",
-  "packageManager": "pnpm@9.7.0",
+  "packageManager": "pnpm@10.33.4",
   "type": "module",
   "lint-staged": {
     "./src/**/*.{ts,vue}": "eslint",

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,6 +161,7 @@ export {
   AnonPersistError,
   AttaformError,
   InvalidPathError,
+  InvalidUseFormConfigError,
   OutsideSetupError,
   RegistryNotInstalledError,
   ReservedFormKeyError,

--- a/src/nuxt.ts
+++ b/src/nuxt.ts
@@ -1,11 +1,15 @@
 import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
-import { addImports, addPlugin, addTypeTemplate, createResolver, defineNuxtModule } from '@nuxt/kit'
-import { inputTextAreaNodeTransform } from './runtime/lib/core/transforms/input-text-area-transform'
-import { selectNodeTransform } from './runtime/lib/core/transforms/select-transform'
-import { vRegisterHintTransform } from './runtime/lib/core/transforms/v-register-hint-transform'
-import { vRegisterPreambleTransform } from './runtime/lib/core/transforms/v-register-preamble-transform'
+import {
+  addImports,
+  addPlugin,
+  addTypeTemplate,
+  addVitePlugin,
+  createResolver,
+  defineNuxtModule,
+} from '@nuxt/kit'
 import type { AttaformDefaults } from './runtime/types/types-api'
+import { attaform as attaformVitePlugin } from './vite'
 
 /**
  * Options accepted by `attaform/nuxt` under the `attaform`
@@ -28,6 +32,14 @@ export interface AttaformModuleOptions {
    * supported option set and merge rules.
    */
   defaults?: AttaformDefaults
+  /**
+   * Forwarded to `attaform/vite`'s `resolveZodAlias` option.
+   * Default `true` — `attaform/zod` imports are rewritten at build
+   * time to either `attaform/zod-v3` or `attaform/zod-v4`, based on
+   * the consumer's installed Zod major. Set to `false` to bypass
+   * the rewrite and ship the runtime-dispatch unified entry instead.
+   */
+  resolveZodAlias?: boolean
 }
 
 /**
@@ -88,15 +100,16 @@ export default defineNuxtModule<AttaformModuleOptions>({
   },
   defaults: {},
   setup(_options, nuxt) {
-    // vRegisterPreambleTransform MUST come before vRegisterHintTransform
-    // — see src/vite.ts for the ordering rationale.
-    nuxt.options.vue.compilerOptions.nodeTransforms ??= []
-    nuxt.options.vue.compilerOptions.nodeTransforms.push(
-      selectNodeTransform,
-      inputTextAreaNodeTransform,
-      vRegisterPreambleTransform,
-      vRegisterHintTransform
-    )
+    // Register `attaform/vite` so the same plugin handles every Vite-
+    // surface concern: pushing the compile-time node transforms into
+    // `@vitejs/plugin-vue`'s `api.options.template.compilerOptions.
+    // nodeTransforms`, AND rewriting `attaform/zod` imports at build
+    // time to either `/zod-v3` or `/zod-v4` based on the consumer's
+    // installed Zod major. Consolidating both behaviors in one Vite
+    // plugin instance keeps the Nuxt-side wiring minimal and ensures
+    // the consumer's Nuxt build sees the exact same DX as a bare-Vite
+    // consumer.
+    addVitePlugin(attaformVitePlugin({ resolveZodAlias: _options.resolveZodAlias !== false }))
 
     // Publish module options to public runtime config so the plugin can
     // read them at install time on both server and client. Frozen-empty
@@ -120,7 +133,8 @@ export default defineNuxtModule<AttaformModuleOptions>({
     //
     // We declare here only deps attaform itself owns the relationship
     // with — `@vue/devtools-api` (attaform's DevTools integration
-    // peer) and `zod` (the `/zod` and `/zod-v3` adapter peer). Consumer-
+    // peer) and `zod` (the adapter peer for `/zod`, `/zod-v3`, and
+    // `/zod-v4`). Consumer-
     // side deps (vue-query, immer, etc.) are the consumer's
     // responsibility — they declare them in their own
     // `vite.optimizeDeps.include`. Each push is gated on the spec

--- a/src/runtime/adapters/unified/use-form.ts
+++ b/src/runtime/adapters/unified/use-form.ts
@@ -1,0 +1,96 @@
+/**
+ * Unified `useForm` for the `attaform/zod` entry. Runtime-dispatches
+ * on schema shape: a Zod v4 schema (`def.type` truthy) routes to the
+ * v4 adapter; a Zod v3 schema (or any other `AbstractSchema`) routes
+ * to the v3 wrapper, which already accepts both Zod v3 input and
+ * `AbstractSchema` directly via its built-in shape branch.
+ *
+ * This module is the FALLBACK path. Vite consumers see the
+ * `attaform/vite` plugin's `resolveId` hook rewrite `attaform/zod`
+ * imports to either `attaform/zod-v3` or `attaform/zod-v4` at build
+ * time — in that case this dispatch never runs and the consumer
+ * bundle ships only the matching adapter. Other bundlers (and
+ * non-bundled ESM consumption) hit this dispatch instead, paying a
+ * modest size cost for the convenience of a single hello-world import.
+ *
+ * Power users who want a guaranteed lean bundle on non-Vite tooling
+ * can import directly from `attaform/zod-v3` or `attaform/zod-v4` —
+ * those subpaths are never rewritten and never load the other
+ * adapter.
+ */
+import type { z } from 'zod'
+import { InvalidUseFormConfigError } from '../../core/errors'
+import { isZodV4SchemaShape } from '../../core/zod-shape'
+import { useForm as useFormV3 } from '../../composables/use-form'
+import { useForm as useFormV4 } from '../zod-v4'
+import type {
+  AbstractSchema,
+  ValidateOnConfig,
+  UseFormReturnType,
+  UseFormConfiguration,
+} from '../../types/types-api'
+import type { DeepPartial, DefaultValuesShape, GenericForm } from '../../types/types-core'
+
+/**
+ * Create a form bound to a Zod schema. Accepts both Zod v3 and Zod v4
+ * schemas; the runtime picks the right adapter from the schema's
+ * shape.
+ *
+ * Type inference targets Zod v4 — the recommended major. Consumers
+ * still on Zod v3 get correct runtime behavior here, but the strongest
+ * TypeScript inference comes from importing `attaform/zod-v3`
+ * directly.
+ *
+ * ```ts
+ * import { useForm } from 'attaform/zod'
+ * import { z } from 'zod'
+ *
+ * const form = useForm({
+ *   schema: z.object({
+ *     email: z.email(),
+ *     password: z.string().min(8),
+ *   }),
+ * })
+ * ```
+ */
+export function useForm<Schema extends z.ZodObject>(
+  configuration: Omit<
+    UseFormConfiguration<
+      z.output<Schema> extends GenericForm ? z.output<Schema> : never,
+      z.output<Schema> extends GenericForm ? z.output<Schema> : never,
+      AbstractSchema<
+        z.output<Schema> extends GenericForm ? z.output<Schema> : never,
+        z.output<Schema> extends GenericForm ? z.output<Schema> : never
+      >,
+      DeepPartial<
+        DefaultValuesShape<z.output<Schema> extends GenericForm ? z.output<Schema> : never>
+      >
+    >,
+    'schema' | 'validateOn' | 'debounceMs'
+  > & { schema: Schema } & ValidateOnConfig
+): UseFormReturnType<
+  z.output<Schema> extends GenericForm ? z.output<Schema> : never,
+  z.output<Schema> extends GenericForm ? z.output<Schema> : never
+> {
+  // Foot-gun guard mirrors the typed wrappers'.
+  if (
+    configuration === undefined ||
+    configuration === null ||
+    (configuration as { schema?: unknown }).schema === undefined
+  ) {
+    throw new InvalidUseFormConfigError()
+  }
+
+  const { schema } = configuration as { schema: unknown }
+  if (isZodV4SchemaShape(schema)) {
+    return useFormV4(configuration as Parameters<typeof useFormV4<Schema>>[0]) as ReturnType<
+      typeof useForm<Schema>
+    >
+  }
+  // Anything else (Zod v3 schema, custom AbstractSchema, schema
+  // factory) goes through the v3 wrapper, which already accepts both
+  // Zod v3 input and AbstractSchema directly via its existing shape
+  // branch. Cast through unknown — the unified entry's TS surface
+  // tracks v4, but the runtime accepts the broader shape.
+  return useFormV3(configuration as never) as unknown as ReturnType<typeof useForm<Schema>>
+}

--- a/src/runtime/adapters/zod-v4/index.ts
+++ b/src/runtime/adapters/zod-v4/index.ts
@@ -5,6 +5,7 @@
  */
 import type { z } from 'zod'
 import { useAbstractForm } from '../../composables/use-abstract-form'
+import { InvalidUseFormConfigError } from '../../core/errors'
 import type {
   AbstractSchema,
   FormKey,
@@ -62,6 +63,20 @@ export function useForm<Schema extends z.ZodObject>(
   z.output<Schema> extends GenericForm ? z.output<Schema> : never,
   z.output<Schema> extends GenericForm ? z.output<Schema> : never
 > {
+  // Foot-gun guard: catches `useForm(z.object({...}))` (raw schema as
+  // the first arg — its `.schema` field is undefined), `useForm()` (no
+  // args), and `useForm({ schema: undefined })` before they reach the
+  // adapter and crash deep with an opaque message. JS callers and
+  // `as any` callers can defy the static signature; the `unknown`
+  // cast forces the runtime checks to stay live under tsc.
+  const candidate = configuration as unknown
+  if (
+    candidate === undefined ||
+    candidate === null ||
+    (candidate as { schema?: unknown }).schema === undefined
+  ) {
+    throw new InvalidUseFormConfigError()
+  }
   type Form = z.output<Schema> extends GenericForm ? z.output<Schema> : never
   // `zodV4Adapter` returns a factory `(formKey: FormKey) => AbstractSchema`;
   // `UseFormConfiguration.schema` accepts `Schema | ((key) => Schema)`, so

--- a/src/runtime/adapters/zod-v4/introspect.ts
+++ b/src/runtime/adapters/zod-v4/introspect.ts
@@ -324,7 +324,13 @@ export function getDiscriminatedOptions(schema: z.ZodType): readonly z.ZodObject
 export function assertZodVersion(schema: unknown): void {
   const def = readDef(schema)
   if (def?.type === undefined) {
-    throw new Error('[attaform/zod] schema is not zod v4. Install zod@^4 or use /zod-v3.')
+    throw new Error(
+      '[attaform/zod-v4] Schema is not a Zod v4 schema. The `attaform/zod-v4` adapter requires ' +
+        'zod@^4. Either: (a) install zod@^4 in your project; (b) import from `attaform/zod`, ' +
+        'which auto-detects the Zod version (and tree-shakes to a single adapter when the ' +
+        '`attaform/vite` plugin is active); or (c) import from `attaform/zod-v3` if you are ' +
+        'staying on Zod v3.'
+    )
   }
 }
 

--- a/src/runtime/composables/use-abstract-form.ts
+++ b/src/runtime/composables/use-abstract-form.ts
@@ -9,7 +9,7 @@ import {
 } from '../core/defaults'
 import { __DEV__ } from '../core/dev'
 import { captureUserCallSite } from '../core/dev-stack-trace'
-import { AnonPersistError, ReservedFormKeyError } from '../core/errors'
+import { AnonPersistError, InvalidUseFormConfigError, ReservedFormKeyError } from '../core/errors'
 import { extractSchemaFields } from '../core/extract-schema-fields'
 import type { FieldState } from '../core/field-state-api'
 import { getComputedSchema } from '../core/get-computed-schema'
@@ -33,6 +33,7 @@ import {
 import { hashStableString } from '../core/hash'
 import { canonicalizePath, type Path, type PathKey } from '../core/paths'
 import { deleteAtPath, getAtPath, setAtPath, isPlainRecord } from '../core/path-walker'
+import { ensureAttaformInstalled } from '../core/plugin'
 import { kFormContext, kFormInstanceId, useRegistry } from '../core/registry'
 import { walkUnsetSentinels } from '../core/unset-walker'
 import type {
@@ -60,10 +61,9 @@ import type { DeepPartial, DefaultValuesShape, GenericForm, WriteShape } from '.
  * })
  * ```
  *
- * Most consumers prefer a typed entry point — e.g.
- * `attaform/zod` (v4) or `attaform/zod-v3` —
- * which wrap the underlying library's schema with the matching
- * adapter automatically.
+ * Most consumers prefer a typed entry point that wraps the underlying
+ * library's schema with the matching adapter automatically; see the
+ * subpath documentation for the available adapters.
  *
  * Returns the same form API as the typed entry points; see
  * `UseFormReturnType` for the full surface.
@@ -80,6 +80,19 @@ export function useAbstractForm<
     DeepPartial<DefaultValuesShape<Form>>
   >
 ): UseFormReturnType<Form, GetValueFormType> {
+  // Foot-gun guard: catches `useForm()` (no args), `useForm(null)`,
+  // `useForm(rawSchema)` (any schema-like object passed as the first
+  // argument — its `.schema` field is undefined), and the explicit
+  // `useForm({ schema: undefined })` case. Throws synchronously
+  // before any downstream code reads `configuration.schema`.
+  if (
+    configuration === undefined ||
+    configuration === null ||
+    (configuration as { schema?: unknown }).schema === undefined
+  ) {
+    throw new InvalidUseFormConfigError()
+  }
+
   const key = resolveFormKey(configuration.key)
 
   // Resolve the schema (accepts either an AbstractSchema or a factory).
@@ -108,6 +121,15 @@ export function useAbstractForm<
   // One FormStore per (app, formKey). Multiple useForm calls with the same
   // key resolve to the same instance — that's the shared-store semantic
   // for forms that explicitly opt in to a stable key.
+  //
+  // Lazy-install: if the consumer hasn't called `createAttaform()`,
+  // attach the registry now. Idempotent — explicit installs (Nuxt
+  // module, manual `app.use(createAttaform({ defaults }))`) win when
+  // they ran first. The strict `useRegistry()` below still throws
+  // `OutsideSetupError` when called outside setup; the lazy install
+  // only ever fires when an instance is available.
+  const instance = getCurrentInstance()
+  if (instance !== null) ensureAttaformInstalled(instance.appContext.app)
   const registry = useRegistry()
 
   // Merge app-level defaults from the registry over per-form options.

--- a/src/runtime/composables/use-form-context.ts
+++ b/src/runtime/composables/use-form-context.ts
@@ -4,6 +4,7 @@ import type { FormStore } from '../core/create-form-store'
 import { __DEV__ } from '../core/dev'
 import { captureUserCallSite } from '../core/dev-stack-trace'
 import type { HistoryModule } from '../core/history'
+import { ensureAttaformInstalled } from '../core/plugin'
 import { kFormContext, kFormInstanceId, useRegistry, type AttaformRegistry } from '../core/registry'
 import type { FormKey, UseFormReturnType } from '../types/types-api'
 import type { GenericForm } from '../types/types-core'
@@ -60,6 +61,15 @@ let injectedInstanceCounter = 0
 export function injectForm<Form extends GenericForm, GetValueFormType extends GenericForm = Form>(
   key?: FormKey
 ): UseFormReturnType<Form, GetValueFormType> | null {
+  // Lazy-install: if no `useForm` ancestor and no explicit
+  // `createAttaform()`, the registry is missing. Auto-install here so
+  // `injectForm` collapses to its existing "no form for that key" /
+  // "no ambient form context" null-return + dev-warning paths instead
+  // of throwing the misleading `RegistryNotInstalledError`. The strict
+  // `useRegistry()` below still surfaces `OutsideSetupError` when
+  // called outside setup.
+  const instance = getCurrentInstance()
+  if (instance !== null) ensureAttaformInstalled(instance.appContext.app)
   const registry = useRegistry()
 
   const state = resolveState<Form>(key, registry)

--- a/src/runtime/composables/use-form.ts
+++ b/src/runtime/composables/use-form.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod-v3'
 import { zodAdapter } from '../adapters/zod-v3'
+import { InvalidUseFormConfigError } from '../core/errors'
 import type { AbstractSchema, UseFormReturnType, UseFormConfiguration } from '../types/types-api'
 import type { DeepPartial, DefaultValuesShape, GenericForm } from '../types/types-core'
 import type { TypeWithNullableDynamicKeys } from '../adapters/zod-v3/types-zod'
@@ -80,6 +81,18 @@ export function useForm<
         DeepPartial<DefaultValuesShape<z.infer<UnwrapZodObject<Schema>>>>
       >
 ): UseFormReturnType<Form, GetValueFormType> {
+  // Foot-gun guard: catches `useForm(z.object({...}))` (raw schema as
+  // the first arg — its `.schema` field is undefined), `useForm()` (no
+  // args), and `useForm({ schema: undefined })` before they reach the
+  // adapter and crash deep with an opaque message.
+  if (
+    configuration === undefined ||
+    configuration === null ||
+    (configuration as { schema?: unknown }).schema === undefined
+  ) {
+    throw new InvalidUseFormConfigError()
+  }
+
   function isZodType(value: unknown): value is z.ZodType {
     return typeof value === 'object' && value !== null && '_def' in value
   }

--- a/src/runtime/composables/use-register.ts
+++ b/src/runtime/composables/use-register.ts
@@ -68,6 +68,7 @@ import {
 } from 'vue'
 import { __DEV__ } from '../core/dev'
 import { captureUserCallSite } from '../core/dev-stack-trace'
+import { ensureAttaformInstalled } from '../core/plugin'
 import type { RegisterValue } from '../types/types-api'
 
 /**
@@ -166,6 +167,15 @@ export function useRegister<V = unknown>(): UseRegisterReturn<V> | undefined {
     warnOutsideSetup()
     return makeRegisterValueProxy<V>(shallowRef<RegisterValue<V> | undefined>(undefined))
   }
+
+  // Lazy-install: even though `useRegister` doesn't read the registry
+  // directly, it's a public setup-context entry point and its template
+  // typically renders `<input v-register="rv" />` — the directive must
+  // be registered on the app at render time. Without auto-install, a
+  // wrapper component used in isolation (no `useForm` ancestor, no
+  // `createAttaform()`) hits Vue's "Failed to resolve directive"
+  // warning. Idempotent — explicit installs win when they ran first.
+  ensureAttaformInstalled(instance.appContext.app)
 
   // Capture the bridge `registerValue` from instance.attrs into a
   // local ref, then STRIP the bridge keys (`registerValue` + `value`)

--- a/src/runtime/core/errors.ts
+++ b/src/runtime/core/errors.ts
@@ -30,6 +30,36 @@ export class AttaformError extends Error {
 export class InvalidPathError extends AttaformError {}
 
 /**
+ * Thrown when `useForm` receives an invalid configuration — most often
+ * a schema passed directly as the first argument, or no argument at
+ * all. The configuration is an options bag; the schema is one of
+ * several fields, even when it's the only one in use.
+ *
+ * ```ts
+ * // ✗ Crashes deep inside the validator with an opaque message:
+ * const form = useForm(z.object({ ... }))
+ * // ✗ Same:
+ * const form = useForm()
+ * // ✓ Pass the schema as the `schema` field:
+ * const form = useForm({ schema: z.object({ ... }) })
+ * ```
+ *
+ * The same shape applies to every entry point: `attaform/zod`,
+ * `attaform/zod-v3`, `attaform/zod-v4`, and the schema-agnostic
+ * `attaform` root.
+ */
+export class InvalidUseFormConfigError extends AttaformError {
+  constructor() {
+    super(
+      '[attaform] useForm received an invalid configuration (a schema directly, no argument, ' +
+        'or no `schema` field). Pass it as `useForm({ schema })` — the schema is one of several ' +
+        'configuration options. See https://attaform.com/docs/api/use-form-return for the full ' +
+        'configuration shape.'
+    )
+  }
+}
+
+/**
  * Thrown when a `handleSubmit`-supplied `onError` callback itself
  * throws or rejects. Wraps the inner failure so both the original
  * cause (via `error.cause`) and the propagation site are visible.
@@ -37,15 +67,28 @@ export class InvalidPathError extends AttaformError {}
 export class SubmitErrorHandlerError extends AttaformError {}
 
 /**
- * Thrown by `useForm` / `injectForm` when the form library's
- * plugin hasn't been installed on the current Vue app.
+ * Thrown when an `attaform` API needs the registry attached to a Vue
+ * app but it isn't there yet. Component-level entry points (`useForm`,
+ * `injectForm`, `useRegister`) lazy-install the registry on first use,
+ * so this error is mostly reached by SSR helpers — `renderAttaformState`
+ * and `hydrateAttaformState` — which run outside a setup context and
+ * have no current instance to install against.
  *
- * Fix: add `app.use(createAttaform())` to your app entry
- * (or `attaform/nuxt` for Nuxt projects).
+ * Fix: add `app.use(createAttaform())` (or `app.use(createAttaform({
+ * ssr: true }))` on the server) to your SSR entry, before
+ * `renderToString` / hydration. Under Nuxt, `attaform/nuxt` already
+ * does this; the error usually points at a non-Nuxt SSR setup that
+ * hasn't installed explicitly.
  */
 export class RegistryNotInstalledError extends AttaformError {
   constructor() {
-    super('[attaform] Registry not found. Install the plugin via `app.use(createAttaform())`.')
+    super(
+      '[attaform] No registry attached to this Vue app. Component-level useForm / injectForm / ' +
+        'useRegister auto-install the registry, but SSR helpers (renderAttaformState, ' +
+        'hydrateAttaformState) run outside setup and require an explicit ' +
+        '`app.use(createAttaform())` at server-render time. Add it to your SSR entry, before ' +
+        '`renderToString`.'
+    )
   }
 }
 

--- a/src/runtime/core/plugin.ts
+++ b/src/runtime/core/plugin.ts
@@ -1,6 +1,6 @@
 import type { App, Plugin } from 'vue'
 import { __DEV__ } from './dev'
-import { attachRegistryToApp, createRegistry } from './registry'
+import { attachRegistryToApp, createRegistry, type AttaformRegistry } from './registry'
 import { vRegister } from './directive'
 import type { SSRDetectOptions } from './ssr'
 import type { AttaformDefaults } from '../types/types-api'
@@ -34,21 +34,104 @@ export type AttaformPluginOptions = SSRDetectOptions & {
 }
 
 /**
+ * Install the form library on a Vue app. Idempotent: a second call
+ * for the same `app` is a no-op (with a dev warning when explicit, no
+ * warning when triggered by the lazy-install path).
+ *
+ * Used internally by:
+ *  - `createAttaform()` — the explicit plugin install path.
+ *  - `ensureAttaformInstalled()` — the lazy-install path triggered by
+ *    `useForm` / `injectForm` / `useRegister` when no explicit install
+ *    has happened yet.
+ *
+ * Both paths converge here so the `_attaform` slot, the
+ * `kAttaformRegistry` provide, the `v-register` directive, and the
+ * devtools attach happen in the same order regardless of how the
+ * registry was first attached.
+ */
+function installAttaformOnApp(
+  app: App,
+  options: AttaformPluginOptions,
+  source: 'explicit' | 'lazy'
+): AttaformRegistry {
+  // Idempotent install: a second call (e.g. createAttaform() registered
+  // twice via vite.config + nuxt module, or createAttaform() after a
+  // lazy useForm call) would otherwise overwrite the existing registry —
+  // orphaning every FormStore the previous instance had built. Detect
+  // via the `_attaform` slot `attachRegistryToApp` writes; bail with a
+  // dev warning ONLY for the explicit path, since the lazy path is
+  // expected to no-op when the user has already installed explicitly.
+  if (app._attaform !== undefined) {
+    if (__DEV__ && source === 'explicit') {
+      console.warn(
+        '[attaform] createAttaform() install was called twice on the same app; ' +
+          'the second call is a no-op. ' +
+          'Likely cause: registering the plugin via both the Nuxt module AND a manual `app.use(...)`.'
+      )
+    }
+    return app._attaform
+  }
+  const registry = createRegistry(options)
+  attachRegistryToApp(app, registry)
+  app.directive('register', vRegister)
+
+  if (options.devtools !== false && !registry.ssr) {
+    void (async () => {
+      try {
+        const { setupAttaformDevtools } = await import('./devtools')
+        await setupAttaformDevtools(app, registry)
+      } catch {
+        // Missing peer dep / DevTools not attached — silently skip.
+        // The form runtime works without DevTools; this is pure-
+        // observability tooling.
+      }
+    })()
+  }
+
+  return registry
+}
+
+/**
+ * Lazy-install the form library on a Vue app from inside a setup
+ * context. Called by `useForm`, `injectForm`, and `useRegister` so
+ * `pnpm install attaform` is the entire setup story for the common
+ * CSR case — no `app.use(createAttaform())` required in `main.ts`.
+ *
+ * If the app already has an attaform registry attached (because the
+ * consumer installed `createAttaform({ defaults, devtools })` or the
+ * Nuxt module ran), this is a no-op and the existing registry is
+ * returned. App-wide options are preserved.
+ *
+ * SSR helpers (`renderAttaformState`, `hydrateAttaformState`) do NOT
+ * use this path — they run outside setup and require explicit
+ * `createAttaform()` install.
+ */
+export function ensureAttaformInstalled(app: App): AttaformRegistry {
+  return installAttaformOnApp(app, {}, 'lazy')
+}
+
+/**
  * Create the Vue plugin that installs the form library on a Vue
- * application. Call once per app, then `app.use(...)` the result.
+ * application. Required only when you want app-wide options
+ * (`defaults`, `devtools: false`, `ssr: true`) — for the default
+ * setup, `useForm` / `injectForm` / `useRegister` lazy-install the
+ * registry on first use.
  *
  * ```ts
  * import { createApp } from 'vue'
  * import { createAttaform } from 'attaform'
  *
  * createApp(App)
- *   .use(createAttaform())
+ *   .use(createAttaform({ defaults: { debounceMs: 100 } }))
  *   .mount('#app')
  * ```
  *
- * Under SSR with bare Vue 3, pass `{ ssr: true }` from your server
- * entry. Under Nuxt, install via `attaform/nuxt` instead —
- * the Nuxt module wires both server and client automatically.
+ * Under SSR with bare Vue 3, install explicitly with `{ ssr: true }`
+ * from your server entry — the SSR serialization helpers
+ * (`renderAttaformState` / `hydrateAttaformState`) require an
+ * already-attached registry and don't trigger lazy install. Under
+ * Nuxt, install via `attaform/nuxt` instead — the Nuxt module wires
+ * both server and client automatically.
  *
  * Installing more than once on the same app is a no-op (the second
  * call logs a dev-mode warning).
@@ -56,40 +139,7 @@ export type AttaformPluginOptions = SSRDetectOptions & {
 export function createAttaform(options: AttaformPluginOptions = {}): Plugin {
   const plugin: Plugin = {
     install(app: App) {
-      // Idempotent install: a second `app.use(createAttaform())`
-      // (e.g. accidentally registered twice in vite.config + nuxt
-      // module, or by a higher-order plugin that installs us alongside
-      // a consumer's own install) would otherwise overwrite the
-      // existing registry — orphaning every FormStore the previous
-      // instance had built. Detect via the `_attaform` slot
-      // `attachRegistryToApp` writes; bail with a dev warning so the
-      // duplicate is visible during development.
-      if (app._attaform !== undefined) {
-        if (__DEV__) {
-          console.warn(
-            '[attaform] createAttaform() install was called twice on the same app; ' +
-              'the second call is a no-op. ' +
-              'Likely cause: registering the plugin via both the Nuxt module AND a manual `app.use(...)`.'
-          )
-        }
-        return
-      }
-      const registry = createRegistry(options)
-      attachRegistryToApp(app, registry)
-      app.directive('register', vRegister)
-
-      if (options.devtools !== false && !registry.ssr) {
-        void (async () => {
-          try {
-            const { setupAttaformDevtools } = await import('./devtools')
-            await setupAttaformDevtools(app, registry)
-          } catch {
-            // Missing peer dep / DevTools not attached — silently
-            // skip. The form runtime works without DevTools; this is
-            // pure-observability tooling.
-          }
-        })()
-      }
+      installAttaformOnApp(app, options, 'explicit')
     },
   }
   return plugin

--- a/src/runtime/core/zod-shape.ts
+++ b/src/runtime/core/zod-shape.ts
@@ -1,0 +1,59 @@
+/**
+ * Shape detectors for Zod schemas. Used by the unified `attaform/zod`
+ * entry's runtime dispatch (`runtime/adapters/unified/use-form.ts`)
+ * to route to the v3 or v4 adapter based on the schema's runtime
+ * shape. Mirrors the discrimination already used by the v4
+ * introspection helper (`adapters/zod-v4/introspect.ts`'s
+ * `assertZodVersion`, which reads `def.type`) and the v3 wrapper's
+ * legitimate-input branch (`composables/use-form.ts`'s `isZodType`,
+ * which reads `_def`).
+ *
+ * Why this discriminator and not `_zod` / `_def`:
+ * - Zod v4 retained `_def` for backward compat — reading `_def` alone
+ *   misclassifies v4 schemas as v3.
+ * - Zod v4's stable shape is `def.type: string` (lowercase tag like
+ *   `'object'`); Zod v3's is `_def.typeName: string` (capitalised tag
+ *   like `'ZodObject'`). Both are checked structurally so consumers
+ *   who alias one Zod major to a non-standard import path still work.
+ */
+
+interface ZodV4Shape {
+  def: { type: unknown }
+}
+
+interface ZodV3Shape {
+  _def: { typeName: unknown }
+}
+
+/**
+ * Returns true when `value` looks like a Zod schema of either major
+ * version. Convenience wrapper around the v3 / v4 detectors.
+ */
+export function isZodSchemaShape(value: unknown): boolean {
+  return isZodV4SchemaShape(value) || isZodV3SchemaShape(value)
+}
+
+/**
+ * Returns true when `value` looks like a Zod v4 schema (has
+ * `def.type: string`). Used by the unified entry's runtime-dispatch
+ * to route to the v4 adapter.
+ */
+export function isZodV4SchemaShape(value: unknown): value is ZodV4Shape {
+  if (typeof value !== 'object' || value === null) return false
+  const def = (value as { def?: unknown }).def
+  if (typeof def !== 'object' || def === null) return false
+  return typeof (def as { type?: unknown }).type === 'string'
+}
+
+/**
+ * Returns true when `value` looks like a Zod v3 schema (has
+ * `_def.typeName: string`). Kept distinct from `isZodV4SchemaShape`
+ * because some v4 schemas also expose `_def` for backward compat —
+ * the v4 detector wins first in `isZodSchemaShape`.
+ */
+export function isZodV3SchemaShape(value: unknown): value is ZodV3Shape {
+  if (typeof value !== 'object' || value === null) return false
+  const def = (value as { _def?: unknown })._def
+  if (typeof def !== 'object' || def === null) return false
+  return typeof (def as { typeName?: unknown }).typeName === 'string'
+}

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -1,6 +1,9 @@
 /**
- * `attaform/vite` — Vite plugin that registers the compile-time
- * node transforms with @vitejs/plugin-vue.
+ * `attaform/vite` — Vite plugin that wires the compile-time node
+ * transforms with @vitejs/plugin-vue AND rewrites `attaform/zod`
+ * imports to either `attaform/zod-v3` or `attaform/zod-v4` at build
+ * time, based on the consumer's installed Zod major. The result is
+ * one Zod adapter shipped per bundle, with no manual subpath choice.
  *
  * Usage (bare Vue 3 consumers):
  *
@@ -12,26 +15,52 @@
  *     plugins: [vue(), attaform()],
  *   })
  *
- * The transforms inject `:value`, `:checked`, and `:selected` bindings into
- * elements that use the `v-register` directive — load-bearing for SSR
- * initial-render correctness. Omitting this plugin under CSR is tolerable
- * (one-frame flash on mount); omitting it under SSR produces visibly wrong
- * initial HTML.
+ * The transforms inject `:value`, `:checked`, and `:selected` bindings
+ * into elements that use the `v-register` directive — load-bearing for
+ * SSR initial-render correctness. Omitting this plugin under CSR is
+ * tolerable (one-frame flash on mount); omitting it under SSR produces
+ * visibly wrong initial HTML.
  *
- * Implementation note: this plugin mutates @vitejs/plugin-vue's options via
- * the documented but somewhat informal `api.options` surface used by
- * VueUse, Vite PWA, and other Vue ecosystem plugins. If you're using a
- * custom Vue plugin wrapper, fall back to `attaform/transforms`
+ * The `resolveZodAlias` option (default `true`) controls the build-time
+ * `attaform/zod` rewrite. Set to `false` if your project intentionally
+ * mixes Zod versions or has a non-standard Zod resolution; the unified
+ * `attaform/zod` entry's runtime dispatch covers that case at the cost
+ * of bundling both adapters.
+ *
+ * Implementation note: this plugin mutates @vitejs/plugin-vue's options
+ * via the documented but somewhat informal `api.options` surface used
+ * by VueUse, Vite PWA, and other Vue ecosystem plugins. If you're
+ * using a custom Vue plugin wrapper, fall back to `attaform/transforms`
  * and wire them yourself.
  */
+import { readFileSync } from 'node:fs'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { join } from 'node:path'
 import type { Plugin } from 'vite'
 import { inputTextAreaNodeTransform } from './runtime/lib/core/transforms/input-text-area-transform'
 import { selectNodeTransform } from './runtime/lib/core/transforms/select-transform'
 import { vRegisterHintTransform } from './runtime/lib/core/transforms/v-register-hint-transform'
 import { vRegisterPreambleTransform } from './runtime/lib/core/transforms/v-register-preamble-transform'
 
-/** Options for `attaform()`. Reserved for future use; pass `{}` or omit. */
-export type AttaformVitePluginOptions = Record<string, never>
+/** Options for `attaform()`. */
+export interface AttaformVitePluginOptions {
+  /**
+   * Rewrite `attaform/zod` imports at build time to either
+   * `attaform/zod-v3` or `attaform/zod-v4`, based on the consumer's
+   * installed Zod major. Default `true` — produces a leaner bundle
+   * for the common case of one Zod version per project.
+   *
+   * Set to `false` to fall through to the unified entry's runtime
+   * dispatch. Useful when:
+   *   - your project intentionally has both `zod` and `zod-v3`
+   *     installed (e.g. via a pnpm alias) and the schema-shape
+   *     dispatch is the right behavior;
+   *   - your monorepo's Zod resolution is non-standard and the
+   *     plugin's detection (`import.meta.resolve('zod/package.json')`)
+   *     would land on the wrong copy.
+   */
+  resolveZodAlias?: boolean
+}
 
 interface VitePluginVueApi {
   options?: {
@@ -43,10 +72,51 @@ interface VitePluginVueApi {
   }
 }
 
+const ZOD_UNIFIED_SPECIFIER = 'attaform/zod'
+const ZOD_V3_SPECIFIER = 'attaform/zod-v3'
+const ZOD_V4_SPECIFIER = 'attaform/zod-v4'
+
+/**
+ * Read the consumer's installed Zod major by resolving
+ * `zod/package.json` from their project root. ESM resolution
+ * (`import.meta.resolve`) is sync and stable on Node 20.6+, follows
+ * pnpm symlinks, and works with attaform's ESM-only `exports` map.
+ *
+ * Returns:
+ *  - `{ major: 3 | 4 }` when zod is resolvable AND its `version`
+ *    field parses to a known major;
+ *  - `{ major: 'missing' }` when zod can't be resolved at all;
+ *  - `{ major: 'unknown' }` for any other failure (corrupted
+ *    package.json, unexpected version string, monorepo edge case).
+ */
+function detectZodMajor(
+  consumerRootDir: string
+): { major: 3 } | { major: 4 } | { major: 'missing' } | { major: 'unknown' } {
+  const consumerURL = pathToFileURL(join(consumerRootDir, 'package.json')).href
+  let resolved: string
+  try {
+    resolved = import.meta.resolve('zod/package.json', consumerURL)
+  } catch {
+    return { major: 'missing' }
+  }
+  try {
+    const pkg = JSON.parse(readFileSync(fileURLToPath(resolved), 'utf8')) as { version?: unknown }
+    const version = pkg.version
+    if (typeof version !== 'string') return { major: 'unknown' }
+    const major = Number.parseInt(version.split('.')[0] ?? '', 10)
+    if (major === 3) return { major: 3 }
+    if (major === 4) return { major: 4 }
+    return { major: 'unknown' }
+  } catch {
+    return { major: 'unknown' }
+  }
+}
+
 /**
  * Vite plugin that wires the form library's compile-time template
- * transforms into `@vitejs/plugin-vue`. Required for SSR and for
- * hydration accuracy under bare Vue 3.
+ * transforms into `@vitejs/plugin-vue` and rewrites the unified
+ * `attaform/zod` import to the matching adapter subpath. Required
+ * for SSR and for hydration accuracy under bare Vue 3.
  *
  * ```ts
  * // vite.config.ts
@@ -61,9 +131,14 @@ interface VitePluginVueApi {
  * Place the call after `vue()` in the plugins array. Nuxt projects
  * don't need this — `attaform/nuxt` handles it.
  */
-export function attaform(_options: AttaformVitePluginOptions = {}): Plugin {
-  // Unused-var suppression until options exist.
-  void _options
+export function attaform(options: AttaformVitePluginOptions = {}): Plugin {
+  const resolveZodAlias = options.resolveZodAlias !== false
+  // Resolution is computed once per plugin instance from the resolved
+  // Vite root in `configResolved`, then cached for every `resolveId`
+  // call (the hook fires many times during dev/build).
+  let aliasTarget: string | null = null
+  let warnedAboutDetection = false
+
   return {
     name: 'attaform',
     enforce: 'pre',
@@ -98,20 +173,60 @@ export function attaform(_options: AttaformVitePluginOptions = {}): Plugin {
       // invariants downstream transforms depend on. We detect the
       // sentinel via reference equality; user-supplied transforms with
       // the same name don't collide.
-      if (existing.includes(vRegisterPreambleTransform as unknown)) return
-      // vRegisterPreambleTransform MUST come before vRegisterHintTransform
-      // — the preamble's pre-order captures each `v-register` expression
-      // in its raw (un-wrapped) form, and the hint then mutates the same
-      // directive's `exp` to wrap it. Reversing the order would have the
-      // preamble pick up an already-wrapped IIFE, double-wrapping it
-      // when injected at the root.
-      api.options.template.compilerOptions.nodeTransforms = [
-        ...existing,
-        selectNodeTransform,
-        inputTextAreaNodeTransform,
-        vRegisterPreambleTransform,
-        vRegisterHintTransform,
-      ]
+      if (!existing.includes(vRegisterPreambleTransform as unknown)) {
+        // vRegisterPreambleTransform MUST come before vRegisterHintTransform
+        // — the preamble's pre-order captures each `v-register` expression
+        // in its raw (un-wrapped) form, and the hint then mutates the same
+        // directive's `exp` to wrap it. Reversing the order would have the
+        // preamble pick up an already-wrapped IIFE, double-wrapping it
+        // when injected at the root.
+        api.options.template.compilerOptions.nodeTransforms = [
+          ...existing,
+          selectNodeTransform,
+          inputTextAreaNodeTransform,
+          vRegisterPreambleTransform,
+          vRegisterHintTransform,
+        ]
+      }
+
+      // Build-time alias resolution. Skip cleanly when the user opted
+      // out so consumers with non-standard Zod setups don't see a
+      // "zod is not installed" error from this plugin.
+      if (!resolveZodAlias) return
+      const detection = detectZodMajor(resolved.root)
+      if (detection.major === 'missing') {
+        throw new Error(
+          '[attaform/vite] zod is not installed. attaform requires zod as a peer dependency. ' +
+            'Install `zod@^3` or `zod@^4`, OR pass `attaform({ resolveZodAlias: false })` ' +
+            'to keep the runtime-dispatch unified entry (and silence this check).'
+        )
+      }
+      if (detection.major === 'unknown') {
+        // Detection landed on a zod resolution but couldn't classify
+        // the version — log once and fall through to runtime dispatch.
+        // The build still works; the consumer just ships both adapters.
+        if (!warnedAboutDetection) {
+          warnedAboutDetection = true
+          console.warn(
+            '[attaform/vite] Could not classify the installed Zod major (corrupted package.json, ' +
+              'monorepo edge case, or an unexpected version string). Falling through to runtime ' +
+              'dispatch — both Zod adapters will ship in the bundle. ' +
+              'Pass `attaform({ resolveZodAlias: false })` to silence this warning.'
+          )
+        }
+        return
+      }
+      aliasTarget = detection.major === 4 ? ZOD_V4_SPECIFIER : ZOD_V3_SPECIFIER
+    },
+    resolveId(source) {
+      // Intercept ONLY the exact unified specifier. Explicit subpaths
+      // (`attaform/zod-v3`, `attaform/zod-v4`) and the root entry
+      // (`attaform`) pass through unchanged — that's the documented
+      // escape hatch for power users.
+      if (!resolveZodAlias) return null
+      if (aliasTarget === null) return null
+      if (source !== ZOD_UNIFIED_SPECIFIER) return null
+      return aliasTarget
     },
   }
 }

--- a/src/zod-v3.ts
+++ b/src/zod-v3.ts
@@ -1,8 +1,16 @@
 /**
- * `attaform/zod-v3` — Zod v3 adapter for projects on Zod 3. New projects
- * should reach for `attaform/zod` (v4 adapter). The two adapters are
- * physically isolated (separate directories, no cross-imports, enforced
- * by ESLint).
+ * `attaform/zod-v3` — explicit Zod v3 adapter subpath.
+ *
+ * Use this when you want to pin the v3 adapter regardless of what
+ * other tooling resolves. Bundles ship a single adapter (no runtime
+ * dispatch) — handy for non-Vite bundlers (webpack, esbuild standalone,
+ * Rollup) where you'd otherwise pay for both adapters via the unified
+ * `attaform/zod` entry's runtime fallback.
+ *
+ * Most Vite consumers should import from `attaform/zod` instead — the
+ * `attaform/vite` plugin rewrites that import to this subpath at build
+ * time when zod@^3 is detected, so the same lean bundle ships with
+ * less ceremony.
  *
  * Prerequisites: install `zod@^3`. The adapter's behavior assumes v3
  * internals (`_def.typeName`, `.unwrap()`, `.innerType()`); importing this

--- a/src/zod-v4.ts
+++ b/src/zod-v4.ts
@@ -1,0 +1,42 @@
+/**
+ * `attaform/zod-v4` — explicit Zod v4 adapter subpath.
+ *
+ * Use this when you want to pin the v4 adapter regardless of what
+ * other tooling resolves. Bundles ship a single adapter (no runtime
+ * dispatch) — handy for non-Vite bundlers (webpack, esbuild standalone,
+ * Rollup) where you'd otherwise pay for both adapters via the unified
+ * `attaform/zod` entry's runtime fallback.
+ *
+ * Most Vite consumers should import from `attaform/zod` instead — the
+ * `attaform/vite` plugin rewrites that import to this subpath at build
+ * time when zod@^4 is detected, so the same lean bundle ships with
+ * less ceremony.
+ *
+ * Requires `zod@^4` in the consumer's project. Importing this subpath
+ * with zod@3 installed throws a clear version-mismatch error from the
+ * adapter at the first schema parse.
+ *
+ * Usage:
+ *
+ *   import { useForm } from 'attaform/zod-v4'
+ *   import { z } from 'zod'
+ *
+ *   const { register, handleSubmit, errors } = useForm({
+ *     schema: z.object({ email: z.email() }),
+ *     key: 'signup',
+ *   })
+ */
+
+export { UnsupportedSchemaError, useForm, zodAdapter } from './runtime/adapters/zod-v4'
+export { assertZodVersion, kindOf } from './runtime/adapters/zod-v4/introspect'
+export type { ZodKind } from './runtime/adapters/zod-v4/introspect'
+// injectForm is schema-agnostic — the consumer supplies the Form
+// generic — so re-exporting from the /zod-v4 subpath is purely for
+// discoverability alongside useForm.
+export { injectForm } from './runtime/composables/use-form-context'
+export { useRegister } from './runtime/composables/use-register'
+export { AttaformErrorCode } from './runtime/core/error-codes'
+export { unset, isUnset } from './runtime/core/unset'
+export type { Unset } from './runtime/core/unset'
+export { fieldMeta, withMeta } from './runtime/adapters/zod-v4/field-meta'
+export type { FieldMetaPayload } from './runtime/core/field-meta'

--- a/src/zod.ts
+++ b/src/zod.ts
@@ -1,8 +1,21 @@
 /**
- * `attaform/zod` — Zod v4 adapter (recommended).
+ * `attaform/zod` — the unified Zod entry. Auto-detects the consumer's
+ * installed Zod major and routes to the matching adapter:
  *
- * Requires `zod@^4` in the consumer's project. If you're still on zod@3,
- * import from `attaform/zod-v3` instead.
+ * - **Build-time alias (recommended).** With the `attaform/vite`
+ *   plugin (or `attaform/nuxt`, which installs it), `attaform/zod`
+ *   imports are rewritten at build time to either `attaform/zod-v3`
+ *   or `attaform/zod-v4` based on the consumer's installed Zod
+ *   version. The bundle ships a single adapter — same DX, smaller
+ *   payload.
+ *
+ * - **Runtime dispatch (fallback).** Without the Vite plugin (other
+ *   bundlers, plain ESM consumption), this entry's `useForm` checks
+ *   the schema's shape at runtime and routes to the v3 or v4
+ *   adapter. The bundle ships both adapters; the size cost is
+ *   modest but real. Power users who want a lean bundle on non-Vite
+ *   bundlers should reach for `attaform/zod-v3` or `attaform/zod-v4`
+ *   directly.
  *
  * Usage:
  *
@@ -13,14 +26,23 @@
  *     schema: z.object({ email: z.email() }),
  *     key: 'signup',
  *   })
+ *
+ * Surface:
+ * - `useForm` — runtime-dispatching wrapper.
+ * - `injectForm`, `useRegister`, `unset` / `isUnset`,
+ *   `AttaformErrorCode` — schema-agnostic; identical across adapters.
+ * - `fieldMeta`, `withMeta` — re-exported from the v4 adapter. With
+ *   the build-time alias the consumer's bundle gets the right
+ *   `fieldMeta` for their Zod version. Without the alias, v3
+ *   consumers should import `fieldMeta` from `attaform/zod-v3`
+ *   directly.
+ *
+ * Surfaces NOT exposed here (use the explicit subpath):
+ * - `UnsupportedSchemaError`, `zodAdapter`, `assertZodVersion`,
+ *   `kindOf`, `ZodKind` — diverge between v3 and v4.
  */
 
-export { UnsupportedSchemaError, useForm, zodAdapter } from './runtime/adapters/zod-v4'
-export { assertZodVersion, kindOf } from './runtime/adapters/zod-v4/introspect'
-export type { ZodKind } from './runtime/adapters/zod-v4/introspect'
-// injectForm is schema-agnostic — the consumer supplies the Form
-// generic — so re-exporting from the /zod subpath is purely for
-// discoverability alongside useForm.
+export { useForm } from './runtime/adapters/unified/use-form'
 export { injectForm } from './runtime/composables/use-form-context'
 export { useRegister } from './runtime/composables/use-register'
 export { AttaformErrorCode } from './runtime/core/error-codes'

--- a/test/adapters/use-form-guard.test.ts
+++ b/test/adapters/use-form-guard.test.ts
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+import { defineComponent, h, createApp } from 'vue'
+import { z as z4 } from 'zod'
+import { z as z3 } from 'zod-v3'
+
+import { useForm as useFormUnified } from '../../src/zod'
+import { useForm as useFormV4 } from '../../src/zod-v4'
+import { useForm as useFormV3 } from '../../src/zod-v3'
+import { useAbstractForm as useFormAbstract } from '../../src/runtime/composables/use-abstract-form'
+import { InvalidUseFormConfigError } from '../../src/runtime/core/errors'
+
+/**
+ * Captures the synchronous throw inside `setup()`. Returns the thrown
+ * value so the caller can `instanceof` check it. Mounts a probe with
+ * the given setup and bails on any error.
+ */
+function runSetup(callback: () => void): unknown {
+  let captured: unknown
+  const Probe = defineComponent({
+    setup() {
+      try {
+        callback()
+      } catch (err) {
+        captured = err
+      }
+      return () => h('div')
+    },
+  })
+  const app = createApp(Probe)
+  const host = document.createElement('div')
+  app.mount(host)
+  app.unmount()
+  return captured
+}
+
+describe('useForm foot-gun guard — `attaform/zod` (unified)', () => {
+  it('throws InvalidUseFormConfigError when called with a Zod v4 schema directly', () => {
+    const err = runSetup(() => {
+      // The mistake the original feedback flagged: schema as the first arg.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(useFormUnified as any)(z4.object({ email: z4.string() }))
+    })
+    expect(err).toBeInstanceOf(InvalidUseFormConfigError)
+  })
+
+  it('throws InvalidUseFormConfigError when called with a Zod v3 schema directly', () => {
+    const err = runSetup(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(useFormUnified as any)(z3.object({ email: z3.string() }))
+    })
+    expect(err).toBeInstanceOf(InvalidUseFormConfigError)
+  })
+
+  it('throws InvalidUseFormConfigError when called with no argument', () => {
+    const err = runSetup(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(useFormUnified as any)()
+    })
+    expect(err).toBeInstanceOf(InvalidUseFormConfigError)
+  })
+
+  it('throws InvalidUseFormConfigError for { schema: undefined }', () => {
+    const err = runSetup(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(useFormUnified as any)({ schema: undefined })
+    })
+    expect(err).toBeInstanceOf(InvalidUseFormConfigError)
+  })
+})
+
+describe('useForm foot-gun guard — `attaform/zod-v4` (explicit v4)', () => {
+  it('throws when called with a Zod v4 schema directly', () => {
+    const err = runSetup(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(useFormV4 as any)(z4.object({ email: z4.string() }))
+    })
+    expect(err).toBeInstanceOf(InvalidUseFormConfigError)
+  })
+
+  it('throws when called with no argument', () => {
+    const err = runSetup(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(useFormV4 as any)()
+    })
+    expect(err).toBeInstanceOf(InvalidUseFormConfigError)
+  })
+})
+
+describe('useForm foot-gun guard — `attaform/zod-v3` (explicit v3)', () => {
+  it('throws when called with a Zod v3 schema directly', () => {
+    const err = runSetup(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(useFormV3 as any)(z3.object({ email: z3.string() }))
+    })
+    expect(err).toBeInstanceOf(InvalidUseFormConfigError)
+  })
+
+  it('throws when called with no argument', () => {
+    const err = runSetup(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(useFormV3 as any)()
+    })
+    expect(err).toBeInstanceOf(InvalidUseFormConfigError)
+  })
+})
+
+describe('useForm foot-gun guard — `attaform` (abstract root)', () => {
+  it('throws when called with a Zod schema directly (no .schema field)', () => {
+    const err = runSetup(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(useFormAbstract as any)(z4.object({ email: z4.string() }))
+    })
+    expect(err).toBeInstanceOf(InvalidUseFormConfigError)
+  })
+
+  it('throws when called with no argument', () => {
+    const err = runSetup(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(useFormAbstract as any)()
+    })
+    expect(err).toBeInstanceOf(InvalidUseFormConfigError)
+  })
+
+  it('throws when called with { schema: undefined }', () => {
+    const err = runSetup(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(useFormAbstract as any)({ schema: undefined })
+    })
+    expect(err).toBeInstanceOf(InvalidUseFormConfigError)
+  })
+})

--- a/test/adapters/use-form-unified.test.ts
+++ b/test/adapters/use-form-unified.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { defineComponent, h, createApp, type App } from 'vue'
+import { z as z4 } from 'zod'
+import { z as z3 } from 'zod-v3'
+
+import { useForm } from '../../src/zod'
+
+/**
+ * The unified `attaform/zod` entry runs only when the `attaform/vite`
+ * plugin's build-time alias is bypassed (other bundlers, or the
+ * plugin disabled). It dispatches on the schema's runtime shape.
+ *
+ * v4 schemas (`def.type` truthy) take the v4 codepath; v3 schemas
+ * (`_def.typeName` truthy without `def.type`) take the v3 codepath.
+ */
+
+const mountedHosts: HTMLElement[] = []
+const mountedApps: App[] = []
+
+function mountWithSetup(setup: () => unknown): { app: App } {
+  const Probe = defineComponent({
+    setup,
+    render: () => h('div'),
+  })
+  const app = createApp(Probe)
+  const host = document.createElement('div')
+  app.mount(host)
+  mountedHosts.push(host)
+  mountedApps.push(app)
+  return { app }
+}
+
+afterEach(() => {
+  for (const app of mountedApps.splice(0)) app.unmount()
+  for (const host of mountedHosts.splice(0)) host.remove()
+})
+
+describe('attaform/zod — unified entry runtime dispatch', () => {
+  it('routes a Zod v4 schema through the v4 adapter (parses v4-only output)', () => {
+    let captured: unknown
+    mountWithSetup(() => {
+      // z4.email() is a v4-only refinement constructor. Routing through
+      // the v3 wrapper would fail to validate `'a@b.co'` correctly
+      // because v3 doesn't recognise the v4 schema's internal layout.
+      const form = useForm({
+        schema: z4.object({ email: z4.email() }),
+        defaultValues: { email: 'a@b.co' },
+        key: 'unified-v4',
+      })
+      captured = form.values.email
+    })
+    expect(captured).toBe('a@b.co')
+  })
+
+  it('routes a Zod v3 schema through the v3 wrapper (parses v3 input)', () => {
+    let captured: unknown
+    mountWithSetup(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const form = (useForm as any)({
+        schema: z3.object({ name: z3.string() }),
+        defaultValues: { name: 'hello' },
+        key: 'unified-v3',
+      })
+      captured = form.values.name
+    })
+    expect(captured).toBe('hello')
+  })
+
+  it('throws InvalidUseFormConfigError for invalid configurations', () => {
+    let outcome: 'threw' | 'no-throw' = 'no-throw'
+    mountWithSetup(() => {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ;(useForm as any)({ schema: undefined })
+      } catch {
+        outcome = 'threw'
+      }
+    })
+    expect(outcome).toBe('threw')
+  })
+})

--- a/test/core/lazy-install.test.ts
+++ b/test/core/lazy-install.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, createApp, type App } from 'vue'
+import { z } from 'zod'
+
+import { useForm } from '../../src/zod'
+import { injectForm } from '../../src/runtime/composables/use-form-context'
+import { useRegister } from '../../src/runtime/composables/use-register'
+import { createAttaform } from '../../src/runtime/core/plugin'
+
+/**
+ * Coverage for the lazy-install path: `useForm`, `injectForm`, and
+ * `useRegister` should each ensure the registry is attached on first
+ * use, so consumers don't need to call `app.use(createAttaform())`
+ * for the common CSR case.
+ *
+ * Each test creates a fresh app to keep the per-app `_attaform` slot
+ * isolated.
+ */
+
+const mountedHosts: HTMLElement[] = []
+const mountedApps: App[] = []
+
+function mountWithSetup(setup: () => unknown): { app: App; host: HTMLElement } {
+  const Probe = defineComponent({
+    setup,
+    render: () => h('div'),
+  })
+  const app = createApp(Probe)
+  const host = document.createElement('div')
+  app.mount(host)
+  mountedHosts.push(host)
+  mountedApps.push(app)
+  return { app, host }
+}
+
+afterEach(() => {
+  for (const app of mountedApps.splice(0)) app.unmount()
+  for (const host of mountedHosts.splice(0)) host.remove()
+})
+
+describe('useForm — lazy install', () => {
+  it('attaches the registry on first call without an explicit createAttaform()', () => {
+    const { app } = mountWithSetup(() => {
+      useForm({
+        schema: z.object({ email: z.string() }),
+        key: 'lazy-useform',
+      })
+    })
+
+    expect(app._attaform).toBeDefined()
+    expect(app._attaform?.forms.has('lazy-useform')).toBe(true)
+  })
+
+  it('does not double-install when createAttaform() ran first (defaults preserved)', () => {
+    const Probe = defineComponent({
+      setup() {
+        useForm({
+          schema: z.object({ email: z.string() }),
+          key: 'lazy-defaults',
+        })
+        return () => h('div')
+      },
+    })
+    const app = createApp(Probe)
+    app.use(createAttaform({ defaults: { debounceMs: 250 } }))
+    const host = document.createElement('div')
+    app.mount(host)
+    mountedHosts.push(host)
+    mountedApps.push(app)
+
+    // Defaults flow through — the explicit install ran first, the lazy
+    // path is a no-op, the registry's defaults reflect the explicit
+    // install's options.
+    expect(app._attaform?.defaults.debounceMs).toBe(250)
+  })
+})
+
+describe('injectForm — lazy install', () => {
+  it('returns null with a dev warning when called as the first attaform call (no useForm ancestor)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    let resolved: unknown = 'not-set'
+    const { app } = mountWithSetup(() => {
+      // No useForm ancestor anywhere, no createAttaform() — pre-fix
+      // this would throw RegistryNotInstalledError. Post-fix: lazy
+      // install attaches the registry, the lookup misses, the warn
+      // path fires, and injectForm returns null.
+      resolved = injectForm('nonexistent')
+    })
+
+    expect(resolved).toBeNull()
+    expect(app._attaform).toBeDefined()
+    expect(warn).toHaveBeenCalled()
+    const firstCall = warn.mock.calls[0] ?? []
+    const message = (firstCall[0] ?? '') as string
+    expect(message).toContain('injectForm')
+    expect(message).toContain('nonexistent')
+    warn.mockRestore()
+  })
+
+  it('returns null with a dev warning when called for an ambient form with no ancestor', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    let resolved: unknown = 'not-set'
+    const { app } = mountWithSetup(() => {
+      resolved = injectForm()
+    })
+
+    expect(resolved).toBeNull()
+    expect(app._attaform).toBeDefined()
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+})
+
+describe('useRegister — lazy install', () => {
+  it('attaches the registry (and registers the v-register directive) on first call', () => {
+    const { app } = mountWithSetup(() => {
+      useRegister()
+    })
+
+    expect(app._attaform).toBeDefined()
+    // Vue keeps directives on `app._context.directives`. The lazy
+    // install path's `app.directive('register', vRegister)` populates
+    // it; we assert by name to avoid a hard dep on an internal
+    // shape.
+    const directives = (app._context as unknown as { directives: Record<string, unknown> })
+      .directives
+    expect(directives['register']).toBeDefined()
+  })
+})

--- a/test/core/zod-shape.test.ts
+++ b/test/core/zod-shape.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { z as z4 } from 'zod'
+import { z as z3 } from 'zod-v3'
+import {
+  isZodSchemaShape,
+  isZodV3SchemaShape,
+  isZodV4SchemaShape,
+} from '../../src/runtime/core/zod-shape'
+
+describe('isZodV4SchemaShape', () => {
+  it('returns true for a Zod v4 schema (def.type is a string)', () => {
+    expect(isZodV4SchemaShape(z4.object({ email: z4.string() }))).toBe(true)
+    expect(isZodV4SchemaShape(z4.string())).toBe(true)
+    expect(isZodV4SchemaShape(z4.number().min(1))).toBe(true)
+  })
+
+  it('returns false for plain objects, primitives, and Zod v3 schemas', () => {
+    expect(isZodV4SchemaShape(undefined)).toBe(false)
+    expect(isZodV4SchemaShape(null)).toBe(false)
+    expect(isZodV4SchemaShape({})).toBe(false)
+    expect(isZodV4SchemaShape({ schema: z4.object({}) })).toBe(false)
+    expect(isZodV4SchemaShape('z.object({})')).toBe(false)
+    expect(isZodV4SchemaShape(42)).toBe(false)
+    expect(isZodV4SchemaShape(z3.object({ email: z3.string() }))).toBe(false)
+  })
+})
+
+describe('isZodV3SchemaShape', () => {
+  it('returns true for a Zod v3 schema (_def.typeName is a string)', () => {
+    expect(isZodV3SchemaShape(z3.object({ email: z3.string() }))).toBe(true)
+    expect(isZodV3SchemaShape(z3.string())).toBe(true)
+    expect(isZodV3SchemaShape(z3.number().min(1))).toBe(true)
+  })
+
+  it('returns false for plain objects, primitives', () => {
+    expect(isZodV3SchemaShape(undefined)).toBe(false)
+    expect(isZodV3SchemaShape(null)).toBe(false)
+    expect(isZodV3SchemaShape({})).toBe(false)
+    expect(isZodV3SchemaShape({ schema: z3.object({}) })).toBe(false)
+    expect(isZodV3SchemaShape(42)).toBe(false)
+  })
+})
+
+describe('isZodSchemaShape (combined)', () => {
+  it('returns true for both Zod v3 and Zod v4 schemas', () => {
+    expect(isZodSchemaShape(z4.object({ email: z4.string() }))).toBe(true)
+    expect(isZodSchemaShape(z3.object({ email: z3.string() }))).toBe(true)
+  })
+
+  it('returns false for everything else', () => {
+    expect(isZodSchemaShape(undefined)).toBe(false)
+    expect(isZodSchemaShape(null)).toBe(false)
+    expect(isZodSchemaShape({})).toBe(false)
+    expect(isZodSchemaShape({ schema: z4.object({}) })).toBe(false)
+    expect(isZodSchemaShape({ parse: () => null, validate: () => null })).toBe(false)
+    expect(isZodSchemaShape('not a schema')).toBe(false)
+  })
+
+  it('does not get confused by objects whose `def` field is not an object', () => {
+    expect(isZodSchemaShape({ def: 'not an object' })).toBe(false)
+    expect(isZodSchemaShape({ def: null })).toBe(false)
+    expect(isZodSchemaShape({ _def: 'not an object' })).toBe(false)
+    expect(isZodSchemaShape({ _def: null })).toBe(false)
+  })
+
+  it('requires the inner type/typeName property to be a string', () => {
+    expect(isZodSchemaShape({ def: { type: 42 } })).toBe(false)
+    expect(isZodSchemaShape({ _def: { typeName: 42 } })).toBe(false)
+    expect(isZodSchemaShape({ def: {} })).toBe(false)
+    expect(isZodSchemaShape({ _def: {} })).toBe(false)
+  })
+})

--- a/test/packaging/exports.test.ts
+++ b/test/packaging/exports.test.ts
@@ -35,6 +35,31 @@ const isRealBuild =
   existsSync(join(distDir, 'index.mjs')) &&
   !/from\s*['"][^'"]*jiti[^'"]*['"]/.test(readFileSync(join(distDir, 'index.mjs'), 'utf-8'))
 
+/**
+ * Walk a dist entry's transitive import graph and return true if any
+ * file in the closure imports the bare `zod` specifier. Unbuild's
+ * shared-chunk splitter can hoist `from 'zod'` out of an entry into
+ * a shared chunk; checking only the entry would miss the dependency.
+ */
+function closureContainsZodImport(entryPath: string): boolean {
+  const seen = new Set<string>()
+  const stack: string[] = [entryPath]
+  while (stack.length > 0) {
+    const current = stack.pop()
+    if (current === undefined || seen.has(current)) continue
+    seen.add(current)
+    if (!existsSync(current)) continue
+    const src = readFileSync(current, 'utf-8')
+    if (/from\s*['"]zod['"]/.test(src) || /require\(\s*['"]zod['"]\s*\)/.test(src)) return true
+    // Pull every relative import so the walk follows shared chunks.
+    for (const match of src.matchAll(/from\s*['"](\.\/[^'"]+)['"]/g)) {
+      const spec = match[1]
+      if (spec !== undefined) stack.push(join(current, '..', spec))
+    }
+  }
+  return false
+}
+
 describe.skipIf(!existsSync(distDir) || !isRealBuild)('packaging: package.json exports', () => {
   it('main points at a file that exists', () => {
     expect(existsSync(join(repoRoot, pkg.main))).toBe(true)
@@ -58,8 +83,8 @@ describe.skipIf(!existsSync(distDir) || !isRealBuild)('packaging: package.json e
     })
   }
 
-  it('all five expected entries are present', () => {
-    for (const name of ['nuxt', 'index', 'vite', 'transforms', 'zod-v3']) {
+  it('all expected entries are present', () => {
+    for (const name of ['nuxt', 'index', 'vite', 'transforms', 'zod', 'zod-v3', 'zod-v4']) {
       expect(existsSync(join(distDir, `${name}.mjs`)), `${name}.mjs`).toBe(true)
       expect(existsSync(join(distDir, `${name}.d.mts`)), `${name}.d.mts`).toBe(true)
     }
@@ -73,9 +98,20 @@ describe.skipIf(!existsSync(distDir) || !isRealBuild)('packaging: package.json e
     expect(src).not.toMatch(/require\(\s*['"]zod['"]\s*\)/)
   })
 
-  it('zod-v3 entry references zod', () => {
-    const src = readFileSync(join(distDir, 'zod-v3.mjs'), 'utf-8')
-    expect(src).toMatch(/from\s*['"]zod['"]/)
+  it('zod-v3 entry references zod (directly or via a shared chunk)', () => {
+    // Unbuild's chunker may pull the zod import into a shared chunk
+    // when more than one entry shares v3 internals (e.g. the unified
+    // entry's runtime dispatch). Either form is correct — the v3
+    // adapter must depend on zod somewhere in its closure.
+    expect(closureContainsZodImport(join(distDir, 'zod-v3.mjs'))).toBe(true)
+  })
+
+  it('zod-v4 entry references zod (directly or via a shared chunk)', () => {
+    expect(closureContainsZodImport(join(distDir, 'zod-v4.mjs'))).toBe(true)
+  })
+
+  it('zod (unified) entry references zod (directly or via a shared chunk)', () => {
+    expect(closureContainsZodImport(join(distDir, 'zod.mjs'))).toBe(true)
   })
 
   it('no dist bundle imports `zod-v3` (the pnpm-alias specifier gets rewritten)', () => {
@@ -84,7 +120,7 @@ describe.skipIf(!existsSync(distDir) || !isRealBuild)('packaging: package.json e
     // externalize as `from 'zod-v3'` and consumers would hit resolution
     // failures at install time. We exclude error-message string literals
     // from the check.
-    for (const name of ['index', 'nuxt', 'vite', 'transforms', 'zod', 'zod-v3']) {
+    for (const name of ['index', 'nuxt', 'vite', 'transforms', 'zod', 'zod-v3', 'zod-v4']) {
       const mjs = readFileSync(join(distDir, `${name}.mjs`), 'utf-8')
       expect(mjs, `${name}.mjs imports zod-v3`).not.toMatch(
         /from\s*['"]zod-v3['"]|require\(\s*['"]zod-v3['"]\s*\)/

--- a/test/vite/resolve-alias.test.ts
+++ b/test/vite/resolve-alias.test.ts
@@ -1,0 +1,171 @@
+import vue from '@vitejs/plugin-vue'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { resolveConfig, type Plugin, type ResolvedConfig } from 'vite'
+import { attaform } from '../../src/vite'
+
+/**
+ * Coverage for the build-time `attaform/zod` alias hook. Drives the
+ * plugin against per-test fixture roots that contain a synthetic
+ * `node_modules/zod/package.json` so we control the resolved Zod
+ * version without touching the real install.
+ *
+ * Fixtures are generated under `os.tmpdir()` rather than committed
+ * into the repo:
+ *   - `test/vite/fixtures/**\/node_modules` would be gitignored, so
+ *     CI wouldn't see the fixtures.
+ *   - Generating in tmpdir also escapes the repo's own
+ *     `node_modules/zod`, so the no-zod case actually fails to
+ *     resolve (it would otherwise walk up and find attaform's own
+ *     dev-dep zod).
+ */
+
+let zodV4Root: string
+let zodV3Root: string
+let noZodRoot: string
+let corruptZodRoot: string
+
+function makeFixtureWithZod(name: string, zodVersion: string | null): string {
+  const root = mkdtempSync(join(tmpdir(), `attaform-vite-fixture-${name}-`))
+  writeFileSync(
+    join(root, 'package.json'),
+    JSON.stringify({ name: `${name}-fixture`, private: true }),
+    'utf8'
+  )
+  if (zodVersion !== null) {
+    const zodDir = join(root, 'node_modules', 'zod')
+    mkdirSync(zodDir, { recursive: true })
+    writeFileSync(
+      join(zodDir, 'package.json'),
+      JSON.stringify({
+        name: 'zod',
+        version: zodVersion,
+        main: './index.js',
+        exports: { './package.json': './package.json', '.': './index.js' },
+      }),
+      'utf8'
+    )
+    writeFileSync(join(zodDir, 'index.js'), 'module.exports = {}\n', 'utf8')
+  }
+  return root
+}
+
+beforeAll(() => {
+  zodV4Root = makeFixtureWithZod('zod-v4-only', '4.3.0')
+  zodV3Root = makeFixtureWithZod('zod-v3-only', '3.24.0')
+  noZodRoot = makeFixtureWithZod('no-zod', null)
+  corruptZodRoot = makeFixtureWithZod('zod-corrupt', 'not-a-real-version')
+})
+
+afterAll(() => {
+  // tmpdir entries are auto-cleaned by the OS on reboot; vitest's
+  // sandbox doesn't require explicit removal. Skip rm-rf to keep the
+  // teardown obviously safe.
+})
+
+async function resolveWithRoot(plugins: Plugin[], root: string): Promise<ResolvedConfig> {
+  return resolveConfig({ plugins, configFile: false, root }, 'serve')
+}
+
+function findAttaformPlugin(config: ResolvedConfig): Plugin {
+  const plugin = config.plugins.find((p) => p.name === 'attaform')
+  if (plugin === undefined) throw new Error('attaform plugin not found in resolved config')
+  return plugin
+}
+
+async function callResolveId(
+  plugin: Plugin,
+  source: string,
+  importer: string | undefined = undefined
+): Promise<unknown> {
+  const hook = plugin.resolveId
+  if (hook === undefined) return null
+  // Vite/Rollup `resolveId` may be either a plain function or
+  // `{ handler, order }`. The plugin we authored uses the function
+  // form, but support both shapes for forward-compat.
+  const handler = typeof hook === 'function' ? hook : hook.handler
+  // The `this` context isn't strictly needed here — our hook reads
+  // closure state — but bind a stub so calls don't blow up if a
+  // future iteration uses `this.resolve`.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (handler as any).call({}, source, importer)
+}
+
+describe('attaform/vite — resolveId alias for `attaform/zod`', () => {
+  it('rewrites `attaform/zod` to `attaform/zod-v4` when zod@4 is installed', async () => {
+    const config = await resolveWithRoot([vue(), attaform()], zodV4Root)
+    const plugin = findAttaformPlugin(config)
+    const resolved = await callResolveId(plugin, 'attaform/zod', undefined)
+    expect(resolved).toBe('attaform/zod-v4')
+  })
+
+  it('rewrites `attaform/zod` to `attaform/zod-v3` when zod@3 is installed', async () => {
+    const config = await resolveWithRoot([vue(), attaform()], zodV3Root)
+    const plugin = findAttaformPlugin(config)
+    const resolved = await callResolveId(plugin, 'attaform/zod', undefined)
+    expect(resolved).toBe('attaform/zod-v3')
+  })
+
+  it('throws at configResolved when zod is not installed', async () => {
+    await expect(resolveWithRoot([vue(), attaform()], noZodRoot)).rejects.toThrow(
+      /zod is not installed/
+    )
+  })
+
+  it('falls through to runtime dispatch (with a one-time warn) when the version is unparseable', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const config = await resolveWithRoot([vue(), attaform()], corruptZodRoot)
+      const plugin = findAttaformPlugin(config)
+      const resolved = await callResolveId(plugin, 'attaform/zod', undefined)
+      // No alias target → resolveId returns null → consumer falls through
+      // to the runtime-dispatch unified entry.
+      expect(resolved).toBeNull()
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('Could not classify the installed Zod major')
+      )
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('passes through `attaform/zod-v3` unchanged (explicit subpath escape hatch)', async () => {
+    const config = await resolveWithRoot([vue(), attaform()], zodV4Root)
+    const plugin = findAttaformPlugin(config)
+    const resolved = await callResolveId(plugin, 'attaform/zod-v3', undefined)
+    expect(resolved).toBeNull()
+  })
+
+  it('passes through `attaform/zod-v4` unchanged', async () => {
+    const config = await resolveWithRoot([vue(), attaform()], zodV4Root)
+    const plugin = findAttaformPlugin(config)
+    const resolved = await callResolveId(plugin, 'attaform/zod-v4', undefined)
+    expect(resolved).toBeNull()
+  })
+
+  it('passes through `attaform` (root) unchanged', async () => {
+    const config = await resolveWithRoot([vue(), attaform()], zodV4Root)
+    const plugin = findAttaformPlugin(config)
+    const resolved = await callResolveId(plugin, 'attaform', undefined)
+    expect(resolved).toBeNull()
+  })
+
+  it('does not rewrite when `resolveZodAlias: false` is passed', async () => {
+    const config = await resolveWithRoot([vue(), attaform({ resolveZodAlias: false })], zodV4Root)
+    const plugin = findAttaformPlugin(config)
+    const resolved = await callResolveId(plugin, 'attaform/zod', undefined)
+    expect(resolved).toBeNull()
+  })
+
+  it('does not throw on missing zod when `resolveZodAlias: false` is passed', async () => {
+    // The opt-out short-circuits BOTH the rewrite and the detection
+    // check, so a consumer with no zod installed who explicitly opted
+    // out doesn't see a build-time error from the plugin.
+    const config = await resolveWithRoot([vue(), attaform({ resolveZodAlias: false })], noZodRoot)
+    const plugin = findAttaformPlugin(config)
+    const resolved = await callResolveId(plugin, 'attaform/zod', undefined)
+    expect(resolved).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Make `pnpm install attaform` the entire setup story for the common bare-Vue + Vite case, with explicit setup as a power-user opt-in. Five threads of work landed across three feature commits + three chore commits:

- **Foot-gun guard.** New `InvalidUseFormConfigError` thrown synchronously at every `useForm` entry when the configuration is missing a schema (raw schema as the first arg, no args, or `{ schema: undefined }`). Catches the pattern flagged in the original feedback — `useForm(z.object({...}))` used to crash either as a misleading "schema is not zod v4" or deep inside `walkUnsetSentinels`.

- **Lazy self-install.** Extracted `installAttaformOnApp` from `createAttaform()` and added `ensureAttaformInstalled(app)`, called from inside the three public setup-context entry points (`useAbstractForm`, `injectForm`, `useRegister`). `app.use(createAttaform())` is now opt-in for app-wide options (`defaults`, `devtools: false`, `ssr: true`) — the "blank page when you forgot the plugin" failure mode is gone.

- **Unified `attaform/zod` entry with build-time alias.** `attaform/zod` now auto-detects the consumer's Zod major and routes to the matching adapter. Three resolution tiers: build-time alias via the Vite plugin's new `resolveId` hook (rewrites to `attaform/zod-v3` or `attaform/zod-v4` for a lean bundle), runtime dispatch fallback for non-Vite bundlers, and explicit `zod-v3` / `zod-v4` subpaths as the escape hatch. Vite plugin gained a `resolveZodAlias: boolean` option (default `true`); the Nuxt module switched to `addVitePlugin(attaform())` so the alias propagates there too.

- **Error-copy tighten.** `assertZodVersion` and `RegistryNotInstalledError` rewritten to reflect the new mental model.

- **Docs reframe.** README + quickstart + troubleshooting + API reference now lead with `pnpm install attaform`. Vite plugin and `createAttaform()` move from required steps to "Going further" sections. New `docs/api/zod-v4.md` for the explicit subpath.

Plus three site / build housekeeping commits picked up along the way:

- Pin nuxt-og-image to Inter so Satori stops failing to fetch Arial as a webfont.
- Set `nitro.static: true` so nuxt-og-image's preset resolver routes to the known `nitro-prerender` profile (silences the "Unknown Nitro preset" warning).
- Cap `engines.node` at `<27` and bump `packageManager` to `pnpm@10.33.4` to silence Vercel's build warnings about unbounded Node range and lockfile/packageManager drift.

Pre-1.0 with no users + the project's "no back-compat" stance — fixing the underlying setup-tax problem rather than papering over the symptoms.

## Test plan

- [x] `pnpm check` clean (lint, typecheck, tests, size, bench, coverage)
- [x] Scratch bare-Vite app: `pnpm install attaform zod`, `useForm` works without `createAttaform()` or the Vite plugin (CSR; one-frame mount flash acceptable)
- [x] Same scratch app + `attaform/vite` plugin: bundle ships only the matching Zod adapter (grep dist for v3-only / v4-only markers)
- [x] Foot-gun: `useForm(z.object(...))` throws `InvalidUseFormConfigError` from all four entry points (`/zod`, `/zod-v3`, `/zod-v4`, root `attaform`)
- [x] Existing `apps/site` SSR pass (Nuxt) still emits `data-atta-pre-mark` and `:value=...` bindings
- [x] Vercel build no longer emits the engines / packageManager / Arial / Unknown-Nitro-preset warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)