### PR TITLE
feat(form): useStepper browser history + SSR active-step selection

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -162,7 +162,16 @@ export default [
     //     factorySettleStarted refs, settle path consult-defer
     //     branch in useAbstractForm.
     // Measured at 36.89 KB.
-    limit: '38 KB',
+    //
+    // Raised 38 → 39 KB on the stepper history + SSR branch:
+    //   - createStepperHistory primitive (push/replace/popstate
+    //     handle around `window.history`, NOOP_STEPPER_HISTORY for
+    //     SSR + disable path)
+    //   - history config + popstate subscription + URL-seed +
+    //     replace-on-mount in use-stepper.ts
+    //   - StepperHistoryConfig + getServerActiveStep option types
+    // Measured at 38.30 KB.
+    limit: '39 KB',
     gzip: true,
     modifyEsbuildConfig: asEsm,
   },

--- a/src/runtime/composables/use-stepper.ts
+++ b/src/runtime/composables/use-stepper.ts
@@ -10,6 +10,7 @@ import {
 import { StepperLateRegistrationError } from '../core/errors'
 import { useRegistry } from '../core/registry'
 import { resolveTrichotomy } from '../core/resolve-default-values'
+import { createStepperHistory, NOOP_STEPPER_HISTORY } from '../core/stepper-history'
 import { createStepperRegistry } from '../core/stepper-registry'
 import { buildStepperStatusesProxy } from '../core/stepper-statuses-proxy'
 import type {
@@ -19,6 +20,7 @@ import type {
   FormStatus,
   KeysOf,
   Statuses,
+  StepperHistoryConfig,
   StepperNavOptions,
   StepperOptions,
   UseStepperReturnType,
@@ -98,13 +100,41 @@ export function useStepper<Forms extends readonly AnyForm[]>(
 
   const stepperRegistry = createStepperRegistry()
   const formKeys = forms.map((form) => form.key)
-  const initialKey = formKeys[0] as KeysOf<Forms>
+
+  // Resolve history config. `history` omitted → default on with the
+  // standard `step` param. `history: true` → same defaults. `false` →
+  // primitive replaced with a no-op (no DOM access, no popstate
+  // subscription).
+  const historyOption = options.history
+  const historyConfig: Required<StepperHistoryConfig> = {
+    enabled: historyOption !== false,
+    param:
+      typeof historyOption === 'object' && historyOption !== null
+        ? (historyOption.param ?? 'step')
+        : 'step',
+  }
+  const stepperHistory = historyConfig.enabled
+    ? createStepperHistory(historyConfig.param)
+    : NOOP_STEPPER_HISTORY
+  // Resolve initial step. URL takes priority when it names a known
+  // key — supports reload-on-step-N. Unknown key falls through to
+  // forms[0] so consumers don't crash on stale links.
+  const fromUrl = stepperHistory.read()
+  const initialKey = (
+    fromUrl !== undefined && formKeys.includes(fromUrl) ? fromUrl : formKeys[0]
+  ) as KeysOf<Forms>
   const current = ref(initialKey) as ReturnType<typeof ref<KeysOf<Forms>>>
 
   stepperRegistry.claim(initialKey, true)
-  for (let i = 1; i < formKeys.length; i += 1) {
-    stepperRegistry.claim(formKeys[i]!, false)
+  for (let i = 0; i < formKeys.length; i += 1) {
+    const key = formKeys[i]!
+    if (key === initialKey) continue
+    stepperRegistry.claim(key, false)
   }
+
+  // Replace the URL so it always reflects the active step on mount —
+  // idempotent when the URL already named the correct key.
+  stepperHistory.replace(initialKey as string)
 
   const registry = useRegistry()
 
@@ -258,6 +288,7 @@ export function useStepper<Forms extends readonly AnyForm[]>(
         if (store !== undefined) store.stepperHandle.value = undefined
       }
       stepperRegistry.dispose()
+      stepperHistory.dispose()
     })
   }
 
@@ -320,11 +351,26 @@ export function useStepper<Forms extends readonly AnyForm[]>(
     return flat
   })
 
-  function setCurrent(nextKey: KeysOf<Forms>): void {
+  /**
+   * Internal navigation. `historyMode` controls how the change is
+   * reflected in `window.history`:
+   *   - `'push'` (default for nav calls) — new history entry.
+   *   - `'replace'` — overwrite the current entry (for
+   *     `goTo({ replace: true })`).
+   *   - `'silent'` — no write. Used by the popstate handler: the
+   *     browser has already moved the entry, writing again would
+   *     double-record.
+   */
+  function setCurrent(
+    nextKey: KeysOf<Forms>,
+    historyMode: 'push' | 'replace' | 'silent' = 'push'
+  ): void {
     const priorKey = current.value as KeysOf<Forms>
     if (priorKey === nextKey) return
     stepperRegistry.markCurrent(nextKey, priorKey)
     current.value = nextKey
+    if (historyMode === 'push') stepperHistory.push(nextKey as string)
+    else if (historyMode === 'replace') stepperHistory.replace(nextKey as string)
     // Synthetic nav-away invocation. `onStatusChange` fires for the
     // form being left, regardless of whether anything materially
     // changed — useful for autosave-on-step-leave patterns.
@@ -340,7 +386,16 @@ export function useStepper<Forms extends readonly AnyForm[]>(
     }
   }
 
-  function next(_options?: StepperNavOptions): void {
+  // Browser back/forward → restore current from URL. The handler is a
+  // no-op when the URL no longer names a known key (consumer linked
+  // outside the wizard, or popped past the original entry).
+  stepperHistory.subscribe((key) => {
+    if (key === undefined) return
+    if (!seenKeys.has(key)) return
+    setCurrent(key as KeysOf<Forms>, 'silent')
+  })
+
+  function next(navOptions?: StepperNavOptions): void {
     const idx = indexOf(current.value as string)
     if (idx === formKeys.length - 1) {
       console.warn(
@@ -348,10 +403,13 @@ export function useStepper<Forms extends readonly AnyForm[]>(
       )
       return
     }
-    setCurrent(formKeys[idx + 1] as KeysOf<Forms>)
+    setCurrent(
+      formKeys[idx + 1] as KeysOf<Forms>,
+      navOptions?.replace === true ? 'replace' : 'push'
+    )
   }
 
-  function back(_options?: StepperNavOptions): void {
+  function back(navOptions?: StepperNavOptions): void {
     const idx = indexOf(current.value as string)
     if (idx === 0) {
       console.warn(
@@ -359,16 +417,19 @@ export function useStepper<Forms extends readonly AnyForm[]>(
       )
       return
     }
-    setCurrent(formKeys[idx - 1] as KeysOf<Forms>)
+    setCurrent(
+      formKeys[idx - 1] as KeysOf<Forms>,
+      navOptions?.replace === true ? 'replace' : 'push'
+    )
   }
 
-  function goTo(key: KeysOf<Forms>, _options?: StepperNavOptions): void {
+  function goTo(key: KeysOf<Forms>, navOptions?: StepperNavOptions): void {
     if (!seenKeys.has(key as string)) {
       throw new Error(
         `[attaform] useStepper.goTo("${String(key)}"): unknown step key. Known keys: ${formKeys.map((k) => `"${k}"`).join(', ')}.`
       )
     }
-    setCurrent(key)
+    setCurrent(key, navOptions?.replace === true ? 'replace' : 'push')
   }
 
   return {

--- a/src/runtime/composables/use-stepper.ts
+++ b/src/runtime/composables/use-stepper.ts
@@ -116,13 +116,21 @@ export function useStepper<Forms extends readonly AnyForm[]>(
   const stepperHistory = historyConfig.enabled
     ? createStepperHistory(historyConfig.param)
     : NOOP_STEPPER_HISTORY
-  // Resolve initial step. URL takes priority when it names a known
-  // key — supports reload-on-step-N. Unknown key falls through to
-  // forms[0] so consumers don't crash on stale links.
+  // Resolve initial step. Priority: `getServerActiveStep()` (SSR
+  // source of truth, returned identically on client) → URL
+  // `?step=<key>` (reload preservation when no getter is wired) →
+  // `forms[0]` fallback. Unknown keys at any level fall through so a
+  // stale link can't crash construction.
+  const fromGetter = options.getServerActiveStep?.()
   const fromUrl = stepperHistory.read()
-  const initialKey = (
-    fromUrl !== undefined && formKeys.includes(fromUrl) ? fromUrl : formKeys[0]
-  ) as KeysOf<Forms>
+  let initialKey: KeysOf<Forms>
+  if (fromGetter !== undefined && formKeys.includes(fromGetter as string)) {
+    initialKey = fromGetter as KeysOf<Forms>
+  } else if (fromUrl !== undefined && formKeys.includes(fromUrl)) {
+    initialKey = fromUrl as KeysOf<Forms>
+  } else {
+    initialKey = formKeys[0] as KeysOf<Forms>
+  }
   const current = ref(initialKey) as ReturnType<typeof ref<KeysOf<Forms>>>
 
   stepperRegistry.claim(initialKey, true)

--- a/src/runtime/core/stepper-history.ts
+++ b/src/runtime/core/stepper-history.ts
@@ -1,0 +1,87 @@
+/**
+ * Browser-history primitive for `useStepper`. Encapsulates the only
+ * DOM-touching surface in the stepper module so the composable can
+ * stay framework-agnostic — no `useRoute()`, no vue-router, no Nuxt
+ * coupling.
+ *
+ * The handle exposes four operations:
+ *   - `push(key)` — pushState that records `key` in `?<param>=<key>`
+ *     while preserving any other search params already on the URL.
+ *   - `replace(key)` — same write, but via replaceState so the
+ *     history stack doesn't grow (used for the initial entry and for
+ *     `goTo({ replace: true })`).
+ *   - `read()` — read the current step key from the URL, or
+ *     `undefined` if the param is absent.
+ *   - `subscribe(cb)` — register a popstate listener; the callback
+ *     receives the key parsed off the new URL (or `undefined`).
+ *   - `dispose()` — tear down. Idempotent.
+ *
+ * SSR safety: when `typeof window === 'undefined'`, the factory
+ * returns a no-op handle. Consumers don't have to gate calls — the
+ * primitive is the gate.
+ */
+
+export type StepperHistoryHandle = {
+  push(key: string): void
+  replace(key: string): void
+  read(): string | undefined
+  subscribe(callback: (key: string | undefined) => void): void
+  dispose(): void
+}
+
+const NOOP_HANDLE: StepperHistoryHandle = {
+  push() {},
+  replace() {},
+  read() {
+    return undefined
+  },
+  subscribe() {},
+  dispose() {},
+}
+
+export function createStepperHistory(param: string): StepperHistoryHandle {
+  if (typeof window === 'undefined') return NOOP_HANDLE
+
+  const subscribers: Array<(key: string | undefined) => void> = []
+  let disposed = false
+
+  function buildUrl(key: string): string {
+    const url = new URL(window.location.href)
+    url.searchParams.set(param, key)
+    return url.toString()
+  }
+
+  function handlePopstate(): void {
+    if (disposed) return
+    const url = new URL(window.location.href)
+    const value = url.searchParams.get(param) ?? undefined
+    for (const subscriber of subscribers) subscriber(value)
+  }
+
+  window.addEventListener('popstate', handlePopstate)
+
+  return {
+    push(key) {
+      if (disposed) return
+      window.history.pushState({}, '', buildUrl(key))
+    },
+    replace(key) {
+      if (disposed) return
+      window.history.replaceState({}, '', buildUrl(key))
+    },
+    read() {
+      const url = new URL(window.location.href)
+      return url.searchParams.get(param) ?? undefined
+    },
+    subscribe(callback) {
+      if (disposed) return
+      subscribers.push(callback)
+    },
+    dispose() {
+      if (disposed) return
+      disposed = true
+      subscribers.length = 0
+      window.removeEventListener('popstate', handlePopstate)
+    },
+  }
+}

--- a/src/runtime/core/stepper-history.ts
+++ b/src/runtime/core/stepper-history.ts
@@ -29,7 +29,12 @@ export type StepperHistoryHandle = {
   dispose(): void
 }
 
-const NOOP_HANDLE: StepperHistoryHandle = {
+/**
+ * No-op handle. Returned by `createStepperHistory` on SSR (no
+ * `window`) and assigned directly when the consumer passes
+ * `history: false`. Every method is a safe call-site shim.
+ */
+export const NOOP_STEPPER_HISTORY: StepperHistoryHandle = {
   push() {},
   replace() {},
   read() {
@@ -40,7 +45,7 @@ const NOOP_HANDLE: StepperHistoryHandle = {
 }
 
 export function createStepperHistory(param: string): StepperHistoryHandle {
-  if (typeof window === 'undefined') return NOOP_HANDLE
+  if (typeof window === 'undefined') return NOOP_STEPPER_HISTORY
 
   const subscribers: Array<(key: string | undefined) => void> = []
   let disposed = false

--- a/src/runtime/types/types-stepper.ts
+++ b/src/runtime/types/types-stepper.ts
@@ -189,6 +189,19 @@ export type StepperOptions<Forms extends readonly AnyForm[] = readonly AnyForm[]
    * underlying primitive is a no-op.
    */
   readonly history?: boolean | StepperHistoryConfig
+  /**
+   * Framework-agnostic SSR active-step source. The library does not
+   * import `useRoute()` or any router — the consumer reads route
+   * state from whichever framework they use and returns the active
+   * step key. The stepper consults this BEFORE form-store settle
+   * microtasks fire so the active step's `onServerPrefetch` runs
+   * server-side and non-active steps stay deferred.
+   *
+   * The getter runs on both server and client (the consumer's route
+   * source must be available on both); returning `undefined` falls
+   * through to URL `?step=<key>` and finally to `forms[0]`.
+   */
+  readonly getServerActiveStep?: () => KeysOf<Forms> | undefined
 }
 
 /**

--- a/src/runtime/types/types-stepper.ts
+++ b/src/runtime/types/types-stepper.ts
@@ -115,6 +115,19 @@ export type StepperStatusesProxy<S extends Record<string, FormStatus>> = ((
   Readonly<S>
 
 /**
+ * Browser-history config. `history: true` (the default when the
+ * option is omitted) enables `?step=<key>` round-tripping via
+ * `window.history.pushState` / `replaceState` / `popstate`.
+ * `history: false` disables the integration entirely — useful for
+ * embedded wizards where step state lives in component state.
+ * `history: { param: 'wiz' }` customises the URL search param.
+ */
+export type StepperHistoryConfig = {
+  readonly enabled?: boolean
+  readonly param?: string
+}
+
+/**
  * `useStepper(forms, options)` — options is positional-required per
  * the "required internal params" doctrine. PR 3 adds
  * `defaultStatuses`; PR 4 adds `history` + `getServerActiveStep`.
@@ -165,6 +178,17 @@ export type StepperOptions<Forms extends readonly AnyForm[] = readonly AnyForm[]
    * form.meta, stepper.statuses, etc.).
    */
   readonly progress?: (forms: Forms) => number
+  /**
+   * Browser-history integration. Default behaviour (option omitted
+   * or `true`) is to record each navigation in `window.history` so
+   * back/forward buttons walk steps and reload preserves the active
+   * step via `?step=<key>`. `false` disables the integration.
+   * An object form lets the consumer rename the URL param.
+   *
+   * SSR-safe regardless of value: when `window` is undefined the
+   * underlying primitive is a no-op.
+   */
+  readonly history?: boolean | StepperHistoryConfig
 }
 
 /**

--- a/test/composables/stepper-get-server-active-step.test.ts
+++ b/test/composables/stepper-get-server-active-step.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, type App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { useStepper } from '../../src/runtime/composables/use-stepper'
+import { createAttaform } from '../../src/runtime/core/plugin'
+
+/**
+ * `getServerActiveStep()` is the framework-agnostic SSR active-step
+ * source. The consumer reads route state from their framework
+ * (vue-router, Nuxt route, custom) and returns the active step key.
+ * The stepper uses the return value to seed `current.value` BEFORE
+ * any form-store settle microtask fires, so the active step's
+ * `onServerPrefetch` runs and non-active steps stay deferred.
+ *
+ * Priority order for initial step selection:
+ *   1. `getServerActiveStep()` if it returns a known key.
+ *   2. URL `?step=<knownKey>` via the history primitive.
+ *   3. `forms[0]` fallback.
+ */
+
+const schemaA = z.object({ a: z.string() })
+const schemaB = z.object({ b: z.string() })
+const schemaC = z.object({ c: z.string() })
+
+function mountHarness<R>(setup: () => R): { app: App; result: R } {
+  const handle: { result?: R } = {}
+  const App = defineComponent({
+    setup() {
+      handle.result = setup()
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  app.config.warnHandler = () => {}
+  app.config.errorHandler = () => {}
+  app.mount(document.createElement('div'))
+  return { app, result: handle.result as R }
+}
+
+describe('useStepper — getServerActiveStep', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('a known key from the getter seeds initial current', () => {
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema: schemaA, key: 'gs-known-a' })
+      const b = useForm({ schema: schemaB, key: 'gs-known-b' })
+      const c = useForm({ schema: schemaC, key: 'gs-known-c' })
+      return useStepper([a, b, c], {
+        getServerActiveStep: () => 'gs-known-b',
+      })
+    })
+    apps.push(app)
+    expect(result.current.value).toBe('gs-known-b')
+  })
+
+  it('an unknown key from the getter falls through to forms[0]', () => {
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema: schemaA, key: 'gs-unk-a' })
+      const b = useForm({ schema: schemaB, key: 'gs-unk-b' })
+      // Cast to bypass the literal-narrow getter type — simulates a
+      // stale URL value reaching the getter. Runtime fallback should
+      // catch it.
+      return useStepper([a, b], {
+        getServerActiveStep: (() => 'gs-unk-zzz') as unknown as () =>
+          | 'gs-unk-a'
+          | 'gs-unk-b'
+          | undefined,
+      })
+    })
+    apps.push(app)
+    expect(result.current.value).toBe('gs-unk-a')
+  })
+
+  it('undefined return falls through to URL/forms[0]', () => {
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema: schemaA, key: 'gs-undef-a' })
+      const b = useForm({ schema: schemaB, key: 'gs-undef-b' })
+      return useStepper([a, b], {
+        getServerActiveStep: () => undefined,
+      })
+    })
+    apps.push(app)
+    expect(result.current.value).toBe('gs-undef-a')
+  })
+
+  it('getter takes priority over `?step=` URL param when both name known keys', () => {
+    window.history.replaceState(null, '', 'http://localhost:3000/wizard?step=gs-prio-b')
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema: schemaA, key: 'gs-prio-a' })
+      const b = useForm({ schema: schemaB, key: 'gs-prio-b' })
+      const c = useForm({ schema: schemaC, key: 'gs-prio-c' })
+      return useStepper([a, b, c], {
+        getServerActiveStep: () => 'gs-prio-c',
+      })
+    })
+    apps.push(app)
+    expect(result.current.value).toBe('gs-prio-c')
+  })
+
+  it('the chosen step is the current claim in the stepper registry', () => {
+    // The deferral lifecycle is driven by `stepperRegistry.claim(key,
+    // isCurrent)`. If the getter's choice doesn't get the current
+    // claim, its async factory would be deferred and never fire on
+    // server. We assert the right step gets the current claim by
+    // checking that `next()` from the seeded step lands on the
+    // following form in the array — proving the seeded step is the
+    // active one in the registry's view.
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema: schemaA, key: 'gs-claim-a' })
+      const b = useForm({ schema: schemaB, key: 'gs-claim-b' })
+      const c = useForm({ schema: schemaC, key: 'gs-claim-c' })
+      return useStepper([a, b, c], {
+        getServerActiveStep: () => 'gs-claim-b',
+      })
+    })
+    apps.push(app)
+    expect(result.current.value).toBe('gs-claim-b')
+    result.next()
+    expect(result.current.value).toBe('gs-claim-c')
+    result.back()
+    result.back()
+    expect(result.current.value).toBe('gs-claim-a')
+  })
+})

