### PR TITLE
fix(zod-v3): array .min and parent .refine no longer break per-field revalidation

### DIFF
--- a/src/runtime/adapters/zod-v3/index.ts
+++ b/src/runtime/adapters/zod-v3/index.ts
@@ -574,16 +574,20 @@ export function zodAdapter<
         }
 
         function nestedSchemasAtPath(p: Path): z.ZodTypeAny[] {
-          const [strippedSchema] = stripRootSchema(_zodSchema, {
-            stripDefaultValues: true,
-            stripNullable: true,
-            stripOptional: true,
-          })
-          const slimSchema = getSlimSchema({
-            schema: strippedSchema,
-            stripConfig: { stripDefaultValues: true },
-          })
-          return getNestedZodSchemasAtPath(slimSchema, p)
+          // Walk the ORIGINAL schema. The walker peels transparent
+          // wrappers (optional / nullable / default / effects /
+          // pipeline / readonly / branded) inline as it descends,
+          // preserving every check (`.min` / `.max` / `.length` /
+          // `.nonempty` / `.refine` / etc.) at the target path so
+          // path-targeted re-validation surfaces issues that depend
+          // on the schema node itself (e.g. an array's `.min(1)`
+          // after a structural mutation, or a leaf's `.min(1)` when
+          // the parent has a refine). The slim-schema pipeline used
+          // for default-value derivation deliberately strips checks
+          // at re-creation sites — appropriate for "here's a
+          // permissive shape to seed defaults," wrong for "here's
+          // the schema we should validate against."
+          return getNestedZodSchemasAtPath(_zodSchema, p)
         }
 
         function pathNotFound(p: Path): ValidationResponse<Form> {
@@ -665,10 +669,23 @@ const NO_SCHEMAS_FOUND_AT_PATH_OF_CONCRETE_SCHEMA = (path: (string | number)[], 
     },
   ] satisfies ValidationError[]
 
-// Note: this function assumes a sufficiently stripped schema.
 // Walks a canonical `Segment[]` directly — every literal-dot key is
 // treated as a single segment, so a field named `"user.email"` no
 // longer collides with the sibling pair `['user', 'email']`.
