### PR TITLE
fix(zod): unify fieldMeta storage; portable hello-world example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ It catches stale `form.values.contacts[N]` reads at compile time. Nuxt 3 / 4 set
   import { useForm } from 'attaform/zod' // auto-detects Zod major
 
   const schema = z.object({
-    email: z.email(),
-    password: z.string().min(8),
+    username: z.string().min(2, 'At least 2 characters'),
+    password: z.string().min(8, 'At least 8 characters'),
   })
 
   const form = useForm({ schema, key: 'signup' })
@@ -89,8 +89,8 @@ It catches stale `form.values.contacts[N]` reads at compile time. Nuxt 3 / 4 set
 
 <template>
   <form @submit.prevent="onSubmit">
-    <input v-register="form.register('email')" placeholder="Email" />
-    <small v-if="form.errors.email?.[0]">{{ form.errors.email[0].message }}</small>
+    <input v-register="form.register('username')" placeholder="Username" />
+    <small v-if="form.errors.username?.[0]">{{ form.errors.username[0].message }}</small>
 
     <input v-register="form.register('password')" type="password" placeholder="Password" />
     <small v-if="form.errors.password?.[0]">{{ form.errors.password[0].message }}</small>
@@ -102,9 +102,9 @@ It catches stale `form.values.contacts[N]` reads at compile time. Nuxt 3 / 4 set
 
 `useForm({ schema, key })` returns a Pinia-style reactive object — read leaves directly, no `.value`:
 
-- **`form.values`** — current values. `form.values.email`, `form.values.address.city`.
-- **`form.errors`** — per-field errors, keyed by dotted path. `form.errors.email?.[0]?.message`.
-- **`form.fields`** — per-field flags (`dirty`, `touched`, `errors`, `blank`, …). `form.fields.email.dirty`.
+- **`form.values`** — current values. `form.values.username`, `form.values.address.city`.
+- **`form.errors`** — per-field errors, keyed by dotted path. `form.errors.username?.[0]?.message`.
+- **`form.fields`** — per-field flags (`dirty`, `touched`, `errors`, `blank`, …). `form.fields.username.dirty`.
 - **`form.meta`** — form-level flags + counters (`isSubmitting`, `isValid`, `canUndo`, `submitCount`, the flat `meta.errors` aggregate, the per-mount `instanceId`, …).
 - **`form.register(path)`** — typed two-way binding; pair with `v-register` on `<input>` / `<textarea>` / `<select>`.
 - **`form.handleSubmit(onValid, onInvalid?)`** — runs validation, dispatches. The valid callback receives the strict zod-inferred type.

--- a/docs/api/zod.md
+++ b/docs/api/zod.md
@@ -11,7 +11,12 @@ The unified Zod entry. Same import for Zod 3 and Zod 4 projects — the runtime 
 import { useForm, fieldMeta, withMeta } from 'attaform/zod'
 import { z } from 'zod'
 
-const form = useForm({ schema: z.object({ email: z.email() }) })
+const form = useForm({
+  schema: z.object({
+    username: z.string().min(2, 'At least 2 characters'),
+    password: z.string().min(8, 'At least 8 characters'),
+  }),
+})
 ```
 
 This is THE recommended import for new projects. Use it whenever you don't have a specific reason to pin one Zod major.
@@ -42,13 +47,13 @@ import {
 import type { FieldMetaPayload, Unset } from 'attaform/zod'
 ```
 
