### PR TITLE
fix(form): v3 parity through the unified attaform/zod entry

### DIFF
--- a/src/runtime/adapters/unified/use-form.ts
+++ b/src/runtime/adapters/unified/use-form.ts
@@ -5,6 +5,22 @@
  * to the v3 wrapper, which already accepts both Zod v3 input and
  * `AbstractSchema` directly via its built-in shape branch.
  *
+ * Type-level dispatch happens through a single signature with a
+ * union constraint — `Schema extends z.ZodObject |
+ * zV3.ZodObject<zV3.ZodRawShape>`. The configuration parameter and
+ * return type both dispatch conditionally on whether `Schema` is a
+ * v4 or v3 object. The two majors don't structurally satisfy each
+ * other's `ZodObject` constraints (v4 has `loose` / `safeExtend` /
+ * `def` / `type` members v3 lacks), so neither alone is enough — the
+ * union accepts both, and the conditional return type routes through
+ * the matching adapter's `StorageShape` / `z.input` / `z.output`.
+ *
+ * A single signature (rather than overloads) keeps `typeof
+ * useForm<X>` instantiation expressions in test code unambiguous:
+ * TypeScript's overload-resolution rules for these expressions are
+ * brittle when multiple overloads partially match, so we collapse to
+ * one signature.
+ *
  * This module is the FALLBACK path. Vite consumers see the
  * `attaform/vite` plugin's `resolveId` hook rewrite `attaform/zod`
  * imports to either `attaform/zod-v3` or `attaform/zod-v4` at build
@@ -19,11 +35,14 @@
  * adapter.
  */
 import type { z } from 'zod'
+import type { z as zV3 } from 'zod-v3'
 import { InvalidUseFormConfigError } from '../../core/errors'
 import { isZodV4SchemaShape } from '../../core/zod-shape'
 import { useForm as useFormV3 } from '../../composables/use-form'
 import { useForm as useFormV4 } from '../zod-v4'
