### PR TITLE
docs(readme): simplify going further snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,12 @@ That's it for client-side rendering. Forms render and validate the moment you ca
 
 ### Going further
 
-**Nuxt 3 / 4** — install the Vue plugin via a Nuxt plugin:
+**Nuxt 3 / 4** — add the module:
 
 ```ts
-// plugins/attaform.ts
-import { createAttaform } from 'attaform'
-
-export default defineNuxtPlugin((nuxtApp) => {
-  nuxtApp.vueApp.use(createAttaform())
+// nuxt.config.ts
+export default defineNuxtConfig({
+  modules: ['attaform/nuxt'],
 })
 ```
 


### PR DESCRIPTION
## Summary

**0.16.1 on npm shipped with the wrong Nuxt install snippet in the README.** PR #178 squash-merged a stray README change from PR #177's branch — the Nuxt subsection was rewritten from `modules: ['attaform/nuxt']` to a manual `defineNuxtPlugin(... vueApp.use(createAttaform()))` snippet. PR #177 was closed unmerged precisely because that pattern is wrong (the Nuxt module is the idiomatic install — it exposes the `attaform` configKey, threads the SSR payload, registers the Vite plugin, and auto-imports `useForm`; the manual snippet loses all of that), but the commit was still on the docs-reference branch when it merged.

Verified by inspecting the published tarball:

```bash
npm pack attaform@0.16.1
grep -A 6 "Nuxt 3 / 4" package/README.md
# → **Nuxt 3 / 4** — install the Vue plugin via a Nuxt plugin:
#   ```ts
#   // plugins/attaform.ts
#   import { createAttaform } from 'attaform'
#   ...
```

## What changed

README-only revert. Restores the Nuxt section to:

```ts
// nuxt.config.ts
export default defineNuxtConfig({
  modules: ['attaform/nuxt'],
})
```

The expanded `docs/api/nuxt.md` from #178 stays — it leads with the same module install and was the correct deliverable from that PR. Only the README needed to be backed out.

## Followup

This needs a **0.16.2 publish** to land on npm — the README in the published tarball is what shows up on the npmjs.com package page. After merge, `Publish to NPM and Version Bump` workflow with `version_type=patch` will cut it.

## Test plan

- [ ] Diff is README-only (`git diff --stat` shows `1 file changed, 4 insertions(+), 6 deletions(-)`)
- [ ] After merge + 0.16.2 publish: `npm pack attaform@0.16.2 && grep -A 6 "Nuxt 3 / 4" package/README.md` shows `modules: ['attaform/nuxt']`

🤖 Generated with [Claude Code](https://claude.com/claude-code)