--- a/test/composables/stepper-history-disabled.test.ts
+++ b/test/composables/stepper-history-disabled.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, type App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { useStepper } from '../../src/runtime/composables/use-stepper'
+import { createAttaform } from '../../src/runtime/core/plugin'
+
+/**
+ * `history: false` opts out of `window.history` integration entirely.
+ * Useful for embedded wizards where the host shell already owns the
+ * URL, or for stepper instances rendered inside dialogs / drawers
+ * where a fresh history entry per step would be surprising.
+ */
+
+const schemaA = z.object({ a: z.string() })
+const schemaB = z.object({ b: z.string() })
+
+function mountHarness<R>(setup: () => R): { app: App; result: R } {
+  const handle: { result?: R } = {}
+  const App = defineComponent({
+    setup() {
+      handle.result = setup()
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  app.config.warnHandler = () => {}
+  app.config.errorHandler = () => {}
+  app.mount(document.createElement('div'))
+  return { app, result: handle.result as R }
+}
+
+describe('useStepper — history disabled', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('history: false does not call pushState or replaceState on nav', () => {
+    const pushSpy = vi.spyOn(window.history, 'pushState')
+    const replaceSpy = vi.spyOn(window.history, 'replaceState')
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema: schemaA, key: 'hd-nav-a' })
+      const b = useForm({ schema: schemaB, key: 'hd-nav-b' })
+      return useStepper([a, b], { history: false })
+    })
+    apps.push(app)
+    pushSpy.mockClear()
+    replaceSpy.mockClear()
+    result.next()
+    result.back()
+    expect(pushSpy).not.toHaveBeenCalled()
+    expect(replaceSpy).not.toHaveBeenCalled()
+    pushSpy.mockRestore()
+    replaceSpy.mockRestore()
+  })
+
+  it('history: false does not seed initial step from `?step=<key>`', () => {
+    window.history.replaceState(null, '', 'http://localhost:3000/wizard?step=hd-seed-b')
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema: schemaA, key: 'hd-seed-a' })
+      const b = useForm({ schema: schemaB, key: 'hd-seed-b' })
+      return useStepper([a, b], { history: false })
+    })
+    apps.push(app)
+    expect(result.current.value).toBe('hd-seed-a')
+  })
+
+  it('history: false leaves the URL untouched on mount', () => {
+    window.history.replaceState(null, '', 'http://localhost:3000/wizard?other=stay')
+    const replaceSpy = vi.spyOn(window.history, 'replaceState')
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema: schemaA, key: 'hd-url-a' })
+      const b = useForm({ schema: schemaB, key: 'hd-url-b' })
+      return useStepper([a, b], { history: false })
+    })
+    apps.push(app)
+    expect(replaceSpy).not.toHaveBeenCalled()
+    expect(new URL(window.location.href).searchParams.get('step')).toBeNull()
+    expect(new URL(window.location.href).searchParams.get('other')).toBe('stay')
+    expect(result.current.value).toBe('hd-url-a')
+    replaceSpy.mockRestore()
+  })
+
+  it('history: false ignores popstate (current does not change)', async () => {
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema: schemaA, key: 'hd-pop-a' })
+      const b = useForm({ schema: schemaB, key: 'hd-pop-b' })
+      return useStepper([a, b], { history: false })
+    })
+    apps.push(app)
+    result.next()
+    expect(result.current.value).toBe('hd-pop-b')
+    // Simulate a navigation event by manually replacing the URL and
+    // dispatching popstate. With history: false the stepper isn't
+    // listening, so `current` should stay put.
+    window.history.replaceState(null, '', 'http://localhost:3000/wizard?step=hd-pop-a')
+    window.dispatchEvent(new PopStateEvent('popstate'))
+    await new Promise((r) => setTimeout(r, 10))
+    expect(result.current.value).toBe('hd-pop-b')
+  })
+})

