### PR TITLE
feat(form): useStepper core — navigation + activation lifecycle

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -154,7 +154,15 @@ export default [
     //     for the post-reset valid:true flash on async-refining
     //     schemas)
     // Measured at 35.47 KB; ~0.5 KB headroom.
-    limit: '36 KB',
+    //
+    // Raised 36 → 38 KB on the useStepper branch:
+    //   - useStepper composable (registration, navigation, claim
+    //     wiring), createStepperRegistry primitive,
+    //     StepperLateRegistrationError, FormStore.stepperHandle +
+    //     factorySettleStarted refs, settle path consult-defer
+    //     branch in useAbstractForm.
+    // Measured at 36.89 KB.
+    limit: '38 KB',
     gzip: true,
     modifyEsbuildConfig: asEsm,
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,19 @@ export { useAbstractForm as useForm } from './runtime/composables/use-abstract-f
 // docblock for the type-erasure reasoning.
 export { injectForm } from './runtime/composables/use-form-context'
 
+// Multistep-form orchestrator. Composes existing `useForm` instances
+// into a wizard with navigation, status aggregation, and activation
+// lifecycle. See the composable's docblock for invariants.
+export { useStepper } from './runtime/composables/use-stepper'
+export type {
+  AnyForm,
+  FormKeyOf,
+  KeysOf,
+  StepperNavOptions,
+  StepperOptions,
+  UseStepperReturnType,
+} from './runtime/types/types-stepper'
+
 // Ambient bridge for components that wrap a single field and want to
 // re-bind v-register onto an inner native element. See the
 // `useRegister` section in `docs/api.md` for the wrapper-component

--- a/src/runtime/composables/use-abstract-form.ts
+++ b/src/runtime/composables/use-abstract-form.ts
@@ -283,6 +283,7 @@ export function useAbstractForm<
       // will fire on activation.
       state.isHydrating.value = true
       onServerPrefetch(() => {
+        state.factorySettleStarted.value = true
         const handle = state.stepperHandle.value
         if (handle !== undefined && handle.shouldDefer()) {
           state.isHydrating.value = false
@@ -300,6 +301,7 @@ export function useAbstractForm<
       // imperative `form.rehydrate()`).
       state.isHydrating.value = true
       void Promise.resolve().then(() => {
+        state.factorySettleStarted.value = true
         const handle = state.stepperHandle.value
         if (handle !== undefined && handle.shouldDefer()) {
           state.isHydrating.value = false

--- a/src/runtime/composables/use-abstract-form.ts
+++ b/src/runtime/composables/use-abstract-form.ts
@@ -277,16 +277,39 @@ export function useAbstractForm<
       // framework's SSR awaiter waits for resolution before the
       // payload is serialised. Resolved values bake into the
       // hydration transfer state and the client never re-fetches.
+      // Stepper claims (synchronous, after this `useForm` call but
+      // before the prefetch flush) can mark this form deferred — in
+      // which case skip the server-side fetch entirely. The client
+      // will fire on activation.
       state.isHydrating.value = true
-      onServerPrefetch(() => state.rehydrate())
+      onServerPrefetch(() => {
+        const handle = state.stepperHandle.value
+        if (handle !== undefined && handle.shouldDefer()) {
+          state.isHydrating.value = false
+          return
+        }
+        return state.rehydrate()
+      })
     } else {
       // CSR: microtask defer leaves a synchronously-following
       // `useStepper` claim a frame to register a deferral before the
-      // factory fires (PR 2). `state.rehydrate` handles the
-      // settle-and-apply cycle (same path as the imperative
-      // `form.rehydrate()`).
+      // factory fires. When a stepper has marked this form deferred,
+      // bail and register an activation callback that runs the factory
+      // once the step becomes current. Otherwise `state.rehydrate`
+      // handles the settle-and-apply cycle (same path as the
+      // imperative `form.rehydrate()`).
       state.isHydrating.value = true
-      void Promise.resolve().then(() => state.rehydrate())
+      void Promise.resolve().then(() => {
+        const handle = state.stepperHandle.value
+        if (handle !== undefined && handle.shouldDefer()) {
+          state.isHydrating.value = false
+          handle.registerActivation(() => {
+            void state.rehydrate()
+          })
+          return
+        }
+        return state.rehydrate()
+      })
     }
   }
 

--- a/src/runtime/composables/use-stepper.ts
+++ b/src/runtime/composables/use-stepper.ts
@@ -64,6 +64,22 @@ export function useStepper<Forms extends readonly AnyForm[]>(
   }
 
   const registry = useRegistry()
+
+  // Wire each form's `stepperHandle` so `useAbstractForm.settle` can
+  // consult the deferral signal before firing an async-defaults
+  // factory. Bound by `key` (not by the form return object) so
+  // future late-arriving forms that resolve to the same store inherit
+  // the claim.
+  for (const key of formKeys) {
+    const store = registry.forms.get(key)
+    if (store !== undefined) {
+      store.stepperHandle.value = {
+        shouldDefer: () => stepperRegistry.shouldDefer(key),
+        registerActivation: (callback) => stepperRegistry.registerActivation(key, callback),
+      }
+    }
+  }
+
   if (getCurrentScope() !== undefined) {
     const releases: Array<() => void> = []
     for (const key of formKeys) {
@@ -71,6 +87,10 @@ export function useStepper<Forms extends readonly AnyForm[]>(
     }
     onScopeDispose(() => {
       for (const release of releases) release()
+      for (const key of formKeys) {
+        const store = registry.forms.get(key)
+        if (store !== undefined) store.stepperHandle.value = undefined
+      }
       stepperRegistry.dispose()
     })
   }

--- a/src/runtime/composables/use-stepper.ts
+++ b/src/runtime/composables/use-stepper.ts
@@ -1,4 +1,5 @@
 import { getCurrentScope, onScopeDispose, readonly, ref } from 'vue'
+import { StepperLateRegistrationError } from '../core/errors'
 import { useRegistry } from '../core/registry'
 import { createStepperRegistry } from '../core/stepper-registry'
 import type {
@@ -64,6 +65,23 @@ export function useStepper<Forms extends readonly AnyForm[]>(
   }
 
   const registry = useRegistry()
+
+  // Late-registration guard. The defer-claim contract relies on
+  // `useStepper` winning the race against the microtask-deferred
+  // factory settle. If any participating form's factory has already
+  // started settling, the claim is too late to honor the privacy
+  // guarantee — throw with a clear message instead of silently
+  // degrading.
+  for (const key of formKeys) {
+    const store = registry.forms.get(key)
+    if (
+      store !== undefined &&
+      store.defaultValuesFactory.value !== undefined &&
+      store.factorySettleStarted.value
+    ) {
+      throw new StepperLateRegistrationError(key)
+    }
+  }
 
   // Wire each form's `stepperHandle` so `useAbstractForm.settle` can
   // consult the deferral signal before firing an async-defaults

--- a/src/runtime/composables/use-stepper.ts
+++ b/src/runtime/composables/use-stepper.ts
@@ -1,0 +1,130 @@
+import { getCurrentScope, onScopeDispose, readonly, ref } from 'vue'
+import { useRegistry } from '../core/registry'
+import { createStepperRegistry } from '../core/stepper-registry'
+import type {
+  AnyForm,
+  KeysOf,
+  StepperNavOptions,
+  StepperOptions,
+  UseStepperReturnType,
+} from '../types/types-stepper'
+
+/**
+ * Multistep-form orchestrator. Composes existing `useForm` instances
+ * into a wizard with navigation, status aggregation (PR 3), browser
+ * history (PR 4), and activation-lifecycle defer (so a step's async
+ * `defaultValues` factory only fires when the step becomes current).
+ *
+ * Construction-time invariants:
+ *   - At least one form.
+ *   - No duplicate keys across the forms array.
+ *   - Each form's `key` is non-empty.
+ *
+ * Navigation behavior:
+ *   - `next()` / `back()` past either end is a silent no-op + dev
+ *     console warning. Crashing here would punish consumers who wire
+ *     navigation buttons without also disabling them at the bounds.
+ *   - `goTo(unknownKey)` throws — typo safety for an explicit jump
+ *     the consumer is asking for by literal value.
+ *
+ * Each form gets a ref-count via `registry.trackConsumer(key)`. This
+ * pins the FormStore for the stepper's lifetime — so a step's state
+ * survives even when its component is unmounted between visits
+ * (v-if pattern). The ref is released on `onScopeDispose`.
+ */
+export function useStepper<Forms extends readonly AnyForm[]>(
+  forms: Forms,
+  _options: StepperOptions
+): UseStepperReturnType<Forms> {
+  if (forms.length === 0) {
+    throw new Error('[attaform] useStepper requires at least one form.')
+  }
+
+  const seenKeys = new Set<string>()
+  for (const form of forms) {
+    if (form.key === '') {
+      throw new Error('[attaform] useStepper: every form must have a non-empty key.')
+    }
+    if (seenKeys.has(form.key)) {
+      throw new Error(
+        `[attaform] useStepper: duplicate form key "${form.key}". Each step needs a distinct key.`
+      )
+    }
+    seenKeys.add(form.key)
+  }
+
+  const stepperRegistry = createStepperRegistry()
+  const formKeys = forms.map((form) => form.key)
+  const initialKey = formKeys[0] as KeysOf<Forms>
+  const current = ref(initialKey) as ReturnType<typeof ref<KeysOf<Forms>>>
+
+  stepperRegistry.claim(initialKey, true)
+  for (let i = 1; i < formKeys.length; i += 1) {
+    stepperRegistry.claim(formKeys[i]!, false)
+  }
+
+  const registry = useRegistry()
+  if (getCurrentScope() !== undefined) {
+    const releases: Array<() => void> = []
+    for (const key of formKeys) {
+      releases.push(registry.trackConsumer(key))
+    }
+    onScopeDispose(() => {
+      for (const release of releases) release()
+      stepperRegistry.dispose()
+    })
+  }
+
+  function indexOf(key: string): number {
+    return formKeys.indexOf(key)
+  }
+
+  function setCurrent(nextKey: KeysOf<Forms>): void {
+    const priorKey = current.value as KeysOf<Forms>
+    if (priorKey === nextKey) return
+    stepperRegistry.markCurrent(nextKey, priorKey)
+    current.value = nextKey
+  }
+
+  function next(_options?: StepperNavOptions): void {
+    const idx = indexOf(current.value as string)
+    if (idx === formKeys.length - 1) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[attaform] useStepper.next(): already on the last step ("${current.value as string}"). Disable the button at the end of the wizard.`
+      )
+      return
+    }
+    setCurrent(formKeys[idx + 1] as KeysOf<Forms>)
+  }
+
+  function back(_options?: StepperNavOptions): void {
+    const idx = indexOf(current.value as string)
+    if (idx === 0) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[attaform] useStepper.back(): already on the first step ("${current.value as string}"). Disable the button at the start of the wizard.`
+      )
+      return
+    }
+    setCurrent(formKeys[idx - 1] as KeysOf<Forms>)
+  }
+
+  function goTo(key: KeysOf<Forms>, _options?: StepperNavOptions): void {
+    if (!seenKeys.has(key as string)) {
+      throw new Error(
+        `[attaform] useStepper.goTo("${String(key)}"): unknown step key. Known keys: ${formKeys.map((k) => `"${k}"`).join(', ')}.`
+      )
+    }
+    setCurrent(key)
+  }
+
+  return {
+    current: readonly(current) as Readonly<typeof current>,
+    forms,
+    count: forms.length,
+    next,
+    back,
+    goTo,
+  } as UseStepperReturnType<Forms>
+}

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -321,6 +321,21 @@ export type FormStore<F extends GenericForm, G extends GenericForm = F> = {
    */
   readonly defaultValuesFactory: Ref<(() => unknown | Promise<unknown>) | undefined>
   /**
+   * Bridge populated by `useStepper` when this form participates in a
+   * stepper. `useAbstractForm.settle` consults `shouldDefer()` before
+   * firing the captured async-defaults factory: if `true`, settle
+   * bails and registers an activation callback that fires the factory
+   * once the step becomes current. `undefined` when the form is
+   * standalone — no defer-claim, factory fires normally.
+   */
+  readonly stepperHandle: Ref<
+    | {
+        shouldDefer: () => boolean
+        registerActivation: (callback: () => void) => void
+      }
+    | undefined
+  >
+  /**
    * Re-fire the captured function-form `defaultValues` factory. Throws
    * synchronously when no factory was captured (plain-value form).
    * Resolves after `isHydrating` flips back to `false`; consumers can
@@ -1264,6 +1279,13 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
   const isHydrating = ref(false)
   const hydrateError = ref<unknown>(null)
   const defaultValuesFactory = ref<(() => unknown | Promise<unknown>) | undefined>(undefined)
+  const stepperHandle = ref<
+    | {
+        shouldDefer: () => boolean
+        registerActivation: (callback: () => void) => void
+      }
+    | undefined
+  >(undefined)
   // Initial-validity gate. See `FormStore.firstValidationDone` JSDoc.
   // Only ASYNC-validating strict schemas need the gate: sync schemas
   // either surface refinement errors at construction (slim parse
@@ -2886,6 +2908,7 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     isHydrating,
     hydrateError,
     defaultValuesFactory,
+    stepperHandle,
     rehydrate,
     submissionGeneration,
     activeValidations,

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -321,6 +321,15 @@ export type FormStore<F extends GenericForm, G extends GenericForm = F> = {
    */
   readonly defaultValuesFactory: Ref<(() => unknown | Promise<unknown>) | undefined>
   /**
+   * `true` once `useAbstractForm`'s settle path has started running
+   * the captured factory (CSR microtask body or
+   * `onServerPrefetch`'s SSR body). Read by `useStepper`'s
+   * late-registration guard: if a stepper-claimed form has settled
+   * before the claim arrived, the defer-claim contract can't honor
+   * the privacy guarantee and we throw `StepperLateRegistrationError`.
+   */
+  readonly factorySettleStarted: Ref<boolean>
+  /**
    * Bridge populated by `useStepper` when this form participates in a
    * stepper. `useAbstractForm.settle` consults `shouldDefer()` before
    * firing the captured async-defaults factory: if `true`, settle
@@ -1279,6 +1288,10 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
   const isHydrating = ref(false)
   const hydrateError = ref<unknown>(null)
   const defaultValuesFactory = ref<(() => unknown | Promise<unknown>) | undefined>(undefined)
+  // Flipped to `true` once `useAbstractForm`'s settle microtask body
+  // starts running (CSR) or `onServerPrefetch` invokes the body
+  // (SSR). Read by `useStepper`'s late-registration guard.
+  const factorySettleStarted = ref(false)
   const stepperHandle = ref<
     | {
         shouldDefer: () => boolean
@@ -2908,6 +2921,7 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     isHydrating,
     hydrateError,
     defaultValuesFactory,
+    factorySettleStarted,
     stepperHandle,
     rehydrate,
     submissionGeneration,

--- a/src/runtime/core/errors.ts
+++ b/src/runtime/core/errors.ts
@@ -110,6 +110,28 @@ export class OutsideSetupError extends AttaformError {
 }
 
 /**
+ * Thrown when `useStepper` is called too late — after a participating
+ * form's async `defaultValues` factory has already settled. The
+ * defer-claim contract relies on `useStepper` winning the race
+ * against a microtask-deferred factory; once the factory has fired,
+ * the claim can no longer hold the privacy guarantee for that step.
+ *
+ * Fix: call `useStepper(...)` in the same synchronous `setup()` as
+ * its participating `useForm(...)` calls. Don't defer the stepper
+ * construction into `onMounted`, a watcher, or an async setup
+ * function that awaits before the call.
+ */
+export class StepperLateRegistrationError extends AttaformError {
+  constructor(key: string) {
+    super(
+      `[attaform] useStepper called after form "${key}" already settled its async defaultValues. ` +
+        `The defer-claim contract needs useStepper to run in the same synchronous setup() as ` +
+        `its useForm() calls. Move the useStepper(...) call up to setup-top, before any await.`
+    )
+  }
+}
+
+/**
  * Thrown when a `useForm({ key })` call uses a key starting with
  * `__atta:`. That prefix is reserved for keys the library generates
  * internally (e.g. for anonymous `useForm()` calls without an

--- a/src/runtime/core/stepper-registry.ts
+++ b/src/runtime/core/stepper-registry.ts
@@ -1,0 +1,101 @@
+import type { FormKey } from '../types/types-api'
+
+/**
+ * Per-stepper bookkeeping. A stepper claims each participating form's
+ * key, marks one claim `current`, and signals "this form's factory
+ * should defer until activated" via `shouldDefer`. `useAbstractForm`'s
+ * settle path consults `shouldDefer` before firing a function-form
+ * `defaultValues` factory.
+ *
+ * Decoupled from `AttaformRegistry` because a stepper's lifetime is
+ * a setup-scope subset of the registry's app lifetime — we want
+ * claims to clear on `onScopeDispose` without touching the form
+ * registry's eviction logic.
+ */
+
+type ClaimRecord = {
+  isCurrent: boolean
+}
+
+export type StepperRegistry = {
+  /**
+   * Record that this stepper owns `key`. Idempotent — repeat claims
+   * of the same key reset the `isCurrent` bit to match the argument.
+   */
+  claim(key: FormKey, isCurrent: boolean): void
+  /** Whether this stepper owns `key`. */
+  isClaimed(key: FormKey): boolean
+  /**
+   * Whether a claimed, non-current form's `defaultValues` factory
+   * should be deferred. Returns `false` for unclaimed or current
+   * keys.
+   */
+  shouldDefer(key: FormKey): boolean
+  /**
+   * Update which claim is `current`. `priorKey === undefined` skips
+   * the prior-clear step (initial mark).
+   */
+  markCurrent(nextKey: FormKey, priorKey: FormKey | undefined): void
+  /**
+   * Register a one-shot callback that fires the first time `key`
+   * becomes current. Fires immediately if `key` is already current.
+   * Used by `useAbstractForm` to lazily run a deferred factory.
+   */
+  registerActivation(key: FormKey, callback: () => void): void
+  /** Clears all claims + pending activations. */
+  dispose(): void
+}
+
+export function createStepperRegistry(): StepperRegistry {
+  const claims = new Map<FormKey, ClaimRecord>()
+  const pendingActivations = new Map<FormKey, () => void>()
+
+  function claim(key: FormKey, isCurrent: boolean): void {
+    const existing = claims.get(key)
+    if (existing) {
+      existing.isCurrent = isCurrent
+      return
+    }
+    claims.set(key, { isCurrent })
+  }
+
+  function isClaimed(key: FormKey): boolean {
+    return claims.has(key)
+  }
+
+  function shouldDefer(key: FormKey): boolean {
+    const record = claims.get(key)
+    if (record === undefined) return false
+    return record.isCurrent === false
+  }
+
+  function markCurrent(nextKey: FormKey, priorKey: FormKey | undefined): void {
+    if (priorKey !== undefined) {
+      const prior = claims.get(priorKey)
+      if (prior) prior.isCurrent = false
+    }
+    const next = claims.get(nextKey)
+    if (next) next.isCurrent = true
+    const pending = pendingActivations.get(nextKey)
+    if (pending !== undefined) {
+      pendingActivations.delete(nextKey)
+      pending()
+    }
+  }
+
+  function registerActivation(key: FormKey, callback: () => void): void {
+    const record = claims.get(key)
+    if (record?.isCurrent === true) {
+      callback()
+      return
+    }
+    pendingActivations.set(key, callback)
+  }
+
+  function dispose(): void {
+    claims.clear()
+    pendingActivations.clear()
+  }
+
+  return { claim, isClaimed, shouldDefer, markCurrent, registerActivation, dispose }
+}

--- a/src/runtime/types/types-stepper.ts
+++ b/src/runtime/types/types-stepper.ts
@@ -1,0 +1,72 @@
+/**
+ * Public types for `useStepper` — the multistep-form orchestrator.
+ *
+ * The stepper composes existing `useForm` instances. Each step is a
+ * form with its own schema, key, validation, and persistence; the
+ * stepper layers navigation, status aggregation, and activation
+ * lifecycle on top.
+ *
+ * Discriminated `current` is the load-bearing type. Threading the
+ * literal `K` through `useForm` (see `UseFormReturnType<..., K>`)
+ * means `stepper.current.value` resolves to the union of participating
+ * keys, and `goTo(key)` autocompletes that union.
+ */
+
+import type { Ref } from 'vue'
+import type { FormKey } from './types-api'
+
+/**
+ * Minimum structural shape the stepper requires from a participating
+ * form. Constraining to the full `UseFormReturnType` would force
+ * contravariant unification of the storage / read shapes across all
+ * steps; the stepper does not care about those — it routes by `key`
+ * at runtime and exposes the original form objects untouched.
+ *
+ * `UseFormReturnType<...>` satisfies this shape because its `key`
+ * field is `readonly key: K extends FormKey`.
+ */
+export type AnyForm = { readonly key: FormKey }
+
+/**
+ * Extracts the literal key from a single keyed form's return type.
+ * Lets the stepper discriminate `stepper.current.value` on the form
+ * that owns the active step.
+ */
+export type FormKeyOf<F extends AnyForm> = F['key']
+
+/**
+ * Union of keys across an array of forms. With three forms keyed
+ * `'a' | 'b' | 'c'`, `KeysOf<typeof forms>` is `'a' | 'b' | 'c'`.
+ */
+export type KeysOf<Forms extends readonly AnyForm[]> = Forms[number]['key']
+
+/**
+ * Per-call navigation options. `replace` reserved for PR 4 (browser
+ * history); included now so the call shape is stable across stepper
+ * versions.
+ */
+export type StepperNavOptions = {
+  readonly replace?: boolean
+}
+
+/**
+ * `useStepper(forms, options)` — options is positional-required per
+ * the "required internal params" doctrine. Empty in PR 2; fields
+ * land in PR 3 (`defaultStatuses`, `onStatusChange`, `progress`) and
+ * PR 4 (`history`, `getServerActiveStep`).
+ */
+export type StepperOptions = Record<string, never>
+
+/**
+ * Return shape of `useStepper`. Reactive `current` is a readonly ref;
+ * `forms` is the original tuple (so consumers can index by key or
+ * iterate); `count` is the static step count.
+ */
+export type UseStepperReturnType<Forms extends readonly AnyForm[]> = {
+  readonly current: Readonly<Ref<KeysOf<Forms>>>
+  readonly forms: Forms
+  readonly count: number
+  readonly next: (options?: StepperNavOptions) => void
+  readonly back: (options?: StepperNavOptions) => void
+  readonly goTo: (key: KeysOf<Forms>, options?: StepperNavOptions) => void
+}

--- a/test/composables/stepper-activation.test.ts
+++ b/test/composables/stepper-activation.test.ts
@@ -1,0 +1,163 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, type App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { useStepper } from '../../src/runtime/composables/use-stepper'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import { waitUntil } from '../utils/form-harness'
+
+/**
+ * Activation-lifecycle contract for `useStepper`. A form's async
+ * `defaultValues` factory does NOT fire on mount when the form is
+ * claimed by a stepper as non-current. It fires on the first
+ * navigation into that step. Re-activation does NOT re-fire (a
+ * factory is a hydration source, not a refresh hook — chain
+ * `form.rehydrate()` to force a re-load).
+ *
+ * The motivating privacy story: a 25-step public-housing form where
+ * Step 14 needs SSN. The stepper guarantees Step 14's factory only
+ * runs once the user reaches Step 14 — even if the consumer wires
+ * all forms in setup.
+ */
+
+const schemaA = z.object({ a: z.string() })
+const schemaB = z.object({ b: z.string() })
+const schemaC = z.object({ c: z.string() })
+
+function mountHarness<R>(setup: () => R): { app: App; result: R } {
+  const handle: { result?: R } = {}
+  const App = defineComponent({
+    setup() {
+      handle.result = setup()
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  app.config.warnHandler = () => {}
+  app.config.errorHandler = () => {}
+  app.mount(document.createElement('div'))
+  return { app, result: handle.result as R }
+}
+
+describe('useStepper — async-defaults activation lifecycle', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('does not fire a non-current form factory on mount', async () => {
+    let aCalls = 0
+    let bCalls = 0
+    let cCalls = 0
+    const { app, result } = mountHarness(() => {
+      const a = useForm({
+        schema: schemaA,
+        key: 'stepper-act-a',
+        defaultValues: () => {
+          aCalls += 1
+          return Promise.resolve({ a: 'A' })
+        },
+      })
+      const b = useForm({
+        schema: schemaB,
+        key: 'stepper-act-b',
+        defaultValues: () => {
+          bCalls += 1
+          return Promise.resolve({ b: 'B' })
+        },
+      })
+      const c = useForm({
+        schema: schemaC,
+        key: 'stepper-act-c',
+        defaultValues: () => {
+          cCalls += 1
+          return Promise.resolve({ c: 'C' })
+        },
+      })
+      return { stepper: useStepper([a, b, c], {}), a, b, c }
+    })
+    apps.push(app)
+    await waitUntil(() => (result.a.isHydrating.value === false ? true : null))
+    expect(aCalls).toBe(1)
+    expect(bCalls).toBe(0)
+    expect(cCalls).toBe(0)
+    expect(result.b.isHydrating.value).toBe(false)
+    expect(result.c.isHydrating.value).toBe(false)
+  })
+
+  it('fires the factory on first activation', async () => {
+    let bCalls = 0
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema: schemaA, key: 'stepper-act-2-a' })
+      const b = useForm({
+        schema: schemaB,
+        key: 'stepper-act-2-b',
+        defaultValues: () => {
+          bCalls += 1
+          return Promise.resolve({ b: 'B' })
+        },
+      })
+      return { stepper: useStepper([a, b], {}), a, b }
+    })
+    apps.push(app)
+    await waitUntil(() => (result.a.isHydrating.value === false ? true : null))
+    expect(bCalls).toBe(0)
+
+    result.stepper.next()
+    await waitUntil(() => (result.b.isHydrating.value === false ? true : null))
+    expect(bCalls).toBe(1)
+    expect(result.b.values.b).toBe('B')
+  })
+
+  it('re-activation does NOT re-fire the factory', async () => {
+    let bCalls = 0
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema: schemaA, key: 'stepper-react-a' })
+      const b = useForm({
+        schema: schemaB,
+        key: 'stepper-react-b',
+        defaultValues: () => {
+          bCalls += 1
+          return Promise.resolve({ b: 'B' })
+        },
+      })
+      return { stepper: useStepper([a, b], {}), a, b }
+    })
+    apps.push(app)
+    await waitUntil(() => (result.a.isHydrating.value === false ? true : null))
+    result.stepper.next()
+    await waitUntil(() => (result.b.isHydrating.value === false ? true : null))
+    expect(bCalls).toBe(1)
+    result.stepper.back()
+    result.stepper.next()
+    await Promise.resolve()
+    expect(bCalls).toBe(1)
+  })
+
+  it('form.rehydrate() re-fires the factory even from a deferred form', async () => {
+    let bCalls = 0
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema: schemaA, key: 'stepper-rehyd-a' })
+      const b = useForm({
+        schema: schemaB,
+        key: 'stepper-rehyd-b',
+        defaultValues: () => {
+          bCalls += 1
+          return Promise.resolve({ b: `B-${bCalls}` })
+        },
+      })
+      return { stepper: useStepper([a, b], {}), a, b }
+    })
+    apps.push(app)
+    await waitUntil(() => (result.a.isHydrating.value === false ? true : null))
+    expect(bCalls).toBe(0)
+
+    await result.b.rehydrate()
+    expect(bCalls).toBe(1)
+    expect(result.b.values.b).toBe('B-1')
+
+    await result.b.rehydrate()
+    expect(bCalls).toBe(2)
+  })
+})

