### PR TITLE
refactor(types): preserve recursive walkers as aliases in bundled .d.ts (PR A of 4)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -93,6 +93,7 @@ export type {
   CoercionResult,
   CustomDirectiveRegisterAssignerFn,
   DefaultValuesResponse,
+  ErrorsProxyShape,
   FieldMetaPayload,
   FieldState,
   FieldStateMap,
@@ -153,6 +154,8 @@ export type {
   LiftedValueShape,
   NestedReadType,
   NestedType,
+  PartialFlatPath,
+  Primitive,
   ValueOfUnion,
   WriteShape,
 } from './runtime/types/types-core'

--- a/src/runtime/adapters/zod-v4/index.ts
+++ b/src/runtime/adapters/zod-v4/index.ts
@@ -28,7 +28,7 @@ export { zodV4Adapter as zodAdapter } from './adapter'
 export { UnsupportedSchemaError } from './errors'
 export { assertZodVersion, kindOf } from './introspect'
 export type { ZodKind } from './introspect'
-export type { StorageShape } from './types-storage-shape'
+export type { StorageLeaf, StorageShape } from './types-storage-shape'
 
 /**
  * Type of the value accepted at `Path` for `setValue` / `defaultValues`

--- a/src/runtime/adapters/zod-v4/types-storage-shape.ts
+++ b/src/runtime/adapters/zod-v4/types-storage-shape.ts
@@ -54,7 +54,15 @@ export type StorageShape<S> = S extends {
   ? { [K in keyof Shape]-?: StorageLeaf<Shape[K]> }
   : StorageLeaf<S>
 
-type StorageLeaf<L> = L extends {
+/**
+ * Implementation-detail per-leaf branching for `StorageShape`.
+ * Exported so the bundled `.d.ts` carries a single alias body —
+ * every leaf of a Zod object schema otherwise re-emits the full
+ * pipe / transform / default conditional ladder, which compounds
+ * badly with multiple complex schemas in the same scope. Consumers
+ * should reach for `StorageShape` instead.
+ */
+export type StorageLeaf<L> = L extends {
   _zod: { def: { type: 'pipe'; in: infer A; out: infer B } }
 }
   ? A extends { _zod: { def: { type: 'transform' } } }

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -2787,7 +2787,15 @@ export type FormErrorsSurface<Form> = ErrorsProxyShape<Form> & {
   (): readonly ValidationError[] | undefined
 }
 
-type ErrorsProxyShape<T> = [T] extends [
+/**
+ * Implementation-detail walker backing `form.errors` typed proxy.
+ * Exported so the bundled `.d.ts` references a single alias body
+ * rather than re-emitting the full union-aware recursion at every
+ * consumer call site that types `form.errors`. Multiple useForm
+ * instances in one scope otherwise compound this into TS2589
+ * territory. Consumers should reach for `FormErrorsSurface` instead.
+ */
+export type ErrorsProxyShape<T> = [T] extends [
   string | number | boolean | bigint | symbol | null | undefined | Date,
 ]
   ? readonly ValidationError[] | undefined

--- a/src/runtime/types/types-core.ts
+++ b/src/runtime/types/types-core.ts
@@ -14,7 +14,17 @@ export type IsObjectOrArray<T> = T extends GenericForm
     ? true
     : false
 
-type PartialFlatPath<Form, Key extends keyof Form = keyof Form> =
+/**
+ * Implementation detail backing `FlatPath` in its default
+ * (partial-path) mode. Exported so `rollup-plugin-dts` preserves it
+ * as a named alias in the bundled `.d.ts` rather than inlining the
+ * full template-literal recursion body at every reference site
+ * (`FlatPath`, `RegisterFlatPath`, every path-addressed API method).
+ * Inlining at consumer call sites compounds into TS2589 territory
+ * when multiple complex forms share a scope. Consumers should reach
+ * for `FlatPath` instead; this alias is not part of the stable surface.
+ */
+export type PartialFlatPath<Form, Key extends keyof Form = keyof Form> =
   IsObjectOrArray<Form> extends true
     ? Key extends string
       ? Form[Key] extends infer Value
@@ -265,8 +275,15 @@ export type NestedType<
           ? ValueOfUnion<_RootValue, FlattenedPath>
           : never
 
-// Helper type for primitive types (non-object and non-array)
-type Primitive = string | number | boolean | symbol | bigint | null | undefined
+/**
+ * Implementation-detail primitive-leaf marker used by `DeepPartial`
+ * and sibling structural walkers. Exported so the bundled `.d.ts`
+ * references one alias instead of re-emitting the union at every
+ * recursion branch of every walker that depends on it. Not part of
+ * the stable consumer-facing surface — reach for `DeepPartial`
+ * instead.
+ */
+export type Primitive = string | number | boolean | symbol | bigint | null | undefined
 
 /**
  * Distinguish a tuple from a regular array.


### PR DESCRIPTION
## Summary

PR A of a 4-PR series refactoring the type system to fix TS2589 ("Type instantiation is excessively deep") that surfaces against the bundled `.d.ts` when consumers wire 3+ `useForm` calls in one scope (multistep wizards, parallel inline pickers). The 4-form `useStepper` shipping-demo restructure is the acceptance test, landing in PR D.

This PR is **mechanical and self-contained** — no runtime changes, no API changes, just type-export plumbing.

## What this PR changes

Four recursive type walkers were private to their modules, so `rollup-plugin-dts` inlined their bodies at every reference site in the bundled `.d.ts`. Promoting them to top-level exports plus passthrough re-exports from the public entries lets the bundler preserve them as named aliases.

- `PartialFlatPath<Form>` (types-core) — was inlined inside `FlatPath` body at every consumer reference
- `Primitive` (types-core) — was inlined inside `DeepPartial`'s base case
- `ErrorsProxyShape<T>` (types-api) — was inlined inside `FormErrorsSurface`'s body  
- `StorageLeaf<L>` (zod-v4 adapter) — was inlined per-key inside `StorageShape`'s mapped type (the worst offender — every leaf re-emitted the full pipe / transform / default conditional ladder)

Re-exports added to `src/index.ts` (for the types-core / types-api helpers) and `src/runtime/adapters/zod-v4/index.ts` (for `StorageLeaf`) so `rollup-plugin-dts`'s tree-shake keeps them.

## Why not `@internal` JSDoc?

The repo's `tsconfig.json` has `stripInternal: true`, which causes `tsc` to strip any declaration tagged `@internal` during `.d.ts` emit — exactly the opposite of what we want here. Docblock prose names each helper as an implementation detail and steers consumers toward the public-facing parent (`FlatPath`, `StorageShape`, `DeepPartial`, `FormErrorsSurface`). Per the inference-first DX, consumers never reach for these types anyway.

## Impact

- **Bundled main chunk** grows ~1.4 KB from the dispatcher overhead (alias bodies emitted once + reference at each consumer site). Negligible relative to the chunk (~175 KB) and the win we're after.
- **Consumer-side type-eval cost** drops as scope-sharing forms accumulate. The real signal lands with the bundled-typecheck CI gate in PR D.
- **Runtime bundle sizes** unchanged: all 7 entries comfortably under their size-limit budgets.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm vitest run` — 2639/2639 pass
- [x] `pnpm prepack` — bundles cleanly
- [x] `pnpm check:size` — all entries under budget
- [x] Bundled `.d.ts` typechecks via standalone tsconfig (no unresolved references — `PartialFlatPath`, `Primitive`, `ErrorsProxyShape`, `StorageLeaf` all declared as aliases in the chunks)

## Series overview

- **PR A (this)** — Export internal recursive walkers (mechanical)
- **PR B** — `DefaultValuesInput<F>` single-walker replaces `DeepPartial<DefaultValuesShape<F>>`
- **PR C** — Fuse `LiftedValueShape` into `WriteShape`; factor shared topology between `FieldStateMap` + `ErrorsProxyShape` via `LeafWalker<T, Kind>`
- **PR D** — Type-pressure regression suite + bundled-typecheck CI gate + 4-form shipment-demo restructure (acceptance test)

Plan lives at the design doc; happy to share if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)