--- a/test/composables/stepper-history-param.test.ts
+++ b/test/composables/stepper-history-param.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, type App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { useStepper } from '../../src/runtime/composables/use-stepper'
+import { createAttaform } from '../../src/runtime/core/plugin'
+
+/**
+ * `history: { param: '<name>' }` lets the consumer rename the URL
+ * search-param key. Useful when `?step=...` collides with an
+ * existing host-app query param, or when the stepper renders inside
+ * a nested wizard that wants its own namespaced param.
+ */
+
+const schemaA = z.object({ a: z.string() })
+const schemaB = z.object({ b: z.string() })
+
+function mountHarness<R>(setup: () => R): { app: App; result: R } {
+  const handle: { result?: R } = {}
+  const App = defineComponent({
+    setup() {
+      handle.result = setup()
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  app.config.warnHandler = () => {}
+  app.config.errorHandler = () => {}
+  app.mount(document.createElement('div'))
+  return { app, result: handle.result as R }
+}
+
+describe('useStepper — history param customization', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('writes to the custom param on next()', () => {
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema: schemaA, key: 'hp-write-a' })
+      const b = useForm({ schema: schemaB, key: 'hp-write-b' })
+      return useStepper([a, b], { history: { param: 'wiz' } })
+    })
+    apps.push(app)
+    result.next()
+    const url = new URL(window.location.href)
+    expect(url.searchParams.get('wiz')).toBe('hp-write-b')
+    expect(url.searchParams.get('step')).toBeNull()
+  })
+
+  it('reads the custom param on mount to seed initial step', () => {
+    window.history.replaceState(null, '', 'http://localhost:3000/wizard?wiz=hp-seed-b')
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema: schemaA, key: 'hp-seed-a' })
+      const b = useForm({ schema: schemaB, key: 'hp-seed-b' })
+      return useStepper([a, b], { history: { param: 'wiz' } })
+    })
+    apps.push(app)
+    expect(result.current.value).toBe('hp-seed-b')
+  })
+
+  it('ignores the default `step` param when a custom param is set', () => {
+    window.history.replaceState(null, '', 'http://localhost:3000/wizard?step=hp-isol-b')
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema: schemaA, key: 'hp-isol-a' })
+      const b = useForm({ schema: schemaB, key: 'hp-isol-b' })
+      return useStepper([a, b], { history: { param: 'wiz' } })
+    })
+    apps.push(app)
+    expect(result.current.value).toBe('hp-isol-a')
+  })
+})

