### PR TITLE
feat(form): defaultValues trichotomy + form.rehydrate() + meta extensions

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -212,7 +212,17 @@ export default [
     // WriteMeta.crossTab/persist threading, noSyncPaths opt-out,
     // sensitive-names factory refactor, insecure-context-warn helper,
     // reset() 4-part hardening). Measured at 47.5 KB.
-    limit: '48 KB',
+    //
+    // Raised 48 → 49 KB on the defaultValues-trichotomy branch:
+    //   - resolveTrichotomy classifier in core/
+    //   - useAbstractForm trichotomy branch + microtask/onServerPrefetch
+    //     settle path + pendingHydration re-fire guard
+    //   - FormStore.defaultValuesFactory + isHydrating + hydrateError
+    //     refs + rehydrate() method that re-fires the captured factory
+    //     and re-applies via applyFormReplacement({ hydration: true })
+    //   - meta.errorCount + meta.isSubmitted computed siblings
+    // Measured at 48.03 KB.
+    limit: '49 KB',
     gzip: true,
     ignore: ['zod'],
     modifyEsbuildConfig: asEsm,
@@ -232,7 +242,10 @@ export default [
     //
     // Raised 36 → 42 KB tracking index.mjs's library-hardening +
     // multi-tab bump (same shared core chunk). Measured at 41.62 KB.
-    limit: '42 KB',
+    //
+    // Raised 42 → 43 KB on the defaultValues-trichotomy branch
+    // (same shared core chunk as zod.mjs). Measured at 42.11 KB.
+    limit: '43 KB',
     gzip: true,
     ignore: ['zod'],
     modifyEsbuildConfig: asEsm,

--- a/src/runtime/adapters/unified/use-form.ts
+++ b/src/runtime/adapters/unified/use-form.ts
@@ -45,6 +45,7 @@ import type { StorageShape as StorageShapeV3 } from '../zod-v3/types-storage-sha
 import type { UnwrapZodObject } from '../zod-v3/types-zod-adapter'
 import type {
   AbstractSchema,
+  FormKey,
   ValidateOnConfig,
   UseFormReturnType,
   UseFormConfiguration,
@@ -96,12 +97,13 @@ type FormStorageShape<Schema> = Schema extends z.ZodObject
 // Schema kind via `FormInput` / `FormOutput`. The runtime cast
 // passes the configuration through unchanged — each adapter's own
 // signature absorbs the residual structural drift.
-type UnifiedConfiguration<Schema> = Omit<
+type UnifiedConfiguration<Schema, K extends FormKey = FormKey> = Omit<
   UseFormConfiguration<
     FormInput<Schema>,
     FormOutput<Schema>,
     AbstractSchema<FormInput<Schema>, FormOutput<Schema>>,
-    DeepPartial<DefaultValuesShape<FormInput<Schema>>>
+    DeepPartial<DefaultValuesShape<FormInput<Schema>>>,
+    K
   >,
   'schema' | 'validateOn' | 'debounceMs'
 > & { schema: Schema } & ValidateOnConfig
@@ -132,9 +134,12 @@ type UnifiedConfiguration<Schema> = Omit<
  * })
  * ```
  */
-export function useForm<Schema extends z.ZodObject | zV3.ZodObject<zV3.ZodRawShape>>(
-  configuration: UnifiedConfiguration<Schema>
-): UseFormReturnType<FormInput<Schema>, FormOutput<Schema>, FormStorageShape<Schema>> {
+export function useForm<
+  Schema extends z.ZodObject | zV3.ZodObject<zV3.ZodRawShape>,
+  K extends FormKey = FormKey,
+>(
+  configuration: UnifiedConfiguration<Schema, K>
+): UseFormReturnType<FormInput<Schema>, FormOutput<Schema>, FormStorageShape<Schema>, K> {
   // Foot-gun guard mirrors the typed wrappers'.
   if (
     configuration === undefined ||
@@ -151,7 +156,8 @@ export function useForm<Schema extends z.ZodObject | zV3.ZodObject<zV3.ZodRawSha
     ) as unknown as UseFormReturnType<
       FormInput<Schema>,
       FormOutput<Schema>,
-      FormStorageShape<Schema>
+      FormStorageShape<Schema>,
+      K
     >
   }
   // Anything else (Zod v3 schema, custom AbstractSchema, schema
@@ -160,5 +166,10 @@ export function useForm<Schema extends z.ZodObject | zV3.ZodObject<zV3.ZodRawSha
   // branch.
   return useFormV3(
     configuration as Parameters<typeof useFormV3>[0]
-  ) as unknown as UseFormReturnType<FormInput<Schema>, FormOutput<Schema>, FormStorageShape<Schema>>
+  ) as unknown as UseFormReturnType<
+    FormInput<Schema>,
+    FormOutput<Schema>,
+    FormStorageShape<Schema>,
+    K
+  >
 }

--- a/src/runtime/adapters/zod-v3/types-zod-adapter.ts
+++ b/src/runtime/adapters/zod-v3/types-zod-adapter.ts
@@ -16,6 +16,7 @@ import type {
 export type UseFormConfigurationWithZod<
   Schema extends z.ZodType<unknown>,
   DefaultValues,
+  K extends FormKey = FormKey,
 > = ValidateOnConfig & {
   /** A Zod v3 `ZodObject` schema (or one wrapped in `.optional()` / `.nullable()` / `.default()` / `.refine()`). */
   schema: Schema extends z.ZodType<unknown>
@@ -26,8 +27,9 @@ export type UseFormConfigurationWithZod<
   // Optional — matches the core `UseFormConfiguration`. Omit for
   // one-off forms; pass a string when the form needs identity (shared
   // state, distant lookup, persistence default, DevTools label). See
-  // types-api.ts for the full rationale.
-  key?: FormKey
+  // types-api.ts for the full rationale. Literal preserved on
+  // `form.key` for typed discrimination.
+  key?: K
   defaultValues?: DefaultValues
   strict?: boolean
   onInvalidSubmit?: OnInvalidSubmitPolicy

--- a/src/runtime/adapters/zod-v3/types-zod-adapter.ts
+++ b/src/runtime/adapters/zod-v3/types-zod-adapter.ts
@@ -30,7 +30,11 @@ export type UseFormConfigurationWithZod<
   // types-api.ts for the full rationale. Literal preserved on
   // `form.key` for typed discrimination.
   key?: K
-  defaultValues?: DefaultValues
+  // See `UseFormConfiguration.defaultValues` for the trichotomy
+  // semantics. Plain value resolves at construction; sync/async
+  // function defers (function-form factories surface via
+  // `form.isHydrating` / `form.hydrateError`).
+  defaultValues?: DefaultValues | (() => DefaultValues) | (() => Promise<DefaultValues>)
   strict?: boolean
   onInvalidSubmit?: OnInvalidSubmitPolicy
   persist?: PersistConfig

--- a/src/runtime/adapters/zod-v4/index.ts
+++ b/src/runtime/adapters/zod-v4/index.ts
@@ -92,7 +92,7 @@ export type PathOutput<Schema extends z.ZodType, Path extends string> =
  *
  * For Zod v3, import from `attaform/zod-v3` instead.
  */
-export function useForm<Schema extends z.ZodObject>(
+export function useForm<Schema extends z.ZodObject, K extends FormKey = FormKey>(
   configuration: Omit<
     UseFormConfiguration<
       z.input<Schema> extends GenericForm ? z.input<Schema> : never,
@@ -101,14 +101,18 @@ export function useForm<Schema extends z.ZodObject>(
         z.input<Schema> extends GenericForm ? z.input<Schema> : never,
         z.output<Schema> extends GenericForm ? z.output<Schema> : never
       >,
-      DeepPartial<DefaultValuesShape<z.input<Schema> extends GenericForm ? z.input<Schema> : never>>
+      DeepPartial<
+        DefaultValuesShape<z.input<Schema> extends GenericForm ? z.input<Schema> : never>
+      >,
+      K
     >,
     'schema' | 'validateOn' | 'debounceMs'
   > & { schema: Schema } & ValidateOnConfig
 ): UseFormReturnType<
   z.input<Schema> extends GenericForm ? z.input<Schema> : never,
   z.output<Schema> extends GenericForm ? z.output<Schema> : never,
-  StorageShape<Schema> extends GenericForm ? StorageShape<Schema> : never
+  StorageShape<Schema> extends GenericForm ? StorageShape<Schema> : never,
+  K
 > {
   // Foot-gun guard: catches `useForm(z.object({...}))` (raw schema as
   // the first arg — its `.schema` field is undefined), `useForm()` (no
@@ -159,8 +163,8 @@ export function useForm<Schema extends z.ZodObject>(
   // `configuration` before we got here), so cast to the parameter
   // type to side-step the structural disagreement.
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-  return useAbstractForm<Form, Out, Read>({
+  return useAbstractForm<Form, Out, Read, K>({
     ...configuration,
     schema: adapter,
-  } as Parameters<typeof useAbstractForm<Form, Out, Read>>[0])
+  } as Parameters<typeof useAbstractForm<Form, Out, Read, K>>[0])
 }

--- a/src/runtime/composables/use-abstract-form.ts
+++ b/src/runtime/composables/use-abstract-form.ts
@@ -44,6 +44,7 @@ import { deleteAtPath, getAtPath, setAtPath, isPlainRecord } from '../core/path-
 import { ensureAttaformInstalled } from '../core/plugin'
 import { kFormContext, kFormInstanceId, useRegistry } from '../core/registry'
 import { resolveShouldShowErrors } from '../core/should-show-errors'
+import { resolveTrichotomy } from '../core/resolve-default-values'
 import { walkUnsetSentinels } from '../core/unset-walker'
 import type {
   AbstractSchema,
@@ -122,6 +123,47 @@ export function useAbstractForm<
   if (instance !== null) ensureAttaformInstalled(instance.appContext.app)
   const registry = useRegistry()
 
+  // Materialise the `defaultValues` trichotomy (`T | (() => T) |
+  // (() => Promise<T>)`) before the merge — downstream consumers
+  // (`mergeWithDefaults`, `walkUnsetSentinels` inside `buildFreshState`)
+  // expect a plain `DeepPartial<...>`, not a function. Sync inputs use
+  // their value as-is; function inputs swap to `undefined` so the form
+  // constructs against the schema's slim defaults, and the factory
+  // settles into `state.applyFormReplacement` once it resolves (wired
+  // below).
+  const resolvedDefaults = resolveTrichotomy<
+    | DeepPartial<DefaultValuesShape<Form>>
+    | undefined
+    | (() => DeepPartial<DefaultValuesShape<Form>> | Promise<DeepPartial<DefaultValuesShape<Form>>>)
+  >(configuration.defaultValues)
+  // Build the materialised override conditionally — exactOptionalPropertyTypes
+  // refuses explicit `undefined` on the optional field, so we omit it
+  // when the resolved value is undefined.
+  const materialisedDefaults: DeepPartial<DefaultValuesShape<Form>> | undefined =
+    resolvedDefaults.kind === 'sync'
+      ? (resolvedDefaults.value as DeepPartial<DefaultValuesShape<Form>> | undefined)
+      : undefined
+  const { defaultValues: _droppedDefaults, ...configWithoutDefaults } = configuration
+  void _droppedDefaults
+  const trichotomyOverride: UseFormConfiguration<
+    Form,
+    GetValueFormType,
+    AbstractSchema<Form, GetValueFormType>,
+    DeepPartial<DefaultValuesShape<Form>>
+  > = materialisedDefaults === undefined
+    ? (configWithoutDefaults as UseFormConfiguration<
+        Form,
+        GetValueFormType,
+        AbstractSchema<Form, GetValueFormType>,
+        DeepPartial<DefaultValuesShape<Form>>
+      >)
+    : ({ ...configWithoutDefaults, defaultValues: materialisedDefaults } as UseFormConfiguration<
+        Form,
+        GetValueFormType,
+        AbstractSchema<Form, GetValueFormType>,
+        DeepPartial<DefaultValuesShape<Form>>
+      >)
+
   // Merge app-level defaults from the registry over per-form options.
   // Per-form values always win for scalars; `validateOn` and `debounceMs`
   // resolve independently so consumers can set `debounceMs` globally
@@ -129,7 +171,7 @@ export function useAbstractForm<
   // `merged` so the merge happens exactly once. Runs BEFORE schema
   // resolution so the merged `maxRecursionDepth` can thread into the
   // adapter factory.
-  const merged = mergeWithDefaults(registry.defaults, configuration)
+  const merged = mergeWithDefaults(registry.defaults, trichotomyOverride)
 
   // Resolve the schema (accepts either an AbstractSchema or a factory).
   // Preserve both generics — dropping `GetValueFormType` here would make
@@ -199,6 +241,45 @@ export function useAbstractForm<
   }
   const state: FormStore<Form, GetValueFormType> =
     existing ?? buildFreshState<Form, GetValueFormType>(key, resolvedSchema, merged, registry)