--- a/test/composables/stepper-active-form-sync.test.ts
+++ b/test/composables/stepper-active-form-sync.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, type App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { useStepper } from '../../src/runtime/composables/use-stepper'
+import { createAttaform } from '../../src/runtime/core/plugin'
+
+/**
+ * Regression guard: the defer-claim hookup must NOT intercept
+ * sync `defaultValues` on the active step (or any step). Sync
+ * values resolve at `buildFreshState` — before any microtask
+ * flush — so they are already in `form.values` by the time
+ * `useStepper` claims keys. The claim is a no-op for sync forms.
+ *
+ * Without this guard, refactoring the trichotomy branch later could
+ * accidentally route sync paths through the deferral signal.
+ */
+
+const schemaA = z.object({ a: z.string() })
+const schemaB = z.object({ b: z.string() })
+
+function mountHarness<R>(setup: () => R): { app: App; result: R } {
+  const handle: { result?: R } = {}
+  const App = defineComponent({
+    setup() {
+      handle.result = setup()
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  app.config.warnHandler = () => {}
+  app.config.errorHandler = () => {}
+  app.mount(document.createElement('div'))
+  return { app, result: handle.result as R }
+}
+
+describe('useStepper — active form with sync defaults', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('sync defaults on step 0 are visible at construction', () => {
+    const { app, result } = mountHarness(() => {
+      const a = useForm({
+        schema: schemaA,
+        key: 'stepper-sync-a',
+        defaultValues: { a: 'A-sync' },
+      })
+      const b = useForm({ schema: schemaB, key: 'stepper-sync-b' })
+      return { stepper: useStepper([a, b], {}), a, b }
+    })
+    apps.push(app)
+    expect(result.a.values.a).toBe('A-sync')
+    expect(result.a.isHydrating.value).toBe(false)
+  })
+
+  it('sync defaults on a non-current step are visible at construction', () => {
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema: schemaA, key: 'stepper-sync-2-a' })
+      const b = useForm({
+        schema: schemaB,
+        key: 'stepper-sync-2-b',
+        defaultValues: { b: 'B-sync' },
+      })
+      return { stepper: useStepper([a, b], {}), a, b }
+    })
+    apps.push(app)
+    expect(result.b.values.b).toBe('B-sync')
+    expect(result.b.isHydrating.value).toBe(false)
+  })
+})