--- a/test/composables/stepper-history-wired.test.ts
+++ b/test/composables/stepper-history-wired.test.ts
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, type App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { useStepper } from '../../src/runtime/composables/use-stepper'
+import { createAttaform } from '../../src/runtime/core/plugin'
+
+/**
+ * Browser-history integration. By default, `useStepper` records each
+ * navigation in `window.history` so the browser back/forward buttons
+ * walk through wizard steps and reload preserves the current step.
+ *
+ *   - `next`/`back`/`goTo` → `pushState` (new entry by default).
+ *   - `{ replace: true }` → `replaceState` (no new entry).
+ *   - `popstate` → restores `current.value` from the URL.
+ *   - Initial URL with `?step=<knownKey>` seeds the active step.
+ */
+
+const ORIGINAL_URL = 'http://localhost:3000/wizard'
+
+const schemaA = z.object({ a: z.string() })
+const schemaB = z.object({ b: z.string() })
+const schemaC = z.object({ c: z.string() })
+
+function mountHarness<R>(setup: () => R): { app: App; result: R } {
+  const handle: { result?: R } = {}
+  const App = defineComponent({
+    setup() {
+      handle.result = setup()
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  app.config.warnHandler = () => {}
+  app.config.errorHandler = () => {}
+  app.mount(document.createElement('div'))
+  return { app, result: handle.result as R }
+}
+
+describe('useStepper — history wired', () => {
+  const apps: App[] = []
+
+  beforeEach(() => {
+    window.history.replaceState(null, '', ORIGINAL_URL)
+  })
+
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+    window.history.replaceState(null, '', ORIGINAL_URL)
+  })
+
+  it('next() calls pushState with the new step key', () => {
+    const pushSpy = vi.spyOn(window.history, 'pushState')
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema: schemaA, key: 'hw-next-a' })
+      const b = useForm({ schema: schemaB, key: 'hw-next-b' })
+      return useStepper([a, b], {})
+    })
+    apps.push(app)
+    pushSpy.mockClear()
+    result.next()
+    expect(pushSpy).toHaveBeenCalledTimes(1)
+    expect(new URL(window.location.href).searchParams.get('step')).toBe('hw-next-b')
+    pushSpy.mockRestore()
+  })
+
+  it('goTo(key) pushes; goTo(key, { replace: true }) replaces', () => {
+    const pushSpy = vi.spyOn(window.history, 'pushState')
+    const replaceSpy = vi.spyOn(window.history, 'replaceState')
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema: schemaA, key: 'hw-go-a' })
+      const b = useForm({ schema: schemaB, key: 'hw-go-b' })
+      const c = useForm({ schema: schemaC, key: 'hw-go-c' })
+      return useStepper([a, b, c], {})
+    })
+    apps.push(app)
+    pushSpy.mockClear()
+    replaceSpy.mockClear()
+    result.goTo('hw-go-b')
+    expect(pushSpy).toHaveBeenCalledTimes(1)
+    expect(replaceSpy).not.toHaveBeenCalled()
+    pushSpy.mockClear()
+    replaceSpy.mockClear()
+    result.goTo('hw-go-c', { replace: true })
+    expect(replaceSpy).toHaveBeenCalledTimes(1)
+    expect(pushSpy).not.toHaveBeenCalled()
+    expect(new URL(window.location.href).searchParams.get('step')).toBe('hw-go-c')
+    pushSpy.mockRestore()
+    replaceSpy.mockRestore()
+  })
+
+  it('popstate restores current.value to the URL key', async () => {
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema: schemaA, key: 'hw-pop-a' })
+      const b = useForm({ schema: schemaB, key: 'hw-pop-b' })
+      return useStepper([a, b], {})
+    })
+    apps.push(app)
+    result.next()
+    expect(result.current.value).toBe('hw-pop-b')
+    window.history.back()
+    await new Promise((r) => setTimeout(r, 20))
+    expect(result.current.value).toBe('hw-pop-a')
+  })
+
+  it('seeds initial current.value from `?step=<knownKey>` on mount', () => {
+    window.history.replaceState(null, '', `${ORIGINAL_URL}?step=hw-seed-b`)
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema: schemaA, key: 'hw-seed-a' })
+      const b = useForm({ schema: schemaB, key: 'hw-seed-b' })
+      const c = useForm({ schema: schemaC, key: 'hw-seed-c' })
+      return useStepper([a, b, c], {})
+    })
+    apps.push(app)
+    expect(result.current.value).toBe('hw-seed-b')
+  })
+
+  it('writes the URL step param on mount to reflect the initial step', () => {
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema: schemaA, key: 'hw-init-a' })
+      const b = useForm({ schema: schemaB, key: 'hw-init-b' })
+      return useStepper([a, b], {})
+    })
+    apps.push(app)
+    expect(new URL(window.location.href).searchParams.get('step')).toBe('hw-init-a')
+    expect(result.current.value).toBe('hw-init-a')
+  })
+
+  it('ignores unknown step keys from URL — falls back to forms[0]', () => {
+    window.history.replaceState(null, '', `${ORIGINAL_URL}?step=notreal`)
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema: schemaA, key: 'hw-unknown-a' })
+      const b = useForm({ schema: schemaB, key: 'hw-unknown-b' })
+      return useStepper([a, b], {})
+    })
+    apps.push(app)
+    expect(result.current.value).toBe('hw-unknown-a')
+  })
+})