+
+  // Wire function-form `defaultValues` once per FormStore. Sync inputs
+  // already applied at construction; async inputs schedule the factory
+  // on a microtask so a synchronously-following `useStepper` claim has
+  // its chance to defer the firing (PR 2). Subsequent `useForm({ key })`
+  // calls that resolve to the same store observe the in-flight state
+  // via `state.isHydrating` rather than re-firing.
+  if (existing === undefined && resolvedDefaults.kind === 'async') {
+    const factory = resolvedDefaults.factory as () =>
+      | DeepPartial<DefaultValuesShape<Form>>
+      | Promise<DeepPartial<DefaultValuesShape<Form>>>
+    state.defaultValuesFactory.value = factory
+    state.isHydrating.value = true
+    const settle = async (): Promise<void> => {
+      try {
+        const value = await factory()
+        const full = mergeSparseHydration(
+          toRaw(state.form.value) as Form,
+          value,
+          state.schema as unknown as Parameters<typeof mergeSparseHydration>[2]
+        )
+        state.applyFormReplacement(full, { hydration: true })
+        // Post-hydration revalidation — mirrors the persistence path
+        // (`scheduleFieldValidation([], true)` further down). Async
+        // refinements that couldn't fire on the slim seed get their
+        // verdict against the resolved values.
+        state.scheduleFieldValidation([], true)
+      } catch (error) {
+        state.hydrateError.value = error
+      } finally {
+        state.isHydrating.value = false
+      }
+    }
+    // CSR: microtask defer. SSR support comes in PR 1.6 — for now an
+    // SSR pass with async defaults would fire its factory on the
+    // server but the result wouldn't bake into the hydration payload
+    // (it's mounted post-render). That's covered next commit.
+    void Promise.resolve().then(settle)
+  }
 
   // Ref-count this consumer. When the component's effect scope tears down,
   // release the count; the registry evicts the FormStore once the last

--- a/src/runtime/composables/use-abstract-form.ts
+++ b/src/runtime/composables/use-abstract-form.ts
@@ -268,26 +268,6 @@ export function useAbstractForm<
       | DeepPartial<DefaultValuesShape<Form>>
       | Promise<DeepPartial<DefaultValuesShape<Form>>>
     state.defaultValuesFactory.value = factory
-    const settle = async (): Promise<void> => {
-      try {
-        const value = await factory()
-        const full = mergeSparseHydration(
-          toRaw(state.form.value) as Form,
-          value,
-          state.schema as unknown as Parameters<typeof mergeSparseHydration>[2]
-        )
-        state.applyFormReplacement(full, { hydration: true })
-        // Post-hydration revalidation — mirrors the persistence path
-        // (`scheduleFieldValidation([], true)` further down). Async
-        // refinements that couldn't fire on the slim seed get their
-        // verdict against the resolved values.
-        state.scheduleFieldValidation([], true)
-      } catch (error) {
-        state.hydrateError.value = error
-      } finally {
-        state.isHydrating.value = false
-      }
-    }
     if (hadPendingHydration) {
       // Server already resolved the factory; client just consumed the
       // payload at `buildFreshState`. Skip the re-fetch.
@@ -298,13 +278,15 @@ export function useAbstractForm<
       // payload is serialised. Resolved values bake into the
       // hydration transfer state and the client never re-fetches.
       state.isHydrating.value = true
-      onServerPrefetch(settle)
+      onServerPrefetch(() => state.rehydrate())
     } else {
       // CSR: microtask defer leaves a synchronously-following
       // `useStepper` claim a frame to register a deferral before the
-      // factory fires (PR 2).
+      // factory fires (PR 2). `state.rehydrate` handles the
+      // settle-and-apply cycle (same path as the imperative
+      // `form.rehydrate()`).
       state.isHydrating.value = true
-      void Promise.resolve().then(settle)
+      void Promise.resolve().then(() => state.rehydrate())
     }
   }
 

--- a/src/runtime/composables/use-abstract-form.ts
+++ b/src/runtime/composables/use-abstract-form.ts
@@ -1,4 +1,12 @@
-import { getCurrentInstance, getCurrentScope, onScopeDispose, provide, toRaw, useId } from 'vue'
+import {
+  getCurrentInstance,
+  getCurrentScope,
+  onScopeDispose,
+  onServerPrefetch,
+  provide,
+  toRaw,
+  useId,
+} from 'vue'
 import { buildFormApi } from '../core/build-form-api'
 import { createFormStore, type FormStore } from '../core/create-form-store'
 import {
@@ -239,11 +247,18 @@ export function useAbstractForm<
     // only and the seed has already fired.
     warnOnPersistDivergence(key, existing, configuration.persist)
   }
+  // Capture whether a hydration payload is waiting for this key BEFORE
+  // `buildFreshState` consumes it. We use this flag to skip re-firing
+  // an async-defaults factory on the client: the server already
+  // resolved it and the resolved values rode the payload, so the
+  // factory call would just double-fetch.
+  const hadPendingHydration = registry.pendingHydration.has(key)
+
   const state: FormStore<Form, GetValueFormType> =
     existing ?? buildFreshState<Form, GetValueFormType>(key, resolvedSchema, merged, registry)
 
   // Wire function-form `defaultValues` once per FormStore. Sync inputs
-  // already applied at construction; async inputs schedule the factory
+  // already applied at construction; async inputs settle the factory
   // on a microtask so a synchronously-following `useStepper` claim has
   // its chance to defer the firing (PR 2). Subsequent `useForm({ key })`
   // calls that resolve to the same store observe the in-flight state
@@ -253,7 +268,6 @@ export function useAbstractForm<
       | DeepPartial<DefaultValuesShape<Form>>
       | Promise<DeepPartial<DefaultValuesShape<Form>>>
     state.defaultValuesFactory.value = factory
-    state.isHydrating.value = true
     const settle = async (): Promise<void> => {
       try {
         const value = await factory()
@@ -274,11 +288,24 @@ export function useAbstractForm<
         state.isHydrating.value = false
       }
     }
