### PR TITLE
docs(readme): use createAttaform() as the canonical Nuxt install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,14 @@ That's it for client-side rendering. Forms render and validate the moment you ca
 
 ### Going further
 
-**Nuxt 3 / 4** — add the module:
+**Nuxt 3 / 4** — install the Vue plugin via a Nuxt plugin:
 
 ```ts
-// nuxt.config.ts
-export default defineNuxtConfig({
-  modules: ['attaform/nuxt'],
+// plugins/attaform.ts
+import { createAttaform } from 'attaform'
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.vueApp.use(createAttaform())
 })
 ```
 


### PR DESCRIPTION
## Summary

Tiny README touch-up — replaces the `modules: ['attaform/nuxt']` snippet with the equivalent `createAttaform()` install via a Nuxt plugin file. Picks one canonical install pattern (`createAttaform()`) for the README hero so the bare-Vue and Nuxt subsections both lead with the same Vue-plugin pattern.

```diff
-**Nuxt 3 / 4** — add the module:
+**Nuxt 3 / 4** — install the Vue plugin via a Nuxt plugin:

 ```ts
-// nuxt.config.ts
-export default defineNuxtConfig({
-  modules: ['attaform/nuxt'],
-})
+// plugins/attaform.ts
+import { createAttaform } from 'attaform'
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.vueApp.use(createAttaform())
+})
 ```
```

The `attaform/nuxt` module still exists and is the richer integration (it adds SSR payload threading, `useForm` auto-imports, and registers the Vite plugin alongside `createAttaform()`). The docs site documents it. For the README hero, the goal is one canonical pattern, deliberately at the cost of those Nuxt-specific extras — Nuxt users who want them follow the docs.

## Test plan

- [ ] Visual check: README "Going further" reads cleanly
- [ ] No CI regressions (this is README-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)