--- a/test/composables/stepper-popstate-midflight.test.ts
+++ b/test/composables/stepper-popstate-midflight.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, nextTick, type App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { useStepper } from '../../src/runtime/composables/use-stepper'
+import { createAttaform } from '../../src/runtime/core/plugin'
+
+/**
+ * Mid-flight popstate safety. The stepper registry's one-shot
+ * activation contract must hold even when the user pops back-and-
+ * forth between steps while a step's async factory is in flight:
+ *
+ *   1. Activate step B → factory starts firing (once).
+ *   2. Pop back to A before B's factory resolves.
+ *   3. Factory eventually resolves; values apply to B's form.
+ *   4. Pop forward to B again — factory MUST NOT re-fire.
+ *
+ * `pendingActivations.delete(nextKey)` in `markCurrent` is what
+ * enforces step 4; this probe locks that contract from the consumer
+ * surface so a future refactor can't reintroduce double-firing.
+ */
+
+const schemaA = z.object({ a: z.string() })
+const schemaB = z.object({ b: z.string() })
+
+function mountHarness<R>(setup: () => R): { app: App; result: R } {
+  const handle: { result?: R } = {}
+  const App = defineComponent({
+    setup() {
+      handle.result = setup()
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  app.config.warnHandler = () => {}
+  app.config.errorHandler = () => {}
+  app.mount(document.createElement('div'))
+  return { app, result: handle.result as R }
+}
+
+describe('useStepper — popstate mid-flight safety', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('async factory fires exactly once across back-and-forth popstate', async () => {
+    let factoryCalls = 0
+    let resolveFactory: ((value: { b: string }) => void) | undefined
+    const factoryPromise = new Promise<{ b: string }>((resolve) => {
+      resolveFactory = resolve
+    })
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema: schemaA, key: 'mf-a', defaultValues: { a: 'a-set' } })
+      const b = useForm({
+        schema: schemaB,
+        key: 'mf-b',
+        defaultValues: () => {
+          factoryCalls += 1
+          return factoryPromise
+        },
+      })
+      return { stepper: useStepper([a, b], {}), a, b }
+    })
+    apps.push(app)
+    expect(factoryCalls).toBe(0)
+
+    // Activate B — factory starts (one call).
+    result.stepper.next()
+    await nextTick()
+    expect(factoryCalls).toBe(1)
+    expect(result.b.isHydrating.value).toBe(true)
+
+    // Pop back to A via popstate (silent setCurrent).
+    window.history.back()
+    await new Promise((r) => setTimeout(r, 20))
+    expect(result.stepper.current.value).toBe('mf-a')
+
+    // Resolve the factory; values apply to B even though it's not current.
+    resolveFactory!({ b: 'fetched' })
+    await factoryPromise
+    for (let i = 0; i < 16; i += 1) {
+      await Promise.resolve()
+      await nextTick()
+      if (!result.b.isHydrating.value) break
+    }
+    expect(result.b.isHydrating.value).toBe(false)
+
+    // Pop forward to B — factory MUST NOT re-fire.
+    window.history.forward()
+    await new Promise((r) => setTimeout(r, 20))
+    expect(result.stepper.current.value).toBe('mf-b')
+    expect(factoryCalls).toBe(1)
+  })
+
+  it('does not deref unresolved factory when popping past it', async () => {
+    let factoryCalls = 0
+    const factoryPromise = new Promise<{ b: string }>(() => {
+      // Never resolves — we want to prove popping doesn't affect the
+      // factory's promise state. The form stays in `isHydrating: true`
+      // throughout this probe.
+    })
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema: schemaA, key: 'mf-deref-a', defaultValues: { a: 'a' } })
+      const b = useForm({
+        schema: schemaB,
+        key: 'mf-deref-b',
+        defaultValues: () => {
+          factoryCalls += 1
+          return factoryPromise
+        },
+      })
+      return { stepper: useStepper([a, b], {}), a, b }
+    })
+    apps.push(app)
+    result.stepper.next()
+    await nextTick()
+    expect(factoryCalls).toBe(1)
+    result.stepper.back()
+    result.stepper.next()
+    result.stepper.back()
+    result.stepper.next()
+    expect(factoryCalls).toBe(1)
+  })
+})

