### PR TITLE
feat(form): close §1–4 of the 0.17.0 feedback — ReadShape, form.clear, preprocess synthesis

### DIFF
--- a/apps/site/composables/useDocsNavigation.ts
+++ b/apps/site/composables/useDocsNavigation.ts
@@ -57,6 +57,7 @@ export const docsNavigation: DocsSection[] = [
       { title: 'Persistence: edge cases', to: '/docs/recipes/persistence-edge-cases' },
       { title: 'Server errors', to: '/docs/recipes/server-errors' },
       { title: 'SSR hydration', to: '/docs/recipes/ssr-hydration' },
+      { title: 'Storage shape', to: '/docs/recipes/storage-shape' },
       { title: 'Transforms', to: '/docs/recipes/transforms' },
       { title: 'Undo / redo', to: '/docs/recipes/undo-redo' },
     ],

--- a/docs/api.md
+++ b/docs/api.md
@@ -88,6 +88,7 @@ helpers, imperative persistence.
 → [Read the useForm return value](/docs/api/use-form-return)
 
 **Recipes that use this:** [Quick start](/docs/quickstart) ·
+[form.values — the storage shape](/docs/recipes/storage-shape) ·
 [Dynamic field arrays](/docs/recipes/dynamic-field-arrays) ·
 [Undo / redo](/docs/recipes/undo-redo) ·
 [Focus on error](/docs/recipes/focus-on-error) ·

--- a/docs/api/use-form-return.md
+++ b/docs/api/use-form-return.md
@@ -182,12 +182,19 @@ registered through THAT callsite. `injectForm()` children inherit
 their ancestor's instance ID, so parent-submit-focus reaches inputs
 registered by deep children.
 
-## Reset
+## Reset and clear
 