-    // CSR: microtask defer. SSR support comes in PR 1.6 — for now an
-    // SSR pass with async defaults would fire its factory on the
-    // server but the result wouldn't bake into the hydration payload
-    // (it's mounted post-render). That's covered next commit.
-    void Promise.resolve().then(settle)
+    if (hadPendingHydration) {
+      // Server already resolved the factory; client just consumed the
+      // payload at `buildFreshState`. Skip the re-fetch.
+      state.isHydrating.value = false
+    } else if (registry.ssr) {
+      // Server side: run the factory inside `onServerPrefetch` so the
+      // framework's SSR awaiter waits for resolution before the
+      // payload is serialised. Resolved values bake into the
+      // hydration transfer state and the client never re-fetches.
+      state.isHydrating.value = true
+      onServerPrefetch(settle)
+    } else {
+      // CSR: microtask defer leaves a synchronously-following
+      // `useStepper` claim a frame to register a deferral before the
+      // factory fires (PR 2).
+      state.isHydrating.value = true
+      void Promise.resolve().then(settle)
+    }
   }
 
   // Ref-count this consumer. When the component's effect scope tears down,

--- a/src/runtime/composables/use-abstract-form.ts
+++ b/src/runtime/composables/use-abstract-form.ts
@@ -83,14 +83,16 @@ export function useAbstractForm<
   Form extends GenericForm,
   GetValueFormType extends GenericForm = Form,
   ReadForm extends GenericForm = Form,
+  K extends FormKey = FormKey,
 >(
   configuration: UseFormConfiguration<
     Form,
     GetValueFormType,
     AbstractSchema<Form, GetValueFormType>,
-    DeepPartial<DefaultValuesShape<Form>>
+    DeepPartial<DefaultValuesShape<Form>>,
+    K
   >
-): UseFormReturnType<Form, GetValueFormType, ReadForm> {
+): UseFormReturnType<Form, GetValueFormType, ReadForm, K> {
   // Foot-gun guard: catches `useForm()` (no args), `useForm(null)`,
   // `useForm(rawSchema)` (any schema-like object passed as the first
   // argument — its `.schema` field is undefined), and the explicit
@@ -434,7 +436,7 @@ export function useAbstractForm<
     state,
     formInstanceId,
     apiOptions
-  ) as unknown as UseFormReturnType<Form, GetValueFormType, ReadForm>
+  ) as unknown as UseFormReturnType<Form, GetValueFormType, ReadForm, K>
 }
 
 /**

--- a/src/runtime/composables/use-form.ts
+++ b/src/runtime/composables/use-form.ts
@@ -30,14 +30,19 @@ import { useAbstractForm } from './use-abstract-form'
  * directly — it wraps the adapter automatically. For Zod v4, import
  * from `attaform/zod` instead.
  */
-export function useForm<Form extends GenericForm, GetValueFormType extends GenericForm = Form>(
+export function useForm<
+  Form extends GenericForm,
+  GetValueFormType extends GenericForm = Form,
+  K extends FormKey = FormKey,
+>(
   configuration: UseFormConfiguration<
     Form,
     GetValueFormType,
     AbstractSchema<Form, GetValueFormType>,
-    DeepPartial<DefaultValuesShape<Form>>
+    DeepPartial<DefaultValuesShape<Form>>,
+    K
   >
-): UseFormReturnType<Form, GetValueFormType>
+): UseFormReturnType<Form, GetValueFormType, Form, K>
 /**
  * Create a form bound to a Zod v3 `ZodObject` schema.
  *
@@ -67,35 +72,41 @@ export function useForm<
   GetValueFormType extends GenericForm = z.output<UnwrapZodObject<Schema>> extends GenericForm
     ? z.output<UnwrapZodObject<Schema>>
     : never,
+  K extends FormKey = FormKey,
 >(
   configuration: UseFormConfigurationWithZod<
     Schema,
-    DeepPartial<DefaultValuesShape<z.input<UnwrapZodObject<Schema>>>>
+    DeepPartial<DefaultValuesShape<z.input<UnwrapZodObject<Schema>>>>,
+    K
   >
 ): UseFormReturnType<
   z.input<UnwrapZodObject<Schema>>,
   GetValueFormType,
   StorageShape<UnwrapZodObject<Schema>> extends GenericForm
     ? StorageShape<UnwrapZodObject<Schema>>
-    : never
+    : never,
+  K
 >
 export function useForm<
   Schema extends z.ZodSchema<unknown>,
   Form extends GenericForm = z.input<UnwrapZodObject<Schema>>,
   GetValueFormType extends GenericForm = Form,
+  K extends FormKey = FormKey,
 >(
   configuration:
     | UseFormConfiguration<
         Form,
         GetValueFormType,
         AbstractSchema<Form, GetValueFormType>,
-        DeepPartial<DefaultValuesShape<Form>>
+        DeepPartial<DefaultValuesShape<Form>>,
+        K
       >
     | UseFormConfigurationWithZod<
         Schema,
-        DeepPartial<DefaultValuesShape<z.input<UnwrapZodObject<Schema>>>>
+        DeepPartial<DefaultValuesShape<z.input<UnwrapZodObject<Schema>>>>,
+        K
       >
-): UseFormReturnType<Form, GetValueFormType> {
+): UseFormReturnType<Form, GetValueFormType, Form, K> {
   // Foot-gun guard: catches `useForm(z.object({...}))` (raw schema as
   // the first arg — its `.schema` field is undefined), `useForm()` (no
   // args), and `useForm({ schema: undefined })` before they reach the
@@ -152,5 +163,5 @@ export function useForm<
       | AbstractSchema<Form, GetValueFormType>
       | ((key: FormKey, options: SchemaFactoryOptions) => AbstractSchema<Form, GetValueFormType>),
     defaultValues: configuration.defaultValues as DeepPartial<DefaultValuesShape<Form>>,
-  }) as unknown as UseFormReturnType<Form, GetValueFormType>
+  }) as unknown as UseFormReturnType<Form, GetValueFormType, Form, K>
 }

--- a/src/runtime/core/build-form-api.ts
+++ b/src/runtime/core/build-form-api.ts
@@ -808,6 +808,11 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
     process: process as UseFormReturnType<Form, GetValueFormType>['process'],
     register: register as UseFormReturnType<Form, GetValueFormType>['register'],
     key: state.formKey,
+    // Read-only views over the per-store async-defaults lifecycle
+    // refs (see FormStore.isHydrating / hydrateError). Plain-value
+    // forms hold these at their zero state for the form's lifetime.
+    isHydrating: readonly(state.isHydrating) as Readonly<Ref<boolean>>,
+    hydrateError: readonly(state.hydrateError) as Readonly<Ref<unknown | null>>,
     errors: errorsProxy as unknown as FormErrorsSurface<Form>,
     toRef: pathToRef as UseFormReturnType<Form, GetValueFormType>['toRef'],
     setFieldErrors,

--- a/src/runtime/core/build-form-api.ts
+++ b/src/runtime/core/build-form-api.ts
@@ -813,6 +813,7 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
     // forms hold these at their zero state for the form's lifetime.
     isHydrating: readonly(state.isHydrating) as Readonly<Ref<boolean>>,
     hydrateError: readonly(state.hydrateError) as Readonly<Ref<unknown | null>>,
+    rehydrate: () => state.rehydrate(),
     errors: errorsProxy as unknown as FormErrorsSurface<Form>,
     toRef: pathToRef as UseFormReturnType<Form, GetValueFormType>['toRef'],
     setFieldErrors,

--- a/src/runtime/core/build-form-api.ts
+++ b/src/runtime/core/build-form-api.ts
@@ -545,11 +545,17 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
   // own showErrors computation.
   const getFormMetaBase = (): FormMetaBase => {
     const rootBase = buildContainerFieldStateBase(state, ROOT_PATH, ROOT_PATH_KEY)
+    const submitCount = state.submitCount.value
     return {
       ...rootBase,
       submitting: state.submitting.value,
-      submitCount: state.submitCount.value,
+      submitCount,
       submitError: state.submitError.value,
+      // Scalar mirrors over `errors.length` and `submitCount` — same
+      // values surfaced on `form.meta`. Available here so predicates
+      // (`shouldShowErrors`) can read them too.
+      errorCount: rootBase.errors.length,
+      isSubmitted: submitCount > 0,
       instanceId: formInstanceId,
     }
   }
@@ -615,6 +621,11 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
       submitting,
       submitCount,
       submitError,
+      // Scalar mirrors over the array / counter — meta is a single
+      // sticky surface for both templates and the upcoming
+      // `useStepper`'s `FormStatus`, so the projections live here.
+      errorCount: computed(() => metaErrors.value.length),
+      isSubmitted: computed(() => submitCount.value > 0),
       // Per-`useForm()`-call identity. Stable for one mount; new on
       // re-mount; orthogonal to `form.key` (which is the user-supplied
       // shared identifier). Useful for devtools panels disambiguating

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -36,6 +36,7 @@ import { __DEV__ } from './dev'
 import { resolveCoercionIndex, type CoercionIndex } from './schema-coerce'
 import { isSlimPrimitiveValid } from './slim-primitive-gate'
 import { walkUnspecified } from './unset-walker'
+import { mergeSparseHydration } from './persistence'
 import {
   createPersistOptInRegistry,
   type PersistOptInRegistry,
@@ -316,9 +317,19 @@ export type FormStore<F extends GenericForm, G extends GenericForm = F> = {
   /**
    * The function-form `defaultValues` factory, captured at the first
    * `useForm({ key })` call that wired this store. `undefined` for
-   * plain-value forms. Read by `form.rehydrate()` (PR 1.7).
+   * plain-value forms. Read by `form.rehydrate()`.
    */
   readonly defaultValuesFactory: Ref<(() => unknown | Promise<unknown>) | undefined>