--- a/test/composables/stepper-basics.test.ts
+++ b/test/composables/stepper-basics.test.ts
@@ -1,0 +1,182 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, type App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { useStepper } from '../../src/runtime/composables/use-stepper'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import type { UseStepperReturnType, AnyForm } from '../../src/runtime/types/types-stepper'
+
+/**
+ * `useStepper` — basic navigation. Three forms keyed `a / b / c`,
+ * mounted in setup order. The stepper records its forms and
+ * exposes:
+ *
+ *   - `count`, `current`, `forms` (introspection)
+ *   - `next()` / `back()` — silent no-op past ends with a dev-warn
+ *   - `goTo(key)` — throws on unknown key
+ *   - duplicate keys / empty forms — throws at construction
+ *
+ * The "no throw past ends" stance is deliberate: this would
+ * otherwise crash a consumer who wires a button to `next()` without
+ * also disabling it at the end of the wizard.
+ */
+
+const schema = z.object({ email: z.string() })
+
+function mountStepperHarness<R>(setup: () => R): { app: App; result: R } {
+  const handle: { result?: R } = {}
+  const App = defineComponent({
+    setup() {
+      handle.result = setup()
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  app.config.warnHandler = () => {}
+  app.config.errorHandler = () => {}
+  app.mount(document.createElement('div'))
+  return { app, result: handle.result as R }
+}
+
+/**
+ * Like `mountStepperHarness`, but captures any error thrown inside
+ * `setup` and re-throws it on the test thread. The app's
+ * `errorHandler` otherwise swallows setup-time throws — we want
+ * `expect(() => ...).toThrow()` to actually see them.
+ */
+function mountAndCaptureSetupError(setup: () => unknown): void {
+  let captured: unknown
+  const App = defineComponent({
+    setup() {
+      try {
+        setup()
+      } catch (error) {
+        captured = error
+      }
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  app.config.warnHandler = () => {}
+  app.config.errorHandler = () => {}
+  app.mount(document.createElement('div'))
+  app.unmount()
+  if (captured !== undefined) throw captured
+}
+
+type StepperWithForms<Keys extends readonly string[]> = UseStepperReturnType<
+  ReadonlyArray<AnyForm & { readonly key: Keys[number] }>
+>
+
+describe('useStepper — basic navigation', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('exposes count, forms, and initial current', () => {
+    const { app, result } = mountStepperHarness(() => {
+      const a = useForm({ schema, key: 'a' })
+      const b = useForm({ schema, key: 'b' })
+      const c = useForm({ schema, key: 'c' })
+      return useStepper([a, b, c], {}) as StepperWithForms<['a', 'b', 'c']>
+    })
+    apps.push(app)
+    expect(result.count).toBe(3)
+    expect(result.forms.length).toBe(3)
+    expect(result.current.value).toBe('a')
+  })
+
+  it('next() advances and back() retreats', () => {
+    const { app, result } = mountStepperHarness(() => {
+      const a = useForm({ schema, key: 'a' })
+      const b = useForm({ schema, key: 'b' })
+      const c = useForm({ schema, key: 'c' })
+      return useStepper([a, b, c], {}) as StepperWithForms<['a', 'b', 'c']>
+    })
+    apps.push(app)
+    result.next()
+    expect(result.current.value).toBe('b')
+    result.next()
+    expect(result.current.value).toBe('c')
+    result.back()
+    expect(result.current.value).toBe('b')
+  })
+
+  it('goTo(key) jumps directly', () => {
+    const { app, result } = mountStepperHarness(() => {
+      const a = useForm({ schema, key: 'a' })
+      const b = useForm({ schema, key: 'b' })
+      const c = useForm({ schema, key: 'c' })
+      return useStepper([a, b, c], {}) as StepperWithForms<['a', 'b', 'c']>
+    })
+    apps.push(app)
+    result.goTo('c')
+    expect(result.current.value).toBe('c')
+    result.goTo('a')
+    expect(result.current.value).toBe('a')
+  })
+
+  it('next() at last step is a no-op and dev-warns', () => {
+    const warnings: string[] = []
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+      warnings.push(args.map((a) => String(a)).join(' '))
+    })
+    const { app, result } = mountStepperHarness(() => {
+      const a = useForm({ schema, key: 'a' })
+      const b = useForm({ schema, key: 'b' })
+      return useStepper([a, b], {}) as StepperWithForms<['a', 'b']>
+    })
+    apps.push(app)
+    result.next()
+    expect(result.current.value).toBe('b')
+    result.next()
+    expect(result.current.value).toBe('b')
+    warnSpy.mockRestore()
+    expect(warnings.some((w) => w.includes('useStepper'))).toBe(true)
+  })
+
+  it('back() at first step is a no-op and dev-warns', () => {
+    const warnings: string[] = []
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+      warnings.push(args.map((a) => String(a)).join(' '))
+    })
+    const { app, result } = mountStepperHarness(() => {
+      const a = useForm({ schema, key: 'a' })
+      const b = useForm({ schema, key: 'b' })
+      return useStepper([a, b], {}) as StepperWithForms<['a', 'b']>
+    })
+    apps.push(app)
+    result.back()
+    expect(result.current.value).toBe('a')
+    warnSpy.mockRestore()
+    expect(warnings.some((w) => w.includes('useStepper'))).toBe(true)
+  })
+
+  it('goTo(unknown) throws', () => {
+    const { app, result } = mountStepperHarness(() => {
+      const a = useForm({ schema, key: 'a' })
+      const b = useForm({ schema, key: 'b' })
+      return useStepper([a, b], {}) as StepperWithForms<['a', 'b']>
+    })
+    apps.push(app)
+    expect(() => (result.goTo as (key: string) => void)('typo')).toThrow(/typo/)
+  })
+
+  it('throws at construction on empty forms array', () => {
+    expect(() => {
+      mountAndCaptureSetupError(() => useStepper([], {}))
+    }).toThrow(/at least one form/i)
+  })
+
+  it('throws at construction on duplicate keys', () => {
+    expect(() => {
+      mountAndCaptureSetupError(() => {
+        const a = useForm({ schema, key: 'a' })
+        const b = useForm({ schema, key: 'a' })
+        return useStepper([a, b], {})
+      })
+    }).toThrow(/duplicate/i)
+  })
+})

--- a/test/composables/stepper-late-registration.test.ts
+++ b/test/composables/stepper-late-registration.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, type App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { useStepper } from '../../src/runtime/composables/use-stepper'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import { StepperLateRegistrationError } from '../../src/runtime/core/errors'
+import { useRegistry } from '../../src/runtime/core/registry'
+
+/**
+ * Runtime guard for the activation-lifecycle defer contract.
+ *
+ * `useStepper` must be called in the same synchronous `setup()` as
+ * its participating `useForm` calls — the defer-claim relies on
+ * winning the race against a microtask-deferred factory settle.
+ * Calling `useStepper` AFTER any participating form's async factory
+ * has already started settling makes the defer impossible to honor,
+ * so we throw `StepperLateRegistrationError` with a clear message
+ * instead of silently letting the privacy contract slip.
+ *
+ * The white-box test below simulates a race-loss by flipping
+ * `state.factorySettleStarted` directly. In practice this can occur
+ * across component-tree boundaries — e.g. a parent component runs
+ * `useForm({ key: 'b', defaultValues: () => Promise.resolve(...) })`,
+ * the factory settles between parent and child setup, then the
+ * child calls `useStepper([..., bFromParent])`.
+ */
+
+const schemaA = z.object({ a: z.string() })
+const schemaB = z.object({ b: z.string() })
+
+function mountAndCaptureSetupError(setup: () => unknown): unknown {
+  let captured: unknown
+  const App = defineComponent({
+    setup() {
+      try {
+        setup()
+      } catch (error) {
+        captured = error
+      }
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  app.config.warnHandler = () => {}
+  app.config.errorHandler = () => {}
+  app.mount(document.createElement('div'))
+  app.unmount()
+  return captured
+}
+
+describe('useStepper — late-registration guard', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('throws StepperLateRegistrationError when a participating async factory has already settled', () => {
+    const result = mountAndCaptureSetupError(() => {
+      const a = useForm({ schema: schemaA, key: 'late-reg-a' })
+      const b = useForm({
+        schema: schemaB,
+        key: 'late-reg-b',
+        defaultValues: () => Promise.resolve({ b: 'B' }),
+      })
+      // Simulate the race-loss: the factory's settle body has
+      // already started running before the useStepper call below.
+      const registry = useRegistry()
+      const bStore = registry.forms.get('late-reg-b')
+      if (bStore === undefined) throw new Error('bStore missing')
+      bStore.factorySettleStarted.value = true
+      return useStepper([a, b], {})
+    })
+    expect(result).toBeInstanceOf(StepperLateRegistrationError)
+    expect(String(result)).toMatch(/late-reg-b/)
+  })
+
+  it('does not throw when no participating form has an async factory', () => {
+    const result = mountAndCaptureSetupError(() => {
+      const a = useForm({ schema: schemaA, key: 'late-reg-sync-a' })
+      const b = useForm({ schema: schemaB, key: 'late-reg-sync-b' })
+      return useStepper([a, b], {})
+    })
+    expect(result).toBeUndefined()
+  })
+
+  it('does not throw when factorySettleStarted is true but no factory is captured', () => {
+    // Sync `defaultValues` produces no factory; the flag would
+    // never flip under normal flow, but we verify the AND guard
+    // correctly skips when only the flag is set.
+    const result = mountAndCaptureSetupError(() => {
+      const a = useForm({ schema: schemaA, key: 'late-reg-no-factory-a' })
+      const b = useForm({
+        schema: schemaB,
+        key: 'late-reg-no-factory-b',
+        defaultValues: { b: 'B-sync' },
+      })
+      const registry = useRegistry()
+      const bStore = registry.forms.get('late-reg-no-factory-b')
+      if (bStore === undefined) throw new Error('bStore missing')
+      bStore.factorySettleStarted.value = true
+      return useStepper([a, b], {})
+    })
+    expect(result).toBeUndefined()
+  })
+})

--- a/test/core/stepper-registry.test.ts
+++ b/test/core/stepper-registry.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import { createStepperRegistry } from '../../src/runtime/core/stepper-registry'
+
+/**
+ * `stepper-registry` is the per-stepper bookkeeping primitive that
+ * coordinates with `useAbstractForm.settle`. A stepper claims each
+ * participating form's key, marks one of those claims `current`, and
+ * (later) signals "this form's factory should defer until activated."
+ *
+ * Contract:
+ *  - `claim(key, isCurrent)` records the claim. Duplicate claim of the
+ *    same key from the same registry returns the same record (idempotent).
+ *  - `isClaimed(key)` returns whether the key is owned by this registry.
+ *  - `shouldDefer(key)` returns `true` for claimed-but-not-current keys.
+ *  - `markCurrent(nextKey, priorKey)` flips the current bit and clears
+ *    the prior's current bit.
+ *  - `registerActivation(key, callback)` attaches a one-shot callback
+ *    that fires the first time the key becomes current.
+ *  - `dispose()` clears everything — for `onScopeDispose`.
+ */
+
+describe('createStepperRegistry', () => {
+  it('records a claim and reports it', () => {
+    const registry = createStepperRegistry()
+    registry.claim('a', false)
+    expect(registry.isClaimed('a')).toBe(true)
+    expect(registry.isClaimed('b')).toBe(false)
+  })
+
+  it('reports current vs deferred', () => {
+    const registry = createStepperRegistry()
+    registry.claim('a', true)
+    registry.claim('b', false)
+    expect(registry.shouldDefer('a')).toBe(false)
+    expect(registry.shouldDefer('b')).toBe(true)
+  })
+
+  it('returns false from shouldDefer for unclaimed keys', () => {
+    const registry = createStepperRegistry()
+    expect(registry.shouldDefer('never-claimed')).toBe(false)
+  })
+
+  it('markCurrent flips the current bit and clears the prior', () => {
+    const registry = createStepperRegistry()
+    registry.claim('a', true)
+    registry.claim('b', false)
+    registry.markCurrent('b', 'a')
+    expect(registry.shouldDefer('a')).toBe(true)
+    expect(registry.shouldDefer('b')).toBe(false)
+  })
+
+  it('registerActivation fires on transition into current', () => {
+    const registry = createStepperRegistry()
+    registry.claim('a', true)
+    registry.claim('b', false)
+    let bActivated = 0
+    registry.registerActivation('b', () => {
+      bActivated += 1
+    })
+    expect(bActivated).toBe(0)
+    registry.markCurrent('b', 'a')
+    expect(bActivated).toBe(1)
+  })
+
+  it('registerActivation is one-shot — re-activation does not re-fire', () => {
+    const registry = createStepperRegistry()
+    registry.claim('a', true)
+    registry.claim('b', false)
+    let bActivated = 0
+    registry.registerActivation('b', () => {
+      bActivated += 1
+    })
+    registry.markCurrent('b', 'a')
+    expect(bActivated).toBe(1)
+    registry.markCurrent('a', 'b')
+    registry.markCurrent('b', 'a')
+    expect(bActivated).toBe(1)
+  })
+
+  it('fires immediately if the key is already current at registration time', () => {
+    const registry = createStepperRegistry()
+    registry.claim('a', true)
+    let aActivated = 0
+    registry.registerActivation('a', () => {
+      aActivated += 1
+    })
+    expect(aActivated).toBe(1)
+  })
+
+  it('dispose clears all claims and activations', () => {
+    const registry = createStepperRegistry()
+    registry.claim('a', true)
+    registry.claim('b', false)
+    registry.registerActivation('b', () => {
+      throw new Error('should not fire after dispose')
+    })
+    registry.dispose()
+    expect(registry.isClaimed('a')).toBe(false)
+    expect(registry.isClaimed('b')).toBe(false)
+    registry.markCurrent('b', 'a')
+    expect(registry.shouldDefer('b')).toBe(false)
+  })
+})

--- a/test/types/stepper-key-union.test.ts
+++ b/test/types/stepper-key-union.test.ts
@@ -1,0 +1,56 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import type { KeysOf, FormKeyOf, AnyForm } from '../../src/runtime/types/types-stepper'
+
+/**
+ * Type-level checks for the stepper's key-union machinery. The motivating
+ * use case is multistep navigation typed by the union of all participating
+ * form keys — `stepper.current.value` is `'a' | 'b'`, `goTo('a')`
+ * autocompletes, `goTo('typo')` is a type error.
+ *
+ * Tests run at typecheck time. `expectTypeOf` chain methods are no-ops
+ * at runtime. The `_neverInvoked` wrappers declare real `useForm` calls
+ * so TypeScript exercises call-site inference; no Vue app context is
+ * needed because the functions are never called.
+ */
+
+const schema = z.object({ email: z.string() })
+
+describe('stepper key-union types', () => {
+  it('FormKeyOf extracts the literal key from a form return type', () => {
+    function _neverInvoked() {
+      const _form = useForm({ schema, key: 'signup' })
+      expectTypeOf<FormKeyOf<typeof _form>>().toEqualTypeOf<'signup'>()
+    }
+    void _neverInvoked
+  })
+
+  it('KeysOf builds a union across an array of forms', () => {
+    function _neverInvoked() {
+      const a = useForm({ schema, key: 'signup' })
+      const b = useForm({ schema, key: 'cargo' })
+      const c = useForm({ schema, key: 'review' })
+      const _forms = [a, b, c] as const
+      expectTypeOf<KeysOf<typeof _forms>>().toEqualTypeOf<'signup' | 'cargo' | 'review'>()
+    }
+    void _neverInvoked
+  })
+
+  it('KeysOf collapses to the same literal for a single-form tuple', () => {
+    function _neverInvoked() {
+      const a = useForm({ schema, key: 'only' })
+      const _forms = [a] as const
+      expectTypeOf<KeysOf<typeof _forms>>().toEqualTypeOf<'only'>()
+    }
+    void _neverInvoked
+  })
+
+  it('AnyForm accepts any keyed useForm return type', () => {
+    function _neverInvoked() {
+      const a = useForm({ schema, key: 'signup' })
+      expectTypeOf(a).toMatchTypeOf<AnyForm>()
+    }
+    void _neverInvoked
+  })
+})


### PR DESCRIPTION
## Summary
- `useStepper(forms, options)` composes existing `useForm` instances into a wizard with reactive `current`, navigation (`next` / `back` / `goTo`), and activation-lifecycle defer.
- A step's async `defaultValues` factory does NOT fire on mount when the form is non-current. It fires on first activation (`goTo` / `next` into that step). Re-activation does not re-fire; chain `form.rehydrate()` to force a reload.
- Construction validates: ≥1 form, no duplicate keys, non-empty keys. `goTo(unknownKey)` throws (typo safety). `next` / `back` past either end is a silent no-op + dev `console.warn` (we don't want to break a consumer who wires nav buttons without disabling at the bounds).

## Activation lifecycle
The stepper claims each form's key BEFORE the microtask flush that fires deferred-defaults factories. `useAbstractForm.settle` consults `stepperRegistry.shouldDefer(key)` and bails for non-current forms, registering a one-shot activation callback that runs `state.rehydrate()` when the step becomes current. SSR follows the same shape inside `onServerPrefetch` — a 25-step form's deferred steps never fetch sensitive data server-side.

## Late-registration guard
`useStepper` must run in the same synchronous `setup()` as its participating `useForm` calls. If the defer-claim arrives after a factory has already settled (e.g. across component-tree boundaries where a parent's form settled between parent and child setup), `useStepper` throws `StepperLateRegistrationError` with a "move the useStepper(...) call up to setup-top" message instead of silently dropping the privacy guarantee.

## Commit ladder (TDD red-green per commit)
1. `feat(types): types-stepper skeleton` — AnyForm / KeysOf / FormKeyOf, type-only
2. `feat(form): stepper-registry primitive` — claim, mark current, defer signal, activation hooks
3. `feat(form): useStepper navigation` — current, next, back, goTo + invariants
4. `feat(form): defer async factories for non-current stepper forms` — settle ↔ claim wire
5. `feat(form): regression guard — sync defaults bypass stepper defer`
6. `feat(form): late-registration guard — StepperLateRegistrationError`
7. `chore(size): bump index.mjs 36→38 kB for useStepper`

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm vitest run` — 2572 passing
- [x] `pnpm check:size` — all budgets green
- [x] `cd apps/site && pnpm bundle:repl` — bundles successfully

## Breaking type changes
None — the stepper is a new export. PR1 (defaultValues trichotomy) is the only behavior-change of this stack.

## Stacks on
PR #199 (`feat/default-values-trichotomy`). Merge that first; this branch will rebase onto `main` automatically.

## Open-question decisions (per kickoff)
1. `next` / `back` past end → silent no-op + dev warn (confirmed: don't break consumer apps)
2. Stepper ref-counts each FormStore via `registry.trackConsumer` → yes
3. Error class name → `StepperLateRegistrationError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)