-| Member             | Signature                                                | What it does                                                                                                                                                                                                               |
-| ------------------ | -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `reset(next?)`     | `(next?: DeepPartial<DefaultValuesShape<Form>>) => void` | Re-seed the whole form. Rebuilds originals, clears errors + touched + submit state. Wipes the persisted draft if `persist:` is configured. Each leaf in `next` may be `unset` to mark the path displayed-empty post-reset. |
-| `resetField(path)` | `(path: FlatPath<Form>) => void`                         | Restore one path (leaf or container) to its original value. Wipes the matching subpath from storage if `persist:` is configured.                                                                                           |
+`reset` restores the schema's declared defaults; `clear` wipes to the
+type's falsy concrete (`''` / `0` / `false` / `[]` / recursively-empty
+object), ignoring any `.default(x)` wrapper. The two are orthogonal —
+see the [storage-shape recipe](/docs/recipes/storage-shape#reset-vs-clear-the-orthogonality)
+for the user-facing model.
+
+| Member             | Signature                                                                   | What it does                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| ------------------ | --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `reset(next?)`     | `(next?: DeepPartial<DefaultValuesShape<Form>>) => void`                    | Re-seed the whole form. Rebuilds originals, clears errors + touched + submit state. Wipes the persisted draft if `persist:` is configured. Each leaf in `next` may be `unset` to mark the path displayed-empty post-reset.                                                                                                                                                                                                                                 |
+| `resetField(path)` | `(path: FlatPath<Form>) => void`                                            | Restore one path (leaf or container) to its original value. Wipes the matching subpath from storage if `persist:` is configured.                                                                                                                                                                                                                                                                                                                           |
+| `clear(path?)`     | `(path?: FlatPath<Form> \| '' \| readonly (string \| number)[]) => boolean` | Wipe a path (or the whole form when called with no arg) to the type's falsy concrete. `.default(x)` / `.catch(x)` wrappers are intentionally skipped — clear ends at `false` / `0` / `''` / `[]` regardless of declared default. `.optional()` → `undefined`, `.nullable()` → `null`. Sugar over `setValue(path, schema.getEmptyValueAtPath(path))`. `clear()` (no arg) is the whole-form variant; `clear('')` targets the empty-string slot specifically. |
 
 ## Persistence (imperative)
 

--- a/docs/recipes/persistence.md
+++ b/docs/recipes/persistence.md
@@ -9,6 +9,39 @@ Long forms — multi-step onboarding, checkout, surveys — should
 survive a navigation mistake or a browser refresh. Attaform persists drafts
 to client-side storage with a per-field opt-in.
 
+## Scope: form state vs generic UI state
+
+Attaform persists **form state** — anything you've declared in
+`schema` is eligible. That covers more than it sounds: selections
+(active org, current chat), toggles, mode pickers, multi-step
+wizards. If the state is schema-shaped and you want the safety
+machinery (schema fingerprint, sensitive-name filtering, blank-
+path tracking, multi-tab sync, hydration-validation), model it as
+a form field:
+
+```ts
+const schema = z.object({
+  // Regular form fields
+  email: z.email(),
+  // Stateful UI selections — also form fields
+  selectedOrg: OrgSchema.nullable(),
+  selectedChat: z.string().nullable(),
+})
+
+const form = useForm({ schema, persist: 'local' })
+
+// Imperative write at any time — same machinery as autosave.
+form.persist('selectedOrg')
+```
+
+On refresh, `selectedOrg` rehydrates like any other field.
+
+For truly form-independent state — UI scratchpads, theme toggles,
+anything with no schema and no participation in submit/validate —
+reach for **[VueUse's `useStorage`](https://vueuse.org/core/useStorage/)**
+instead. Two persistence stories, each purpose-built for its
+state-shape; one library for each, no cross-coupling.
+
 ## Security: what not to persist
 
 Client-side storage is unencrypted at rest, readable by any

--- a/docs/recipes/storage-shape.md
+++ b/docs/recipes/storage-shape.md
@@ -1,0 +1,191 @@
+---
+title: 'form.values — the storage shape'
+description: 'A single mental model for what form.values returns. Defaults are pre-resolved; preprocess is normalised; optional/nullable keep their wrappers; transforms only run at parse time.'
+---
+
+# `form.values` — the storage shape
+
+`form.values.<path>` answers one question: **what does storage hold
+right now at this path?** This page is the mental model that lets you
+predict the answer for any schema, at compile time and at runtime.
+
+The short version: storage holds the **resolved, concrete type** at
+every path. `.default()` has fired. Preprocess has normalised. Blank
+required leaves have been filled with the type's falsy. The static
+type agrees end-to-end — so direct reads (`form.values.flag`,
+`form.values.address.city.length`) just work without `?.` chains,
+casts, or schema re-parses.
+
+## The three shapes
+
+A schema produces three different views of its data, each with a
+distinct surface:
+
+| Surface                           | Shape      | What it answers                                          |
+| --------------------------------- | ---------- | -------------------------------------------------------- |
+| `form.values` / `form.fields`     | **read**   | What does storage hold now? (`ReadShape<Schema>`)        |
+| `setValue` / `defaultValues`      | **write**  | What may the consumer pass in? (`z.input<Schema>`)       |
+| `handleSubmit` / `form.process()` | **submit** | What does a successful parse yield? (`z.output<Schema>`) |
+
+The same schema produces all three; the surface determines which one
+you're holding.
+
+```ts
+const schema = z.object({
+  flag: z.boolean().default(true),
+  count: z.number().default(0),
+  trimmed: z.preprocess((v) => (typeof v === 'string' ? v.trim() : v), z.string()),
+  ratio: z.string().transform((v) => Number(v) / 100),
+})
+
+const form = useForm({ schema })
+
+// Read — storage holds the concrete, resolved type
+form.values.flag // boolean       ← .default(true) peeled
+form.values.count // number        ← .default(0) peeled
+form.values.trimmed // string        ← preprocess peeled to inner input
+form.values.ratio // string        ← transform deferred to parse
+
+// Write — `unknown` for preprocess slots, `undefined` allowed for defaulted
+form.setValue('flag', undefined) // OK — default fills the gap
+form.setValue('trimmed', '  hi  ') // OK — preprocess normalises at write
+
+// Submit — transforms run, refinements fire
+form.handleSubmit((data) => {
+  data.ratio // number ← .transform() produced this
+})
+```
+
+## Per-wrapper read-shape policy
+
+`ReadShape<Schema>` (the type behind `form.values`) walks each field
+in the schema's shape and applies one of these rules:
+
+| Wrapper               | Field key | Field type at the key               | Rationale                                                                                         |
+| --------------------- | --------- | ----------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `.default(x)`         | required  | inner type (no `\| undefined`)      | Storage always holds `x` or a write — never empty.                                                |
+| `.prefault(x)`        | required  | inner type                          | Same as `.default(x)`.                                                                            |
+| `.catch(x)`           | required  | inner type                          | Catch wraps a fallback; storage holds a value.                                                    |
+| `.optional()`         | optional  | `inner \| undefined`                | Genuinely optional — `undefined` is the wrapper's marker.                                         |
+| `.nullable()`         | required  | `inner \| null`                     | `null` is the wrapper's "explicit empty".                                                         |
+| `.readonly()`         | required  | inner type                          | Read-only is type-only; the read shape is its inner.                                              |
+| `z.preprocess(fn, T)` | required  | inner-T input shape (not `unknown`) | Preprocess normalises at the write boundary; storage holds the post-preprocess inner-input value. |
+| `.transform(fn)`      | required  | source input shape                  | Transforms run at parse, not read — storage holds the pre-transform value.                        |
+| (plain / fallthrough) | required  | `z.input<T>`                        | Default for anything else.                                                                        |
+
+Reads at every nested level get the same treatment recursively.
+
+## Blank-path synthesis
+
+Required leaves that haven't been written to yet aren't `undefined` —
+the form library fills them with the type's falsy concrete at mount:
+
+| Schema at path    | Initial `form.values.<path>`                           |
+| ----------------- | ------------------------------------------------------ |
+| `z.string()`      | `''`                                                   |
+| `z.number()`      | `0`                                                    |
+| `z.boolean()`     | `false`                                                |
+| `z.bigint()`      | `0n`                                                   |
+| `z.date()`        | `new Date(0)`                                          |
+| `z.array(...)`    | `[]`                                                   |
+| `z.set(...)`      | `new Set()`                                            |
+| `z.record(...)`   | `{}`                                                   |
+| `z.object({...})` | recursive — every required property gets its own falsy |
+
+The runtime tracks which paths are still "blank" through the same
+field-state bit `field.blank` covers — see the [blank inputs
+recipe](/docs/recipes/blank-inputs) for the storage / display
+divergence story. Submit / validate raise `'No value supplied'` for
+required blanks; user-typed `0` / `''` / `false` are honoured.
+
+## Three edges the invariant doesn't promise to flatten
+
+These read as honest `T | undefined` / `T | null` / `T | undefined`
+respectively — they're documented edges, not bugs:
+
+### `.optional()` (no default) — `T | undefined`
+
+```ts
+const schema = z.object({ bio: z.string().optional() })
+const form = useForm({ schema })
+
+form.values.bio // string | undefined
+```
+
+The wrapper's whole point is "this slot may be absent." Storage
+respects it — synthesis doesn't substitute an empty string. Reach
+for `field.blank` if you need the storage / display distinction.
+
+### `.nullable()` — `T | null`
+
+```ts
+const schema = z.object({ ref: z.string().nullable() })
+form.values.ref // string | null
+```
+
+`null` is the wrapper's "explicit empty" signal — distinct from
+`undefined` and from `''`.
+
+### Array element past `length` — `T | undefined`
+
+```ts
+const schema = z.object({ tags: z.array(z.string()) })
+form.values.tags[0] // string | undefined
+```
+
+The `| undefined` taint comes from TypeScript's
+`noUncheckedIndexedAccess: true` (which this repo and most strict
+configs set), not from the storage invariant. Iteration
+(`for (const tag of form.values.tags)`) keeps the strict `string`
+element type — only direct numeric indexing is tainted.
+
+## When to reach for which surface
+
+A quick cheatsheet, mapped to the three shapes above:
+
+```ts
+const form = useForm({ schema })
+
+// READ — anywhere you need the current value
+form.values.email // primary path
+form.fields.email.value // same value, plus per-field state
+form.toRef('email') // ref-shaped interop for external composables
+
+// WRITE — anywhere you set a value
+form.setValue('email', 'a@b.c') // single path
+form.setValue({ email: 'a@b.c' }) // whole-form merge
+form.clear('email') // wipe to falsy-for-type
+form.reset() // re-seed from declared defaults
+
+// SUBMIT — once on form submission
+form.handleSubmit((data) => apiPost(data)) // `data` is the post-transform output
+const result = await form.process() // imperative one-shot parse
+```
+
+Each surface uses the shape that's correct for its purpose. The mental
+discipline is: **don't reach across surfaces.** If you want post-
+transform output, go through submit. If you want the raw user input,
+go through `form.values`. If you want to write, go through `setValue`
+or `clear` — the proxy at `form.values` is read-only on purpose.
+
+## Reset vs clear — the orthogonality
+
+The two operations look adjacent but mean different things:
+
+```ts
+const schema = z.object({
+  notify: z.boolean().default(true),
+  count: z.number().default(5),
+})
+const form = useForm({ schema })
+
+form.reset() // notify → true,  count → 5  (declared defaults)
+form.clear() // notify → false, count → 0  (falsy-for-type)
+```
+
+`reset` re-applies the schema's declared `.default()` values; `clear`
+ignores them and writes the type's falsy concrete instead. Both
+accept a path argument (`reset(next?)` reseeds the whole form;
+`resetField(path)` reseeds one; `clear(path?)` wipes one or the whole
+form). The full surface lives in [the useForm return
+reference](/docs/api/use-form-return#reset).

--- a/src/runtime/adapters/unified/use-form.ts
+++ b/src/runtime/adapters/unified/use-form.ts
@@ -23,6 +23,7 @@ import { InvalidUseFormConfigError } from '../../core/errors'
 import { isZodV4SchemaShape } from '../../core/zod-shape'
 import { useForm as useFormV3 } from '../../composables/use-form'
 import { useForm as useFormV4 } from '../zod-v4'
+import type { ReadShape } from '../zod-v4/types-read-shape'
 import type {
   AbstractSchema,
   ValidateOnConfig,
@@ -68,7 +69,8 @@ export function useForm<Schema extends z.ZodObject>(
   > & { schema: Schema } & ValidateOnConfig
 ): UseFormReturnType<
   z.input<Schema> extends GenericForm ? z.input<Schema> : never,
-  z.output<Schema> extends GenericForm ? z.output<Schema> : never
+  z.output<Schema> extends GenericForm ? z.output<Schema> : never,
+  ReadShape<Schema> extends GenericForm ? ReadShape<Schema> : never
 > {
   // Foot-gun guard mirrors the typed wrappers'.
   if (

--- a/src/runtime/adapters/zod-v3/index.ts
+++ b/src/runtime/adapters/zod-v3/index.ts
@@ -403,6 +403,21 @@ export function zodAdapter<
         const peeled = unwrapStructuralLeafV3(leaf)
         return getDefaultValuesFromZodSchema(peeled as z.ZodSchema, true, _formKey)
       },
+      getEmptyValueAtPath(path) {
+        // `clear`'s underlying value lookup. Same path-resolution flow
+        // as `getDefaultAtPath` but with `useDefaultSchemaValues=false`
+        // so `.default(x)` / `.catch(x)` wrappers are skipped — the
+        // walker yields the inner-schema's empty concrete instead.
+        // Structural wrappers (`.optional()` / `.nullable()`) are NOT
+        // peeled here: clearing an `.optional()` slot is legitimately
+        // `undefined`, clearing a `.nullable()` slot is `null`.
+        if (path.length === 0) {
+          return getDefaultValuesFromZodSchema(_zodSchema, false, _formKey)
+        }
+        const leaf = walkV3ToLeafSchema(_zodSchema, path)
+        if (!leaf) return undefined
+        return getDefaultValuesFromZodSchema(leaf as z.ZodSchema, false, _formKey)
+      },
       arrayShapeAtPath(path) {
         if (path.length === 0) return undefined
         const leaf = walkV3ToLeafSchema(_zodSchema, path)

--- a/src/runtime/adapters/zod-v3/types-read-shape.ts
+++ b/src/runtime/adapters/zod-v3/types-read-shape.ts
@@ -1,0 +1,73 @@
+import type { z } from 'zod-v3'
+
+/**
+ * The "read shape" of a Zod v3 schema — the type
+ * `form.values.<path>` resolves to at runtime once defaults have
+ * fired and synthesis has filled blank fields. Mirror of the Zod v4
+ * `ReadShape` (see `src/runtime/adapters/zod-v4/types-read-shape.ts`
+ * for the full rationale).
+ *
+ *  | Wrapper             | Key | Value at the key            |
+ *  | ------------------- | --- | --------------------------- |
+ *  | `ZodDefault<T>`     | req | `z.input<T>` (no undefined) |
+ *  | `ZodOptional<T>`    | opt | `z.input<T> \| undefined`   |
+ *  | `ZodNullable<T>`    | req | `z.input<T> \| null`        |
+ *  | `ZodEffects<T>`     | req | `z.input<T>`                |
+ *  | `ZodReadonly<T>`    | req | `z.input<T>`                |
+ *  | `ZodCatch<T>`       | req | `z.input<T>`                |
+ *  | nested `ZodObject`  | req | recursed read shape         |
+ *  | nested `ZodArray`   | req | `Array<inner read shape>`   |
+ *  | plain / fallthrough | req | `z.input<T>`                |
+ *
+ * `ZodEffects<T>` covers both `.transform()` and
+ * `z.preprocess(fn, T)` in Zod v3 — at the TS level they share one
+ * class. Peeling to `Inner` is correct for both: for `.transform()`
+ * the inner IS the source schema (input matches existing behaviour),
+ * and for `preprocess(fn, T)` the inner is `T` (peels through the
+ * `unknown` preprocess input to the inner-schema input).
+ *
+ * Wrapper peeling is intentionally NOT chained through nested
+ * descent — each conditional branch costs TS instantiation depth, and
+ * v3's full wrapper set (Default / Optional / Nullable / Effects /
+ * Pipeline / Readonly / Catch / Branded) combined with Object /
+ * Array recursion hits the TS2589 ceiling. The static type sees a
+ * one-level peel (the outer wrapper) followed by `z.input<Inner>`
+ * for deeper paths. The runtime synthesis still resolves nested
+ * defaults to concrete values; the type just stays at the input
+ * shape for fields nested inside an array element or another
+ * defaulted leaf. Most defaulted fields are top-level — the deeper
+ * case is a documented edge.
+ */
+export type ReadShape<S> =
+  S extends z.ZodObject<infer Shape>
+    ? { [K in keyof Shape]: ReadShapeField<Shape[K]> }
+    : ReadShapeField<S>
+
+export type ReadShapeField<T> =
+  T extends z.ZodDefault<infer Inner>
+    ? ReadShapeInnerNoPeel<Inner>
+    : T extends z.ZodCatch<infer Inner>
+      ? ReadShapeInnerNoPeel<Inner>
+      : T extends z.ZodReadonly<infer Inner>
+        ? ReadShapeInnerNoPeel<Inner>
+        : T extends z.ZodOptional<infer Inner>
+          ? ReadShapeInnerNoPeel<Inner> | undefined
+          : T extends z.ZodNullable<infer Inner>
+            ? ReadShapeInnerNoPeel<Inner> | null
+            : T extends z.ZodEffects<infer Inner>
+              ? ReadShapeInnerNoPeel<Inner>
+              : ReadShapeInnerNoPeel<T>
+
+/**
+ * One-level deeper resolution that descends into nested
+ * `ZodObject` / `ZodArray` but does NOT re-enter the wrapper-peeling
+ * chain. Keeps TS's instantiation depth bounded.
+ */
+type ReadShapeInnerNoPeel<T> =
+  T extends z.ZodObject<infer Shape>
+    ? { [K in keyof Shape]: ReadShapeField<Shape[K]> }
+    : T extends z.ZodArray<infer Item>
+      ? Array<ReadShapeField<Item>>
+      : T extends z.ZodTypeAny
+        ? z.input<T>
+        : T

--- a/src/runtime/adapters/zod-v4/adapter.ts
+++ b/src/runtime/adapters/zod-v4/adapter.ts
@@ -449,6 +449,23 @@ export function zodV4Adapter<
         return deriveDefault(unwrapStructuralWrappers(first), true, maxRecursionDepth)
       },
 
+      getEmptyValueAtPath(path) {
+        // `clear`'s underlying value lookup. Same path-resolution flow
+        // as `getDefaultAtPath` (root for empty path, first candidate
+        // for unions), but `useDefault=false` so `.default(x)` /
+        // `.prefault(x)` / `.catch(x)` wrappers are skipped — the
+        // walker yields the inner-schema's empty/falsy concrete
+        // instead. Structural wrappers (`.optional()` / `.nullable()`)
+        // are NOT peeled: clearing an `.optional()` slot is
+        // legitimately `undefined`, clearing a `.nullable()` slot is
+        // `null` — that's the user's "this slot is empty" signal at
+        // those wrapper types.
+        if (path.length === 0) return deriveDefault(rootSchema, false, maxRecursionDepth)
+        const [first] = getNestedZodSchemasAtPath(rootSchema, path, maxRecursionDepth)
+        if (first === undefined) return undefined
+        return deriveDefault(first, false, maxRecursionDepth)
+      },
+
       arrayShapeAtPath(path) {
         if (path.length === 0) return undefined
         const [first] = getNestedZodSchemasAtPath(rootSchema, path, maxRecursionDepth)

--- a/src/runtime/adapters/zod-v4/default-values.ts
+++ b/src/runtime/adapters/zod-v4/default-values.ts
@@ -17,7 +17,8 @@ import {
   kindOf,
   unwrapInner,
   unwrapLazy,
-  unwrapPipe,
+  unwrapPipeIn,
+  unwrapPipeOut,
   type ZodKind,
 } from './introspect'
 import { getNestedZodSchemasAtPath } from './path-walker'
@@ -79,10 +80,26 @@ function defaultForKind(
         : defaultForKind(kindOf(inner), inner, useDefault, maxDepth, lazyDepth)
     }
     case 'pipe': {
-      const inner = unwrapPipe(schema)
-      return inner === undefined
+      // `z.preprocess(fn, inner)` desugars to a pipe whose `in` is a
+      // ZodTransform (the user-supplied `fn`) and whose `out` is the
+      // inner schema. The "real" schema we want to draw a default from
+      // is the side that ISN'T a transform — `out` for preprocess,
+      // `in` for `.transform()` (where the source schema is on the
+      // in side and the transform itself is on the out side). Falling
+      // through to the transform side returns `undefined` and breaks
+      // the storage invariant (blank-path synthesis would leave the
+      // slot at `undefined` instead of the inner-schema's falsy).
+      const out = unwrapPipeOut(schema)
+      const inn = unwrapPipeIn(schema)
+      const real =
+        inn !== undefined && kindOf(inn) !== 'transform'
+          ? inn
+          : out !== undefined && kindOf(out) !== 'transform'
+            ? out
+            : (inn ?? out)
+      return real === undefined
         ? undefined
-        : defaultForKind(kindOf(inner), inner, useDefault, maxDepth, lazyDepth)
+        : defaultForKind(kindOf(real), real, useDefault, maxDepth, lazyDepth)
     }
     case 'array':
       return []

--- a/src/runtime/adapters/zod-v4/index.ts
+++ b/src/runtime/adapters/zod-v4/index.ts
@@ -22,11 +22,13 @@ import type {
   NestedType,
 } from '../../types/types-core'
 import { zodV4Adapter } from './adapter'
+import type { ReadShape } from './types-read-shape'
 
 export { zodV4Adapter as zodAdapter } from './adapter'
 export { UnsupportedSchemaError } from './errors'
 export { assertZodVersion, kindOf } from './introspect'
 export type { ZodKind } from './introspect'
+export type { ReadShape, ReadShapeField } from './types-read-shape'
 
 /**
  * Type of the value accepted at `Path` for `setValue` / `defaultValues`
@@ -105,7 +107,8 @@ export function useForm<Schema extends z.ZodObject>(
   > & { schema: Schema } & ValidateOnConfig
 ): UseFormReturnType<
   z.input<Schema> extends GenericForm ? z.input<Schema> : never,
-  z.output<Schema> extends GenericForm ? z.output<Schema> : never
+  z.output<Schema> extends GenericForm ? z.output<Schema> : never,
+  ReadShape<Schema> extends GenericForm ? ReadShape<Schema> : never
 > {
   // Foot-gun guard: catches `useForm(z.object({...}))` (raw schema as
   // the first arg — its `.schema` field is undefined), `useForm()` (no
@@ -147,9 +150,10 @@ export function useForm<Schema extends z.ZodObject>(
   // public `useForm` signature already enforced the discriminant on
   // `configuration` before we got here), so cast to the parameter
   // type to side-step the structural disagreement.
+  type Read = ReadShape<Schema> extends GenericForm ? ReadShape<Schema> : never
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-  return useAbstractForm<Form, Out>({
+  return useAbstractForm<Form, Out, Read>({
     ...configuration,
     schema: adapter,
-  } as Parameters<typeof useAbstractForm<Form, Out>>[0])
+  } as Parameters<typeof useAbstractForm<Form, Out, Read>>[0])
 }

--- a/src/runtime/adapters/zod-v4/strip.ts
+++ b/src/runtime/adapters/zod-v4/strip.ts
@@ -19,7 +19,8 @@ import {
   kindOf,
   unwrapInner,
   unwrapLazy,
-  unwrapPipe,
+  unwrapPipeIn,
+  unwrapPipeOut,
 } from './introspect'
 
 type StripConfigInternal = Pick<StripConfig, 'stripRefinements'> & {
@@ -436,10 +437,23 @@ function walkSlim(
       // transformation, so by default we return the original schema
       // unchanged. Consumers who explicitly opt in via `stripPipe`
       // (e.g. default-values derivation, where a transform doesn't make
-      // sense) get the upstream leg of the pipe only.
+      // sense) get the "real" leg of the pipe — the side that ISN'T
+      // a ZodTransform. For `z.preprocess(fn, inner)` that's `def.out`
+      // (the inner schema); for `someSchema.transform(fn)` that's
+      // `def.in` (the source schema). Falling through to the transform
+      // side would re-run the user's fn during default-values
+      // derivation — for preprocess that means a throwing fn crashes
+      // mount even though there's nothing to normalize at init time.
       if (stripConfig.stripPipe === true) {
-        const inner = unwrapPipe(schema) ?? schema
-        return walkSlim(inner, stripConfig, maxDepth, lazyDepth)
+        const pipeIn = unwrapPipeIn(schema)
+        const pipeOut = unwrapPipeOut(schema)
+        const real =
+          pipeIn !== undefined && kindOf(pipeIn) !== 'transform'
+            ? pipeIn
+            : pipeOut !== undefined && kindOf(pipeOut) !== 'transform'
+              ? pipeOut
+              : (pipeIn ?? pipeOut ?? schema)
+        return walkSlim(real, stripConfig, maxDepth, lazyDepth)
       }
       return schema
     }

--- a/src/runtime/adapters/zod-v4/types-read-shape.ts
+++ b/src/runtime/adapters/zod-v4/types-read-shape.ts
@@ -1,0 +1,76 @@
+import type { z } from 'zod'
+
+/**
+ * The "read shape" of a Zod v4 schema — the type `form.values.<path>`
+ * resolves to at runtime once defaults have fired and synthesis has
+ * filled blank fields.
+ *
+ * Why this exists: `z.input<Schema>` answers "what may be passed at
+ * the ingestion boundary," which is fundamentally permissive — an
+ * object field wrapped in `.default()` shows up as a KEY-OPTIONAL
+ * property, so under `exactOptionalPropertyTypes: true` direct access
+ * resolves to `T | undefined`. The runtime never holds that
+ * `undefined`: storage init fires defaults, blank-path synthesis
+ * fills required leaves with falsy concrete, and only genuinely
+ * optional / nullable wrappers leave a slot empty.
+ *
+ * `ReadShape<S>` rebuilds the object type from the schema's `Shape`
+ * (not from `z.input<S>`), so per-field key-presence becomes a
+ * library decision driven by which wrapper class is in the field:
+ *
+ *  | Wrapper             | Key | Value at the key            |
+ *  | ------------------- | --- | --------------------------- |
+ *  | `ZodDefault<T>`     | req | `z.input<T>` (no undefined) |
+ *  | `ZodOptional<T>`    | opt | `z.input<T> \| undefined`   |
+ *  | `ZodNullable<T>`    | req | `z.input<T> \| null`        |
+ *  | `ZodPreprocess<T>`  | req | `z.input<T>` (peel cb→unknown)
+ *  | plain wrapper / T   | req | `z.input<T>`                |
+ *
+ * Composes with `WriteShape<>` (primitive-literal widening) at the
+ * `form.values` boundary: `ValuesSurface<WriteShape<ReadShape<S>>>`.
+ *
+ * Ingestion surfaces (`setValue`, `defaultValues`, `register` write
+ * path) keep `z.input<S>` — those need to admit `undefined` for
+ * defaulted fields and `unknown` for preprocess slots.
+ */
+export type ReadShape<S> =
+  S extends z.ZodObject<infer Shape extends z.ZodRawShape>
+    ? { [K in keyof Shape]: ReadShapeField<Shape[K]> }
+    : ReadShapeField<S>
+
+/**
+ * Per-field resolution for {@link ReadShape}. Recurses into nested
+ * `ZodObject` / `ZodArray`; peels wrappers per the policy table.
+ */
+export type ReadShapeField<T> =
+  T extends z.ZodDefault<infer Inner>
+    ? ReadShapeField<Inner>
+    : T extends z.ZodPrefault<infer Inner>
+      ? ReadShapeField<Inner>
+      : T extends z.ZodCatch<infer Inner>
+        ? ReadShapeField<Inner>
+        : T extends z.ZodReadonly<infer Inner>
+          ? ReadShapeField<Inner>
+          : T extends z.ZodOptional<infer Inner>
+            ? ReadShapeField<Inner> | undefined
+            : T extends z.ZodNullable<infer Inner>
+              ? ReadShapeField<Inner> | null
+              : T extends z.ZodPreprocess<infer Inner>
+                ? ReadShapeField<Inner>
+                : T extends z.ZodObject<infer Shape extends z.ZodRawShape>
+                  ? { [K in keyof Shape]: ReadShapeField<Shape[K]> }
+                  : T extends z.ZodArray<infer Item>
+                    ? Array<ReadShapeField<Item>>
+                    : T extends z.ZodTuple<infer Items>
+                      ? { -readonly [K in keyof Items]: ReadShapeField<Items[K]> }
+                      : T extends z.ZodRecord<infer _Key, infer Value>
+                        ? Record<string, ReadShapeField<Value>>
+                        : T extends z.ZodDiscriminatedUnion<infer Options, string>
+                          ? Options extends ReadonlyArray<infer Opt>
+                            ? Opt extends z.ZodType
+                              ? ReadShapeField<Opt>
+                              : never
+                            : never
+                          : T extends z.ZodType
+                            ? z.input<T>
+                            : T

--- a/src/runtime/composables/use-abstract-form.ts
+++ b/src/runtime/composables/use-abstract-form.ts
@@ -82,6 +82,7 @@ import type { DeepPartial, DefaultValuesShape, GenericForm, WriteShape } from '.
 export function useAbstractForm<
   Form extends GenericForm,
   GetValueFormType extends GenericForm = Form,
+  ReadForm extends GenericForm = Form,
 >(
   configuration: UseFormConfiguration<
     Form,
@@ -89,7 +90,7 @@ export function useAbstractForm<
     AbstractSchema<Form, GetValueFormType>,
     DeepPartial<DefaultValuesShape<Form>>
   >
-): UseFormReturnType<Form, GetValueFormType> {
+): UseFormReturnType<Form, GetValueFormType, ReadForm> {
   // Foot-gun guard: catches `useForm()` (no args), `useForm(null)`,
   // `useForm(rawSchema)` (any schema-like object passed as the first
   // argument — its `.schema` field is undefined), and the explicit
@@ -425,7 +426,15 @@ export function useAbstractForm<
   if (merged.rememberVariants !== undefined) {
     apiOptions.rememberVariants = merged.rememberVariants
   }
-  return buildFormApi<Form, GetValueFormType>(state, formInstanceId, apiOptions)
+  // `buildFormApi` returns the schema-agnostic shape (`ReadForm = Form`).
+  // Adapter callers compute the richer `ReadForm` (e.g. zod-v4's
+  // `ReadShape<Schema>`) and assert it through the public return type —
+  // at runtime the same proxies serve both views.
+  return buildFormApi<Form, GetValueFormType>(
+    state,
+    formInstanceId,
+    apiOptions
+  ) as unknown as UseFormReturnType<Form, GetValueFormType, ReadForm>
 }
 
 /**

--- a/src/runtime/composables/use-form.ts
+++ b/src/runtime/composables/use-form.ts
@@ -14,6 +14,7 @@ import type {
   UnwrapZodObject,
   UseFormConfigurationWithZod,
 } from '../adapters/zod-v3/types-zod-adapter'
+import type { ReadShape } from '../adapters/zod-v3/types-read-shape'
 import { useAbstractForm } from './use-abstract-form'
 
 /**
@@ -69,7 +70,11 @@ export function useForm<
     Schema,
     DeepPartial<DefaultValuesShape<z.input<UnwrapZodObject<Schema>>>>
   >
-): UseFormReturnType<z.input<UnwrapZodObject<Schema>>, GetValueFormType>
+): UseFormReturnType<
+  z.input<UnwrapZodObject<Schema>>,
+  GetValueFormType,
+  ReadShape<Schema> extends GenericForm ? ReadShape<Schema> : never
+>
 export function useForm<
   Schema extends z.ZodSchema<unknown>,
   Form extends GenericForm = z.input<UnwrapZodObject<Schema>>,
@@ -118,7 +123,8 @@ export function useForm<
   // (`createAttaform({ defaults: { strict: false } })`).
   // The library-level fallback to `true` lives downstream in
   // `createFormStore`, where it can apply *after* the registry merge.
-  return useAbstractForm<Form, GetValueFormType>({
+  type Read = ReadShape<Schema> extends GenericForm ? ReadShape<Schema> : never
+  return useAbstractForm<Form, GetValueFormType, Read>({
     ...(configuration as UseFormConfiguration<
       Form,
       GetValueFormType,
@@ -135,5 +141,5 @@ export function useForm<
       | AbstractSchema<Form, GetValueFormType>
       | ((key: FormKey, options: SchemaFactoryOptions) => AbstractSchema<Form, GetValueFormType>),
     defaultValues: configuration.defaultValues as DeepPartial<DefaultValuesShape<Form>>,
-  })
+  }) as unknown as UseFormReturnType<Form, GetValueFormType>
 }

--- a/src/runtime/core/build-form-api.ts
+++ b/src/runtime/core/build-form-api.ts
@@ -685,6 +685,18 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
     }
   }
 
+  // --- Clear ---
+  // `clear()` wipes the whole form to per-leaf falsy concrete; `clear(path)`
+  // wipes a sub-tree. The `pathInput === undefined` check is what
+  // distinguishes "no arg" (whole-form) from explicit `clear('')`
+  // (the empty-string path slot); canonicalizePath preserves the
+  // distinction (`''` → `['']` segments, undefined never reaches it).
+  // Mirrors `touch`'s arg handling.
+  function clear(pathInput?: string | readonly (string | number)[]): boolean {
+    const segments = pathInput === undefined ? ROOT_PATH : canonicalizePath(pathInput).segments
+    return state.clear(segments)
+  }
+
   // --- Persistence (imperative APIs) ---
 
   const persist = async (
@@ -795,6 +807,7 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
     meta: formMeta,
     reset: reset as UseFormReturnType<Form, GetValueFormType>['reset'],
     resetField: resetField as UseFormReturnType<Form, GetValueFormType>['resetField'],
+    clear: clear as UseFormReturnType<Form, GetValueFormType>['clear'],
     persist: persist as UseFormReturnType<Form, GetValueFormType>['persist'],
     clearPersistedDraft: clearPersistedDraft as UseFormReturnType<
       Form,

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -400,9 +400,17 @@ export type FormStore<F extends GenericForm, G extends GenericForm = F> = {
   setValueAtPath(path: Path, value: unknown, meta?: WriteMeta): boolean
   getValueAtPath(path: Path): unknown
 
-  // --- reset ---
+  // --- reset / clear ---
   reset(nextDefaultValues?: DeepPartial<WriteShape<F>>): void
   resetField(path: Path): void
+  /**
+   * Wipe `path` (or the whole form when `path === ''`) to the
+   * schema's "appropriate nullish value" — the underlying type's
+   * empty/falsy concrete, with `.default()` / `.catch()` wrappers
+   * INTENTIONALLY skipped. Sugar for
+   * `setValueAtPath(path, schema.getEmptyValueAtPath(path))`.
+   */
+  clear(path: Path): boolean
 
   // --- errors ---
   // Schema-driven writers. Used by the validation pipeline + handleSubmit.
@@ -2372,6 +2380,30 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     }
   }
 
+  // --- Clear ---
+
+  function clear(path: Path): boolean {
+    // `clear` is sugar over `setValueAtPath`: ask the adapter for the
+    // "appropriate nullish value" at this path (the underlying type's
+    // empty/falsy concrete, with `.default()` / `.catch()` wrappers
+    // intentionally skipped) and write it. No bookkeeping that
+    // `setValueAtPath` doesn't already do — variant memory, history,
+    // persistence, and listeners all see this as a regular write.
+    //
+    // `path` is segments (canonical form). An empty segment list
+    // (`[]`) targets the whole form; `['']` targets the empty-string
+    // slot (`form.errors('')` bucket / `form.touch('')` semantics
+    // from #184). The two are NOT interchangeable — special-casing
+    // either would create a maintenance footgun.
+    //
+    // The adapter may legitimately return `undefined` as the empty
+    // value (e.g. `z.string().optional()` — the wrapper's "absent"
+    // marker IS `undefined`). The slim-primitive write gate inside
+    // `setValueAtPath` decides whether that's an acceptable write at
+    // the path — we forward unconditionally and let it adjudicate.
+    return setValueAtPath(path, schema.getEmptyValueAtPath(path))
+  }
+
   // --- Reset ---
 
   function reset(nextDefaultValues?: DeepPartial<WriteShape<F>>): void {
@@ -2783,6 +2815,7 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
 
     reset,
     resetField,
+    clear,
 
     setSchemaErrorsForPath,
     setAllSchemaErrors,

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -240,6 +240,34 @@ export type AbstractSchema<Form, GetValueFormType> = {
    */
   getDefaultAtPath(path: Path): unknown
   /**
+   * Return the schema's "appropriate nullish value" at the given path
+   * — the underlying type's empty/falsy concrete, with `.default(x)`
+   * wrappers explicitly NOT honoured. Powers `form.clear(path)`:
+   * `clear` differs from `reset` precisely in that it ignores
+   * declared defaults and produces `false` / `0` / `''` / `[]` / a
+   * recursively-empty object instead.
+   *
+   * Semantics (mirrors `getDefaultAtPath`'s sub-path resolution,
+   * differs at leaves):
+   * - **Primitive leaf:** the primitive's falsy concrete
+   *   (`''` / `0` / `false` / `0n` / `new Date(0)`, etc.).
+   * - **Array / Set / Record:** empty.
+   * - **Optional<T>:** `undefined` (the wrapper's "absent" marker).
+   * - **Nullable<T>:** `null` (the wrapper's "explicit empty").
+   * - **Default<T> / Prefault<T> / Catch<T>:** inner-schema empty
+   *   — the declared default value is INTENTIONALLY skipped.
+   * - **Readonly<T> / preprocess(fn, T):** inner-schema empty.
+   * - **Object:** recursive — every property gets its own empty.
+   * - **Discriminated union:** first variant's recursive empty
+   *   (parallels `getDefaultAtPath`'s first-success precedent).
+   * - **Path doesn't exist in schema:** `undefined`.
+   *
+   * Adapters may return `undefined` when the path can't be resolved;
+   * callers treat that as "don't write" and leave existing storage
+   * unchanged.
+   */
+  getEmptyValueAtPath(path: Path): unknown
+  /**
    * Give the schema a chance to normalize the consumer's write value
    * before it lands in storage / hits the slim-primitive gate. Each
    * schema library exposes this concept differently — Zod calls it
@@ -3407,6 +3435,54 @@ export type UseFormReturnType<
    * from the persisted draft too.
    */
   resetField: (path: FlatPath<Form>) => void
+
+  /**
+   * Wipe a field (or the whole form) to the "appropriate nullish
+   * value" for its declared type — the underlying type's empty/falsy
+   * concrete, with any `.default(x)` wrapper INTENTIONALLY skipped.
+   * Orthogonal to `reset` / `resetField` by design.
+   *
+   * ```ts
+   * const schema = z.object({
+   *   notify: z.boolean().default(true),
+   *   count: z.number().default(5),
+   * })
+   * const form = useForm({ schema })
+   *
+   * form.reset()         // notify → true,  count → 5  (defaults)
+   * form.clear()         // notify → false, count → 0  (falsy-for-type)
+   * form.clear('notify') // → false (NOT the declared default true)
+   * ```
+   *
+   * Per-wrapper semantics:
+   *
+   * - `.default(x)` / `.prefault(x)` / `.catch(x)` → inner-schema
+   *   empty (default is INTENTIONALLY skipped).
+   * - `.optional()` → `undefined` (the wrapper's "absent" marker).
+   * - `.nullable()` → `null` (the wrapper's "explicit empty").
+   * - Object → recursive (every property gets its own empty).
+   * - Array / Set / Record → empty.
+   *
+   * Returns `true` when the write was accepted, `false` when the
+   * adapter couldn't resolve an empty value at the path (e.g. the
+   * path doesn't exist in the schema). The form state is unchanged
+   * on a `false` return.
+   *
+   * Sugar over `setValue(path, schema.getEmptyValueAtPath(path))` —
+   * no separate bookkeeping. Variant memory, history, persistence,
+   * and listeners all see this as a regular write at the path.
+   *
+   * `clear()` (no arg) targets the whole form. `clear('')` targets
+   * the empty-string path slot SPECIFICALLY — the two are NOT
+   * interchangeable, matching `touch()` / `touch('')` from #184.
+   */
+  clear: {
+    (): boolean
+    <Path extends FlatPath<Form> | ''>(path: Path): boolean
+    <const S extends ReadonlyArray<string | number>>(
+      segments: S & ([JoinSegments<S>] extends [FlatPath<Form> | ''] ? unknown : never)
+    ): boolean
+  }
 
   // --- Persistence (imperative APIs) ---
 

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -2951,12 +2951,23 @@ export type FormMeta<F = unknown> = FieldState<F> & {
  *   callback and by `form.process()`'s success payload. This is the
  *   shape after refinements have fired and transforms have run.
  *
- * For schemas without transforms the two are identical, and the
- * default `GetValueFormType = Form` keeps the surface ergonomic.
+ * - `ReadForm` — the **read / storage shape** — the type
+ *   `form.values.<path>` resolves to at runtime once defaults have
+ *   fired and blank-path synthesis has filled required leaves. For a
+ *   Zod schema this is `ReadShape<Schema>` (provided by the adapter);
+ *   for schema-agnostic call sites it defaults to `Form`, preserving
+ *   the existing surface. Used by `values`, `fields`, `register`'s
+ *   read side, and `toRef`.
+ *
+ * For schemas without transforms the input and output shapes are
+ * identical; for schemas without defaults / preprocess the input and
+ * read shapes are identical. Defaults keep the surface ergonomic when
+ * the adapter doesn't compute the richer shapes.
  */
 export type UseFormReturnType<
   Form extends GenericForm,
   GetValueFormType extends GenericForm = Form,
+  ReadForm extends GenericForm = Form,
 > = {
   /**
    * Wraps your submit logic with validation and error routing.
@@ -3005,7 +3016,7 @@ export type UseFormReturnType<
    * value reads as `string`, not `boolean`. Use `handleSubmit` or
    * `form.process()` when you need the post-transform output shape.
    */
-  values: ValuesSurface<WriteShape<Form>>
+  values: ValuesSurface<WriteShape<ReadForm>>
 
   /**
    * Reactive per-field state proxy. Pinia-style nested object — read
@@ -3035,7 +3046,7 @@ export type UseFormReturnType<
    * Document edge case; rename the offending schema field if the
    * collision matters.
    */
-  fields: FieldStateMap<WriteShape<Form>>
+  fields: FieldStateMap<WriteShape<ReadForm>>
 
   /**
    * Write to the form programmatically. Two forms:
@@ -3203,12 +3214,12 @@ export type UseFormReturnType<
     <Path extends RegisterFlatPath<Form, keyof Form>>(
       path: Path,
       options?: RegisterOptions
-    ): RegisterValue<NestedReadType<WriteShape<Form>, Path>>
+    ): RegisterValue<NestedReadType<WriteShape<ReadForm>, Path>>
     <const S extends ReadonlyArray<string | number>>(
       segments: S &
         ([JoinSegments<S>] extends [RegisterFlatPath<Form, keyof Form>] ? unknown : never),
       options?: RegisterOptions
-    ): RegisterValue<NestedReadType<WriteShape<Form>, JoinSegments<S>>>
+    ): RegisterValue<NestedReadType<WriteShape<ReadForm>, JoinSegments<S>>>
   }
   /**
    * The form's identifier — either the explicit `key` passed to
@@ -3267,10 +3278,12 @@ export type UseFormReturnType<
    * scripts; `toRef` is for ref-shaped interop only.
    */
   toRef: {
-    <Path extends FlatPath<Form>>(path: Path): Readonly<Ref<NestedReadType<WriteShape<Form>, Path>>>
+    <Path extends FlatPath<Form>>(
+      path: Path
+    ): Readonly<Ref<NestedReadType<WriteShape<ReadForm>, Path>>>
     <const S extends ReadonlyArray<string | number>>(
       segments: S & ([JoinSegments<S>] extends [FlatPath<Form>] ? unknown : never)
-    ): Readonly<Ref<NestedReadType<WriteShape<Form>, JoinSegments<S>>>>
+    ): Readonly<Ref<NestedReadType<WriteShape<ReadForm>, JoinSegments<S>>>>
   }
 
   /**

--- a/src/zod-v3.ts
+++ b/src/zod-v3.ts
@@ -43,5 +43,6 @@ export type {
   UnwrapZodObject,
   UseFormConfigurationWithZod,
 } from './runtime/adapters/zod-v3/types-zod-adapter'
+export type { ReadShape, ReadShapeField } from './runtime/adapters/zod-v3/types-read-shape'
 export { fieldMeta, withMeta } from './runtime/adapters/zod-v3/field-meta'
 export type { FieldMetaPayload } from './runtime/core/field-meta'

--- a/test/composables/clear-v3.test.ts
+++ b/test/composables/clear-v3.test.ts
@@ -1,0 +1,195 @@
+// @vitest-environment jsdom
+import { createApp, defineComponent, h } from 'vue'
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod-v3'
+import { useForm } from '../../src/zod-v3'
+import { createAttaform } from '../../src/runtime/core/plugin'
+
+/**
+ * `form.clear(path?)` — Zod v3 mirror of `clear.test.ts`. Pins the
+ * same orthogonality with `reset`: clear wipes to falsy-for-type,
+ * reset restores declared defaults.
+ */
+
+function mountForm<R>(setup: () => R): { api: R; unmount: () => void } {
+  let captured: R | undefined
+  const App = defineComponent({
+    setup() {
+      captured = setup()
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  const root = document.createElement('div')
+  document.body.appendChild(root)
+  app.mount(root)
+  if (captured === undefined) throw new Error('mountForm: setup never returned')
+  return {
+    api: captured,
+    unmount: () => {
+      app.unmount()
+      document.body.removeChild(root)
+    },
+  }
+}
+
+function uniqueKey(prefix: string): string {
+  return `v3-clear-${prefix}-${Math.random().toString(36).slice(2)}`
+}
+
+const schema = z.object({
+  urls: z.array(z.string()).default(['https://a.test']),
+  name: z.string().default('ozzy'),
+  notify: z.boolean().default(true),
+  count: z.number().default(5),
+  config: z
+    .object({
+      enabled: z.boolean().default(true),
+      label: z.string().default('default-label'),
+    })
+    .default({ enabled: true, label: 'default-label' }),
+  optionalBio: z.string().optional(),
+  nullableRef: z.string().nullable(),
+})
+
+describe('v3 — form.clear(path) wipes primitives to falsy', () => {
+  it('clear("name") → "" (NOT the default "ozzy")', () => {
+    const { api, unmount } = mountForm(() => useForm({ schema, key: uniqueKey('str') }))
+    try {
+      expect(api.values.name).toBe('ozzy')
+      api.clear('name')
+      expect(api.values.name).toBe('')
+    } finally {
+      unmount()
+    }
+  })
+
+  it('clear("notify") → false (NOT the default true)', () => {
+    const { api, unmount } = mountForm(() => useForm({ schema, key: uniqueKey('bool') }))
+    try {
+      expect(api.values.notify).toBe(true)
+      api.clear('notify')
+      expect(api.values.notify).toBe(false)
+    } finally {
+      unmount()
+    }
+  })
+
+  it('clear("count") → 0 (NOT the default 5)', () => {
+    const { api, unmount } = mountForm(() => useForm({ schema, key: uniqueKey('num') }))
+    try {
+      expect(api.values.count).toBe(5)
+      api.clear('count')
+      expect(api.values.count).toBe(0)
+    } finally {
+      unmount()
+    }
+  })
+
+  it('clear("urls") → []', () => {
+    const { api, unmount } = mountForm(() => useForm({ schema, key: uniqueKey('arr') }))
+    try {
+      expect(api.values.urls).toEqual(['https://a.test'])
+      api.clear('urls')
+      expect(api.values.urls).toEqual([])
+    } finally {
+      unmount()
+    }
+  })
+})
+
+describe('v3 — nested object descent', () => {
+  it('clear("config") → recursively-empty inner shape', () => {
+    const { api, unmount } = mountForm(() => useForm({ schema, key: uniqueKey('obj') }))
+    try {
+      expect(api.values.config).toEqual({ enabled: true, label: 'default-label' })
+      api.clear('config')
+      expect(api.values.config).toEqual({ enabled: false, label: '' })
+    } finally {
+      unmount()
+    }
+  })
+
+  it('clear("config.enabled") → false (sub-path)', () => {
+    const { api, unmount } = mountForm(() => useForm({ schema, key: uniqueKey('obj-sub') }))
+    try {
+      api.clear('config.enabled')
+      expect(api.values.config.enabled).toBe(false)
+      expect(api.values.config.label).toBe('default-label')
+    } finally {
+      unmount()
+    }
+  })
+})
+
+describe('v3 — wrapper semantics', () => {
+  it('clear("optionalBio") → undefined', () => {
+    const { api, unmount } = mountForm(() => useForm({ schema, key: uniqueKey('opt') }))
+    try {
+      api.setValue('optionalBio', 'hello')
+      expect(api.values.optionalBio).toBe('hello')
+      api.clear('optionalBio')
+      expect(api.values.optionalBio).toBeUndefined()
+    } finally {
+      unmount()
+    }
+  })
+
+  it('clear("nullableRef") → null', () => {
+    const { api, unmount } = mountForm(() => useForm({ schema, key: uniqueKey('nul') }))
+    try {
+      api.setValue('nullableRef', 'something')
+      expect(api.values.nullableRef).toBe('something')
+      api.clear('nullableRef')
+      expect(api.values.nullableRef).toBeNull()
+    } finally {
+      unmount()
+    }
+  })
+})
+
+describe("v3 — whole-form and `''` distinction", () => {
+  it('clear() (no arg) wipes every leaf to falsy', () => {
+    const { api, unmount } = mountForm(() => useForm({ schema, key: uniqueKey('whole') }))
+    try {
+      api.clear()
+      expect(api.values.notify).toBe(false)
+      expect(api.values.count).toBe(0)
+      expect(api.values.name).toBe('')
+    } finally {
+      unmount()
+    }
+  })
+
+  it("clear('') targets the empty-string path slot, does NOT wipe whole form", () => {
+    const { api, unmount } = mountForm(() => useForm({ schema, key: uniqueKey('empty-path') }))
+    try {
+      expect(api.values.notify).toBe(true)
+      expect(api.values.name).toBe('ozzy')
+
+      api.clear('')
+
+      expect(api.values.notify).toBe(true)
+      expect(api.values.name).toBe('ozzy')
+    } finally {
+      unmount()
+    }
+  })
+})
+
+describe('v3 — orthogonality with reset', () => {
+  it('reset restores defaults; clear wipes to falsy', () => {
+    const { api, unmount } = mountForm(() => useForm({ schema, key: uniqueKey('vs') }))
+    try {
+      api.setValue('notify', false)
+      api.reset()
+      expect(api.values.notify).toBe(true)
+
+      api.setValue('notify', true)
+      api.clear('notify')
+      expect(api.values.notify).toBe(false)
+    } finally {
+      unmount()
+    }
+  })
+})

--- a/test/composables/clear.test.ts
+++ b/test/composables/clear.test.ts
@@ -1,0 +1,274 @@
+// @vitest-environment jsdom
+import { createApp, defineComponent, h } from 'vue'
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { createAttaform } from '../../src/runtime/core/plugin'
+
+/**
+ * `form.clear(path?)` — wipe a path (or the whole form) to the
+ * "appropriate nullish value" for the schema-declared type at that
+ * path, regardless of any `.default(...)` wrapper. Orthogonal to
+ * `reset()` (which restores declared defaults) by design: a user
+ * with `z.boolean().default(true)` who calls `clear` ends up at
+ * `false`, never `true`. From feedback doc §2.1.
+ *
+ * Implementation note: `clear` is sugar for `setValue(path,
+ * appropriateNullishValue)`, where the nullish value comes from the
+ * adapter's underlying "schema empty for type" walk (in zod-v4, the
+ * `deriveDefault(schema, useDefault=false, ...)` branch — the same
+ * machinery that produces blank-path synthesis falsy values).
+ */
+
+function mountForm<R>(setup: () => R): { api: R; unmount: () => void } {
+  let captured: R | undefined
+  const App = defineComponent({
+    setup() {
+      captured = setup()
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  const root = document.createElement('div')
+  document.body.appendChild(root)
+  app.mount(root)
+  if (captured === undefined) throw new Error('mountForm: setup never returned')
+  return {
+    api: captured,
+    unmount: () => {
+      app.unmount()
+      document.body.removeChild(root)
+    },
+  }
+}
+
+function uniqueKey(prefix: string): string {
+  return `clear-${prefix}-${Math.random().toString(36).slice(2)}`
+}
+
+const schema = z.object({
+  urls: z.array(z.string()).default(['https://a.test']),
+  name: z.string().default('ozzy'),
+  notify: z.boolean().default(true),
+  count: z.number().default(5),
+  config: z
+    .object({
+      enabled: z.boolean().default(true),
+      label: z.string().default('default-label'),
+    })
+    .default({ enabled: true, label: 'default-label' }),
+  optionalBio: z.string().optional(),
+  nullableRef: z.string().nullable(),
+})
+
+describe('form.clear(path) — primitive leaves wipe to falsy, not default', () => {
+  it('clear("urls") → []', () => {
+    const { api, unmount } = mountForm(() => useForm({ schema, key: uniqueKey('arr') }))
+    try {
+      expect(api.values.urls).toEqual(['https://a.test']) // schema default
+      api.clear('urls')
+      expect(api.values.urls).toEqual([])
+    } finally {
+      unmount()
+    }
+  })
+
+  it('clear("name") → "" (NOT the default "ozzy")', () => {
+    const { api, unmount } = mountForm(() => useForm({ schema, key: uniqueKey('str') }))
+    try {
+      expect(api.values.name).toBe('ozzy')
+      api.clear('name')
+      expect(api.values.name).toBe('')
+    } finally {
+      unmount()
+    }
+  })
+
+  it('clear("notify") → false (NOT the default true)', () => {
+    const { api, unmount } = mountForm(() => useForm({ schema, key: uniqueKey('bool') }))
+    try {
+      expect(api.values.notify).toBe(true)
+      api.clear('notify')
+      expect(api.values.notify).toBe(false)
+    } finally {
+      unmount()
+    }
+  })
+
+  it('clear("count") → 0 (NOT the default 5)', () => {
+    const { api, unmount } = mountForm(() => useForm({ schema, key: uniqueKey('num') }))
+    try {
+      expect(api.values.count).toBe(5)
+      api.clear('count')
+      expect(api.values.count).toBe(0)
+    } finally {
+      unmount()
+    }
+  })
+})
+
+describe('form.clear(path) — nested objects recurse to per-leaf falsy', () => {
+  it('clear("config") → { enabled: false, label: "" }', () => {
+    const { api, unmount } = mountForm(() => useForm({ schema, key: uniqueKey('obj') }))
+    try {
+      expect(api.values.config).toEqual({ enabled: true, label: 'default-label' })
+      api.clear('config')
+      expect(api.values.config).toEqual({ enabled: false, label: '' })
+    } finally {
+      unmount()
+    }
+  })
+
+  it('clear("config.enabled") → false (sub-path)', () => {
+    const { api, unmount } = mountForm(() => useForm({ schema, key: uniqueKey('obj-sub') }))
+    try {
+      expect(api.values.config.enabled).toBe(true)
+      api.clear('config.enabled')
+      expect(api.values.config.enabled).toBe(false)
+      // Sibling untouched.
+      expect(api.values.config.label).toBe('default-label')
+    } finally {
+      unmount()
+    }
+  })
+})
+
+describe('form.clear(path) — optional / nullable respect their wrapper semantic', () => {
+  it('clear("optionalBio") → undefined (the wrapper\'s "absent" marker)', () => {
+    const { api, unmount } = mountForm(() => useForm({ schema, key: uniqueKey('opt') }))
+    try {
+      api.setValue('optionalBio', 'hello')
+      expect(api.values.optionalBio).toBe('hello')
+      api.clear('optionalBio')
+      expect(api.values.optionalBio).toBeUndefined()
+    } finally {
+      unmount()
+    }
+  })
+
+  it('clear("nullableRef") → null (the wrapper\'s "explicit empty")', () => {
+    const { api, unmount } = mountForm(() => useForm({ schema, key: uniqueKey('nul') }))
+    try {
+      api.setValue('nullableRef', 'something')
+      expect(api.values.nullableRef).toBe('something')
+      api.clear('nullableRef')
+      expect(api.values.nullableRef).toBeNull()
+    } finally {
+      unmount()
+    }
+  })
+})
+
+describe('form.clear() — whole-form variant clears every leaf to its falsy', () => {
+  it('clear() with no path wipes every leaf to falsy-for-type', () => {
+    const { api, unmount } = mountForm(() => useForm({ schema, key: uniqueKey('whole') }))
+    try {
+      api.clear()
+      expect(api.values.urls).toEqual([])
+      expect(api.values.name).toBe('')
+      expect(api.values.notify).toBe(false)
+      expect(api.values.count).toBe(0)
+      expect(api.values.config).toEqual({ enabled: false, label: '' })
+    } finally {
+      unmount()
+    }
+  })
+
+  // `''` is a real, distinct path (the form-level slot post-#184), NOT
+  // equivalent to "no arg / whole-form". The implementation must NOT
+  // collapse them via special-casing — otherwise it has to maintain a
+  // nuanced exception every time the empty-string path matters. This
+  // probe locks the disambiguation so a refactor that conflates `''`
+  // with "no path" trips immediately.
+  it("clear('') is path-targeted and does NOT wipe non-empty-path values", () => {
+    const { api, unmount } = mountForm(() => useForm({ schema, key: uniqueKey('empty-path') }))
+    try {
+      // Sanity — every named field carries its declared default.
+      expect(api.values.notify).toBe(true)
+      expect(api.values.name).toBe('ozzy')
+      expect(api.values.count).toBe(5)
+
+      api.clear('')
+
+      // The named fields stay at their declared defaults; clear('')
+      // touches only the '' slot (if any), never collapses to
+      // whole-form clear.
+      expect(api.values.notify).toBe(true)
+      expect(api.values.name).toBe('ozzy')
+      expect(api.values.count).toBe(5)
+    } finally {
+      unmount()
+    }
+  })
+})
+
+describe('form.clear vs form.reset — orthogonality', () => {
+  it('reset restores schema defaults; clear wipes to falsy', () => {
+    const { api, unmount } = mountForm(() => useForm({ schema, key: uniqueKey('vs') }))
+    try {
+      // After mount: defaults apply.
+      expect(api.values.notify).toBe(true)
+
+      // setValue → false; reset → back to default true.
+      api.setValue('notify', false)
+      api.reset()
+      expect(api.values.notify).toBe(true)
+
+      // setValue → true; clear → false (NOT the default).
+      api.setValue('notify', true)
+      api.clear('notify')
+      expect(api.values.notify).toBe(false)
+    } finally {
+      unmount()
+    }
+  })
+
+  it('whole-form reset() vs clear() produce different end states', () => {
+    const { api, unmount } = mountForm(() => useForm({ schema, key: uniqueKey('whole-vs') }))
+    try {
+      api.reset()
+      expect(api.values.notify).toBe(true)
+      expect(api.values.count).toBe(5)
+      expect(api.values.name).toBe('ozzy')
+
+      api.clear()
+      expect(api.values.notify).toBe(false)
+      expect(api.values.count).toBe(0)
+      expect(api.values.name).toBe('')
+    } finally {
+      unmount()
+    }
+  })
+})
+
+describe('form.clear — type-level signature', () => {
+  it('accepts FlatPath strings (same as setValue / resetField)', () => {
+    const { api, unmount } = mountForm(() => useForm({ schema, key: uniqueKey('types') }))
+    try {
+      // These compile, asserting the path types are recognised.
+      api.clear('urls')
+      api.clear('name')
+      api.clear('config.enabled')
+      api.clear() // whole-form
+      expectTypeOf(api.clear).toBeFunction()
+      // Bad paths rejected.
+      // @ts-expect-error - path not in schema
+      api.clear('definitely.not.a.path')
+    } finally {
+      unmount()
+    }
+  })
+})
+
+describe('form.clear — tuple-segment path form', () => {
+  it('accepts [segment, ...] tuples (parallels setValue / toRef)', () => {
+    const { api, unmount } = mountForm(() => useForm({ schema, key: uniqueKey('tuple') }))
+    try {
+      api.clear(['config', 'enabled'])
+      expect(api.values.config.enabled).toBe(false)
+      expect(api.values.config.label).toBe('default-label')
+    } finally {
+      unmount()
+    }
+  })
+})

--- a/test/composables/values-storage-shape-v3.test.ts
+++ b/test/composables/values-storage-shape-v3.test.ts
@@ -1,0 +1,213 @@
+// @vitest-environment jsdom
+import { createApp, defineComponent, h } from 'vue'
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import { z } from 'zod-v3'
+import { useForm } from '../../src/zod-v3'
+import { createAttaform } from '../../src/runtime/core/plugin'
+
+/**
+ * Storage-shape invariant probes — Zod v3 mirror of
+ * `values-storage-shape.test.ts`. Same invariant ("`form.values.<path>`
+ * always returns the resolved concrete type storage holds"), pinned
+ * against the v3 adapter via `ReadShape<Schema>` from
+ * `src/runtime/adapters/zod-v3/types-read-shape.ts`.
+ *
+ * v3 ReadShape peels wrappers (`ZodDefault` / `ZodOptional` /
+ * `ZodNullable` / `ZodEffects` / `ZodReadonly` / `ZodCatch`) at the
+ * top level of an object's shape and descends one further level into
+ * nested `ZodObject` / `ZodArray`. Deeper-nested wrapper peeling
+ * intentionally stays at `z.input<Inner>` to keep TS instantiation
+ * depth bounded — see the doc on `ReadShape` for the rationale.
+ *
+ * v3's `useForm` has multiple overloads, so the proxy-based
+ * `ReturnType<typeof useForm<...>>` pattern used by the v4 matrix
+ * doesn't resolve consistently. We mount each scenario and run both
+ * type-level (`expectTypeOf(api.values.X)`) and runtime
+ * (`expect(api.values.X)`) assertions against the live API instance.
+ */
+
+function mountWith<R>(setup: () => R): { api: R; unmount: () => void } {
+  let captured: R | undefined
+  const App = defineComponent({
+    setup() {
+      captured = setup()
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  const root = document.createElement('div')
+  document.body.appendChild(root)
+  app.mount(root)
+  if (captured === undefined) throw new Error('mountWith: setup never returned')
+  return {
+    api: captured,
+    unmount: () => {
+      app.unmount()
+      document.body.removeChild(root)
+    },
+  }
+}
+
+function uniqueKey(prefix: string): string {
+  return `v3-${prefix}-${Math.random().toString(36).slice(2)}`
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// ZodDefault — type peels `| undefined`; runtime resolves the default.
+// ──────────────────────────────────────────────────────────────────────
+
+const defaultsSchema = z.object({
+  flag: z.boolean().default(true),
+  count: z.number().default(0),
+  name: z.string().default('attaform'),
+  tags: z.array(z.string()).default([]),
+})
+
+describe('v3 — ZodDefault peels `| undefined`, runtime resolves the default', () => {
+  it('z.boolean().default(true) → boolean / runtime true', () => {
+    const { api, unmount } = mountWith(() =>
+      useForm({ schema: defaultsSchema, key: uniqueKey('zd-bool') })
+    )
+    try {
+      expectTypeOf(api.values.flag).toEqualTypeOf<boolean>()
+      expect(api.values.flag).toBe(true)
+    } finally {
+      unmount()
+    }
+  })
+
+  it('z.number().default(0) → number / runtime 0', () => {
+    const { api, unmount } = mountWith(() =>
+      useForm({ schema: defaultsSchema, key: uniqueKey('zd-num') })
+    )
+    try {
+      expectTypeOf(api.values.count).toEqualTypeOf<number>()
+      expect(api.values.count).toBe(0)
+    } finally {
+      unmount()
+    }
+  })
+
+  it('z.string().default("attaform") → string / runtime "attaform"', () => {
+    const { api, unmount } = mountWith(() =>
+      useForm({ schema: defaultsSchema, key: uniqueKey('zd-str') })
+    )
+    try {
+      expectTypeOf(api.values.name).toEqualTypeOf<string>()
+      expect(api.values.name).toBe('attaform')
+    } finally {
+      unmount()
+    }
+  })
+
+  it('z.array(z.string()).default([]) → string[] / runtime []', () => {
+    const { api, unmount } = mountWith(() =>
+      useForm({ schema: defaultsSchema, key: uniqueKey('zd-arr') })
+    )
+    try {
+      expectTypeOf(api.values.tags).toEqualTypeOf<string[]>()
+      expect(api.values.tags).toEqual([])
+    } finally {
+      unmount()
+    }
+  })
+
+  it('reset restores defaults', () => {
+    const { api, unmount } = mountWith(() =>
+      useForm({ schema: defaultsSchema, key: uniqueKey('zd-reset') })
+    )
+    try {
+      api.setValue('flag', false)
+      api.setValue('count', 42)
+      api.reset()
+      expect(api.values.flag).toBe(true)
+      expect(api.values.count).toBe(0)
+    } finally {
+      unmount()
+    }
+  })
+})
+
+// ──────────────────────────────────────────────────────────────────────
+// Bare-required fields — synthesis resolves to falsy concrete.
+// ──────────────────────────────────────────────────────────────────────
+
+const bareRequiredSchema = z.object({
+  s: z.string(),
+  n: z.number(),
+  b: z.boolean(),
+  arr: z.array(z.string()),
+})
+
+describe('v3 — Bare-required fields resolve to a falsy concrete value', () => {
+  it('plain primitives — type + runtime', () => {
+    const { api, unmount } = mountWith(() =>
+      useForm({ schema: bareRequiredSchema, key: uniqueKey('bare') })
+    )
+    try {
+      expectTypeOf(api.values.s).toEqualTypeOf<string>()
+      expectTypeOf(api.values.n).toEqualTypeOf<number>()
+      expectTypeOf(api.values.b).toEqualTypeOf<boolean>()
+      expectTypeOf(api.values.arr).toEqualTypeOf<string[]>()
+      expect(api.values.s).toBe('')
+      expect(api.values.n).toBe(0)
+      expect(api.values.b).toBe(false)
+      expect(api.values.arr).toEqual([])
+    } finally {
+      unmount()
+    }
+  })
+})
+
+// ──────────────────────────────────────────────────────────────────────
+// Nested object descent — one level deep is peeled at the type level.
+// ──────────────────────────────────────────────────────────────────────
+
+const nestedSchema = z.object({
+  user: z.object({
+    name: z.string(),
+    age: z.number().default(0),
+  }),
+})
+
+describe('v3 — Nested object descent (one level)', () => {
+  it('nested leaves keep their peeled types and resolve at runtime', () => {
+    const { api, unmount } = mountWith(() =>
+      useForm({ schema: nestedSchema, key: uniqueKey('nested') })
+    )
+    try {
+      expectTypeOf(api.values.user.name).toEqualTypeOf<string>()
+      expectTypeOf(api.values.user.age).toEqualTypeOf<number>()
+      expect(api.values.user.name).toBe('')
+      expect(api.values.user.age).toBe(0)
+    } finally {
+      unmount()
+    }
+  })
+})
+
+// ──────────────────────────────────────────────────────────────────────
+// Genuinely uncertain — invariant does NOT promise to peel.
+// ──────────────────────────────────────────────────────────────────────
+
+describe('v3 — Genuinely uncertain edges', () => {
+  it('z.string().optional() keeps `| undefined`', () => {
+    const schema = z.object({ bio: z.string().optional() })
+    const { api, unmount } = mountWith(() => useForm({ schema, key: uniqueKey('opt') }))
+    try {
+      expectTypeOf(api.values.bio).toEqualTypeOf<string | undefined>()
+    } finally {
+      unmount()
+    }
+  })
+
+  it('z.string().nullable() keeps `| null`', () => {
+    const schema = z.object({ ref: z.string().nullable() })
+    const { api, unmount } = mountWith(() => useForm({ schema, key: uniqueKey('nul') }))
+    try {
+      expectTypeOf(api.values.ref).toEqualTypeOf<string | null>()
+    } finally {
+      unmount()
+    }
+  })
+})

--- a/test/composables/values-storage-shape.test.ts
+++ b/test/composables/values-storage-shape.test.ts
@@ -1,0 +1,531 @@
+// @vitest-environment jsdom
+import { createApp, defineComponent, h } from 'vue'
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { createAttaform } from '../../src/runtime/core/plugin'
+
+/**
+ * Storage-shape invariant probes (feedback §1.2).
+ *
+ * The invariant: `form.values.<path>` always returns the resolved
+ * concrete type that storage holds. `.default()` has fired,
+ * preprocess has normalised, blank-path synthesis has filled the
+ * skeleton. Reads NEVER produce `undefined` for a slot the schema
+ * resolved to a concrete type — and the static type SHOULD agree.
+ *
+ * Today, `form.values` is typed as `z.input<Schema>`, which leaves a
+ * gap: `ZodDefault<T>`'s input is `T | undefined`, even though the
+ * runtime resolves it to `T` at storage-init. That gap is the §1.1
+ * "type lies" friction.
+ *
+ * RED-today markers: every type-level assertion in the deltas below
+ * carries `@ts-expect-error - POST-FIX (storage-shape)`. Once the
+ * `StorageShape<Schema>` mapped type lands, those directives become
+ * invalid (TS2578) and force co-removal in the fix commit. Runtime
+ * assertions stay unmarked — the storage invariant already holds at
+ * runtime; this matrix exists to ensure the static type catches up
+ * AND to flag any runtime corner that contradicts the invariant.
+ *
+ * Out-of-scope edges (kept here as guardrails, not bugs):
+ *  - `ZodOptional<T>` without a default — genuinely optional; type
+ *    correctly carries `| undefined`.
+ *  - `ZodNullable<T>` — type carries `| null`.
+ *  - Array index access past `length` — tainted by
+ *    `noUncheckedIndexedAccess`, not by the storage invariant.
+ *  - `.transform()` — storage holds pre-transform input; post-transform
+ *    output is exposed via `handleSubmit` / `form.process()`.
+ */
+
+function makeFormProxy<T>(): T {
+  const handler: ProxyHandler<() => unknown> = {
+    get: () => proxy,
+    apply: () => proxy,
+  }
+  const proxy: unknown = new Proxy(() => undefined, handler)
+  return proxy as T
+}
+
+function mountForm<R>(setup: () => R): { api: R; unmount: () => void } {
+  let captured: R | undefined
+  const App = defineComponent({
+    setup() {
+      captured = setup()
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  const root = document.createElement('div')
+  document.body.appendChild(root)
+  app.mount(root)
+  if (captured === undefined) throw new Error('mountForm: setup never returned')
+  return {
+    api: captured,
+    unmount: () => {
+      app.unmount()
+      document.body.removeChild(root)
+    },
+  }
+}
+
+function uniqueKey(prefix: string): string {
+  return `${prefix}-${Math.random().toString(36).slice(2)}`
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// ZodDefault — type should peel `| undefined`; runtime resolves the default.
+// ──────────────────────────────────────────────────────────────────────
+
+const defaultsSchema = z.object({
+  flag: z.boolean().default(true),
+  count: z.number().default(0),
+  name: z.string().default('attaform'),
+  tags: z.array(z.string()).default([]),
+  config: z
+    .object({
+      enabled: z.boolean().default(true),
+      label: z.string().default('default-label'),
+    })
+    .default({ enabled: true, label: 'default-label' }),
+})
+
+describe('ZodDefault — type peels `| undefined`, runtime resolves the default', () => {
+  type Form = ReturnType<typeof useForm<typeof defaultsSchema>>
+  const formT = makeFormProxy<Form>()
+
+  it('z.boolean().default(true) → boolean (type)', () => {
+    // @ts-expect-error - POST-FIX (storage-shape): should be `boolean`
+    expectTypeOf(formT.values.flag).toEqualTypeOf<boolean>()
+  })
+  it('z.boolean().default(true) → true (runtime)', () => {
+    const { api, unmount } = mountForm(() =>
+      useForm({ schema: defaultsSchema, key: uniqueKey('zd-bool') })
+    )
+    try {
+      expect(api.values.flag).toBe(true)
+      expect(typeof api.values.flag).toBe('boolean')
+    } finally {
+      unmount()
+    }
+  })
+
+  it('z.number().default(0) → number (type)', () => {
+    // @ts-expect-error - POST-FIX (storage-shape): should be `number`
+    expectTypeOf(formT.values.count).toEqualTypeOf<number>()
+  })
+  it('z.number().default(0) → 0 (runtime)', () => {
+    const { api, unmount } = mountForm(() =>
+      useForm({ schema: defaultsSchema, key: uniqueKey('zd-num') })
+    )
+    try {
+      expect(api.values.count).toBe(0)
+      expect(typeof api.values.count).toBe('number')
+    } finally {
+      unmount()
+    }
+  })
+
+  it('z.string().default("attaform") → string (type)', () => {
+    // @ts-expect-error - POST-FIX (storage-shape): should be `string`
+    expectTypeOf(formT.values.name).toEqualTypeOf<string>()
+  })
+  it('z.string().default("attaform") → "attaform" (runtime)', () => {
+    const { api, unmount } = mountForm(() =>
+      useForm({ schema: defaultsSchema, key: uniqueKey('zd-str') })
+    )
+    try {
+      expect(api.values.name).toBe('attaform')
+      expect(typeof api.values.name).toBe('string')
+    } finally {
+      unmount()
+    }
+  })
+
+  it('z.array(z.string()).default([]) → string[] (type)', () => {
+    // @ts-expect-error - POST-FIX (storage-shape): should be `string[]`
+    expectTypeOf(formT.values.tags).toEqualTypeOf<string[]>()
+  })
+  it('z.array(z.string()).default([]) → [] (runtime)', () => {
+    const { api, unmount } = mountForm(() =>
+      useForm({ schema: defaultsSchema, key: uniqueKey('zd-arr') })
+    )
+    try {
+      expect(api.values.tags).toEqual([])
+      expect(Array.isArray(api.values.tags)).toBe(true)
+    } finally {
+      unmount()
+    }
+  })
+
+  it('nested ZodDefault — type resolves inner shape', () => {
+    // @ts-expect-error - POST-FIX (storage-shape): should be `{ enabled: boolean; label: string }`
+    expectTypeOf(formT.values.config).toEqualTypeOf<{ enabled: boolean; label: string }>()
+    // @ts-expect-error - POST-FIX (storage-shape): should be `boolean`
+    expectTypeOf(formT.values.config.enabled).toEqualTypeOf<boolean>()
+  })
+  it('nested ZodDefault — runtime resolves the inner shape', () => {
+    const { api, unmount } = mountForm(() =>
+      useForm({ schema: defaultsSchema, key: uniqueKey('zd-obj') })
+    )
+    try {
+      expect(api.values.config).toEqual({ enabled: true, label: 'default-label' })
+      // @ts-expect-error - POST-FIX (storage-shape): config is non-undefined post-default-resolution
+      expect(api.values.config.enabled).toBe(true)
+    } finally {
+      unmount()
+    }
+  })
+
+  it('reset restores defaults (sanity: ZodDefault is the source of truth)', () => {
+    const { api, unmount } = mountForm(() =>
+      useForm({ schema: defaultsSchema, key: uniqueKey('zd-reset') })
+    )
+    try {
+      api.setValue('flag', false)
+      api.setValue('count', 42)
+      api.reset()
+      expect(api.values.flag).toBe(true)
+      expect(api.values.count).toBe(0)
+    } finally {
+      unmount()
+    }
+  })
+})
+
+// ──────────────────────────────────────────────────────────────────────
+// Bare-required fields — synthesis resolves to a falsy concrete value.
+// ──────────────────────────────────────────────────────────────────────
+
+const bareRequiredSchema = z.object({
+  s: z.string(),
+  n: z.number(),
+  b: z.boolean(),
+  arr: z.array(z.string()),
+})
+
+describe('Synthesis — bare-required fields resolve to a falsy concrete value', () => {
+  type Form = ReturnType<typeof useForm<typeof bareRequiredSchema>>
+  const formT = makeFormProxy<Form>()
+
+  it('z.string() (no default) → string (type)', () => {
+    expectTypeOf(formT.values.s).toEqualTypeOf<string>()
+  })
+  it('z.string() (no default) → "" (runtime)', () => {
+    const { api, unmount } = mountForm(() =>
+      useForm({ schema: bareRequiredSchema, key: uniqueKey('synth-str') })
+    )
+    try {
+      expect(api.values.s).toBe('')
+      expect(typeof api.values.s).toBe('string')
+    } finally {
+      unmount()
+    }
+  })
+
+  it('z.number() (no default) → number (type)', () => {
+    expectTypeOf(formT.values.n).toEqualTypeOf<number>()
+  })
+  it('z.number() (no default) → 0 (runtime)', () => {
+    const { api, unmount } = mountForm(() =>
+      useForm({ schema: bareRequiredSchema, key: uniqueKey('synth-num') })
+    )
+    try {
+      expect(api.values.n).toBe(0)
+      expect(typeof api.values.n).toBe('number')
+    } finally {
+      unmount()
+    }
+  })
+
+  it('z.boolean() (no default) → boolean (type)', () => {
+    expectTypeOf(formT.values.b).toEqualTypeOf<boolean>()
+  })
+  it('z.boolean() (no default) → false (runtime)', () => {
+    const { api, unmount } = mountForm(() =>
+      useForm({ schema: bareRequiredSchema, key: uniqueKey('synth-bool') })
+    )
+    try {
+      expect(api.values.b).toBe(false)
+      expect(typeof api.values.b).toBe('boolean')
+    } finally {
+      unmount()
+    }
+  })
+
+  it('z.array(z.string()) (no default) → string[] (type)', () => {
+    expectTypeOf(formT.values.arr).toEqualTypeOf<string[]>()
+  })
+  it('z.array(z.string()) (no default) → [] (runtime)', () => {
+    const { api, unmount } = mountForm(() =>
+      useForm({ schema: bareRequiredSchema, key: uniqueKey('synth-arr') })
+    )
+    try {
+      expect(api.values.arr).toEqual([])
+      expect(Array.isArray(api.values.arr)).toBe(true)
+    } finally {
+      unmount()
+    }
+  })
+})
+
+// ──────────────────────────────────────────────────────────────────────
+// Deep nested synthesis — invariant holds all the way down.
+// ──────────────────────────────────────────────────────────────────────
+
+const deepSchema = z.object({
+  user: z.object({
+    name: z.string(),
+    profile: z.object({
+      bio: z.string(),
+    }),
+  }),
+  a: z.object({
+    b: z.object({
+      c: z.object({
+        d: z.string(),
+      }),
+    }),
+  }),
+})
+
+describe('Synthesis — deep nested objects resolve recursively', () => {
+  type Form = ReturnType<typeof useForm<typeof deepSchema>>
+  const formT = makeFormProxy<Form>()
+
+  it('two-level descent — type stays strict', () => {
+    expectTypeOf(formT.values.user.name).toEqualTypeOf<string>()
+    expectTypeOf(formT.values.user.profile.bio).toEqualTypeOf<string>()
+  })
+  it('two-level descent — every leaf falsy-concrete at runtime', () => {
+    const { api, unmount } = mountForm(() =>
+      useForm({ schema: deepSchema, key: uniqueKey('deep-2') })
+    )
+    try {
+      expect(api.values.user.name).toBe('')
+      expect(api.values.user.profile.bio).toBe('')
+      expect(typeof api.values.user.name).toBe('string')
+      expect(typeof api.values.user.profile.bio).toBe('string')
+    } finally {
+      unmount()
+    }
+  })
+
+  it('four-level descent — type stays strict', () => {
+    expectTypeOf(formT.values.a.b.c.d).toEqualTypeOf<string>()
+  })
+  it('four-level descent does not short-circuit to undefined', () => {
+    const { api, unmount } = mountForm(() =>
+      useForm({ schema: deepSchema, key: uniqueKey('deep-4') })
+    )
+    try {
+      expect(api.values.a.b.c.d).toBe('')
+      expect(typeof api.values.a.b.c.d).toBe('string')
+    } finally {
+      unmount()
+    }
+  })
+})
+
+// ──────────────────────────────────────────────────────────────────────
+// Discriminated union — stub state before the discriminator is chosen.
+// ──────────────────────────────────────────────────────────────────────
+
+const duSchema = z.object({
+  tagged: z.discriminatedUnion('type', [
+    z.object({ type: z.literal('a'), a: z.string() }),
+    z.object({ type: z.literal('b'), b: z.number() }),
+  ]),
+})
+
+describe('Discriminated union — stub state before discriminator chosen', () => {
+  it('discriminator path is readable and falls in the literal union at runtime', () => {
+    const { api, unmount } = mountForm(() =>
+      useForm({ schema: duSchema, key: uniqueKey('du-stub') })
+    )
+    try {
+      expect(['a', 'b']).toContain(api.values.tagged.type)
+    } finally {
+      unmount()
+    }
+  })
+
+  it('active-variant leaf reads as its resolved falsy-concrete', () => {
+    const { api, unmount } = mountForm(() =>
+      useForm({ schema: duSchema, key: uniqueKey('du-leaf') })
+    )
+    try {
+      const active = api.values.tagged
+      if (active.type === 'a') {
+        expect(active.a).toBe('')
+        expect(typeof active.a).toBe('string')
+      } else if (active.type === 'b') {
+        expect(active.b).toBe(0)
+        expect(typeof active.b).toBe('number')
+      } else {
+        throw new Error(`unexpected DU stub variant: ${String(active.type)}`)
+      }
+    } finally {
+      unmount()
+    }
+  })
+})
+
+// ──────────────────────────────────────────────────────────────────────
+// Genuinely uncertain — invariant does NOT promise to peel these.
+// ──────────────────────────────────────────────────────────────────────
+
+const optionalSchema = z.object({ bio: z.string().optional() })
+const nullableSchema = z.object({ ref: z.string().nullable() })
+const arrSchema = z.object({ tags: z.array(z.string()) })
+
+describe('Genuinely uncertain — invariant does NOT promise to peel', () => {
+  it('z.string().optional() keeps `| undefined` at the type level', () => {
+    type Form = ReturnType<typeof useForm<typeof optionalSchema>>
+    const formT = makeFormProxy<Form>()
+    expectTypeOf(formT.values.bio).toEqualTypeOf<string | undefined>()
+  })
+  it('z.string().optional() — runtime behaviour documented', () => {
+    const { api, unmount } = mountForm(() =>
+      useForm({ schema: optionalSchema, key: uniqueKey('opt') })
+    )
+    try {
+      // Pin whatever the runtime returns today; the assertion's role is
+      // to document the synthesized value for optional-without-default,
+      // not to claim a target. Flip the matcher if a future intentional
+      // change in synthesis policy lands.
+      expect(api.values.bio).toBeUndefined()
+    } finally {
+      unmount()
+    }
+  })
+
+  it('z.string().nullable() keeps `| null` at the type level', () => {
+    type Form = ReturnType<typeof useForm<typeof nullableSchema>>
+    const formT = makeFormProxy<Form>()
+    expectTypeOf(formT.values.ref).toEqualTypeOf<string | null>()
+  })
+  it('z.string().nullable() — runtime behaviour documented', () => {
+    const { api, unmount } = mountForm(() =>
+      useForm({ schema: nullableSchema, key: uniqueKey('nul') })
+    )
+    try {
+      // Pin whatever the runtime returns today (likely null or
+      // undefined); the assertion documents synthesis for nullable-
+      // without-default.
+      const ref: unknown = api.values.ref
+      expect(ref === null || ref === undefined).toBe(true)
+    } finally {
+      unmount()
+    }
+  })
+
+  it('array element past length is `T | undefined` — noUncheckedIndexedAccess, not storage', () => {
+    type Form = ReturnType<typeof useForm<typeof arrSchema>>
+    const formT = makeFormProxy<Form>()
+    expectTypeOf(formT.values.tags[0]).toEqualTypeOf<string | undefined>()
+  })
+  it('array element past length — runtime is undefined (just the indexing edge)', () => {
+    const { api, unmount } = mountForm(() =>
+      useForm({ schema: arrSchema, key: uniqueKey('arr-edge') })
+    )
+    try {
+      expect(api.values.tags[0]).toBeUndefined()
+      expect(api.values.tags.length).toBe(0)
+    } finally {
+      unmount()
+    }
+  })
+})
+
+// ──────────────────────────────────────────────────────────────────────
+// preprocess / transform — write-boundary vs parse-time semantics.
+// ──────────────────────────────────────────────────────────────────────
+
+const preprocessSchema = z.object({
+  trimmed: z.preprocess((v) => (typeof v === 'string' ? v.trim() : v), z.string()),
+})
+
+const transformSchema = z.object({
+  letterCount: z.string().transform((s) => s.length),
+})
+
+describe('preprocess / transform — write-boundary vs parse-time semantics', () => {
+  it('z.preprocess(fn, z.string()) — type peels to inner-schema input', () => {
+    type Form = ReturnType<typeof useForm<typeof preprocessSchema>>
+    const formT = makeFormProxy<Form>()
+    // @ts-expect-error - POST-FIX (storage-shape): preprocess input shape
+    // peels to the inner schema's input (z.string() → string), not unknown.
+    expectTypeOf(formT.values.trimmed).toEqualTypeOf<string>()
+  })
+
+  // RED today: synthesis bails on preprocess wrappers and the field
+  // reads as `undefined`. POST-FIX, the blank-path skeleton descends
+  // through the preprocess wrapper to the inner schema's falsy — the
+  // storage invariant holds for preprocess slots too. `.fails` flips
+  // to a passing assertion when the synthesis path peels through.
+  it.fails(
+    'z.preprocess(fn, z.string()) — storage holds the inner-schema falsy, not undefined',
+    () => {
+      const { api, unmount } = mountForm(() =>
+        useForm({ schema: preprocessSchema, key: uniqueKey('pre-synth') })
+      )
+      try {
+        expect(api.values.trimmed).toBe('')
+        expect(typeof api.values.trimmed).toBe('string')
+      } finally {
+        unmount()
+      }
+    }
+  )
+
+  // RED today: preprocess throwing on a write leaves the field at
+  // `undefined` (or whatever the throw policy is). POST-FIX, the
+  // field falls back to a "reasonable value" — concrete sub-policy
+  // (inner-falsy vs prior-value) settled when the implementation
+  // lands. The narrow guarantee this probe pins: NEVER undefined.
+  it.fails('preprocess failure on write does not strand the field at undefined', () => {
+    const throwyPreprocess = z.object({
+      v: z.preprocess(() => {
+        throw new Error('preprocess refused')
+      }, z.string()),
+    })
+    const { api, unmount } = mountForm(() =>
+      useForm({ schema: throwyPreprocess, key: uniqueKey('pre-throw') })
+    )
+    try {
+      // Pre-write: synthesis path holds (inner falsy).
+      expect(api.values.v).toBe('')
+      // Write attempt that triggers the throw.
+      try {
+        api.setValue('v', 'anything')
+      } catch {
+        // Throw policy at the write boundary is open; the probe only
+        // pins the resulting storage state.
+      }
+      expect(api.values.v).not.toBeUndefined()
+      expect(typeof api.values.v).toBe('string')
+    } finally {
+      unmount()
+    }
+  })
+
+  it('z.string().transform(fn) — storage holds PRE-transform input (existing rationale)', () => {
+    type Form = ReturnType<typeof useForm<typeof transformSchema>>
+    const formT = makeFormProxy<Form>()
+    // Transforms run at parse, not at write. The storage view stays the
+    // input shape — string here, not number. This is the case the §1.1
+    // tightening DELIBERATELY leaves alone.
+    expectTypeOf(formT.values.letterCount).toEqualTypeOf<string>()
+  })
+
+  it('z.string().transform(fn) — runtime stores the pre-transform string', () => {
+    const { api, unmount } = mountForm(() =>
+      useForm({ schema: transformSchema, key: uniqueKey('tx') })
+    )
+    try {
+      expect(typeof api.values.letterCount).toBe('string')
+    } finally {
+      unmount()
+    }
+  })
+})

--- a/test/composables/values-storage-shape.test.ts
+++ b/test/composables/values-storage-shape.test.ts
@@ -14,11 +14,6 @@ import { createAttaform } from '../../src/runtime/core/plugin'
  * skeleton. Reads NEVER produce `undefined` for a slot the schema
  * resolved to a concrete type — and the static type SHOULD agree.
  *
- * Today, `form.values` is typed as `z.input<Schema>`, which leaves a
- * gap: `ZodDefault<T>`'s input is `T | undefined`, even though the
- * runtime resolves it to `T` at storage-init. That gap is the §1.1
- * "type lies" friction.
- *
  * Type-level assertions pin the surface so a future regression to
  * `z.input<Schema>`-only typing (or any drift in `ReadShape<>`) trips
  * `expectTypeOf` at compile time. Runtime assertions confirm the
@@ -447,32 +442,24 @@ describe('preprocess / transform — write-boundary vs parse-time semantics', ()
     expectTypeOf(formT.values.trimmed).toEqualTypeOf<string>()
   })
 
-  // RED today: synthesis bails on preprocess wrappers and the field
-  // reads as `undefined`. POST-FIX, the blank-path skeleton descends
-  // through the preprocess wrapper to the inner schema's falsy — the
-  // storage invariant holds for preprocess slots too. `.fails` flips
-  // to a passing assertion when the synthesis path peels through.
-  it.fails(
-    'z.preprocess(fn, z.string()) — storage holds the inner-schema falsy, not undefined',
-    () => {
-      const { api, unmount } = mountForm(() =>
-        useForm({ schema: preprocessSchema, key: uniqueKey('pre-synth') })
-      )
-      try {
-        expect(api.values.trimmed).toBe('')
-        expect(typeof api.values.trimmed).toBe('string')
-      } finally {
-        unmount()
-      }
+  it('z.preprocess(fn, z.string()) — storage holds the inner-schema falsy, not undefined', () => {
+    const { api, unmount } = mountForm(() =>
+      useForm({ schema: preprocessSchema, key: uniqueKey('pre-synth') })
+    )
+    try {
+      expect(api.values.trimmed).toBe('')
+      expect(typeof api.values.trimmed).toBe('string')
+    } finally {
+      unmount()
     }
-  )
+  })
 
   // RED today: preprocess throwing on a write leaves the field at
   // `undefined` (or whatever the throw policy is). POST-FIX, the
   // field falls back to a "reasonable value" — concrete sub-policy
   // (inner-falsy vs prior-value) settled when the implementation
   // lands. The narrow guarantee this probe pins: NEVER undefined.
-  it.fails('preprocess failure on write does not strand the field at undefined', () => {
+  it('preprocess failure on write does not strand the field at undefined', () => {
     const throwyPreprocess = z.object({
       v: z.preprocess(() => {
         throw new Error('preprocess refused')

--- a/test/composables/values-storage-shape.test.ts
+++ b/test/composables/values-storage-shape.test.ts
@@ -19,13 +19,11 @@ import { createAttaform } from '../../src/runtime/core/plugin'
  * runtime resolves it to `T` at storage-init. That gap is the §1.1
  * "type lies" friction.
  *
- * RED-today markers: every type-level assertion in the deltas below
- * carries `@ts-expect-error - POST-FIX (storage-shape)`. Once the
- * `StorageShape<Schema>` mapped type lands, those directives become
- * invalid (TS2578) and force co-removal in the fix commit. Runtime
- * assertions stay unmarked — the storage invariant already holds at
- * runtime; this matrix exists to ensure the static type catches up
- * AND to flag any runtime corner that contradicts the invariant.
+ * Type-level assertions pin the surface so a future regression to
+ * `z.input<Schema>`-only typing (or any drift in `ReadShape<>`) trips
+ * `expectTypeOf` at compile time. Runtime assertions confirm the
+ * storage invariant holds end-to-end; together the matrix is the
+ * cross-check that the static type and the runtime agree.
  *
  * Out-of-scope edges (kept here as guardrails, not bugs):
  *  - `ZodOptional<T>` without a default — genuinely optional; type
@@ -94,7 +92,6 @@ describe('ZodDefault — type peels `| undefined`, runtime resolves the default'
   const formT = makeFormProxy<Form>()
 
   it('z.boolean().default(true) → boolean (type)', () => {
-    // @ts-expect-error - POST-FIX (storage-shape): should be `boolean`
     expectTypeOf(formT.values.flag).toEqualTypeOf<boolean>()
   })
   it('z.boolean().default(true) → true (runtime)', () => {
@@ -110,7 +107,6 @@ describe('ZodDefault — type peels `| undefined`, runtime resolves the default'
   })
 
   it('z.number().default(0) → number (type)', () => {
-    // @ts-expect-error - POST-FIX (storage-shape): should be `number`
     expectTypeOf(formT.values.count).toEqualTypeOf<number>()
   })
   it('z.number().default(0) → 0 (runtime)', () => {
@@ -126,7 +122,6 @@ describe('ZodDefault — type peels `| undefined`, runtime resolves the default'
   })
 
   it('z.string().default("attaform") → string (type)', () => {
-    // @ts-expect-error - POST-FIX (storage-shape): should be `string`
     expectTypeOf(formT.values.name).toEqualTypeOf<string>()
   })
   it('z.string().default("attaform") → "attaform" (runtime)', () => {
@@ -142,7 +137,6 @@ describe('ZodDefault — type peels `| undefined`, runtime resolves the default'
   })
 
   it('z.array(z.string()).default([]) → string[] (type)', () => {
-    // @ts-expect-error - POST-FIX (storage-shape): should be `string[]`
     expectTypeOf(formT.values.tags).toEqualTypeOf<string[]>()
   })
   it('z.array(z.string()).default([]) → [] (runtime)', () => {
@@ -158,9 +152,7 @@ describe('ZodDefault — type peels `| undefined`, runtime resolves the default'
   })
 
   it('nested ZodDefault — type resolves inner shape', () => {
-    // @ts-expect-error - POST-FIX (storage-shape): should be `{ enabled: boolean; label: string }`
     expectTypeOf(formT.values.config).toEqualTypeOf<{ enabled: boolean; label: string }>()
-    // @ts-expect-error - POST-FIX (storage-shape): should be `boolean`
     expectTypeOf(formT.values.config.enabled).toEqualTypeOf<boolean>()
   })
   it('nested ZodDefault — runtime resolves the inner shape', () => {
@@ -169,7 +161,6 @@ describe('ZodDefault — type peels `| undefined`, runtime resolves the default'
     )
     try {
       expect(api.values.config).toEqual({ enabled: true, label: 'default-label' })
-      // @ts-expect-error - POST-FIX (storage-shape): config is non-undefined post-default-resolution
       expect(api.values.config.enabled).toBe(true)
     } finally {
       unmount()
@@ -453,8 +444,6 @@ describe('preprocess / transform — write-boundary vs parse-time semantics', ()
   it('z.preprocess(fn, z.string()) — type peels to inner-schema input', () => {
     type Form = ReturnType<typeof useForm<typeof preprocessSchema>>
     const formT = makeFormProxy<Form>()
-    // @ts-expect-error - POST-FIX (storage-shape): preprocess input shape
-    // peels to the inner schema's input (z.string() → string), not unknown.
     expectTypeOf(formT.values.trimmed).toEqualTypeOf<string>()
   })
 

--- a/test/utils/fake-schema.ts
+++ b/test/utils/fake-schema.ts
@@ -80,6 +80,13 @@ export function fakeSchema<F extends GenericForm>(
       }
       return current
     },
+    getEmptyValueAtPath() {
+      // fakeSchema can't model per-type empty values without per-leaf
+      // schemas. Return `undefined` so `form.clear` no-ops under the
+      // fake adapter — callers needing real empty-value semantics
+      // should use a Zod adapter.
+      return undefined
+    },
     arrayShapeAtPath(path) {
       // fakeSchema can't model element schemas — return `undefined` so
       // the runtime falls back to the legacy probe loop, matching the


### PR DESCRIPTION
## Summary

Closes the substantive items in the 2026-05-12 feedback doc on Attaform 0.17.0. Four code/test commits plus a docs commit, fully addressed across both Zod adapters and verified in Docker (`2469 passing, 0 failed`).

### What landed

- **`ReadShape<Schema>`** — new mapped type powering a richer `form.values` typing. Defaults peel `| undefined`, preprocess slots peel to inner-schema input, `.optional()` / `.nullable()` keep their genuine modifiers, `.transform()` stays at input shape. Wired through a new third generic slot on `UseFormReturnType` (defaults to `Form` for back-compat); mirrored in `zod-v3` + `zod-v4`. Closes §1.1.

- **Storage-shape probe matrix** — 45 paired type-level + runtime probes across both adapters pin the invariant ("`form.values.<path>` always returns the resolved concrete type storage holds"). Surfaced one runtime gap: preprocess synthesis returned `undefined` because the slim-schema path was descending to the in-side of the pipe (the user's transform fn) instead of the out-side (the inner schema). Fixed in `default-values.ts` + `strip.ts`. Closes §1.2.

- **`form.clear(path?)`** — new public surface. Wipes a path (or the whole form when called with no arg) to the type's falsy concrete, regardless of any `.default()` wrapper. Sugar over `setValue(path, schema.getEmptyValueAtPath(path))` — no separate bookkeeping. Orthogonal to `reset` / `resetField`: `reset` restores declared defaults; `clear` ignores them and writes `false` / `0` / `''` / `[]` / recursively-empty object. `.optional()` clears to `undefined`, `.nullable()` clears to `null`. `clear('')` SPECIFICALLY targets the empty-string slot (matching `touch('')`'s disambiguation from #184). Closes §2.1.

- **Docs** — new `storage-shape` recipe covering the three-shape mental model (write input / read storage / submit output), the `ReadShape` policy table, blank-path synthesis, edge cases, and the `reset` vs `clear` orthogonality. Persistence recipe gets a "Scope" section drawing the boundary between form-state persistence (model as schema, use `form.persist('path')`) and generic state (use VueUse's `useStorage`). Closes §4.1 + §4.3 (docs) and closes §2.2 + §3.2 without new code.

### What's out

§5 (bus factor, pre-1.0 plan, SEO) — dropped per the author's call; not code-side. §3.1 (drop schema-generated forms) — already the maintainer's position, no roadmap change needed. §3.3 (error rendering) — already covered by the existing `showErrors` / `firstError` recipe.

## Commits

```
b9ce7f6 docs: storage-shape recipe + scope boundary on persistence
855f507 feat(form): add form.clear(path?) — wipe to falsy-for-type
46d8ed5 fix(form): preprocess synthesis respects the storage invariant
034207e feat(form): align form.values type with runtime storage via ReadShape
f22aa44 test(form): pin storage-shape invariant for form.values reads
```

## Test plan

- [x] Storage-shape probes pass v4 + v3 (45/45 green, no `.fails`, no `@ts-expect-error` markers)
- [x] `form.clear` probes pass v4 + v3 (25/25 green; covers primitive leaves, nested descent, `.optional()` → `undefined`, `.nullable()` → `null`, whole-form, `clear('')` vs `clear()` disambiguation, orthogonality with `reset`)
- [x] Full suite in Docker (`docker compose run --rm --no-deps --service-ports=false attaform sh -c 'pnpm vitest run'`) — 2469 passing, 16 skipped, 0 failed
- [x] tsc + site typecheck both clean
- [ ] Verify Vercel preview builds the new recipe and the persistence recipe renders the new section
- [ ] Smoke-test `form.clear` and `form.values.<defaulted-field>` in the docs playground

🤖 Generated with [Claude Code](https://claude.com/claude-code)