-import type { StorageShape } from '../zod-v4/types-storage-shape'
+import type { StorageShape as StorageShapeV4 } from '../zod-v4/types-storage-shape'
+import type { StorageShape as StorageShapeV3 } from '../zod-v3/types-storage-shape'
+import type { UnwrapZodObject } from '../zod-v3/types-zod-adapter'
 import type {
   AbstractSchema,
   ValidateOnConfig,
@@ -32,15 +51,74 @@ import type {
 } from '../../types/types-api'
 import type { DeepPartial, DefaultValuesShape, GenericForm } from '../../types/types-core'
 
+// ───────────────────────────────────────────────────────────────────
+// Per-major projections. Each dispatches a single Schema to the
+// matching adapter's input / output / storage-shape slot. The
+// trailing `never` arms catch the "other major" case so an isolated
+// instantiation stays well-formed; the union constraint on the
+// public signature guarantees one arm always fires.
+// ───────────────────────────────────────────────────────────────────
+
+type FormInput<Schema> = Schema extends z.ZodObject
+  ? z.input<Schema> extends GenericForm
+    ? z.input<Schema>
+    : never
+  : Schema extends zV3.ZodObject<zV3.ZodRawShape>
+    ? zV3.input<UnwrapZodObject<Schema>> extends GenericForm
+      ? zV3.input<UnwrapZodObject<Schema>>
+      : never
+    : never
+
+type FormOutput<Schema> = Schema extends z.ZodObject
+  ? z.output<Schema> extends GenericForm
+    ? z.output<Schema>
+    : never
+  : Schema extends zV3.ZodObject<zV3.ZodRawShape>
+    ? zV3.output<UnwrapZodObject<Schema>> extends GenericForm
+      ? zV3.output<UnwrapZodObject<Schema>>
+      : never
+    : never
+
+type FormStorageShape<Schema> = Schema extends z.ZodObject
+  ? StorageShapeV4<Schema> extends GenericForm
+    ? StorageShapeV4<Schema>
+    : never
+  : Schema extends zV3.ZodObject<zV3.ZodRawShape>
+    ? StorageShapeV3<UnwrapZodObject<Schema>> extends GenericForm
+      ? StorageShapeV3<UnwrapZodObject<Schema>>
+      : never
+    : never
+
+// Single unified configuration shape. The outer structure is
+// non-conditional (so TS can resolve it for any Schema satisfying
+// the union constraint, including generic `F extends z.ZodObject`
+// helpers in test code); only the field-level types dispatch on
+// Schema kind via `FormInput` / `FormOutput`. The runtime cast
+// passes the configuration through unchanged — each adapter's own
+// signature absorbs the residual structural drift.
+type UnifiedConfiguration<Schema> = Omit<
+  UseFormConfiguration<
+    FormInput<Schema>,
+    FormOutput<Schema>,
+    AbstractSchema<FormInput<Schema>, FormOutput<Schema>>,
+    DeepPartial<DefaultValuesShape<FormInput<Schema>>>
+  >,
+  'schema' | 'validateOn' | 'debounceMs'
+> & { schema: Schema } & ValidateOnConfig
+
 /**
  * Create a form bound to a Zod schema. Accepts both Zod v3 and Zod v4
  * schemas; the runtime picks the right adapter from the schema's
  * shape.
  *
- * Type inference targets Zod v4 — the recommended major. Consumers
- * still on Zod v3 get correct runtime behavior here, but the strongest
- * TypeScript inference comes from importing `attaform/zod-v3`
- * directly.
+ * Type inference works transparently for both Zod v3 and Zod v4
+ * schemas — the adapter is selected from the schema's shape at both
+ * runtime and type-check time. `form.values`, `form.fields`,
+ * `register`, and the `handleSubmit` callback data type all resolve
+ * against the matching adapter's storage shape; consumers don't need
+ * to reach for `attaform/zod-v3` or `attaform/zod-v4` to get full
+ * inference. Those subpath entries remain as lean-bundle escape
+ * hatches for non-Vite tooling, not correctness escape hatches.
  *
  * ```ts
  * import { useForm } from 'attaform/zod'
@@ -54,24 +132,9 @@ import type { DeepPartial, DefaultValuesShape, GenericForm } from '../../types/t
  * })
  * ```
  */
-export function useForm<Schema extends z.ZodObject>(
-  configuration: Omit<
-    UseFormConfiguration<
-      z.input<Schema> extends GenericForm ? z.input<Schema> : never,
-      z.output<Schema> extends GenericForm ? z.output<Schema> : never,
-      AbstractSchema<
-        z.input<Schema> extends GenericForm ? z.input<Schema> : never,
-        z.output<Schema> extends GenericForm ? z.output<Schema> : never
-      >,
-      DeepPartial<DefaultValuesShape<z.input<Schema> extends GenericForm ? z.input<Schema> : never>>
-    >,
-    'schema' | 'validateOn' | 'debounceMs'
-  > & { schema: Schema } & ValidateOnConfig
-): UseFormReturnType<
-  z.input<Schema> extends GenericForm ? z.input<Schema> : never,
-  z.output<Schema> extends GenericForm ? z.output<Schema> : never,
-  StorageShape<Schema> extends GenericForm ? StorageShape<Schema> : never
-> {
+export function useForm<Schema extends z.ZodObject | zV3.ZodObject<zV3.ZodRawShape>>(
+  configuration: UnifiedConfiguration<Schema>
+): UseFormReturnType<FormInput<Schema>, FormOutput<Schema>, FormStorageShape<Schema>> {
   // Foot-gun guard mirrors the typed wrappers'.
   if (
     configuration === undefined ||
@@ -83,14 +146,19 @@ export function useForm<Schema extends z.ZodObject>(
 
   const { schema } = configuration as { schema: unknown }
   if (isZodV4SchemaShape(schema)) {
-    return useFormV4(configuration as Parameters<typeof useFormV4<Schema>>[0]) as ReturnType<
-      typeof useForm<Schema>
+    return useFormV4(
+      configuration as Parameters<typeof useFormV4>[0]
+    ) as unknown as UseFormReturnType<
+      FormInput<Schema>,
+      FormOutput<Schema>,
+      FormStorageShape<Schema>
     >
   }
   // Anything else (Zod v3 schema, custom AbstractSchema, schema
   // factory) goes through the v3 wrapper, which already accepts both
   // Zod v3 input and AbstractSchema directly via its existing shape
-  // branch. Cast through unknown — the unified entry's TS surface
-  // tracks v4, but the runtime accepts the broader shape.
-  return useFormV3(configuration as never) as unknown as ReturnType<typeof useForm<Schema>>
+  // branch.
+  return useFormV3(
+    configuration as Parameters<typeof useFormV3>[0]
+  ) as unknown as UseFormReturnType<FormInput<Schema>, FormOutput<Schema>, FormStorageShape<Schema>>
 }

--- a/src/runtime/composables/use-form.ts
+++ b/src/runtime/composables/use-form.ts
@@ -64,7 +64,9 @@ export function useForm<Form extends GenericForm, GetValueFormType extends Gener
  */
 export function useForm<
   Schema extends z.ZodObject<z.ZodRawShape>,
-  GetValueFormType extends GenericForm = TypeWithNullableDynamicKeys<Schema>,
+  GetValueFormType extends GenericForm = z.output<UnwrapZodObject<Schema>> extends GenericForm
+    ? z.output<UnwrapZodObject<Schema>>
+    : never,
 >(
   configuration: UseFormConfigurationWithZod<
     Schema,
@@ -136,12 +138,16 @@ export function useForm<
       AbstractSchema<Form, GetValueFormType>,
       DeepPartial<DefaultValuesShape<Form>>
     >),
-    // The v3 adapter widens the read-side type through
-    // `TypeWithNullableDynamicKeys<Schema>` (records/arrays/DUs get
-    // `| undefined` markers); useAbstractForm's parameter expects the
-    // exact `GetValueFormType` (defaults to `Form`). The runtime
-    // accepts the widened shape unchanged — cast across the gap so
-    // the structural disagreement doesn't reach the caller.
+    // `zodAdapter`'s constraint on its third generic is
+    // `GetValueFormType extends TypeWithNullableDynamicKeys<FormSchema>`,
+    // and `Schema` at this implementation overload is only constrained
+    // by `extends z.ZodSchema<unknown>` — too loose for
+    // `z.output<UnwrapZodObject<typeof schema>>` to resolve concretely.
+    // Pass `TypeWithNullableDynamicKeys<typeof schema>` here purely to
+    // satisfy the adapter's constraint at the structural-cast layer.
+    // The PUBLIC signature's `GetValueFormType` default (line 67) is
+    // what consumers see — that's `z.output<UnwrapZodObject<Schema>>`,
+    // matching the docstring promise. Runtime is unaffected either way.
     schema: abstractSchema as
       | AbstractSchema<Form, GetValueFormType>
       | ((key: FormKey, options: SchemaFactoryOptions) => AbstractSchema<Form, GetValueFormType>),

--- a/test/composables/values-storage-shape-v3.test.ts
+++ b/test/composables/values-storage-shape-v3.test.ts
@@ -3,6 +3,7 @@ import { createApp, defineComponent, h } from 'vue'
 import { describe, expect, expectTypeOf, it } from 'vitest'
 import { z } from 'zod-v3'
 import { useForm } from '../../src/zod-v3'
+import { useForm as useFormUnified } from '../../src/zod'
 import { createAttaform } from '../../src/runtime/core/plugin'
 
 /**
@@ -206,6 +207,245 @@ describe('v3 — Genuinely uncertain edges', () => {
     const { api, unmount } = mountWith(() => useForm({ schema, key: uniqueKey('nul') }))
     try {
       expectTypeOf(api.values.ref).toEqualTypeOf<string | null>()
+    } finally {
+      unmount()
+    }
+  })
+})
+
+// ──────────────────────────────────────────────────────────────────────
+// Unified entry (`attaform/zod`) + v3 schema. The unified entry's
+// `StorageShape` previously resolved against v4's `_zod.def.*`
+// discriminant only — v3 schemas missed every branch and collapsed
+// `form.values` to `never`. These probes pin that regression: v3
+// schemas reaching the unified entry must resolve through v3's own
+// storage-shape via the discriminating dispatch in
+// `src/runtime/adapters/unified/types-storage-shape.ts`.
+// ──────────────────────────────────────────────────────────────────────
+
+describe('Unified entry — v3 schema inference (Friction 1 regression)', () => {
+  it('boolean.default + array — form.values resolves concretely, not never', () => {
+    const schema = z.object({
+      flag: z.boolean().default(true),
+      items: z.array(z.string()),
+    })
+    const { api, unmount } = mountWith(() =>
+      useFormUnified({ schema, key: uniqueKey('unified-v3-simple') })
+    )
+    try {
+      expectTypeOf(api.values.flag).toEqualTypeOf<boolean>()
+      expectTypeOf(api.values.items).toEqualTypeOf<string[]>()
+      expect(api.values.flag).toBe(true)
+      expect(api.values.items).toEqual([])
+    } finally {
+      unmount()
+    }
+  })
+
+  it('nested object descent resolves under the v3 storage-shape', () => {
+    const schema = z.object({
+      user: z.object({
+        name: z.string(),
+        age: z.number().default(0),
+      }),
+    })
+    const { api, unmount } = mountWith(() =>
+      useFormUnified({ schema, key: uniqueKey('unified-v3-nested') })
+    )
+    try {
+      expectTypeOf(api.values.user.name).toEqualTypeOf<string>()
+      expectTypeOf(api.values.user.age).toEqualTypeOf<number>()
+      expect(api.values.user.name).toBe('')
+      expect(api.values.user.age).toBe(0)
+    } finally {
+      unmount()
+    }
+  })
+})
+
+// ──────────────────────────────────────────────────────────────────────
+// Depth-pressure regression — multi-step booking schema (v3 mirror of
+// the shipment-demo probe in `values-storage-shape.test.ts`). The v3
+// `StorageShape` is a single mapped type with a per-key conditional
+// (`ZodEffects | ZodPipeline` vs not). This probe holds the TS2589
+// canary: if instantiation depth ever explodes through the unified
+// entry's v3 branch, this is where it surfaces first.
+// ──────────────────────────────────────────────────────────────────────
+
+describe('Depth pressure — multi-step booking schema (unified entry + v3)', () => {
+  const COUNTRIES = ['US', 'CA', 'MX', 'GB', 'DE', 'FR', 'JP', 'CN', 'AU'] as const
+  const HAZARD_CLASSES = ['1', '2', '3', '4', '5', '6', '7', '8', '9'] as const
+  const TRUCK_TYPES = ['box', 'flatbed', 'reefer', 'tanker'] as const
+  const CONTAINER_SIZES = ['20FT', '40FT', '40FTHC', '45FTHC'] as const
+  const COVERAGES = ['none', 'basic', 'full'] as const
+
+  const addressSchema = z.object({
+    line1: z.string().min(1),
+    line2: z.string().optional(),
+    city: z.string().min(1),
+    region: z.string().min(2),
+    postalCode: z.string().min(3),
+    country: z.enum(COUNTRIES),
+  })
+  const lineItemSchema = z.object({
+    sku: z.string(),
+    description: z.string().min(1).max(120),
+    quantity: z.number().int().min(1).max(10_000),
+    unitWeightLb: z.number().positive(),
+  })
+  const dryDetails = z.object({ type: z.literal('dry'), fragile: z.boolean() })
+  const refrigeratedDetails = z.object({
+    type: z.literal('refrigerated'),
+    tempMinF: z.number(),
+    tempMaxF: z.number(),
+  })
+  const hazmatDetails = z.object({
+    type: z.literal('hazmat'),
+    unNumber: z.string(),
+    hazardClass: z.enum(HAZARD_CLASSES),
+    acknowledged: z.literal(true),
+  })
+  const oversizedDetails = z.object({
+    type: z.literal('oversized'),
+    lengthIn: z.number().positive(),
+    widthIn: z.number().positive(),
+    heightIn: z.number().positive(),
+    permitNumber: z.string().optional(),
+  })
+  const cargoSchema = z.object({
+    items: z.array(lineItemSchema).min(1),
+    details: z.discriminatedUnion('type', [
+      dryDetails,
+      refrigeratedDetails,
+      hazmatDetails,
+      oversizedDetails,
+    ]),
+  })
+  const truckService = z.object({
+    mode: z.literal('truck'),
+    truckType: z.enum(TRUCK_TYPES),
+    liftgate: z.boolean(),
+  })
+  const airService = z.object({
+    mode: z.literal('air'),
+    airline: z.string().min(2),
+    awbPrefix: z.string(),
+  })
+  const oceanService = z.object({
+    mode: z.literal('ocean'),
+    vessel: z.string().min(2),
+    containerSize: z.enum(CONTAINER_SIZES),
+  })
+  const serviceSchema = z.discriminatedUnion('mode', [truckService, airService, oceanService])
+
+  const shipmentSchema = z.object({
+    reference: z.string(),
+    pickup: addressSchema,
+    delivery: addressSchema,
+    useSameDeliveryAddress: z.boolean(),
+    cargo: cargoSchema,
+    service: serviceSchema,
+    desiredPickupDate: z.string().min(1),
+    desiredDeliveryDate: z.string().min(1),
+    insurance: z.object({
+      declaredValueUSD: z.number().min(0),
+      coverage: z.enum(COVERAGES),
+    }),
+    notes: z.string().max(500).optional(),
+  })
+
+  it('top-level scalars resolve without TS2589', () => {
+    const { api, unmount } = mountWith(() =>
+      useFormUnified({
+        schema: shipmentSchema,
+        key: uniqueKey('unified-v3-shipment'),
+        defaultValues: {
+          reference: 'SHP-V3-0001',
+          cargo: { items: [], details: { type: 'dry', fragile: false } },
+          service: { mode: 'truck', truckType: 'box', liftgate: false },
+          insurance: { declaredValueUSD: 0, coverage: 'basic' },
+          pickup: { country: 'US' },
+          delivery: { country: 'US' },
+          useSameDeliveryAddress: false,
+        },
+      })
+    )
+    try {
+      expectTypeOf(api.values.reference).toEqualTypeOf<string>()
+      expectTypeOf(api.values.useSameDeliveryAddress).toEqualTypeOf<boolean>()
+      expect(api.values.reference).toBe('SHP-V3-0001')
+      expect(api.values.useSameDeliveryAddress).toBe(false)
+    } finally {
+      unmount()
+    }
+  })
+
+  it('nested address objects descend through the v3 storage-shape', () => {
+    const { api, unmount } = mountWith(() =>
+      useFormUnified({
+        schema: shipmentSchema,
+        key: uniqueKey('unified-v3-shipment-nested'),
+        defaultValues: {
+          cargo: { items: [], details: { type: 'dry', fragile: false } },
+          service: { mode: 'truck', truckType: 'box', liftgate: false },
+          insurance: { declaredValueUSD: 0, coverage: 'basic' },
+          pickup: { country: 'US' },
+          delivery: { country: 'US' },
+          useSameDeliveryAddress: false,
+        },
+      })
+    )
+    try {
+      expectTypeOf(api.values.pickup.city).toEqualTypeOf<string>()
+      expectTypeOf(api.values.delivery.region).toEqualTypeOf<string>()
+      expectTypeOf(api.values.notes).toEqualTypeOf<string | undefined>()
+    } finally {
+      unmount()
+    }
+  })
+})
+
+// ──────────────────────────────────────────────────────────────────────
+// `handleSubmit` callback data — must match `z.output<Schema>`, not
+// `TypeWithNullableDynamicKeys<Schema>`. Previously the v3
+// `useForm`'s second generic defaulted to the widening type,
+// surfacing `(T | undefined)[]` for any array leaf post-parse — a
+// type-lie at the most consumer-facing surface in the v3 path.
+// ──────────────────────────────────────────────────────────────────────
+
+describe('v3 — handleSubmit callback data matches z.output<Schema> (Friction 2 regression)', () => {
+  it('z.array(z.string().transform(...)) — data is string[], not (string | undefined)[]', () => {
+    const schema = z.object({
+      urls: z
+        .array(
+          z.string().transform((val, ctx) => {
+            if (!/^https?:\/\//.test(val)) {
+              ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Invalid URL' })
+              return z.NEVER
+            }
+            return val
+          })
+        )
+        .min(1),
+    })
+    const { api: _api, unmount } = mountWith(() => useForm({ schema, key: uniqueKey('hs-urls') }))
+    try {
+      type CallbackData = Parameters<Parameters<typeof _api.handleSubmit>[0]>[0]
+      expectTypeOf<CallbackData>().toEqualTypeOf<z.output<typeof schema>>()
+    } finally {
+      unmount()
+    }
+  })
+
+  it('nested record / array combinations — data matches z.output, no `| undefined` widening', () => {
+    const schema = z.object({
+      tags: z.array(z.string()),
+      meta: z.record(z.string(), z.number()),
+    })
+    const { api: _api, unmount } = mountWith(() => useForm({ schema, key: uniqueKey('hs-tags') }))
+    try {
+      type CallbackData = Parameters<Parameters<typeof _api.handleSubmit>[0]>[0]
+      expectTypeOf<CallbackData>().toEqualTypeOf<z.output<typeof schema>>()
     } finally {
       unmount()
     }


### PR DESCRIPTION
## Summary

Two type-system bugs surfaced during 0.17.1 dogfooding on a real Zod 3.25 / Vue 3.5 / vue-tsc 3.2 project. Both broke at the most consumer-facing surfaces in the v3 path. This PR fixes both, threading v3 through the same care v4 just got in #197.

### Friction 1 — Unified `attaform/zod` entry collapsed for Zod v3 schemas

The unified entry's `StorageShape` only matched on v4's `_zod.def.*` discriminant. A v3 schema missed every branch and fell through to `never`, surfacing TS2339 (`Property 'X' does not exist on type 'never'`) on every property access. The runtime worked correctly; the type-side hit was harder than the docstring suggested.

Compounding factor: v3 schemas don't structurally satisfy v4's `z.ZodObject` constraint either (v4 has `loose` / `safeExtend` / `def` / `type` members v3 lacks). So even adding a discriminating `StorageShape` wasn't enough — the signature constraint itself rejected v3 schemas.

### Friction 2 — v3 `handleSubmit` data type contradicted its docstring

The v3 `useForm` defaulted `GetValueFormType` to `TypeWithNullableDynamicKeys<Schema>`. That generic walks arrays / records / DUs and widens every descendant leaf with `| undefined`. The public docstring promised `z.output<Schema>`. Result: `data.tags` for any `z.array(z.string())` schema types as `(string | undefined)[]` post-parse — fictional, since validation rejected any actual undefined elements at the boundary.

## Fix

### Unified entry — single signature, union constraint

`src/runtime/adapters/unified/use-form.ts` now uses a single signature with a union constraint (`Schema extends z.ZodObject | zV3.ZodObject<zV3.ZodRawShape>`) and conditional field-level dispatch via `FormInput<Schema>` / `FormOutput<Schema>` / `FormStorageShape<Schema>`. Each helper routes through the matching adapter's `z.input` / `z.output` / `StorageShape`.

Single signature (vs overloads) keeps `typeof useForm<X>` instantiation expressions in test code unambiguous — TS's overload-resolution for those expressions partially-matched both v3 and v4 in confusing ways. One signature, one resolution path.

The configuration parameter is also non-conditional at the outer level (`UnifiedConfiguration<Schema>` always resolves to the same shape); only the field-level types dispatch on Schema kind. This lets generic test helpers like `function setupForm<F extends z.ZodObject>(schema: F, ...)` resolve their `useForm({ schema, ... })` calls without TS choking on a conditional parameter type.

### v3 `useForm` — honest `handleSubmit` data type

`src/runtime/composables/use-form.ts:66` — `GetValueFormType` now defaults to `z.output<UnwrapZodObject<Schema>>` (with `extends GenericForm ? … : never` guard, mirroring the v4 path). The structural cast inside the implementation overload (line ~115) retains `TypeWithNullableDynamicKeys<typeof schema>` purely to satisfy `zodAdapter`'s constraint at that internal call site — `Schema` is too loose there for the new default to resolve concretely. Runtime is unchanged either way.

`TypeWithNullableDynamicKeys` stays publicly importable as a power-user opt-in to looser typing.

## Test plan

- [x] `test/composables/values-storage-shape-v3.test.ts` — appended:
  - Unified entry + v3 schema: feedback's exact failing case (`z.boolean().default(true) + z.array(z.string())`) — `form.values.flag: boolean`, `form.values.items: string[]`, both non-`never`.
  - Unified entry + v3 schema: nested object descent.
  - Unified entry + v3 schema: multi-step booking schema depth-pressure mirror (TS2589 canary).
  - v3-direct `handleSubmit`: array-with-transform — `data.urls: string[]`, no `| undefined` widening.
  - v3-direct `handleSubmit`: array + record — matches `z.output<typeof schema>`.
- [x] `pnpm vitest run` — 2508 tests, 159 files, all green.
- [x] `pnpm typecheck` — workspace clean.
- [x] `apps/site` `vue-tsc --noEmit` — clean.
- [x] `pnpm lint` — clean.
- [x] `pnpm bundle:repl` — playground type bundle regenerated; bundled `zod.d.ts` carries `FormInput` / `FormOutput` / `FormStorageShape` / `UnifiedConfiguration` with both `z$1` (v4) and `z` (v3) namespaces.

## Scope guard

- `TypeWithNullableDynamicKeys` stays public at `src/zod-v3.ts:39`. No deprecation, no removal. Consumers wanting the loose shape pass it explicitly as the second generic.
- v4's `StorageShape` is untouched (just landed in #197).
- No runtime adapter changes — every edit is in type position.

## Release framing

Type-only, no runtime breakage, no consumer API removal. Reads as a 0.17.2 patch. The two workarounds from the dogfooding feedback (switch import path; pin `GetValueFormType` generic) come out cleanly on consumer bump — no semver pressure from their side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)