--- a/test/core/stepper-history.test.ts
+++ b/test/core/stepper-history.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createStepperHistory } from '../../src/runtime/core/stepper-history'
+
+/**
+ * `createStepperHistory(param)` encapsulates `window.history` for the
+ * stepper. The primitive is the only DOM-touching module in the
+ * stepper surface — it abstracts pushState / replaceState / popstate
+ * behind a small handle, lets the stepper composable stay focused on
+ * navigation semantics, and stays SSR-safe by returning a no-op
+ * handle when `window` is undefined.
+ */
+
+const ORIGINAL_URL = 'http://localhost:3000/wizard'
+
+describe('createStepperHistory — primitive', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', ORIGINAL_URL)
+  })
+
+  afterEach(() => {
+    window.history.replaceState(null, '', ORIGINAL_URL)
+  })
+
+  it('push(key) adds a history entry and writes `?step=<key>`', () => {
+    const handle = createStepperHistory('step')
+    const before = window.history.length
+    handle.push('cargo')
+    expect(window.history.length).toBeGreaterThan(before)
+    expect(new URL(window.location.href).searchParams.get('step')).toBe('cargo')
+    handle.dispose()
+  })
+
+  it('replace(key) updates current entry without growing history', () => {
+    const handle = createStepperHistory('step')
+    handle.push('cargo')
+    const beforeLen = window.history.length
+    handle.replace('review')
+    expect(window.history.length).toBe(beforeLen)
+    expect(new URL(window.location.href).searchParams.get('step')).toBe('review')
+    handle.dispose()
+  })
+
+  it('read() returns the current step param value (or undefined)', () => {
+    const handle = createStepperHistory('step')
+    expect(handle.read()).toBeUndefined()
+    handle.push('reference')
+    expect(handle.read()).toBe('reference')
+    handle.dispose()
+  })
+
+  it('subscribe(cb) fires the callback on popstate with the new key', async () => {
+    const handle = createStepperHistory('step')
+    const seen: Array<string | undefined> = []
+    handle.subscribe((key) => seen.push(key))
+    handle.push('a')
+    handle.push('b')
+    window.history.back()
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(seen[seen.length - 1]).toBe('a')
+    handle.dispose()
+  })
+
+  it('dispose() removes the popstate listener (idempotent)', async () => {
+    const handle = createStepperHistory('step')
+    const cb = vi.fn()
+    handle.subscribe(cb)
+    handle.push('a')
+    handle.dispose()
+    handle.dispose() // idempotent
+    window.history.replaceState(null, '', ORIGINAL_URL + '?step=zzz')
+    window.dispatchEvent(new PopStateEvent('popstate'))
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(cb).not.toHaveBeenCalled()
+  })
+
+  it('preserves existing search params when writing the step param', () => {
+    window.history.replaceState(null, '', `${ORIGINAL_URL}?ref=email&utm=launch`)
+    const handle = createStepperHistory('step')
+    handle.push('cargo')
+    const url = new URL(window.location.href)
+    expect(url.searchParams.get('step')).toBe('cargo')
+    expect(url.searchParams.get('ref')).toBe('email')
+    expect(url.searchParams.get('utm')).toBe('launch')
+    handle.dispose()
+  })
+})

