### PR TITLE
feat(form): useStepper on zod entries + useForm type-alias factoring

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -239,7 +239,12 @@ export default [
     //     and re-applies via applyFormReplacement({ hydration: true })
     //   - meta.errorCount + meta.isSubmitted computed siblings
     // Measured at 48.03 KB.
-    limit: '49 KB',
+    //
+    // Raised 49 → 51 KB when `useStepper` was re-exported from the
+    // unified `attaform/zod` entry. The full stepper surface
+    // (composable + registry + statuses proxy + history primitive)
+    // now ships through this bundle too. Measured at 50.40 KB.
+    limit: '51 KB',
     gzip: true,
     ignore: ['zod'],
     modifyEsbuildConfig: asEsm,
@@ -262,7 +267,11 @@ export default [
     //
     // Raised 42 → 43 KB on the defaultValues-trichotomy branch
     // (same shared core chunk as zod.mjs). Measured at 42.11 KB.
-    limit: '43 KB',
+    //
+    // Raised 43 → 45 KB when `useStepper` was re-exported from the
+    // `attaform/zod-v4` subpath. Same surface addition as the
+    // `attaform/zod` unified entry. Measured at 44.46 KB.
+    limit: '45 KB',
     gzip: true,
     ignore: ['zod'],
     modifyEsbuildConfig: asEsm,
@@ -311,7 +320,11 @@ export default [
     //
     // Raised 36 → 42 KB tracking index.mjs's library-hardening +
     // multi-tab bump (same shared core chunk). Measured at 41.03 KB.
-    limit: '42 KB',
+    //
+    // Raised 42 → 44 KB when `useStepper` was re-exported from the
+    // `attaform/zod-v3` subpath. Same surface addition as the
+    // `attaform/zod` unified entry. Measured at 43.86 KB.
+    limit: '44 KB',
     gzip: true,
     ignore: ['zod', 'lodash-es'],
     modifyEsbuildConfig: asEsm,

--- a/src/runtime/adapters/unified/use-form.ts
+++ b/src/runtime/adapters/unified/use-form.ts
@@ -60,34 +60,44 @@ import type { DeepPartial, DefaultValuesShape, GenericForm } from '../../types/t
 // public signature guarantees one arm always fires.
 // ───────────────────────────────────────────────────────────────────
 
-type FormInput<Schema> = Schema extends z.ZodObject
-  ? z.input<Schema> extends GenericForm
-    ? z.input<Schema>
+// Per-major helpers. Naming each variant keeps `rollup-plugin-dts`
+// from inlining the `z.input<X> extends GenericForm ? z.input<X> :
+// never` conditional twice inside each branch of the unified
+// `FormInput` / `FormOutput` / `FormStorageShape` aliases — the
+// bundled `.d.ts` preserves the helper as a single alias rather
+// than re-evaluating it at every consumer call site. Critical for
+// TS2589 headroom in setups that wire several `useForm` calls in
+// one scope (multistep wizards, parallel inline pickers, etc.).
+type FormInputV4<S extends z.ZodObject> = z.input<S> extends GenericForm ? z.input<S> : never
+type FormOutputV4<S extends z.ZodObject> = z.output<S> extends GenericForm ? z.output<S> : never
+type FormStorageShapeV4<S extends z.ZodObject> =
+  StorageShapeV4<S> extends GenericForm ? StorageShapeV4<S> : never
+
+type FormInputV3<S extends zV3.ZodObject<zV3.ZodRawShape>> =
+  zV3.input<UnwrapZodObject<S>> extends GenericForm ? zV3.input<UnwrapZodObject<S>> : never
+type FormOutputV3<S extends zV3.ZodObject<zV3.ZodRawShape>> =
+  zV3.output<UnwrapZodObject<S>> extends GenericForm ? zV3.output<UnwrapZodObject<S>> : never
+type FormStorageShapeV3<S extends zV3.ZodObject<zV3.ZodRawShape>> =
+  StorageShapeV3<UnwrapZodObject<S>> extends GenericForm
+    ? StorageShapeV3<UnwrapZodObject<S>>
     : never
+
+type FormInput<Schema> = Schema extends z.ZodObject
+  ? FormInputV4<Schema>
   : Schema extends zV3.ZodObject<zV3.ZodRawShape>
-    ? zV3.input<UnwrapZodObject<Schema>> extends GenericForm
-      ? zV3.input<UnwrapZodObject<Schema>>
-      : never
+    ? FormInputV3<Schema>
     : never
 
 type FormOutput<Schema> = Schema extends z.ZodObject
-  ? z.output<Schema> extends GenericForm
-    ? z.output<Schema>
-    : never
+  ? FormOutputV4<Schema>
   : Schema extends zV3.ZodObject<zV3.ZodRawShape>
-    ? zV3.output<UnwrapZodObject<Schema>> extends GenericForm
-      ? zV3.output<UnwrapZodObject<Schema>>
-      : never
+    ? FormOutputV3<Schema>
     : never
 
 type FormStorageShape<Schema> = Schema extends z.ZodObject
-  ? StorageShapeV4<Schema> extends GenericForm
-    ? StorageShapeV4<Schema>
-    : never
+  ? FormStorageShapeV4<Schema>
   : Schema extends zV3.ZodObject<zV3.ZodRawShape>
-    ? StorageShapeV3<UnwrapZodObject<Schema>> extends GenericForm
-      ? StorageShapeV3<UnwrapZodObject<Schema>>
-      : never
+    ? FormStorageShapeV3<Schema>
     : never
 
 // Single unified configuration shape. The outer structure is

--- a/src/runtime/adapters/zod-v4/index.ts
+++ b/src/runtime/adapters/zod-v4/index.ts
@@ -92,28 +92,37 @@ export type PathOutput<Schema extends z.ZodType, Path extends string> =
  *
  * For Zod v3, import from `attaform/zod-v3` instead.
  */
+/**
+ * `FormOf` / `OutOf` / `ReadOf` factor the three identical-shape
+ * conditionals out of `useForm`'s public signature. The bundled
+ * `.d.ts` then carries one alias per shape rather than re-inlining
+ * `z.input<Schema> extends GenericForm ? z.input<Schema> : never`
+ * four times — which is what produces TS2589 ("Type instantiation
+ * is excessively deep") on consumer call sites with complex schemas
+ * (discriminated unions, transform pipes, deep `.register()` chains).
+ * Each alias is computed once per `Schema` instantiation; downstream
+ * generics ride on the alias rather than re-evaluating the
+ * conditional from scratch.
+ */
+type FormOf<Schema extends z.ZodObject> =
+  z.input<Schema> extends GenericForm ? z.input<Schema> : never
+type OutOf<Schema extends z.ZodObject> =
+  z.output<Schema> extends GenericForm ? z.output<Schema> : never
+type ReadOf<Schema extends z.ZodObject> =
+  StorageShape<Schema> extends GenericForm ? StorageShape<Schema> : never
+
 export function useForm<Schema extends z.ZodObject, K extends FormKey = FormKey>(
   configuration: Omit<
     UseFormConfiguration<
-      z.input<Schema> extends GenericForm ? z.input<Schema> : never,
-      z.output<Schema> extends GenericForm ? z.output<Schema> : never,
-      AbstractSchema<
-        z.input<Schema> extends GenericForm ? z.input<Schema> : never,
-        z.output<Schema> extends GenericForm ? z.output<Schema> : never
-      >,
-      DeepPartial<
-        DefaultValuesShape<z.input<Schema> extends GenericForm ? z.input<Schema> : never>
-      >,
+      FormOf<Schema>,
+      OutOf<Schema>,
+      AbstractSchema<FormOf<Schema>, OutOf<Schema>>,
+      DeepPartial<DefaultValuesShape<FormOf<Schema>>>,
       K
     >,
     'schema' | 'validateOn' | 'debounceMs'
   > & { schema: Schema } & ValidateOnConfig
-): UseFormReturnType<
-  z.input<Schema> extends GenericForm ? z.input<Schema> : never,
-  z.output<Schema> extends GenericForm ? z.output<Schema> : never,
-  StorageShape<Schema> extends GenericForm ? StorageShape<Schema> : never,
-  K
-> {
+): UseFormReturnType<FormOf<Schema>, OutOf<Schema>, ReadOf<Schema>, K> {
   // Foot-gun guard: catches `useForm(z.object({...}))` (raw schema as
   // the first arg — its `.schema` field is undefined), `useForm()` (no
   // args), and `useForm({ schema: undefined })` before they reach the

--- a/src/zod-v3.ts
+++ b/src/zod-v3.ts
@@ -30,6 +30,20 @@
 export { useForm } from './runtime/composables/use-form'
 export { injectForm } from './runtime/composables/use-form-context'
 export { useRegister } from './runtime/composables/use-register'
+export { useStepper } from './runtime/composables/use-stepper'
+export type {
+  AggregateError,
+  AnyForm,
+  FormKeyOf,
+  FormStatus,
+  KeysOf,
+  Statuses,
+  StepperHistoryConfig,
+  StepperNavOptions,
+  StepperOptions,
+  StepperStatusesProxy,
+  UseStepperReturnType,
+} from './runtime/types/types-stepper'
 export { zodAdapter } from './runtime/adapters/zod-v3'
 export { isZodSchemaType } from './runtime/adapters/zod-v3/helpers'
 export { AttaformErrorCode } from './runtime/core/error-codes'

--- a/src/zod-v4.ts
+++ b/src/zod-v4.ts
@@ -36,6 +36,20 @@ export type { ZodKind } from './runtime/adapters/zod-v4/introspect'
 // discoverability alongside useForm.
 export { injectForm } from './runtime/composables/use-form-context'
 export { useRegister } from './runtime/composables/use-register'
+export { useStepper } from './runtime/composables/use-stepper'
+export type {
+  AggregateError,
+  AnyForm,
+  FormKeyOf,
+  FormStatus,
+  KeysOf,
+  Statuses,
+  StepperHistoryConfig,
+  StepperNavOptions,
+  StepperOptions,
+  StepperStatusesProxy,
+  UseStepperReturnType,
+} from './runtime/types/types-stepper'
 export { AttaformErrorCode } from './runtime/core/error-codes'
 export { unset, isUnset } from './runtime/core/unset'
 export type { Unset } from './runtime/core/unset'

--- a/src/zod.ts
+++ b/src/zod.ts
@@ -49,6 +49,20 @@ export { useForm } from './runtime/adapters/unified/use-form'
 export type { PathInput, PathOutput } from './runtime/adapters/zod-v4'
 export { injectForm } from './runtime/composables/use-form-context'
 export { useRegister } from './runtime/composables/use-register'
+export { useStepper } from './runtime/composables/use-stepper'
+export type {
+  AggregateError,
+  AnyForm,
+  FormKeyOf,
+  FormStatus,
+  KeysOf,
+  Statuses,
+  StepperHistoryConfig,
+  StepperNavOptions,
+  StepperOptions,
+  StepperStatusesProxy,
+  UseStepperReturnType,
+} from './runtime/types/types-stepper'
 export { AttaformErrorCode } from './runtime/core/error-codes'
 export { unset, isUnset } from './runtime/core/unset'
 export type { Unset } from './runtime/core/unset'


### PR DESCRIPTION
## Summary

Two consumer-facing improvements discovered while attempting the multistep shipment-demo restructure. The demo work itself is deferred to a follow-up — it surfaced a deeper depth-budget pressure in `DeepPartial<DefaultValuesShape<Form>>` × N forms that warrants its own focused PR.

### `useStepper` on the zod entries
Previously `useStepper` lived only on the main `attaform` entry, so consumers had to import from two paths for one wizard. With the wrong path, vue-tsc produced cascading spurious `TS2589` errors at unrelated `useForm` call sites — a confusing debugging trail. Re-exporting `useStepper` (plus the stepper type set: `AnyForm`, `FormKeyOf`, `FormStatus`, `KeysOf`, `Statuses`, `StepperHistoryConfig`, `StepperNavOptions`, `StepperOptions`, `StepperStatusesProxy`, `UseStepperReturnType`, `AggregateError`) from `attaform/zod`, `attaform/zod-v3`, and `attaform/zod-v4` gives consumers a one-stop import for the multistep API.

### Type-alias factoring in bundled `.d.ts`
The Zod v4 adapter's `useForm` signature inlined `z.input<Schema> extends GenericForm ? z.input<Schema> : never` **four times** in the public type. `rollup-plugin-dts` preserved every occurrence, so consumer call sites paid the conditional cost per use. Factored into `FormOf<Schema>` / `OutOf<Schema>` / `ReadOf<Schema>` helpers — bundled `.d.ts` now carries one alias per shape.

Same treatment for the unified `attaform/zod` entry's `FormInput` / `FormOutput` / `FormStorageShape` branches — each major dispatches through named per-major helpers (`FormInputV4`, `FormInputV3`, etc.) so bundled aliases survive intact rather than being re-inlined per branch.

### Size budgets
The `useStepper` re-export pulls the stepper module set into the three zod bundles. Measured:
- `dist/zod.mjs`    49 → 51 KB (50.40)
- `dist/zod-v4.mjs` 43 → 45 KB (44.46)
- `dist/zod-v3.mjs` 42 → 44 KB (43.86)

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm --filter attaform-site typecheck` clean
- [x] `pnpm vitest run` — 2623 passed, 16 skipped (packaging-exports CI-only)
- [x] `pnpm check:size` green at the bumped budgets
- [x] `pnpm bundle:repl` succeeds

## Follow-up
The shipment-demo restructure (the original PR5 scope) still trips depth at the demo's full stress-test schemas. The remaining lever is consolidating `DeepPartial<DefaultValuesShape<Form>>` into a single recursive walker so each `useForm` call evaluates one type traversal per Form rather than two. That's a focused library refactor worth its own investigation PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)