-| Export                                      | What it does                                                                            |
-| ------------------------------------------- | --------------------------------------------------------------------------------------- |
-| `useForm`                                   | Runtime-dispatching wrapper. Type signature targets Zod 4. See [usage](#useform).       |
-| `injectForm`, `useRegister`                 | Schema-agnostic — identical across the two adapters.                                    |
-| `fieldMeta`, `withMeta`, `FieldMetaPayload` | Re-exported from the v4 adapter; see [Caveats](#caveats) for the runtime-dispatch case. |
-| `unset`, `isUnset`, `Unset`                 | Sentinel for "displayed empty"; identical across adapters.                              |
-| `AttaformErrorCode`                         | Library-emitted error-code enum (`atta:*`).                                             |
+| Export                                      | What it does                                                                                                                                                            |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `useForm`                                   | Runtime-dispatching wrapper. Type signature targets Zod 4. See [usage](#useform).                                                                                       |
+| `injectForm`, `useRegister`                 | Schema-agnostic — identical across the two adapters.                                                                                                                    |
+| `fieldMeta`, `withMeta`, `FieldMetaPayload` | Cross-major schema metadata. Backed by a shared store so writes here are read by whichever adapter dispatches; `withMeta` runtime-branches on schema shape for cloning. |
+| `unset`, `isUnset`, `Unset`                 | Sentinel for "displayed empty"; identical across adapters.                                                                                                              |
+| `AttaformErrorCode`                         | Library-emitted error-code enum (`atta:*`).                                                                                                                             |
 
 For `zodAdapter`, `kindOf`, `assertZodVersion`, `ZodKind`, and `UnsupportedSchemaError` — the surfaces that diverge between v3 and v4 — use the [`attaform/zod-v3`](/docs/api/zod-v3) or [`attaform/zod-v4`](/docs/api/zod-v4) explicit subpath.
 
@@ -58,7 +63,10 @@ Same surface as the per-major adapters. See [The useForm return value](/docs/api
 
 ```ts
 const form = useForm({
-  schema: z.object({ email: z.email() }),
+  schema: z.object({
+    username: z.string().min(2, 'At least 2 characters'),
+    password: z.string().min(8, 'At least 8 characters'),
+  }),
   key: 'signup',
 })
 ```
@@ -67,11 +75,28 @@ When the build-time alias is in play, the consumer's bundled code resolves to th
 
 ## Schema-attached metadata
 
-`fieldMeta` and `withMeta` are re-exported from the v4 adapter. Same surface as documented in [`attaform/zod-v4` § Schema-attached metadata](/docs/api/zod-v4#schema-attached-metadata).
+`fieldMeta` and `withMeta` write to a cross-adapter store, so a payload registered through this entry is visible at lookup whether the v3 or v4 adapter actually runs. `withMeta` runtime-branches on the schema's shape: Zod 4 schemas are cloned via the native `.clone()`, Zod 3 schemas via constructor + `_def` reconstruction. The native `schema.register(fieldMeta, payload)` chain still works for v4 schemas — Zod 4's `.register()` only needs `.add(this, payload)` on the registry, which the shared store provides.
+
+```ts
+import { z } from 'zod'
+import { useForm, withMeta } from 'attaform/zod'
+
+const schema = z.object({
+  username: withMeta(z.string().min(2, 'At least 2 characters'), {
+    label: 'Username',
+    placeholder: 'your-handle',
+  }),
+})
+
+const form = useForm({ schema })
+// form.fields.username.label       → 'Username'
+// form.fields.username.placeholder → 'your-handle'
+```
+
+See [`attaform/zod-v4` § Schema-attached metadata](/docs/api/zod-v4#schema-attached-metadata) for the resolution-order table and the registration-pattern notes — both apply identically to the unified entry.
 
 ## Caveats
 
-- **`fieldMeta` shape on Zod 3 without the Vite plugin.** Without the build-time alias, the unified entry exports the v4 `fieldMeta` registry. The v4 registry's `getFieldMetaList` helper isn't available on Zod 3. If you're on Zod 3 and not using Vite, import `fieldMeta` from [`attaform/zod-v3`](/docs/api/zod-v3) directly.
 - **Both Zod versions installed.** Aliasing both `zod` and `zod-v3` (or similar) bypasses the Vite plugin's detection — pass `attaform({ resolveZodAlias: false })` and consume the runtime dispatch, or import the explicit subpath at every call site.
 - **TypeScript inference.** The unified entry's `useForm` signature targets Zod 4. With the build-time alias, the consumer's code is rewritten to the explicit subpath, so post-build inference is exact. Without it, Zod 3 consumers should reach for [`attaform/zod-v3`](/docs/api/zod-v3) for the strongest inference.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -21,7 +21,7 @@ Get a working Attaform form on screen in under five minutes.
   import { useForm } from 'attaform/zod'
 
   const schema = z.object({
-    email: z.email(),
+    username: z.string().min(2, 'At least 2 characters'),
     password: z.string().min(8, 'At least 8 characters'),
   })
 
@@ -36,9 +36,9 @@ Get a working Attaform form on screen in under five minutes.
 <template>
   <form @submit.prevent="onSubmit">
     <label>
-      Email
-      <input v-register="form.register('email')" type="email" />
-      <small>{{ form.errors.email?.[0]?.message }}</small>
+      Username
+      <input v-register="form.register('username')" />
+      <small>{{ form.errors.username?.[0]?.message }}</small>
     </label>
 
     <label>
@@ -75,14 +75,16 @@ Attach metadata to fields so the schema stays the single source of truth for bot
 ```vue
 <script setup lang="ts">
   import { z } from 'zod'
-  import { useForm, fieldMeta } from 'attaform/zod'
+  import { useForm, withMeta } from 'attaform/zod'
 
   const schema = z.object({
-    email: z.email().register(fieldMeta, {
-      label: 'Email',
-      placeholder: 'you@example.com',
+    username: withMeta(z.string().min(2, 'At least 2 characters'), {
+      label: 'Username',
+      placeholder: 'your-handle',
     }),
-    password: z.string().min(8).register(fieldMeta, { label: 'Password' }),
+    password: withMeta(z.string().min(8, 'At least 8 characters'), {
+      label: 'Password',
+    }),
   })
 
   const form = useForm({ schema, key: 'signup' })
@@ -90,12 +92,8 @@ Attach metadata to fields so the schema stays the single source of truth for bot
 
 <template>
   <label>
-    {{ form.fields.email.label }}
-    <input
-      v-register="form.register('email')"
-      type="email"
-      :placeholder="form.fields.email.placeholder"
-    />
+    {{ form.fields.username.label }}
+    <input v-register="form.register('username')" :placeholder="form.fields.username.placeholder" />
   </label>
 </template>
 ```

--- a/src/runtime/adapters/unified/field-meta.ts
+++ b/src/runtime/adapters/unified/field-meta.ts
@@ -1,0 +1,71 @@
+/**
+ * Field-metadata write/read API for the unified `attaform/zod` entry.
+ *
+ * Storage is shared with both adapters via `field-meta-store` — a
+ * payload written here is visible to whichever adapter the unified
+ * `useForm` dispatches to at runtime, regardless of Zod major. No
+ * `zod` runtime import; the type-only `import type` is erased at
+ * build, so `attaform/zod` carries no `z.registry` reference even
+ * when consumed by a Zod 3 project without the Vite plugin alias.
+ *
+ * The native v4 chain `schema.register(fieldMeta, payload)` continues
+ * to work — Zod 4's `.register()` only calls `.add(this, payload)`
+ * structurally, satisfied by the shared store.
+ */
+import type { z } from 'zod'
+import type { FieldMetaPayload } from '../../core/field-meta'
+import { fieldMetaStore, getFieldMetaForSchema } from '../../core/field-meta-store'
+
+// Zod v4's `$ZodRegistry` class isn't surfaced under the `z` namespace
+// of the classic external entry, but `z.registry()` returns one — so
+// `ReturnType<typeof z.registry<T>>` resolves to the registry type
+// without needing a direct import. The `import type` keeps the
+// reference type-only; nothing about `z.registry` lands in the bundle.
+type ZodFieldMetaRegistry = ReturnType<typeof z.registry<FieldMetaPayload>>
+
+/**
+ * The shared registry every Attaform-aware Zod schema can register
+ * field metadata against, regardless of major. Same instance the v3
+ * and v4 adapter entries expose — write in one place, read from
+ * any.
+ *
+ * Cast to Zod 4's `$ZodRegistry<FieldMetaPayload>` so the native
+ * `schema.register(fieldMeta, payload)` chain type-checks for v4
+ * users; the runtime call only needs `.add` structurally, which the
+ * shared store provides.
+ */
+export const fieldMeta = fieldMetaStore as unknown as ZodFieldMetaRegistry
+
+/**
+ * Attach `payload` to `schema` in the shared registry and return a
+ * clone of `schema` so each call gets its own identity (the registry
+ * keys on schema reference, so cloning prevents last-write-wins
+ * collisions for sub-schemas reused at multiple paths).
+ *
+ * Works on both Zod 3 and Zod 4 schemas — branches on the runtime
+ * shape of the schema:
+ * - Zod 4 schemas expose a public `.clone()` method; we call it.
+ * - Zod 3 schemas don't, so we reconstruct via
+ *   `new schema.constructor(schema._def)`.
+ *
+ * Both forms produce a fresh schema with the same effective
+ * structure, so the registry slot is unique to this call site.
+ */
+export function withMeta<S>(schema: S, payload: FieldMetaPayload): S {
+  const target = schema as object
+  const existing = getFieldMetaForSchema(target) ?? {}
+  const cloned = cloneSchema(schema)
+  fieldMetaStore.add(cloned as object, { ...existing, ...payload })
+  return cloned
+}
+
+function cloneSchema<S>(schema: S): S {
+  const candidate = schema as { clone?: unknown; constructor: unknown; _def: unknown }
+  if (typeof candidate.clone === 'function') {
+    return (candidate.clone as () => S)()
+  }
+  // Zod 3 path: reconstruct via constructor + _def (no public
+  // `.clone()` on v3).
+  const Ctor = candidate.constructor as new (def: unknown) => S
+  return new Ctor(candidate._def)
+}

--- a/src/runtime/adapters/unified/use-form.ts
+++ b/src/runtime/adapters/unified/use-form.ts
@@ -47,8 +47,8 @@ import type { DeepPartial, DefaultValuesShape, GenericForm } from '../../types/t
  *
  * const form = useForm({
  *   schema: z.object({
- *     email: z.email(),
- *     password: z.string().min(8),
+ *     username: z.string().min(2, 'At least 2 characters'),
+ *     password: z.string().min(8, 'At least 8 characters'),
  *   }),
  * })
  * ```

--- a/src/runtime/adapters/zod-v3/field-meta.ts
+++ b/src/runtime/adapters/zod-v3/field-meta.ts
@@ -1,11 +1,16 @@
 /**
  * Field-metadata write/read API for the Zod v3 adapter.
  *
- * Zod 3 has no `z.registry()` mechanism, so we shim one with a
- * module-scoped `WeakMap<ZodTypeAny, FieldMetaPayload>` plus a
- * registry-shaped object exposing `add` / `get` / `has`. The public
- * `withMeta(schema, payload)` write API matches `attaform/zod` so
- * schema authoring reads identically across the two adapters.
+ * Storage lives in the shared `field-meta-store` core — every entry
+ * (`attaform/zod`, `attaform/zod-v3`, `attaform/zod-v4`) writes to and
+ * reads from the same `WeakMap`s, so a payload registered via any
+ * entry surfaces at lookup regardless of which adapter actually runs.
+ *
+ * Zod 3 has no `z.registry()` mechanism, so `fieldMeta` is the
+ * shared registry-shaped object exposing `add` / `get` / `has` /
+ * `remove`. The public `withMeta(schema, payload)` write API matches
+ * `attaform/zod`'s so schema authoring reads identically across the
+ * two adapters.
  *
  * **Registration patterns:** both styles work — register on whatever
  * schema reference you assign into the parent's shape, OR on the
@@ -23,14 +28,13 @@
  */
 import type { z } from 'zod-v3'
 import type { FieldMetaPayload } from '../../core/field-meta'
-
-const store = new WeakMap<z.ZodTypeAny, FieldMetaPayload>()
+import { fieldMetaStore, getFieldMetaForSchema } from '../../core/field-meta-store'
 
 /**
  * The shared registry every Attaform-aware Zod 3 schema can register
- * field metadata against. Exposes a registry-shaped surface so that
- * v3 user code can use the same idiom v4 users do (`fieldMeta.add(schema,
- * payload)`); under the hood it's just a `WeakMap`.
+ * field metadata against. Backed by the cross-adapter
+ * `fieldMetaStore` — a payload registered here is visible to the v4
+ * adapter and the unified `attaform/zod` entry, and vice versa.
  */
 type FieldMetaRegistryV3 = {
   /**
@@ -47,25 +51,14 @@ type FieldMetaRegistryV3 = {
   has(schema: z.ZodTypeAny): boolean
 }
 
-export const fieldMeta: FieldMetaRegistryV3 = {
-  add(schema, payload) {
-    store.set(schema, payload)
-    return fieldMeta
-  },
-  get(schema) {
-    return store.get(schema)
-  },
-  has(schema) {
-    return store.has(schema)
-  },
-}
+export const fieldMeta = fieldMetaStore as unknown as FieldMetaRegistryV3
 
 /**
  * Attach `payload` to `schema` in the shared `fieldMeta` registry
  * and return a clone of `schema` (chainable, with the new metadata).
  * Cross-version with `attaform/zod`'s `withMeta()`.
  *
- * **Why clone, not mutate.** The WeakMap shim keys metadata on the
+ * **Why clone, not mutate.** The shared store keys metadata on the
  * schema reference. Calling `withMeta` twice on the same instance
  * would overwrite (last-write-wins) — so a sub-schema reused at
  * multiple form paths (e.g. an address schema shared between pickup
@@ -83,18 +76,18 @@ export const fieldMeta: FieldMetaRegistryV3 = {
  * registers once and surfaces at every path.
  *
  * `schema.register()` does NOT exist on Zod 3 — `withMeta` is the
- * only write API. Register on the inner schema before wrapping;
- * see the "Registration rule" note in this file's header.
+ * only fluent write API. Register on the inner schema before
+ * wrapping; see the "Registration rule" note in this file's header.
  */
 export function withMeta<S extends z.ZodTypeAny>(schema: S, payload: FieldMetaPayload): S {
-  const existing = store.get(schema) ?? {}
+  const existing = getFieldMetaForSchema(schema as object) ?? {}
   // Zod 3 lacks a public `.clone()`, so reconstruct via the
   // constructor + _def. Each ZodSchema subclass's constructor takes
   // a `_def` object and produces an instance — same shape, fresh
   // identity.
   const Ctor = schema.constructor as new (def: S['_def']) => S
   const cloned = new Ctor(schema._def)
-  store.set(cloned, { ...existing, ...payload })
+  fieldMetaStore.add(cloned as object, { ...existing, ...payload })
   return cloned
 }
 
@@ -107,5 +100,5 @@ export function withMeta<S extends z.ZodTypeAny>(schema: S, payload: FieldMetaPa
  * Not part of the public `attaform/zod-v3` surface.
  */
 export function getFieldMeta(schema: z.ZodTypeAny): FieldMetaPayload | undefined {
-  return store.get(schema)
+  return getFieldMetaForSchema(schema as object)
 }

--- a/src/runtime/adapters/zod-v4/field-meta.ts
+++ b/src/runtime/adapters/zod-v4/field-meta.ts
@@ -1,11 +1,14 @@
 /**
  * Field-metadata write/read API for the Zod v4 adapter.
  *
- * Backed by Zod 4's native `z.registry<T>()` mechanism — the schema
- * carries the metadata directly through `schema.register(fieldMeta,
- * payload)` (returns the schema, chainable) or the `withMeta()`
- * helper (same effect, version-agnostic across the v3 / v4 adapter
- * split).
+ * Storage lives in the shared `field-meta-store` core — every entry
+ * (`attaform/zod`, `attaform/zod-v3`, `attaform/zod-v4`) writes to and
+ * reads from the same `WeakMap`s, so a payload registered via any
+ * entry surfaces at lookup regardless of which adapter actually runs.
+ *
+ * The native chain `schema.register(fieldMeta, payload)` still works
+ * — Zod 4's `.register` calls `registry.add(this, payload)` and
+ * returns the schema; the shared store satisfies that structurally.
  *
  * **Registration patterns:** both styles work — register on whatever
  * schema reference you assign into the parent's shape, OR on the
@@ -26,14 +29,27 @@
  * reach the inner object). The two-stage lookup covers both leaf
  * and container registrations symmetrically.
  */
-import { z } from 'zod'
+import type { z } from 'zod'
 import type { FieldMetaPayload } from '../../core/field-meta'
+import {
+  fieldMetaStore,
+  getFieldMetaForSchema,
+  getFieldMetaListForSchema,
+} from '../../core/field-meta-store'
+
+// `$ZodRegistry` isn't surfaced under zod's classic external `z`
+// namespace, but `z.registry()` returns one — `ReturnType<typeof
+// z.registry<T>>` resolves to the registry type without a direct
+// import. The `import type` keeps the reference type-only so no
+// `z.registry` lands in the bundle.
+type ZodFieldMetaRegistry = ReturnType<typeof z.registry<FieldMetaPayload>>
 
 /**
  * The shared registry every Attaform-aware Zod 4 schema can register
- * field metadata against. One module-scoped instance per consumer
- * project — re-exported from `attaform/zod` so user code reads the
- * same registry the runtime does.
+ * field metadata against. Backed by the cross-adapter
+ * `fieldMetaStore` — one module-scoped instance, shared with the v3
+ * adapter and the unified `attaform/zod` entry, so a `.register()`
+ * chain in one place is read by adapters in another.
  *
  * Consumers extending `FieldMetaPayload` via declaration merging
  * automatically get the richer payload type at every `register` /
@@ -43,12 +59,12 @@ import type { FieldMetaPayload } from '../../core/field-meta'
  * at multiple form paths (e.g. one address schema bound to both
  * `pickup` and `delivery`) can carry distinct metadata per path —
  * even via the canonical `schema.register(fieldMeta, payload)` chain.
- * Internally we maintain a parallel WeakMap of payload LISTS indexed
- * per schema reference, and the path-resolver walks the form's
- * schema tree counting per-schema occurrences to pick the right
- * payload for each path. Object literals evaluate left-to-right, so
- * registration order matches tree-walk order, and shared schemas
- * pair their two registrations to the two paths correctly:
+ * The shared store keeps a parallel list of every registration; the
+ * path-resolver walks the form's schema tree counting per-schema
+ * occurrences to pick the right payload for each path. Object
+ * literals evaluate left-to-right, so registration order matches
+ * tree-walk order, and shared schemas pair their two registrations
+ * to the two paths correctly:
  *
  *     z.object({
  *       pickup: addressSchema.register(fieldMeta, { label: 'Pickup address' }),
@@ -60,29 +76,13 @@ import type { FieldMetaPayload } from '../../core/field-meta'
  * Schemas reused via `withMeta()` get a fresh clone per call (see
  * `withMeta` below), so they never share a registry slot in the
  * first place.
+ *
+ * Cast to `z.$ZodRegistry<FieldMetaPayload>` so that
+ * `schema.register(fieldMeta, payload)` chains type-check at the call
+ * site — Zod 4's `.register()` only calls `.add(this, payload)`
+ * structurally, so the cast is sound at runtime.
  */
-export const fieldMeta = z.registry<FieldMetaPayload>()
-
-// Parallel list-per-schema store used by the path-resolver to pick
-// the right payload when one schema instance is registered at
-// multiple paths. The native registry only stores last-write-wins;
-// this list captures every registration so the resolver can
-// disambiguate by tree-walk order. Module-scoped so it survives
-// across multiple useForm calls; WeakMap so schemas GC normally.
-const fieldMetaLists = new WeakMap<object, FieldMetaPayload[]>()
-
-const originalAdd = fieldMeta.add.bind(fieldMeta)
-fieldMeta.add = function add(schema, payload) {
-  // The `add` overload's type uses Zod's `$ZodType` (core) while our
-  // public `getFieldMetaList` exposes `z.ZodType` (classic). Both
-  // are objects with stable identity at runtime — the WeakMap is
-  // typed as `object` to bridge the two without a noisy cast at
-  // every call site.
-  const list = fieldMetaLists.get(schema as object) ?? []
-  list.push(payload as FieldMetaPayload)
-  fieldMetaLists.set(schema as object, list)
-  return originalAdd(schema, payload)
-} as typeof fieldMeta.add
+export const fieldMeta = fieldMetaStore as unknown as ZodFieldMetaRegistry
 
 /**
  * Read the list of payloads registered against `schema`, in
@@ -94,7 +94,7 @@ fieldMeta.add = function add(schema, payload) {
  * the single-payload case.
  */
 export function getFieldMetaList(schema: z.ZodType): readonly FieldMetaPayload[] {
-  return fieldMetaLists.get(schema as object) ?? []
+  return getFieldMetaListForSchema(schema as object)
 }
 
 /**
@@ -125,9 +125,9 @@ export function withMeta<S extends z.ZodType>(schema: S, payload: FieldMetaPaylo
   // Merge any existing payload through so chaining accumulates
   // fields rather than replacing — `withMeta(withMeta(s, {label}), {description})`
   // keeps both keys.
-  const existing = fieldMeta.get(schema) ?? {}
+  const existing = getFieldMetaForSchema(schema as object) ?? {}
   const cloned = schema.clone() as S
-  fieldMeta.add(cloned, { ...existing, ...payload })
+  fieldMetaStore.add(cloned as object, { ...existing, ...payload })
   return cloned
 }
 
@@ -140,5 +140,5 @@ export function withMeta<S extends z.ZodType>(schema: S, payload: FieldMetaPaylo
  * Not part of the public `attaform/zod` surface.
  */
 export function getFieldMeta(schema: z.ZodType): FieldMetaPayload | undefined {
-  return fieldMeta.get(schema)
+  return getFieldMetaForSchema(schema as object)
 }

--- a/src/runtime/core/field-meta-store.ts
+++ b/src/runtime/core/field-meta-store.ts
@@ -1,0 +1,94 @@
+/**
+ * Shared field-metadata storage. Both Zod adapters (v3 and v4) and the
+ * unified `attaform/zod` entry read from the same `WeakMap`s so a
+ * payload written via any entry's `withMeta` / `fieldMeta.add` is
+ * visible to whichever adapter actually runs at lookup time.
+ *
+ * No `zod` runtime import — pure JavaScript primitives. The previous
+ * v4 adapter built `fieldMeta` via `z.registry<FieldMetaPayload>()`,
+ * which left a `z.registry` namespace reference reachable from
+ * `attaform/zod`'s module graph; bundlers analysing a `zod@^3` consumer
+ * resolved that against zod 3's exports map (no `registry` export) and
+ * emitted an `IMPORT_IS_UNDEFINED` warning. Lifting storage here drops
+ * that reference entirely so the unified entry behaves cleanly on any
+ * Zod major.
+ *
+ * The native v4 chain `schema.register(fieldMeta, payload)` still
+ * works against this shim — Zod 4's `.register()` only calls
+ * `registry.add(this, payload)` and returns the schema; structural
+ * matching is enough.
+ *
+ * Two parallel maps:
+ * - `store` — last-write-wins single payload per schema reference.
+ *   Backs `fieldMeta.get(schema)` and the adapter's
+ *   `getFieldMetaAtPath` single-payload fallback.
+ * - `lists` — every registration in order, per schema reference.
+ *   Backs the v4 adapter's path-walker disambiguation when the same
+ *   schema instance is bound at multiple form paths.
+ */
+
+import type { FieldMetaPayload } from './field-meta'
+
+/**
+ * Minimal registry shape the shared store satisfies — `.add` / `.get`
+ * / `.has` / `.remove`. Cast to `z.$ZodRegistry<FieldMetaPayload>` at
+ * the v4 adapter's re-export so the native `schema.register(fieldMeta,
+ * payload)` chain type-checks; the v3 adapter exports it as its own
+ * registry-shaped surface.
+ */
+export type FieldMetaStore = {
+  add(schema: object, payload: FieldMetaPayload): FieldMetaStore
+  get(schema: object): FieldMetaPayload | undefined
+  has(schema: object): boolean
+  remove(schema: object): FieldMetaStore
+}
+
+const store = new WeakMap<object, FieldMetaPayload>()
+const lists = new WeakMap<object, FieldMetaPayload[]>()
+
+const registry: FieldMetaStore = {
+  add(schema, payload) {
+    store.set(schema, payload)
+    const list = lists.get(schema) ?? []
+    list.push(payload)
+    lists.set(schema, list)
+    return registry
+  },
+  get(schema) {
+    return store.get(schema)
+  },
+  has(schema) {
+    return store.has(schema)
+  },
+  remove(schema) {
+    store.delete(schema)
+    lists.delete(schema)
+    return registry
+  },
+}
+
+/**
+ * The shared registry every Attaform-aware Zod schema can register
+ * field metadata against, regardless of Zod major. One module-scoped
+ * instance — every adapter entry re-exports this same object so
+ * writes from one entry are visible at lookup through any other.
+ */
+export const fieldMetaStore: FieldMetaStore = registry
+
+/**
+ * Last-write-wins payload lookup for a schema reference. Returns
+ * `undefined` if nothing has been registered.
+ */
+export function getFieldMetaForSchema(schema: object): FieldMetaPayload | undefined {
+  return store.get(schema)
+}
+
+/**
+ * Read every payload registered against `schema` in registration
+ * order. Empty list when nothing has been registered. Used by the v4
+ * adapter's path-resolver to disambiguate per occurrence when one
+ * schema instance is bound at multiple form paths.
+ */
+export function getFieldMetaListForSchema(schema: object): readonly FieldMetaPayload[] {
+  return lists.get(schema) ?? []
+}

--- a/src/runtime/core/field-meta.ts
+++ b/src/runtime/core/field-meta.ts
@@ -1,13 +1,21 @@
 /**
  * Schema-attached field metadata — the shared types used by both Zod
- * adapters (`attaform/zod` for v4 and `attaform/zod-v3` for v3) so a
- * consumer's data flow reads the same shape regardless of adapter.
+ * adapters and the unified `attaform/zod` entry so a consumer's data
+ * flow reads the same shape regardless of which path runs at lookup.
  *
- * The Zod 4 adapter creates a typed `z.registry<FieldMetaPayload>()`
- * and writes through `schema.register(fieldMeta, payload)` (native) or
- * the `withMeta(schema, payload)` helper. The Zod 3 adapter has no
- * native registry — it shims a `WeakMap<ZodTypeAny, FieldMetaPayload>`
- * with the same write API via `withMeta`.
+ * Storage lives in the cross-adapter `field-meta-store` core: a pair
+ * of WeakMaps (single-payload for last-write-wins reads, list-of-
+ * payloads for shared-schema disambiguation). Every entry's
+ * `fieldMeta` re-exports the same registry-shaped object, so
+ * `withMeta`/`fieldMeta.add` writes from one entry surface at lookup
+ * through any other.
+ *
+ * `withMeta(schema, payload)` clones the schema before registering,
+ * so each call gets fresh identity (the WeakMap keys on reference).
+ * The cloning strategy depends on the major: Zod 4 schemas use the
+ * native `.clone()`, Zod 3 schemas reconstruct via constructor +
+ * `_def`. The unified entry's `withMeta` runtime-branches on which
+ * one is in play.
  *
  * Reads are unified through `AbstractSchema.getFieldMetaAtPath(path)`,
  * which returns a fully-resolved `ResolvedFieldMeta` (label /

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -441,8 +441,8 @@ export type AbstractSchema<Form, GetValueFormType> = {
    * Return the resolved field metadata for the schema node at `path`
    * — label, description, placeholder, plus the full registered
    * payload as `meta` for consumer-augmented keys. Reads through the
-   * adapter's metadata mechanism (Zod 4: `z.registry()`; Zod 3:
-   * a WeakMap shim) and applies these one-way fallbacks:
+   * shared cross-adapter field-meta store and applies these one-way
+   * fallbacks:
    *
    *   - `label`:       registry payload → `humanize(lastSegment)`
    *   - `description`: registry payload → `schema.description`
@@ -1947,9 +1947,9 @@ export type FieldState<Value = unknown> = {
   readonly blank: boolean
   /**
    * Presentational label for this field. Resolves through the
-   * adapter's metadata mechanism — Zod 4's `z.registry()` (typed
-   * payload via `schema.register(fieldMeta, {...})` or the
-   * `withMeta()` helper); Zod 3's WeakMap shim — and falls back to
+   * shared cross-adapter field-meta store — written via
+   * `schema.register(fieldMeta, {...})` (Zod 4 native chain) or the
+   * `withMeta()` helper (works on both majors) — and falls back to
    * a humanized form of the path's last segment when nothing has
    * been registered. Always a string.
    *

--- a/src/zod.ts
+++ b/src/zod.ts
@@ -23,7 +23,10 @@
  *   import { z } from 'zod'
  *
  *   const { register, handleSubmit, errors } = useForm({
- *     schema: z.object({ email: z.email() }),
+ *     schema: z.object({
+ *       username: z.string().min(2, 'At least 2 characters'),
+ *       password: z.string().min(8, 'At least 8 characters'),
+ *     }),
  *     key: 'signup',
  *   })
  *
@@ -31,11 +34,11 @@
  * - `useForm` — runtime-dispatching wrapper.
  * - `injectForm`, `useRegister`, `unset` / `isUnset`,
  *   `AttaformErrorCode` — schema-agnostic; identical across adapters.
- * - `fieldMeta`, `withMeta` — re-exported from the v4 adapter. With
- *   the build-time alias the consumer's bundle gets the right
- *   `fieldMeta` for their Zod version. Without the alias, v3
- *   consumers should import `fieldMeta` from `attaform/zod-v3`
- *   directly.
+ * - `fieldMeta`, `withMeta` — backed by a shared cross-adapter store
+ *   so writes from this entry are visible at lookup whether the v3
+ *   or v4 adapter runs at call time. `withMeta` runtime-branches on
+ *   schema shape so the right cloning strategy applies for each
+ *   major.
  *
  * Surfaces NOT exposed here (use the explicit subpath):
  * - `UnsupportedSchemaError`, `zodAdapter`, `assertZodVersion`,
@@ -48,5 +51,5 @@ export { useRegister } from './runtime/composables/use-register'
 export { AttaformErrorCode } from './runtime/core/error-codes'
 export { unset, isUnset } from './runtime/core/unset'
 export type { Unset } from './runtime/core/unset'
-export { fieldMeta, withMeta } from './runtime/adapters/zod-v4/field-meta'
+export { fieldMeta, withMeta } from './runtime/adapters/unified/field-meta'
 export type { FieldMetaPayload } from './runtime/core/field-meta'

--- a/test/core/field-meta-store.test.ts
+++ b/test/core/field-meta-store.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { z as z4 } from 'zod'
+import { z as z3 } from 'zod-v3'
+import { fieldMeta, withMeta } from '../../src/runtime/adapters/unified/field-meta'
+import { getFieldMeta as getFieldMetaV4 } from '../../src/runtime/adapters/zod-v4/field-meta'
+import { getFieldMeta as getFieldMetaV3 } from '../../src/runtime/adapters/zod-v3/field-meta'
+
+describe('Unified fieldMeta store — cross-adapter storage', () => {
+  it('round-trips a payload on a Zod 4 schema via withMeta', () => {
+    const schema = withMeta(z4.string(), { label: 'Username', placeholder: 'your-handle' })
+    expect(getFieldMetaV4(schema)).toEqual({ label: 'Username', placeholder: 'your-handle' })
+  })
+
+  it('round-trips a payload on a Zod 3 schema via withMeta', () => {
+    const schema = withMeta(z3.string(), { label: 'Username', placeholder: 'your-handle' })
+    expect(getFieldMetaV3(schema)).toEqual({ label: 'Username', placeholder: 'your-handle' })
+  })
+
+  it('clones the schema (fresh identity, payload on the clone only)', () => {
+    const innerV4 = z4.string()
+    const afterV4 = withMeta(innerV4, { label: 'A' })
+    expect(afterV4).not.toBe(innerV4)
+    expect(getFieldMetaV4(innerV4)).toBeUndefined()
+    expect(getFieldMetaV4(afterV4)).toEqual({ label: 'A' })
+
+    const innerV3 = z3.string()
+    const afterV3 = withMeta(innerV3, { label: 'A' })
+    expect(afterV3).not.toBe(innerV3)
+    expect(getFieldMetaV3(innerV3)).toBeUndefined()
+    expect(getFieldMetaV3(afterV3)).toEqual({ label: 'A' })
+  })
+
+  it('chained withMeta merges payloads through clones', () => {
+    // Same accumulating-merge semantics on both majors.
+    const v4 = withMeta(withMeta(z4.string(), { label: 'X' }), { description: 'Y' })
+    expect(getFieldMetaV4(v4)).toEqual({ label: 'X', description: 'Y' })
+
+    const v3 = withMeta(withMeta(z3.string(), { label: 'X' }), { description: 'Y' })
+    expect(getFieldMetaV3(v3)).toEqual({ label: 'X', description: 'Y' })
+  })
+
+  it('fieldMeta.add writes that the per-major getters can read', () => {
+    const v4Schema = z4.string()
+    fieldMeta.add(v4Schema, { description: 'Free-form notes' })
+    expect(getFieldMetaV4(v4Schema)).toEqual({ description: 'Free-form notes' })
+
+    // The unified `fieldMeta` is typed as Zod 4's $ZodRegistry — the
+    // structurally-loose runtime accepts a Zod 3 schema fine, but the
+    // type system needs an `as never`-style cast at this call site.
+    const v3Schema = z3.string()
+    ;(fieldMeta.add as (s: object, p: { description: string }) => unknown)(v3Schema, {
+      description: 'Free-form notes',
+    })
+    expect(getFieldMetaV3(v3Schema)).toEqual({ description: 'Free-form notes' })
+  })
+
+  it('Zod 4 native .register chain delegates to the shared store', () => {
+    // Native .register() calls registry.add(this, payload); the shared
+    // store's structural shape (.add) satisfies it at runtime, and the
+    // payload surfaces through the v4 adapter's getter.
+    const schema = z4
+      .string()
+      .register(fieldMeta, { label: 'Username', placeholder: 'your-handle' })
+    expect(getFieldMetaV4(schema)).toEqual({ label: 'Username', placeholder: 'your-handle' })
+  })
+
+  it('does not leak between independently constructed schemas', () => {
+    const a = withMeta(z4.string(), { label: 'A' })
+    const b = z4.string()
+    expect(getFieldMetaV4(a)).toEqual({ label: 'A' })
+    expect(getFieldMetaV4(b)).toBeUndefined()
+
+    const c = withMeta(z3.string(), { label: 'C' })
+    const d = z3.string()
+    expect(getFieldMetaV3(c)).toEqual({ label: 'C' })
+    expect(getFieldMetaV3(d)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

- A bare-Vue + Zod 3 consumer importing `attaform/zod` (no Vite plugin) hit a Rollup build warning: `[IMPORT_IS_UNDEFINED] Warning: Import 'registry' will always be undefined ...`. The trigger was the v4 adapter's `field-meta.ts` calling `z.registry()` at module top level, which left a `z.registry` namespace reference statically reachable from the unified entry's module graph.
- Lifts field-metadata storage into a shared core (`src/runtime/core/field-meta-store.ts`) — pure WeakMap-backed, no `zod` runtime import. Every entry (`attaform/zod`, `attaform/zod-v3`, `attaform/zod-v4`) re-exports the same shim so a payload registered through any entry surfaces at lookup whichever adapter dispatches.
- The native v4 chain `schema.register(fieldMeta, payload)` keeps working — Zod 4's `.register()` only calls `.add(this, payload)` structurally, satisfied by the shared store.
- Unified `withMeta` runtime-branches on schema shape: Zod 4 schemas clone via `.clone()`, Zod 3 schemas via `new Ctor(_def)`. Same end result, both write to the same WeakMap.
- Switches the hello-world example from `z.email()` (v4-only standalone) to `z.string().min(2, ERROR)` so a Zod 3 user copying the README quickstart compiles without changes. Touches README, /docs/quickstart, /docs/api/zod, and the unified `useForm` JSDoc — explicit `attaform/zod-v4` docs untouched.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 2088 passing, including the new `test/core/field-meta-store.test.ts` that exercises cross-major round-trips through the unified entry
- [x] `pnpm lint` clean
- [x] `pnpm check:size` — every entry within budget; `dist/zod.mjs` essentially unchanged at 40.58 KB
- [x] `pnpm check:bench` — every scenario inside the 3× floor
- [x] `grep z.registry|z.email dist/` returns no matches — the v4-only references are no longer reachable from `attaform/zod`'s module graph
- [ ] Manual repro: build a tiny v3 + bare-Vue consumer of `attaform/zod` and confirm the `IMPORT_IS_UNDEFINED` warning no longer fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)