+//
+// Each iteration peels transparent wrappers (`peelV3Wrappers` —
+// optional / nullable / default / effects / pipeline / readonly /
+// branded) BEFORE checking the kind for descent. Peeling is what
+// lets the walker step through e.g. `z.object({...}).refine(...)`
+// (a `ZodEffects` at the root) into the inner shape without
+// requiring callers to pre-strip wrappers. Importantly the peel is
+// applied only when descending — once the loop exits, the schema
+// at the target segment is returned as-is (including its own
+// wrapper, since that wrapper carries semantic meaning at parse
+// time, e.g. `.optional()` admits `undefined`, `.default(x)`
+// substitutes, `.refine(...)` runs the predicate). For path = []
+// (no segments) the original schema is returned unchanged so
+// whole-form `validateAtPath` keeps the root's refine intact.
 function getNestedZodSchemasAtPath<Schema extends z.ZodSchema>(
   zodSchema: Schema,
   segments: readonly (string | number)[]
@@ -693,6 +710,9 @@ function getNestedZodSchemasAtPath<Schema extends z.ZodSchema>(
 
   for (let index = 0; index < segments.length; index++) {
     const key = String(segments[index] ?? '')
+    if (currentSchema !== undefined) {
+      currentSchema = peelV3Wrappers(currentSchema) as z.ZodSchema
+    }
     if (isZodSchemaType(currentSchema, 'ZodObject')) {
       const shape = currentSchema._def.shape() as z.ZodRawShape
       // Own-property check: a bare `shape[key]` returns

--- a/test/composables/ancestor-revalidation.test.ts
+++ b/test/composables/ancestor-revalidation.test.ts
@@ -1,0 +1,228 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, nextTick, type App } from 'vue'
+import { z as zV4 } from 'zod'
+import { z as zV3 } from 'zod-v3'
+import { useForm as useFormV4 } from '../../src/zod-v4'
+import { useForm as useFormV3 } from '../../src/zod-v3'
+import { createAttaform } from '../../src/runtime/core/plugin'
+
+/**
+ * Path-local validation contract — ancestor re-runs.
+ *
+ * Per-field validation only re-validates the touched path. Two
+ * classes of constraint depend on state OUTSIDE that path and
+ * therefore need ancestor re-runs after a mutation:
+ *
+ *   1. Array shape constraints (`.min`/`.max`/`.nonempty`/`.length`)
+ *      depend on the array's length — which changes on every
+ *      append/remove/insert/move/swap. After a structural mutation
+ *      the array PATH must re-validate the array's own checks.
+ *
+ *   2. Object refinements (`.refine`/`.superRefine` on a parent
+ *      object) depend on sibling field values. After a leaf mutation
+ *      the parent's path must re-run the refinement.
+ *
+ * Both bugs were observed by a consumer dogfooding 0.16.3:
+ *   - Bug 1: `.min(1)` array error never re-appears after
+ *     `form.remove()` empties the array.
+ *   - Bug 2: with `.refine()` on the parent object, clearing a
+ *     leaf does not restore the leaf's `.min(1)` error.
+ *
+ * Scope: both adapters (v3 and v4). Same runtime contract —
+ * `validateAtPath(value, path)` must surface every check that
+ * applies AT `path`, including checks that live on the schema node
+ * itself (array shape, object refines). If either adapter strips
+ * checks during slim/path-walk, the bug surfaces here.
+ */
+
+const apps: App[] = []
+afterEach(() => {
+  while (apps.length > 0) apps.pop()?.unmount()
+  document.body.innerHTML = ''
+})
+
+function mountWithApp<T>(setup: () => T): T {
+  const handle: { captured?: T } = {}
+  const App = defineComponent({
+    setup() {
+      handle.captured = setup()
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform({ override: true }))
+  const root = document.createElement('div')
+  document.body.appendChild(root)
+  app.mount(root)
+  apps.push(app)
+  if (handle.captured === undefined) throw new Error('mountWithApp: setup never returned')
+  return handle.captured
+}
+
+// `scheduleFieldValidation` runs through `Promise.resolve().then(...)` +
+// adapter `safeParseAsync`. The chain is several microtasks deep —
+// flush aggressively until the in-flight counter drops to zero so the
+// assertion sees the post-validation state.
+async function flushValidations(form: { meta: { validating: boolean } }): Promise<void> {
+  for (let i = 0; i < 20; i++) {
+    await nextTick()
+    if (!form.meta.validating) break
+  }
+  // Two extra ticks so the final `.then` writing schemaErrors flushes
+  // through Vue's reactive subscribers before the assertion reads.
+  await nextTick()
+  await nextTick()
+}
+
+type ErrorAtPath = (p: string) => Array<{ message: string }> | undefined
+function errorsAt(form: { errors: unknown }): ErrorAtPath {
+  return form.errors as unknown as ErrorAtPath
+}
+
+// -----------------------------------------------------------------------------
+// Bug 1 — Array structural mutations re-validate parent array constraints
+// -----------------------------------------------------------------------------
+
+describe('Bug 1 — array .min(1) re-validates after append/remove', () => {
+  it('v3: restores the array-level error when remove empties the array', async () => {
+    const schema = zV3.object({
+      items: zV3.array(zV3.string()).min(1, 'At least one item required'),
+    })
+    const form = mountWithApp(() =>
+      useFormV3({
+        schema,
+        key: `bug1-v3-${Math.random()}`,
+        strict: false,
+        defaultValues: { items: [] },
+      })
+    )
+
+    // Drive the initial error via handleSubmit, mirroring the bug repro.
+    await form.handleSubmit(
+      () => {},
+      () => {}
+    )()
+    expect(errorsAt(form)('items')?.[0]?.message).toBe('At least one item required')
+
+    // Append → array now satisfies .min(1) → array-level error must clear.
+    form.append('items', '')
+    await flushValidations(form)
+    expect(errorsAt(form)('items')).toBeUndefined()
+
+    // Remove → array empty again → array-level error must come back.
+    form.remove('items', 0)
+    await flushValidations(form)
+    expect(errorsAt(form)('items')?.[0]?.message).toBe('At least one item required')
+  })
+
+  it('v4: restores the array-level error when remove empties the array', async () => {
+    const schema = zV4.object({
+      items: zV4.array(zV4.string()).min(1, 'At least one item required'),
+    })
+    const form = mountWithApp(() =>
+      useFormV4({
+        schema,
+        key: `bug1-v4-${Math.random()}`,
+        strict: false,
+        defaultValues: { items: [] },
+      })
+    )
+
+    await form.handleSubmit(
+      () => {},
+      () => {}
+    )()
+    expect(errorsAt(form)('items')?.[0]?.message).toBe('At least one item required')
+
+    form.append('items', '')
+    await flushValidations(form)
+    expect(errorsAt(form)('items')).toBeUndefined()
+
+    form.remove('items', 0)
+    await flushValidations(form)
+    expect(errorsAt(form)('items')?.[0]?.message).toBe('At least one item required')
+  })
+})
+
+// -----------------------------------------------------------------------------
+// Bug 2 — .refine() on a parent object preserves per-field re-validation
+// -----------------------------------------------------------------------------
+
+describe('Bug 2 — parent .refine does not break per-field revalidation', () => {
+  it('v3: restores the leaf .min(1) error when the field is cleared', async () => {
+    // `.refine()` on a v3 ZodObject returns `ZodEffects<ZodObject>` —
+    // the public `useForm` signature narrows to `ZodObject`, so cast
+    // here to exercise the same wrapped shape consumers hit when they
+    // attach a cross-field refinement to the form's root schema.
+    const schema = zV3
+      .object({
+        fromCountry: zV3.string().min(1, 'Required'),
+        toCountry: zV3.string().min(1, 'Required'),
+      })
+      .refine((v) => v.fromCountry.trim().toLowerCase() !== v.toCountry.trim().toLowerCase(), {
+        message: 'From and To must differ',
+      })
+
+    const form = mountWithApp(() =>
+      useFormV3({
+        schema: schema as unknown as zV3.ZodObject<{
+          fromCountry: zV3.ZodString
+          toCountry: zV3.ZodString
+        }>,
+        key: `bug2-v3-${Math.random()}`,
+        strict: false,
+        defaultValues: { fromCountry: '', toCountry: '' },
+      })
+    )
+
+    await form.handleSubmit(
+      () => {},
+      () => {}
+    )()
+    expect(errorsAt(form)('fromCountry')?.[0]?.message).toBe('Required')
+
+    // Type a value — leaf .min(1) now passes → error must clear.
+    form.setValue('fromCountry', 'a')
+    await flushValidations(form)
+    expect(errorsAt(form)('fromCountry')).toBeUndefined()
+
+    // Clear the value — leaf .min(1) fails again → error must return.
+    form.setValue('fromCountry', '')
+    await flushValidations(form)
+    expect(errorsAt(form)('fromCountry')?.[0]?.message).toBe('Required')
+  })
+
+  it('v4: restores the leaf .min(1) error when the field is cleared', async () => {
+    const schema = zV4
+      .object({
+        fromCountry: zV4.string().min(1, 'Required'),
+        toCountry: zV4.string().min(1, 'Required'),
+      })
+      .refine((v) => v.fromCountry.trim().toLowerCase() !== v.toCountry.trim().toLowerCase(), {
+        message: 'From and To must differ',
+      })
+
+    const form = mountWithApp(() =>
+      useFormV4({
+        schema,
+        key: `bug2-v4-${Math.random()}`,
+        strict: false,
+        defaultValues: { fromCountry: '', toCountry: '' },
+      })
+    )
+
+    await form.handleSubmit(
+      () => {},
+      () => {}
+    )()
+    expect(errorsAt(form)('fromCountry')?.[0]?.message).toBe('Required')
+
+    form.setValue('fromCountry', 'a')
+    await flushValidations(form)
+    expect(errorsAt(form)('fromCountry')).toBeUndefined()
+
+    form.setValue('fromCountry', '')
+    await flushValidations(form)
+    expect(errorsAt(form)('fromCountry')?.[0]?.message).toBe('Required')
+  })
+})


### PR DESCRIPTION
## Summary

A consumer dogfooding 0.16.3 hit two related re-validation bugs in the v3 adapter ([bug report](attaform-bug-report.txt)):

- **Bug 1** — `form.remove()` doesn't restore an array's `.min(1)` error when the array empties. The slim-schema pipeline used inside `validateAtPath` re-created `ZodArray` nodes without their `.min/.max/.length/.nonempty` checks, so post-remove validation always reported success.
- **Bug 2** — with `.refine()` on a parent object (`ZodEffects(ZodObject)`), clearing a leaf field doesn't restore the leaf's `.min(1)` error. The path walker had no rule for `ZodEffects` and bailed out, so per-field re-validation reported a "path not found" stub instead of the leaf's own check.

Both share one root cause: the v3 adapter's `validateAtPath` walked a slim-and-stripped derivative of the user's schema. The v4 adapter already handles both cases correctly.

## Fix

Two surgical changes in `src/runtime/adapters/zod-v3/index.ts`:

- `getNestedZodSchemasAtPath` peels transparent wrappers (optional / nullable / default / effects / pipeline / readonly / branded) before the kind check inside the descent loop, so structural descent works regardless of which wrapper sits between the parent and the target. The peel is applied only when stepping into a child; the schema returned at the target segment keeps its own wrapper so parse-time semantics are preserved.
- `nestedSchemasAtPath` (inside `validateAtPath`) walks the ORIGINAL schema directly. The slim-schema pipeline is appropriate for default-value derivation but strips the very checks per-field re-validation needs to surface.

## Test plan

- [x] Failing repros in `test/composables/ancestor-revalidation.test.ts` — both adapters, both bugs (4 tests; v3 versions failed before the fix, v4 versions passed unchanged)
- [x] `pnpm test` — 2092 / 2092 pass
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm check:size` — within limits
- [x] `pnpm check:bench` — within ratio floor
- [x] `pnpm check:coverage` — above thresholds (lines 89.63%, branches 79.41%, functions 86.15%, statements 85.57%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)