+  /**
+   * Re-fire the captured function-form `defaultValues` factory. Throws
+   * synchronously when no factory was captured (plain-value form).
+   * Resolves after `isHydrating` flips back to `false`; consumers can
+   * `await form.rehydrate()` to gate UI on the fresh load.
+   *
+   * Does NOT touch dirty / touched / submit state — chain
+   * `form.reset()` if you want a clean baseline.
+   */
+  rehydrate(): Promise<void>
   /**
    * Incremented by every `reset()` call. The submit wrapper captures
    * this at entry and skips writing `submitError` from a catch that
@@ -2430,6 +2441,49 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     return setValueAtPath(path, schema.getEmptyValueAtPath(path))
   }
 
+  // --- Rehydrate ---
+  // Imperative re-fire of the captured function-form `defaultValues`
+  // factory. Lives on the store so every consumer of the shared key
+  // sees one source of truth for `isHydrating`. Mirrors the
+  // construction-time settle path: factory result merges over the
+  // current values via `mergeSparseHydration`, applies through
+  // `applyFormReplacement({ hydration: true })` (history-module aware),
+  // and triggers a post-hydration validation sweep. Does NOT clear
+  // dirty / touched / submit state — chain `form.reset()` for that.
+
+  function rehydrate(): Promise<void> {
+    const factory = defaultValuesFactory.value
+    if (factory === undefined) {
+      // Sync throw — misuse should surface at the call site, not at
+      // await time. Mirrors the type-system contract: `rehydrate()`
+      // only makes sense after a function-form `defaultValues` was
+      // captured.
+      throw new Error(
+        '[attaform] form.rehydrate(): no defaultValues factory was captured. Configure useForm({ defaultValues: () => ... }) to enable rehydrate.'
+      )
+    }
+    return runFactoryAndApply(factory)
+  }
+
+  async function runFactoryAndApply(factory: () => unknown | Promise<unknown>): Promise<void> {
+    isHydrating.value = true
+    try {
+      const value = await factory()
+      const full = mergeSparseHydration(
+        toRaw(form.value) as F,
+        value,
+        schema as unknown as Parameters<typeof mergeSparseHydration>[2]
+      )
+      applyFormReplacement(full, { hydration: true })
+      scheduleFieldValidation([], true /* immediate */)
+      hydrateError.value = null
+    } catch (error) {
+      hydrateError.value = error
+    } finally {
+      isHydrating.value = false
+    }
+  }
+
   // --- Reset ---
 
   function reset(nextDefaultValues?: DeepPartial<WriteShape<F>>): void {
@@ -2832,6 +2886,7 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     isHydrating,
     hydrateError,
     defaultValuesFactory,
+    rehydrate,
     submissionGeneration,
     activeValidations,
     firstValidationDone,

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -300,6 +300,25 @@ export type FormStore<F extends GenericForm, G extends GenericForm = F> = {
   readonly activeSubmissions: Ref<number>
   readonly submitCount: Ref<number>
   readonly submitError: Ref<unknown>
+
+  /**
+   * `true` while a function-form `defaultValues` factory is in flight.
+   * Stays `false` for plain-value `defaultValues`. Shared across every
+   * `useForm({ key })` call that resolves to this store — the second
+   * caller sees the first caller's hydration state.
+   */
+  readonly isHydrating: Ref<boolean>
+  /**
+   * Error from the most recent function-form `defaultValues` factory.
+   * `null` when no factory has fired or the last one succeeded.
+   */
+  readonly hydrateError: Ref<unknown>
+  /**
+   * The function-form `defaultValues` factory, captured at the first
+   * `useForm({ key })` call that wired this store. `undefined` for
+   * plain-value forms. Read by `form.rehydrate()` (PR 1.7).
+   */
+  readonly defaultValuesFactory: Ref<(() => unknown | Promise<unknown>) | undefined>
   /**
    * Incremented by every `reset()` call. The submit wrapper captures
    * this at entry and skips writing `submitError` from a catch that
@@ -1227,6 +1246,13 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
   const submitError = ref<unknown>(null)
   const submissionGeneration = ref(0)
   const activeValidations = ref(0)
+  // Async-defaults lifecycle. `useAbstractForm` writes these on the
+  // first call for this key: `defaultValuesFactory` captures the
+  // function-form input, `isHydrating` flips true until settle
+  // completes. Plain-value forms leave the refs at their zero state.
+  const isHydrating = ref(false)
+  const hydrateError = ref<unknown>(null)
+  const defaultValuesFactory = ref<(() => unknown | Promise<unknown>) | undefined>(undefined)
   // Initial-validity gate. See `FormStore.firstValidationDone` JSDoc.
   // Only ASYNC-validating strict schemas need the gate: sync schemas
   // either surface refinement errors at construction (slim parse
@@ -2803,6 +2829,9 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     activeSubmissions,
     submitCount,
     submitError,
+    isHydrating,
+    hydrateError,
+    defaultValuesFactory,
     submissionGeneration,
     activeValidations,
     firstValidationDone,

--- a/src/runtime/core/resolve-default-values.ts
+++ b/src/runtime/core/resolve-default-values.ts
@@ -1,0 +1,29 @@
+/**
+ * Generic classifier for the `T | (() => T) | (() => Promise<T>)`
+ * trichotomy used by `useForm({ defaultValues })` and (in PR 3)
+ * `useStepper({ defaultStatuses })`.
+ *
+ * Plain values (including `undefined` and `null`) resolve immediately
+ * at construction — there's nothing to defer, the literal already
+ * paid the cost. Function inputs (sync or async) resolve on a
+ * microtask: the form starts with the schema's slim defaults, and the
+ * factory's resolved payload applies once it settles. Inside the
+ * `'async'` branch, consumers `await result.factory()` — a sync
+ * function's return resolves on the next microtask, identical in
+ * shape to an immediate `Promise.resolve`.
+ *
+ * The seam stays at the boundary so downstream wiring branches once
+ * on `kind`, not on `typeof` everywhere.
+ */
+export type ResolvedTrichotomy<T> =
+  | { readonly kind: 'sync'; readonly value: T }
+  | { readonly kind: 'async'; readonly factory: () => T | Promise<T> }
+
+export function resolveTrichotomy<T>(
+  input: T | (() => T) | (() => Promise<T>)
+): ResolvedTrichotomy<T> {
+  if (typeof input === 'function') {
+    return { kind: 'async', factory: input as () => T | Promise<T> }
+  }
+  return { kind: 'sync', value: input as T }
+}

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -2932,6 +2932,27 @@ export type FormMeta<F = unknown> = FieldState<F> & {
   readonly submitError: unknown
 
   /**
+   * Scalar mirror of `meta.errors.length`. Read it from templates and
+   * `watch()` without indexing the underlying array.
+   *
+   * Always tracks `errors.length` exactly — reactivity is wired through
+   * the same computed graph, so a `watch(form.meta.errorCount, ...)`
+   * fires when (and only when) the aggregate error count changes.
+   */
+  readonly errorCount: number
+
+  /**
+   * `true` once `handleSubmit` has been invoked at least once, success
+   * or failure. Equivalent to `submitCount > 0`, exposed as a scalar
+   * for "show this only after the first submit attempt" UX in
+   * templates.
+   *
+   * Monotonically non-decreasing over the form's lifetime — once
+   * flipped, it stays `true` even after `form.reset()`.
+   */
+  readonly isSubmitted: boolean
+
+  /**
    * Per-`useForm()`-call identity. Stable for the lifetime of one
    * `useForm()` call; new on every fresh mount. Orthogonal to
    * `form.key`: the key identifies a SHARED FormStore (so two

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -1032,6 +1032,7 @@ export type UseFormConfiguration<
   GetValueFormType,
   Schema extends AbstractSchema<Form, GetValueFormType>,
   DefaultValues extends DeepPartial<DefaultValuesShape<Form>>,
+  K extends FormKey = FormKey,
 > = {
   /**
    * The schema describing the form's shape and validation rules.
@@ -1063,8 +1064,12 @@ export type UseFormConfiguration<
    *
    * Keys starting with `__atta:` are reserved for internal use and
    * throw `ReservedFormKeyError` if passed.
+   *
+   * When passed as a string literal, the literal is preserved on
+   * `form.key` so `useStepper` and other consumers can discriminate
+   * against the union of known keys at compile time.
    */
-  key?: FormKey
+  key?: K
   /**
    * Initial values applied over the schema's defaults. Each field
    * falls back to the schema default (or the primitive default for
@@ -2993,6 +2998,7 @@ export type UseFormReturnType<
   Form extends GenericForm,
   GetValueFormType extends GenericForm = Form,
   ReadForm extends GenericForm = Form,
+  K extends FormKey = FormKey,
 > = {
   /**
    * Wraps your submit logic with validation and error routing.
@@ -3255,8 +3261,11 @@ export type UseFormReturnType<
    * const result = parseApiErrors(serverPayload, { formKey: form.key })
    * if (result.ok) form.setFieldErrors(result.errors)
    * ```
+   *
+   * Typed as the literal `K` when an explicit `key` was passed; falls
+   * back to `FormKey` when omitted (auto-generated id).
    */
-  key: FormKey
+  key: K
 
   // --- Reactive field-error API ---
 

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -1081,8 +1081,30 @@ export type UseFormConfiguration<
    * membership, length / range bounds). Refinement-invalid defaults
    * pass through and surface as field errors — this lets you
    * rehydrate stale saved data without losing the user's input.
+   *
+   * Accepts a plain value, a sync function, or an async function:
+   *
+   * ```ts
+   * // Plain value — applies at construction.
+   * defaultValues: { email: '' }
+   *
+   * // Sync function — invoked on a microtask after construction.
+   * defaultValues: () => buildDraft()
+   *
+   * // Async function — form starts with the schema's slim defaults
+   * // and `form.isHydrating` flips true while the promise is
+   * // in flight; on resolve the values apply and `isHydrating` flips
+   * // false. Under SSR the factory fires via `onServerPrefetch` so
+   * // the resolved payload bakes into hydration transfer state and
+   * // the client never re-fetches.
+   * defaultValues: async () => api.fetchDraft(userId)
+   * ```
+   *
+   * Errors thrown by a function-form factory surface on
+   * `form.hydrateError`; the form stays usable with slim defaults.
+   * Call `form.rehydrate()` to re-fire the factory.
    */
-  defaultValues?: DefaultValues
+  defaultValues?: DefaultValues | (() => DefaultValues) | (() => Promise<DefaultValues>)
   /**
    * Whether to validate default values at construction. Default
    * `true`.
@@ -3287,6 +3309,37 @@ export type UseFormReturnType<
    * back to `FormKey` when omitted (auto-generated id).
    */
   key: K
+
+  // --- Async-defaults lifecycle ---
+
+  /**
+   * `true` while a function-form `defaultValues` factory is in flight
+   * — between `useForm` construction and the moment the factory
+   * resolves (sync function on the next microtask; async function when
+   * its promise settles). `false` otherwise, including when
+   * `defaultValues` is a plain value.
+   *
+   * The form is fully usable while `isHydrating` is `true` — it holds
+   * the schema's slim defaults. The flag exists so templates can show
+   * a spinner / dim the form while real data loads, e.g.
+   *
+   * ```vue
+   * <div :aria-busy="form.isHydrating">…</div>
+   * ```
+   */
+  readonly isHydrating: Readonly<Ref<boolean>>
+
+  /**
+   * The error thrown or rejected by the most recent function-form
+   * `defaultValues` factory. `null` on construction, on successful
+   * resolution, and whenever no factory has fired. Updates with each
+   * `form.rehydrate()` call.
+   *
+   * Distinct from `meta.submitError` so retry buttons and recovery
+   * UX can stay focused on the load-time failure without entangling
+   * the submit pipeline.
+   */
+  readonly hydrateError: Readonly<Ref<unknown | null>>
 
   // --- Reactive field-error API ---
 

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -3341,6 +3341,19 @@ export type UseFormReturnType<
    */
   readonly hydrateError: Readonly<Ref<unknown | null>>
 
+  /**
+   * Re-fire the captured `defaultValues` factory and re-apply its
+   * payload over the current form values. Useful when the upstream
+   * source changes (the user picks a different draft, a background
+   * sync indicates fresh server data, etc.).
+   *
+   * Resolves after `isHydrating` flips back to `false`. Throws
+   * synchronously when the form was constructed with a plain-value
+   * `defaultValues` (nothing to re-fire). Does NOT clear dirty /
+   * touched / submit state — chain `form.reset()` for that.
+   */
+  rehydrate(): Promise<void>
+
   // --- Reactive field-error API ---
 
   /**

--- a/test/composables/default-values-async-function.test.ts
+++ b/test/composables/default-values-async-function.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, type App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import type { UseFormReturnType } from '../../src/runtime/types/types-api'
+import { waitUntil } from '../utils/form-harness'
+
+/**
+ * Function-form `defaultValues` — both sync and async factories.
+ *
+ * Memo (`project_use_stepper_design.md`): "Function (sync or async)
+ * → defer until first needed." Both forms settle on a microtask after
+ * construction, so the form starts with the schema's slim defaults
+ * and `form.isHydrating` is `true` until the factory's result lands.
+ *
+ * SSR coverage moves to PR 1.6's `test/ssr.test.ts` extension. This
+ * file covers the CSR path: microtask defer, reactive `isHydrating`,
+ * resolved values overlay onto slim defaults.
+ */
+
+type ApiFor<Schema extends z.ZodObject> = UseFormReturnType<z.output<Schema>>
+
+function mountForm<Schema extends z.ZodObject>(
+  schema: Schema,
+  defaultValues: NonNullable<Parameters<typeof useForm<Schema>>[0]['defaultValues']>
+): { app: App; api: ApiFor<Schema> } {
+  const handle: { api?: ApiFor<Schema> } = {}
+  const App = defineComponent({
+    setup() {
+      handle.api = useForm({
+        schema,
+        key: `async-defaults-${Math.random().toString(36).slice(2)}`,
+        defaultValues,
+      }) as unknown as ApiFor<Schema>
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  app.config.warnHandler = () => {}
+  app.config.errorHandler = () => {}
+  app.mount(document.createElement('div'))
+  return { app, api: handle.api as ApiFor<Schema> }
+}
+
+describe('useForm — function-form defaultValues', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  const schema = z.object({
+    email: z.string(),
+    name: z.string(),
+  })
+
+  it('plain-value defaultValues leaves isHydrating false', () => {
+    const { app, api } = mountForm(schema, { email: 'a@b.c', name: 'Ada' })
+    apps.push(app)
+    expect(api.isHydrating.value).toBe(false)
+    expect(api.hydrateError.value).toBeNull()
+    expect(api.values.email).toBe('a@b.c')
+  })
+
+  it('sync function defaultValues settles on a microtask', async () => {
+    let calls = 0
+    const factory = () => {
+      calls += 1
+      return { email: 'sync@example.com', name: 'Grace' }
+    }
+    const { app, api } = mountForm(schema, factory)
+    apps.push(app)
+    // Microtask not yet flushed — factory has been queued but not
+    // necessarily invoked. We assert behavior at the post-flush state.
+    await waitUntil(() => (api.isHydrating.value === false ? true : null))
+    expect(calls).toBe(1)
+    expect(api.values.email).toBe('sync@example.com')
+    expect(api.values.name).toBe('Grace')
+    expect(api.hydrateError.value).toBeNull()
+  })
+
+  it('async function defaultValues flips isHydrating true → false', async () => {
+    let resolveFactory!: (value: { email: string; name: string }) => void
+    const promise = new Promise<{ email: string; name: string }>((r) => {
+      resolveFactory = r
+    })
+    const { app, api } = mountForm(schema, () => promise)
+    apps.push(app)
+    expect(api.isHydrating.value).toBe(true)
+    resolveFactory({ email: 'async@example.com', name: 'Lovelace' })
+    await waitUntil(() => (api.isHydrating.value === false ? true : null))
+    expect(api.values.email).toBe('async@example.com')
+    expect(api.values.name).toBe('Lovelace')
+    expect(api.hydrateError.value).toBeNull()
+  })
+
+  it('partial async resolution overlays onto schema slim defaults', async () => {
+    // Factory returns only `email` — `name` should keep its schema
+    // slim default (empty string for z.string()).
+    const { app, api } = mountForm(schema, () => Promise.resolve({ email: 'partial@example.com' }))
+    apps.push(app)
+    await waitUntil(() => (api.isHydrating.value === false ? true : null))
+    expect(api.values.email).toBe('partial@example.com')
+    expect(api.values.name).toBe('')
+  })
+})

--- a/test/composables/default-values-async-rejection.test.ts
+++ b/test/composables/default-values-async-rejection.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, type App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import type { UseFormReturnType } from '../../src/runtime/types/types-api'
+import { waitUntil } from '../utils/form-harness'
+
+/**
+ * Function-form `defaultValues` — factory rejection path.
+ *
+ * When a factory throws or its promise rejects, the form keeps its
+ * schema slim defaults and surfaces the error on `form.hydrateError`.
+ * `isHydrating` still flips to `false` (the load attempt is done,
+ * even if it failed). The form remains fully functional — consumers
+ * can show an error banner, offer a retry button, and let users
+ * proceed manually.
+ */
+
+type ApiFor<Schema extends z.ZodObject> = UseFormReturnType<z.output<Schema>>
+
+function mountForm<Schema extends z.ZodObject>(
+  schema: Schema,
+  defaultValues: NonNullable<Parameters<typeof useForm<Schema>>[0]['defaultValues']>
+): { app: App; api: ApiFor<Schema> } {
+  const handle: { api?: ApiFor<Schema> } = {}
+  const App = defineComponent({
+    setup() {
+      handle.api = useForm({
+        schema,
+        key: `async-defaults-rej-${Math.random().toString(36).slice(2)}`,
+        defaultValues,
+      }) as unknown as ApiFor<Schema>
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  app.config.warnHandler = () => {}
+  app.config.errorHandler = () => {}
+  app.mount(document.createElement('div'))
+  return { app, api: handle.api as ApiFor<Schema> }
+}
+
+describe('useForm — function-form defaultValues, rejection path', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  const schema = z.object({
+    email: z.string(),
+    name: z.string(),
+  })
+
+  it('surfaces a thrown sync-factory error on hydrateError', async () => {
+    const boom = new Error('fetch failed')
+    const factory = (): { email: string; name: string } => {
+      throw boom
+    }
+    const { app, api } = mountForm(schema, factory)
+    apps.push(app)
+    await waitUntil(() => (api.isHydrating.value === false ? true : null))
+    expect(api.hydrateError.value).toBe(boom)
+    expect(api.isHydrating.value).toBe(false)
+  })
+
+  it('surfaces a rejected async-factory promise on hydrateError', async () => {
+    const boom = new Error('network down')
+    const { app, api } = mountForm(schema, () => Promise.reject(boom))
+    apps.push(app)
+    await waitUntil(() => (api.isHydrating.value === false ? true : null))
+    expect(api.hydrateError.value).toBe(boom)
+  })
+
+  it('leaves the form usable with schema slim defaults after rejection', async () => {
+    const { app, api } = mountForm(schema, () => Promise.reject(new Error('boom')))
+    apps.push(app)
+    await waitUntil(() => (api.isHydrating.value === false ? true : null))
+    expect(api.values.email).toBe('')
+    expect(api.values.name).toBe('')
+    // Consumers can still mutate the form post-rejection.
+    api.setValue('email', 'recover@example.com')
+    expect(api.values.email).toBe('recover@example.com')
+  })
+})

--- a/test/composables/default-values-async-ssr.test.ts
+++ b/test/composables/default-values-async-ssr.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+import { renderToString } from '@vue/server-renderer'
+import { createApp, createSSRApp, defineComponent, h } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import { hydrateAttaformState, renderAttaformState } from '../../src/runtime/core/serialize'
+import { getRegistryFromApp } from '../../src/runtime/core/registry'
+import type { UseFormReturnType } from '../../src/runtime/types/types-api'
+
+/**
+ * SSR + hydration path for async-defaults forms.
+ *
+ * On the server, function-form `defaultValues` factories fire via
+ * `onServerPrefetch`. The framework's SSR awaiter waits for them to
+ * resolve before the payload is serialised, so the resolved values
+ * bake into the hydration transfer state. On the client, the matching
+ * `useForm({ key })` call consumes `pendingHydration` at construction
+ * time AND skips re-firing the factory — same data, no double-fetch.
+ *
+ * Tests run under @vitest-environment node so `@vue/server-renderer`'s
+ * `renderToString` can run.
+ */
+
+const schema = z.object({ email: z.string(), name: z.string() })
+
+describe('async-defaults SSR + hydration', () => {
+  it('resolves the factory server-side before payload serialization', async () => {
+    let calls = 0
+    const App = defineComponent({
+      setup() {
+        useForm({
+          schema,
+          key: 'ssr-async-defaults',
+          defaultValues: () => {
+            calls += 1
+            return Promise.resolve({ email: 'server@example.com', name: 'Ada' })
+          },
+        })
+        return () => h('div')
+      },
+    })
+    const ssrApp = createSSRApp(App).use(createAttaform({ ssr: true }))
+    await renderToString(ssrApp)
+    expect(calls).toBe(1)
+
+    const payload = renderAttaformState(ssrApp)
+    expect(payload.forms).toHaveLength(1)
+    const entry = payload.forms[0]
+    expect(entry).toBeDefined()
+    if (entry === undefined) return
+    const [key, data] = entry
+    expect(key).toBe('ssr-async-defaults')
+    // Resolved values rode the payload — proves `onServerPrefetch`
+    // awaited the factory before serialization.
+    expect(data.form).toMatchObject({ email: 'server@example.com', name: 'Ada' })
+  })
+
+  it('client consumes pendingHydration and skips re-firing the factory', async () => {
+    // Server side: same as above.
+    let serverCalls = 0
+    const ServerApp = defineComponent({
+      setup() {
+        useForm({
+          schema,
+          key: 'ssr-async-no-refire',
+          defaultValues: () => {
+            serverCalls += 1
+            return Promise.resolve({ email: 'server@example.com', name: 'Ada' })
+          },
+        })
+        return () => h('div')
+      },
+    })
+    const ssrApp = createSSRApp(ServerApp).use(createAttaform({ ssr: true }))
+    await renderToString(ssrApp)
+    const payload = renderAttaformState(ssrApp)
+    expect(serverCalls).toBe(1)
+
+    // Client side: fresh app, stage hydration, then mount a form with
+    // the same key and async factory. The factory must NOT fire.
+    let clientCalls = 0
+    const clientHandle: { api?: UseFormReturnType<{ email: string; name: string }> } = {}
+    const ClientApp = defineComponent({
+      setup() {
+        clientHandle.api = useForm({
+          schema,
+          key: 'ssr-async-no-refire',
+          defaultValues: () => {
+            clientCalls += 1
+            return Promise.resolve({ email: 'client-would-fetch@example.com', name: 'Hopper' })
+          },
+        }) as unknown as UseFormReturnType<{ email: string; name: string }>
+        return () => h('div')
+      },
+    })
+    const clientApp = createApp(ClientApp).use(createAttaform())
+    hydrateAttaformState(clientApp, payload)
+    const registry = getRegistryFromApp(clientApp)
+    expect(registry.pendingHydration.has('ssr-async-no-refire')).toBe(true)
+    clientApp.config.warnHandler = () => {}
+    clientApp.mount(document.createElement('div'))
+
+    const api = clientHandle.api
+    expect(api).toBeDefined()
+    if (api === undefined) return
+    expect(clientCalls).toBe(0)
+    expect(api.isHydrating.value).toBe(false)
+    expect(api.values.email).toBe('server@example.com')
+    expect(api.values.name).toBe('Ada')
+  })
+})

--- a/test/composables/default-values-history-skip.test.ts
+++ b/test/composables/default-values-history-skip.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, type App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import type { UseFormReturnType } from '../../src/runtime/types/types-api'
+import { waitUntil } from '../utils/form-harness'
+
+/**
+ * Regression: when an async-defaults factory settles, the resulting
+ * `applyFormReplacement` carries `meta: { hydration: true }`. The
+ * undo/redo `history` module's `meta.hydration === true` guard
+ * (`history.ts:256`) must skip recording this as a user mutation, so
+ * the consumer can't undo "back through" the hydration to the
+ * transient slim defaults.
+ *
+ * If this regresses, `form.history.canUndo` will flip true immediately
+ * after async resolution, exposing the intermediate state.
+ */
+
+type ApiFor<Schema extends z.ZodObject> = UseFormReturnType<z.output<Schema>>
+
+function mountForm<Schema extends z.ZodObject>(
+  schema: Schema,
+  defaultValues: NonNullable<Parameters<typeof useForm<Schema>>[0]['defaultValues']>
+): { app: App; api: ApiFor<Schema> } {
+  const handle: { api?: ApiFor<Schema> } = {}
+  const App = defineComponent({
+    setup() {
+      handle.api = useForm({
+        schema,
+        key: `history-skip-${Math.random().toString(36).slice(2)}`,
+        defaultValues,
+        history: { max: 20 },
+      }) as unknown as ApiFor<Schema>
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  app.config.warnHandler = () => {}
+  app.config.errorHandler = () => {}
+  app.mount(document.createElement('div'))
+  return { app, api: handle.api as ApiFor<Schema> }
+}
+
+describe('default-values hydration skips history', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  const schema = z.object({ email: z.string(), name: z.string() })
+
+  it('async resolution does not push an undo entry', async () => {
+    const { app, api } = mountForm(schema, () => Promise.resolve({ email: 'a@b.c', name: 'Ada' }))
+    apps.push(app)
+    await waitUntil(() => (api.isHydrating.value === false ? true : null))
+    expect(api.values.email).toBe('a@b.c')
+    // Despite the apply that just landed, history must remain clean —
+    // undo would otherwise expose the transient slim-default state.
+    expect(api.history.canUndo).toBe(false)
+  })
+
+  it('user mutations after hydration record normally', async () => {
+    const { app, api } = mountForm(schema, () => Promise.resolve({ email: 'a@b.c', name: 'Ada' }))
+    apps.push(app)
+    await waitUntil(() => (api.isHydrating.value === false ? true : null))
+    expect(api.history.canUndo).toBe(false)
+
+    api.setValue('email', 'updated@example.com')
+    await waitUntil(() => (api.history.canUndo ? true : null))
+    expect(api.history.canUndo).toBe(true)
+  })
+})

--- a/test/composables/default-values-rehydrate.test.ts
+++ b/test/composables/default-values-rehydrate.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, type App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import type { UseFormReturnType } from '../../src/runtime/types/types-api'
+import { waitUntil } from '../utils/form-harness'
+
+/**
+ * `form.rehydrate()` re-fires the captured `defaultValues` factory and
+ * re-applies the resolved payload. Useful when the upstream source
+ * changed (the user picked a different draft from a list, the
+ * background sync indicates fresh server data, etc.).
+ *
+ * Contract:
+ *  - Returns a promise that resolves AFTER `isHydrating` flips back to
+ *    `false`.
+ *  - Re-fires the captured factory each call (so consumers don't have
+ *    to maintain their own loader).
+ *  - Throws synchronously if the form was constructed with a
+ *    plain-value `defaultValues` (no factory to invoke).
+ *  - Leaves dirty/touched/submit state alone — chain `form.reset()`
+ *    for a clean baseline.
+ */
+
+type Defaults = { email: string; name: string }
+type ApiFor<Schema extends z.ZodObject> = UseFormReturnType<z.output<Schema>>
+
+function mountForm<Schema extends z.ZodObject>(
+  schema: Schema,
+  defaultValues: NonNullable<Parameters<typeof useForm<Schema>>[0]['defaultValues']>
+): { app: App; api: ApiFor<Schema> } {
+  const handle: { api?: ApiFor<Schema> } = {}
+  const App = defineComponent({
+    setup() {
+      handle.api = useForm({
+        schema,
+        key: `rehydrate-${Math.random().toString(36).slice(2)}`,
+        defaultValues,
+      }) as unknown as ApiFor<Schema>
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  app.config.warnHandler = () => {}
+  app.config.errorHandler = () => {}
+  app.mount(document.createElement('div'))
+  return { app, api: handle.api as ApiFor<Schema> }
+}
+
+describe('form.rehydrate', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  const schema = z.object({ email: z.string(), name: z.string() })
+
+  it('re-fires the captured factory and applies the new payload', async () => {
+    let calls = 0
+    const factory = (): Promise<Defaults> => {
+      calls += 1
+      return Promise.resolve(
+        calls === 1
+          ? { email: 'first@example.com', name: 'Ada' }
+          : { email: 'second@example.com', name: 'Hopper' }
+      )
+    }
+    const { app, api } = mountForm(schema, factory)
+    apps.push(app)
+    await waitUntil(() => (api.isHydrating.value === false ? true : null))
+    expect(calls).toBe(1)
+    expect(api.values.email).toBe('first@example.com')
+
+    await api.rehydrate()
+    expect(calls).toBe(2)
+    expect(api.values.email).toBe('second@example.com')
+    expect(api.values.name).toBe('Hopper')
+  })
+
+  it('resolves only after isHydrating flips back to false', async () => {
+    let resolveFactory!: (value: Defaults) => void
+    let calls = 0
+    const factory = (): Promise<Defaults> => {
+      calls += 1
+      if (calls === 1) return Promise.resolve({ email: 'first@example.com', name: 'Ada' })
+      return new Promise<Defaults>((r) => {
+        resolveFactory = r
+      })
+    }
+    const { app, api } = mountForm(schema, factory)
+    apps.push(app)
+    await waitUntil(() => (api.isHydrating.value === false ? true : null))
+
+    const promise = api.rehydrate()
+    expect(api.isHydrating.value).toBe(true)
+    resolveFactory({ email: 'second@example.com', name: 'Hopper' })
+    await promise
+    expect(api.isHydrating.value).toBe(false)
+    expect(api.values.email).toBe('second@example.com')
+  })
+
+  it('throws synchronously when no factory was captured', () => {
+    const { app, api } = mountForm(schema, { email: 'a@b.c', name: 'Ada' })
+    apps.push(app)
+    expect(() => api.rehydrate()).toThrow()
+  })
+
+  it('reports a rejected factory through hydrateError', async () => {
+    let calls = 0
+    const factory = (): Promise<Defaults> => {
+      calls += 1
+      if (calls === 1) return Promise.resolve({ email: 'first@example.com', name: 'Ada' })
+      return Promise.reject(new Error('rehydrate failed'))
+    }
+    const { app, api } = mountForm(schema, factory)
+    apps.push(app)
+    await waitUntil(() => (api.isHydrating.value === false ? true : null))
+    expect(api.hydrateError.value).toBeNull()
+
+    await api.rehydrate()
+    expect(api.hydrateError.value).toBeInstanceOf(Error)
+    expect((api.hydrateError.value as Error).message).toBe('rehydrate failed')
+    expect(api.isHydrating.value).toBe(false)
+  })
+})

--- a/test/composables/form-meta-error-count.test.ts
+++ b/test/composables/form-meta-error-count.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, type App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import type { UseFormReturnType } from '../../src/runtime/types/types-api'
+import { waitUntil } from '../utils/form-harness'
+
+/**
+ * `form.meta.errorCount` is a scalar mirror of `form.meta.errors.length`,
+ * exposed as a top-level meta field so consumers can read it in
+ * templates and `watch(form.meta, ...)` without indexing an array. PR 3
+ * (`useStepper`) consumes this through `FormStatus`; PR 1 ships it as a
+ * standalone meta extension so the friction is fixed for non-stepper
+ * forms too.
+ *
+ * Contract: `errorCount === errors.length` across every reactive
+ * mutation. Reactivity follows the same graph as `errors`, so a single
+ * `watch(form.meta.errorCount, ...)` fires exactly when a meaningful
+ * error change has happened.
+ */
+
+type ApiFor<Schema extends z.ZodObject> = Omit<UseFormReturnType<z.output<Schema>>, 'setValue'> & {
+  setValue: (path: string, value: unknown) => boolean
+}
+
+function mountForm<Schema extends z.ZodObject>(
+  schema: Schema,
+  defaultValues: NonNullable<Parameters<typeof useForm<Schema>>[0]['defaultValues']>
+): { app: App; api: ApiFor<Schema> } {
+  const handle: { api?: ApiFor<Schema> } = {}
+  const App = defineComponent({
+    setup() {
+      handle.api = useForm({
+        schema,
+        key: `error-count-${Math.random().toString(36).slice(2)}`,
+        defaultValues,
+        validateOn: 'change',
+        debounceMs: 0,
+      }) as unknown as ApiFor<Schema>
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  app.config.warnHandler = () => {}
+  app.config.errorHandler = () => {}
+  app.mount(document.createElement('div'))
+  return { app, api: handle.api as ApiFor<Schema> }
+}
+
+describe('form.meta.errorCount', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  const schema = z.object({
+    email: z.email(),
+    password: z.string().min(8, 'At least 8 characters.'),
+  })
+
+  it('starts equal to errors.length after construction-time validation', async () => {
+    const { app, api } = mountForm(schema, { email: '', password: '' })
+    apps.push(app)
+    await waitUntil(() => api.meta.errors.length > 0)
+    expect(api.meta.errorCount).toBe(api.meta.errors.length)
+    expect(api.meta.errorCount).toBe(2)
+  })
+
+  it('tracks errors.length as fields become valid', async () => {
+    const { app, api } = mountForm(schema, { email: '', password: '' })
+    apps.push(app)
+    await waitUntil(() => api.meta.errorCount === 2)
+
+    // Drive validation by submitting — re-runs the whole schema and
+    // re-sorts the aggregate. The invariant `errorCount === errors.length`
+    // must hold at every reactive frame, regardless of WHICH path
+    // triggers the recomputation.
+    api.setValue('email', 'user@example.com')
+    await api.handleSubmit(async () => {})(new Event('submit'))
+    expect(api.meta.errorCount).toBe(api.meta.errors.length)
+    expect(api.meta.errorCount).toBe(1)
+
+    api.setValue('password', 'longenough')
+    await api.handleSubmit(async () => {})(new Event('submit'))
+    expect(api.meta.errorCount).toBe(api.meta.errors.length)
+    expect(api.meta.errorCount).toBe(0)
+  })
+
+  it('tracks errors.length as valid fields become invalid', async () => {
+    const { app, api } = mountForm(schema, {
+      email: 'user@example.com',
+      password: 'longenough',
+    })
+    apps.push(app)
+    expect(api.meta.errorCount).toBe(api.meta.errors.length)
+
+    api.setValue('email', 'not-an-email')
+    await api.handleSubmit(async () => {})(new Event('submit'))
+    expect(api.meta.errorCount).toBe(api.meta.errors.length)
+    expect(api.meta.errorCount).toBe(1)
+  })
+})

--- a/test/composables/form-meta-is-submitted.test.ts
+++ b/test/composables/form-meta-is-submitted.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, type App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import type { UseFormReturnType } from '../../src/runtime/types/types-api'
+import { waitUntil } from '../utils/form-harness'
+
+/**
+ * `form.meta.isSubmitted` is the boolean mirror of `submitCount > 0`,
+ * surfaced so templates and `useStepper`'s `FormStatus` can read a
+ * single scalar instead of comparing the counter against zero.
+ *
+ * Once a form has been submitted at all (success or failure), the flag
+ * stays `true` — like `submitCount`, it's monotonically non-decreasing
+ * over the form's lifetime. Resetting the form does not retroactively
+ * un-submit it; if a consumer wants that semantic, they own it.
+ */
+
+type ApiFor<Schema extends z.ZodObject> = UseFormReturnType<z.output<Schema>>
+
+function mountForm<Schema extends z.ZodObject>(
+  schema: Schema,
+  defaultValues: NonNullable<Parameters<typeof useForm<Schema>>[0]['defaultValues']>
+): { app: App; api: ApiFor<Schema> } {
+  const handle: { api?: ApiFor<Schema> } = {}
+  const App = defineComponent({
+    setup() {
+      handle.api = useForm({
+        schema,
+        key: `is-submitted-${Math.random().toString(36).slice(2)}`,
+        defaultValues,
+      }) as unknown as ApiFor<Schema>
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  app.config.warnHandler = () => {}
+  app.config.errorHandler = () => {}
+  app.mount(document.createElement('div'))
+  return { app, api: handle.api as ApiFor<Schema> }
+}
+
+describe('form.meta.isSubmitted', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  const schema = z.object({
+    email: z.email(),
+  })
+
+  it('starts false before any submit', () => {
+    const { app, api } = mountForm(schema, { email: 'user@example.com' })
+    apps.push(app)
+    expect(api.meta.isSubmitted).toBe(false)
+    expect(api.meta.submitCount).toBe(0)
+  })
+
+  it('flips true on the first successful submit', async () => {
+    const { app, api } = mountForm(schema, { email: 'user@example.com' })
+    apps.push(app)
+    const handler = api.handleSubmit(async () => {})
+    await handler(new Event('submit'))
+    await waitUntil(() => api.meta.isSubmitted)
+    expect(api.meta.isSubmitted).toBe(true)
+    expect(api.meta.submitCount).toBe(1)
+  })
+
+  it('flips true on the first failed submit too (validation failure counts)', async () => {
+    const { app, api } = mountForm(schema, { email: '' })
+    apps.push(app)
+    const handler = api.handleSubmit(async () => {})
+    await handler(new Event('submit'))
+    await waitUntil(() => api.meta.isSubmitted)
+    expect(api.meta.isSubmitted).toBe(true)
+    expect(api.meta.submitCount).toBe(1)
+  })
+
+  it('stays true across subsequent submits', async () => {
+    const { app, api } = mountForm(schema, { email: 'user@example.com' })
+    apps.push(app)
+    const handler = api.handleSubmit(async () => {})
+    await handler(new Event('submit'))
+    await waitUntil(() => api.meta.submitCount === 1)
+    await handler(new Event('submit'))
+    await waitUntil(() => api.meta.submitCount === 2)
+    expect(api.meta.isSubmitted).toBe(true)
+  })
+})

--- a/test/core/resolve-default-values.test.ts
+++ b/test/core/resolve-default-values.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+import { resolveTrichotomy } from '../../src/runtime/core/resolve-default-values'
+
+/**
+ * `resolveTrichotomy` classifies a `T | (() => T) | (() => Promise<T>)`
+ * input into the discriminated union that downstream consumers branch
+ * on:
+ *  - `kind: 'sync'`  → use `.value` directly at construction.
+ *  - `kind: 'async'` → defer via `.factory()` (may be sync or async
+ *    function; consumers `await` either way).
+ *
+ * The classifier is the shared seam for `useForm({ defaultValues })`
+ * (PR 1) and `useStepper({ defaultStatuses })` (PR 3). It's
+ * intentionally simple — just a `typeof` check — so the contract is
+ * easy to reason about and the seam stays at the boundary, not buried
+ * downstream.
+ */
+
+describe('resolveTrichotomy', () => {
+  it('classifies a plain object value as sync', () => {
+    const value = { email: 'a@b.c' }
+    const result = resolveTrichotomy(value)
+    expect(result.kind).toBe('sync')
+    if (result.kind === 'sync') {
+      expect(result.value).toBe(value)
+    }
+  })
+
+  it('classifies undefined as sync (value pass-through)', () => {
+    const result = resolveTrichotomy<{ email: string } | undefined>(undefined)
+    expect(result.kind).toBe('sync')
+    if (result.kind === 'sync') {
+      expect(result.value).toBeUndefined()
+    }
+  })
+
+  it('classifies null as sync (value pass-through)', () => {
+    const result = resolveTrichotomy<{ email: string } | null>(null)
+    expect(result.kind).toBe('sync')
+    if (result.kind === 'sync') {
+      expect(result.value).toBeNull()
+    }
+  })
+
+  it('classifies a sync factory as async (deferred path)', () => {
+    let calls = 0
+    const factory = () => {
+      calls += 1
+      return { email: 'a@b.c' }
+    }
+    const result = resolveTrichotomy(factory)
+    expect(result.kind).toBe('async')
+    // Factory is captured, NOT invoked.
+    expect(calls).toBe(0)
+  })
+
+  it('classifies an async factory as async', async () => {
+    const factory = () => Promise.resolve({ email: 'a@b.c' })
+    const result = resolveTrichotomy(factory)
+    expect(result.kind).toBe('async')
+    if (result.kind === 'async') {
+      const value = await result.factory()
+      expect(value).toEqual({ email: 'a@b.c' })
+    }
+  })
+
+  it('async-branch factory normalises sync and async returns via await', async () => {
+    // Consumers `await` the factory either way — sync function returns
+    // resolve on the next microtask, identical to a Promise that
+    // resolved synchronously. The classifier doesn't fork on this.
+    const syncFactory = () => ({ count: 1 })
+    const asyncFactory = () => Promise.resolve({ count: 2 })
+
+    const a = resolveTrichotomy(syncFactory)
+    const b = resolveTrichotomy(asyncFactory)
+
+    if (a.kind === 'async' && b.kind === 'async') {
+      const aValue = await a.factory()
+      const bValue = await b.factory()
+      expect(aValue).toEqual({ count: 1 })
+      expect(bValue).toEqual({ count: 2 })
+    } else {
+      throw new Error('factory branches should classify as async')
+    }
+  })
+
+  it('factory reference is the same function passed in', () => {
+    const factory = () => ({ x: 1 })
+    const result = resolveTrichotomy(factory)
+    if (result.kind === 'async') {
+      expect(result.factory).toBe(factory)
+    } else {
+      throw new Error('expected async classification')
+    }
+  })
+})

--- a/test/types/use-form-key-literal.test.ts
+++ b/test/types/use-form-key-literal.test.ts
@@ -1,0 +1,84 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import { z } from 'zod'
+import { z as zV3 } from 'zod-v3'
+import { useForm as useFormZ } from '../../src/zod'
+import { useForm as useFormV3 } from '../../src/zod-v3'
+import { useForm as useFormV4 } from '../../src/zod-v4'
+import type { FormKey } from '../../src'
+
+/**
+ * Type-level test for `form.key` literal preservation through the
+ * `useForm` overloads. Threading `K extends FormKey` lets the stepper
+ * (and any other consumer) discriminate on the literal — `goTo('signup')`
+ * autocompletes the known keys, `stepper.statuses.signup` resolves to
+ * the matching form.
+ *
+ * Three entry points each get the same treatment:
+ *  - `attaform/zod` (unified runtime dispatch)
+ *  - `attaform/zod-v3`
+ *  - `attaform/zod-v4`
+ *
+ * Tests run at typecheck time. The `_neverInvoked` wrappers declare real
+ * `useForm` calls so TypeScript exercises call-site inference, but the
+ * functions are never called — no Vue app context is needed.
+ * `expectTypeOf` chain methods are no-ops at runtime.
+ */
+
+const schemaV4 = z.object({ email: z.string() })
+const schemaV3 = zV3.object({ email: zV3.string() })
+
+describe('useForm — form.key literal preservation', () => {
+  describe('attaform/zod (unified)', () => {
+    it('captures literal key string', () => {
+      function _neverInvoked() {
+        const form = useFormZ({ schema: schemaV4, key: 'signup' })
+        expectTypeOf(form.key).toEqualTypeOf<'signup'>()
+      }
+      void _neverInvoked
+    })
+
+    it('falls back to FormKey when key is omitted', () => {
+      function _neverInvoked() {
+        const form = useFormZ({ schema: schemaV4 })
+        expectTypeOf(form.key).toEqualTypeOf<FormKey>()
+      }
+      void _neverInvoked
+    })
+  })
+
+  describe('attaform/zod-v3', () => {
+    it('captures literal key string', () => {
+      function _neverInvoked() {
+        const form = useFormV3({ schema: schemaV3, key: 'cargo' })
+        expectTypeOf(form.key).toEqualTypeOf<'cargo'>()
+      }
+      void _neverInvoked
+    })
+
+    it('falls back to FormKey when key is omitted', () => {
+      function _neverInvoked() {
+        const form = useFormV3({ schema: schemaV3 })
+        expectTypeOf(form.key).toEqualTypeOf<FormKey>()
+      }
+      void _neverInvoked
+    })
+  })
+
+  describe('attaform/zod-v4', () => {
+    it('captures literal key string', () => {
+      function _neverInvoked() {
+        const form = useFormV4({ schema: schemaV4, key: 'review' })
+        expectTypeOf(form.key).toEqualTypeOf<'review'>()
+      }
+      void _neverInvoked
+    })
+
+    it('falls back to FormKey when key is omitted', () => {
+      function _neverInvoked() {
+        const form = useFormV4({ schema: schemaV4 })
+        expectTypeOf(form.key).toEqualTypeOf<FormKey>()
+      }
+      void _neverInvoked
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Foundation PR for the upcoming `useStepper` work. Three feature strands land together because they share the same files (`types-api.ts`, `use-form.ts`, `use-abstract-form.ts`, `build-form-api.ts`):

- `defaultValues` now accepts the full trichotomy `T | (() => T) | (() => Promise<T>)`. Plain values resolve at construction; function inputs settle on a microtask after setup so a synchronously-following `useStepper` claim (PR 2) can defer the firing. Function-form factories surface via `form.isHydrating` / `form.hydrateError`.
- `form.rehydrate(): Promise<void>` — imperative re-fire of the captured factory. Throws synchronously when there's no factory (plain-value form). Does NOT clear dirty / touched / submit state; chain `form.reset()` for that.
- `meta.errorCount` (scalar mirror of `errors.length`) and `meta.isSubmitted` (`submitCount > 0`) — feeds PR 3's `FormStatus` shape and fixes the friction templates were already paying.
- `K extends FormKey` threaded through `useForm` so `form.key` preserves the literal type — required for the upcoming `stepper.current` / `stepper.statuses.<key>.isValid` typing.

SSR path uses `onServerPrefetch` so the framework's SSR awaiter waits for resolution before the payload is serialised. Client-side, when `pendingHydration` already holds an entry for the key (SSR payload landed), we skip the re-fire — server values flow through unchanged.

History module's existing `meta.hydration === true` skip (`history.ts:256`) carries over, so async resolution does NOT seed an undo entry.

## Test plan

- [x] `docker compose exec attaform pnpm typecheck`
- [x] `docker compose exec attaform pnpm lint`
- [x] `docker compose exec attaform pnpm vitest run` — 168 files, 2543 tests, all green
- [x] `docker compose exec attaform sh -c "cd apps/site && pnpm bundle:repl"`

New tests:
- `test/types/use-form-key-literal.test.ts` — literal preservation across all three entry points
- `test/composables/form-meta-error-count.test.ts` — invariant under mutation
- `test/composables/form-meta-is-submitted.test.ts` — flips on first submit (success or failure), monotonic
- `test/core/resolve-default-values.test.ts` — classifier behavior
- `test/composables/default-values-async-function.test.ts` — sync function, async function, partial overlay
- `test/composables/default-values-async-rejection.test.ts` — thrown / rejected factory surfaces on hydrateError
- `test/composables/default-values-async-ssr.test.ts` — server `onServerPrefetch` resolution + client `pendingHydration` skip
- `test/composables/default-values-history-skip.test.ts` — async resolution does not seed an undo entry
- `test/composables/default-values-rehydrate.test.ts` — re-fire, sync throw, async rejection on retry

## Commit ladder

Each commit lands one behavior with its tests:
1. `feat(types): thread K extends FormKey through useForm`
2. `feat(form): add meta.errorCount and meta.isSubmitted`
3. `feat(form): introduce resolveTrichotomy classifier`
4. `feat(form): function-form defaultValues with isHydrating`
5. `feat(form): ssr via onServerPrefetch for async defaults`
6. `feat(form): add form.rehydrate() to re-fire async factory`

## Breaking type changes (pre-1.0, acceptable)

- `UseFormConfiguration` / `UseFormReturnType` gain a `K extends FormKey` generic (defaulted, backwards-compatible for omitted-K instantiations).
- `defaultValues` type widened from `DeepPartial<...>` to the trichotomy union.

🤖 Generated with [Claude Code](https://claude.com/claude-code)