--- a/test/core/stepper-history.test.ts
+++ b/test/core/stepper-history.test.ts
@@ -22,22 +22,26 @@ describe('createStepperHistory — primitive', () => {
     window.history.replaceState(null, '', ORIGINAL_URL)
   })
 
-  it('push(key) adds a history entry and writes `?step=<key>`', () => {
+  it('push(key) calls pushState and writes `?step=<key>`', () => {
     const handle = createStepperHistory('step')
-    const before = window.history.length
+    const pushSpy = vi.spyOn(window.history, 'pushState')
     handle.push('cargo')
-    expect(window.history.length).toBeGreaterThan(before)
+    expect(pushSpy).toHaveBeenCalledTimes(1)
     expect(new URL(window.location.href).searchParams.get('step')).toBe('cargo')
+    pushSpy.mockRestore()
     handle.dispose()
   })
 
-  it('replace(key) updates current entry without growing history', () => {
+  it('replace(key) calls replaceState — no pushState', () => {
     const handle = createStepperHistory('step')
-    handle.push('cargo')
-    const beforeLen = window.history.length
+    const pushSpy = vi.spyOn(window.history, 'pushState')
+    const replaceSpy = vi.spyOn(window.history, 'replaceState')
     handle.replace('review')
-    expect(window.history.length).toBe(beforeLen)
+    expect(replaceSpy).toHaveBeenCalledTimes(1)
+    expect(pushSpy).not.toHaveBeenCalled()
     expect(new URL(window.location.href).searchParams.get('step')).toBe('review')
+    pushSpy.mockRestore()
+    replaceSpy.mockRestore()
     handle.dispose()
   })
 

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,4 +1,4 @@
-import { afterEach } from 'vitest'
+import { afterEach, beforeEach } from 'vitest'
 import { resetInsecureContextWarnDedup } from '../src/runtime/core/insecure-context-warn'
 
 /**
@@ -38,4 +38,19 @@ if (typeof window !== 'undefined') {
 
 afterEach(() => {
   resetInsecureContextWarnDedup()
+})
+
+// Reset `window.location` to the jsdom default before each test so
+// stepper history tests can't leak `?step=<key>` into the next test's
+// initial-seed read. The default `http://localhost:3000/` matches
+// jsdom's origin so `history.replaceState` won't trip a SecurityError.
+beforeEach(() => {
+  if (typeof window !== 'undefined') {
+    try {
+      window.history.replaceState(null, '', 'http://localhost:3000/')
+    } catch {
+      // jsdom origin policy may reject in unusual configs; the local
+      // beforeEach in stepper tests handles their cases explicitly.
+    }
+  }
 })


### PR DESCRIPTION
## Summary

PR4 of the useStepper plan. Wires browser history and SSR active-step selection into the stepper composable. Library stays framework-agnostic — no `useRoute()`, no vue-router, no Nuxt imports. All `window.history` access goes through a dedicated primitive; `window` is gated at the module boundary.

### What ships
- **`createStepperHistory(param)` primitive** — `push`/`replace`/`read`/`subscribe`/`dispose` around `window.history`. `NOOP_STEPPER_HISTORY` shim returned when `typeof window === 'undefined'` (SSR) or when `history: false` is passed.
- **Default-on history integration** — every `next`/`back`/`goTo` calls `pushState` with `?step=<key>`. `{ replace: true }` flips to `replaceState`. `popstate` (browser back/forward) restores `current.value` from the URL. Mount seeds initial step from `?step=<knownKey>` when present and replaces the URL so it always reflects the active step.
- **Disable path** — `history: false` skips every DOM access: no `pushState`/`replaceState` on nav, no popstate listener, no URL-seed on mount, no URL-write on mount.
- **Custom URL param** — `history: { param: 'wiz' }` renames the search param for namespaced wizards.
- **`getServerActiveStep()` getter** — framework-agnostic SSR active-step source. Consumer reads route state from their framework; library does not import any router. Initial-step priority is now: getter (known key) → URL param (known key) → `forms[0]`.
- **Popstate mid-flight safety** — async-defaults factory fires exactly once across back-and-forth popstate sequences. Pinned by `stepper-registry.markCurrent`'s `pendingActivations.delete(nextKey)` step.

### Test plan
- [x] `test/core/stepper-history.test.ts` (6) — primitive contract (push/replace/read/subscribe/dispose/param preservation).
- [x] `test/composables/stepper-history-wired.test.ts` (6) — navigation writes URL, popstate restores, mount seeds + replaces.
- [x] `test/composables/stepper-history-disabled.test.ts` (4) — every DOM access skipped under `history: false`.
- [x] `test/composables/stepper-history-param.test.ts` (3) — custom param round-trip.
- [x] `test/composables/stepper-get-server-active-step.test.ts` (5) — known/unknown/undefined return, getter > URL priority, claim correctness.
- [x] `test/composables/stepper-popstate-midflight.test.ts` (2) — one-shot activation under back-and-forth nav.
- [x] Full suite green: **2639 / 2639** tests passing.
- [x] Typecheck + lint clean; size-limit green after `dist/index.mjs` cap nudged 38 → 39 KB (measured 38.30 KB).
- [x] `pnpm bundle:repl` succeeds.

### Notes
- Global `test/setup.ts` now resets `window.location` to `http://localhost:3000/` before each test so stepper URL state can't leak across files in vitest's shared-worker jsdom. Per-file `beforeEach` in stepper tests still set their own scenarios.
- History tests use `vi.spyOn(window.history, 'pushState'/'replaceState')` rather than measuring `window.history.length`, which is unreliable across a long-running test session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)