### PR TITLE
refactor(types): fuse DeepPartial+DefaultValuesShape into DefaultValuesInput (PR B of 4)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -144,6 +144,7 @@ export type {
   ArrayItem,
   ArrayPath,
   DeepPartial,
+  DefaultValuesInput,
   DefaultValuesShape,
   FlatPath,
   GenericForm,

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,6 +93,7 @@ export type {
   CoercionResult,
   CustomDirectiveRegisterAssignerFn,
   DefaultValuesResponse,
+  ErrorsProxyShape,
   FieldMetaPayload,
   FieldState,
   FieldStateMap,
@@ -153,6 +154,8 @@ export type {
   LiftedValueShape,
   NestedReadType,
   NestedType,
+  PartialFlatPath,
+  Primitive,
   ValueOfUnion,
   WriteShape,
 } from './runtime/types/types-core'

--- a/src/runtime/adapters/unified/use-form.ts
+++ b/src/runtime/adapters/unified/use-form.ts
@@ -50,7 +50,7 @@ import type {
   UseFormReturnType,
   UseFormConfiguration,
 } from '../../types/types-api'
-import type { DeepPartial, DefaultValuesShape, GenericForm } from '../../types/types-core'
+import type { DefaultValuesInput, GenericForm } from '../../types/types-core'
 
 // ───────────────────────────────────────────────────────────────────
 // Per-major projections. Each dispatches a single Schema to the
@@ -112,7 +112,7 @@ type UnifiedConfiguration<Schema, K extends FormKey = FormKey> = Omit<
     FormInput<Schema>,
     FormOutput<Schema>,
     AbstractSchema<FormInput<Schema>, FormOutput<Schema>>,
-    DeepPartial<DefaultValuesShape<FormInput<Schema>>>,
+    DefaultValuesInput<FormInput<Schema>>,
     K
   >,
   'schema' | 'validateOn' | 'debounceMs'

--- a/src/runtime/adapters/zod-v4/index.ts
+++ b/src/runtime/adapters/zod-v4/index.ts
@@ -14,13 +14,7 @@ import type {
   UseFormReturnType,
   UseFormConfiguration,
 } from '../../types/types-api'
-import type {
-  DeepPartial,
-  DefaultValuesShape,
-  FlatPath,
-  GenericForm,
-  NestedType,
-} from '../../types/types-core'
+import type { DefaultValuesInput, FlatPath, GenericForm, NestedType } from '../../types/types-core'
 import { zodV4Adapter } from './adapter'
 import type { StorageShape } from './types-storage-shape'
 
@@ -117,7 +111,7 @@ export function useForm<Schema extends z.ZodObject, K extends FormKey = FormKey>
       FormOf<Schema>,
       OutOf<Schema>,
       AbstractSchema<FormOf<Schema>, OutOf<Schema>>,
-      DeepPartial<DefaultValuesShape<FormOf<Schema>>>,
+      DefaultValuesInput<FormOf<Schema>>,
       K
     >,
     'schema' | 'validateOn' | 'debounceMs'

--- a/src/runtime/adapters/zod-v4/index.ts
+++ b/src/runtime/adapters/zod-v4/index.ts
@@ -28,7 +28,7 @@ export { zodV4Adapter as zodAdapter } from './adapter'
 export { UnsupportedSchemaError } from './errors'
 export { assertZodVersion, kindOf } from './introspect'
 export type { ZodKind } from './introspect'
-export type { StorageShape } from './types-storage-shape'
+export type { StorageLeaf, StorageShape } from './types-storage-shape'
 
 /**
  * Type of the value accepted at `Path` for `setValue` / `defaultValues`

--- a/src/runtime/adapters/zod-v4/types-storage-shape.ts
+++ b/src/runtime/adapters/zod-v4/types-storage-shape.ts
@@ -54,7 +54,15 @@ export type StorageShape<S> = S extends {
   ? { [K in keyof Shape]-?: StorageLeaf<Shape[K]> }
   : StorageLeaf<S>
 
-type StorageLeaf<L> = L extends {
+/**
+ * Implementation-detail per-leaf branching for `StorageShape`.
+ * Exported so the bundled `.d.ts` carries a single alias body —
+ * every leaf of a Zod object schema otherwise re-emits the full
+ * pipe / transform / default conditional ladder, which compounds
+ * badly with multiple complex schemas in the same scope. Consumers
+ * should reach for `StorageShape` instead.
+ */
+export type StorageLeaf<L> = L extends {
   _zod: { def: { type: 'pipe'; in: infer A; out: infer B } }
 }
   ? A extends { _zod: { def: { type: 'transform' } } }

--- a/src/runtime/composables/use-abstract-form.ts
+++ b/src/runtime/composables/use-abstract-form.ts
@@ -64,7 +64,7 @@ import type {
   UseFormConfiguration,
   ValidationError,
 } from '../types/types-api'
-import type { DeepPartial, DefaultValuesShape, GenericForm, WriteShape } from '../types/types-core'
+import type { DeepPartial, DefaultValuesInput, GenericForm, WriteShape } from '../types/types-core'
 
 /**
  * Schema-agnostic `useForm`. Accepts any object that implements
@@ -98,7 +98,7 @@ export function useAbstractForm<
     Form,
     GetValueFormType,
     AbstractSchema<Form, GetValueFormType>,
-    DeepPartial<DefaultValuesShape<Form>>,
+    DefaultValuesInput<Form>,
     K
   >
 ): UseFormReturnType<Form, GetValueFormType, ReadForm, K> {
@@ -140,16 +140,16 @@ export function useAbstractForm<
   // settles into `state.applyFormReplacement` once it resolves (wired
   // below).
   const resolvedDefaults = resolveTrichotomy<
-    | DeepPartial<DefaultValuesShape<Form>>
+    | DefaultValuesInput<Form>
     | undefined
-    | (() => DeepPartial<DefaultValuesShape<Form>> | Promise<DeepPartial<DefaultValuesShape<Form>>>)
+    | (() => DefaultValuesInput<Form> | Promise<DefaultValuesInput<Form>>)
   >(configuration.defaultValues)
   // Build the materialised override conditionally — exactOptionalPropertyTypes
   // refuses explicit `undefined` on the optional field, so we omit it
   // when the resolved value is undefined.
-  const materialisedDefaults: DeepPartial<DefaultValuesShape<Form>> | undefined =
+  const materialisedDefaults: DefaultValuesInput<Form> | undefined =
     resolvedDefaults.kind === 'sync'
-      ? (resolvedDefaults.value as DeepPartial<DefaultValuesShape<Form>> | undefined)
+      ? (resolvedDefaults.value as DefaultValuesInput<Form> | undefined)
       : undefined
   const { defaultValues: _droppedDefaults, ...configWithoutDefaults } = configuration
   void _droppedDefaults
@@ -157,19 +157,19 @@ export function useAbstractForm<
     Form,
     GetValueFormType,
     AbstractSchema<Form, GetValueFormType>,
-    DeepPartial<DefaultValuesShape<Form>>
+    DefaultValuesInput<Form>
   > = materialisedDefaults === undefined
     ? (configWithoutDefaults as UseFormConfiguration<
         Form,
         GetValueFormType,
         AbstractSchema<Form, GetValueFormType>,
-        DeepPartial<DefaultValuesShape<Form>>
+        DefaultValuesInput<Form>
       >)
     : ({ ...configWithoutDefaults, defaultValues: materialisedDefaults } as UseFormConfiguration<
         Form,
         GetValueFormType,
         AbstractSchema<Form, GetValueFormType>,
-        DeepPartial<DefaultValuesShape<Form>>
+        DefaultValuesInput<Form>
       >)
 
   // Merge app-level defaults from the registry over per-form options.
@@ -273,8 +273,8 @@ export function useAbstractForm<
   }
   if (existing === undefined && resolvedDefaults.kind === 'async') {
     const factory = resolvedDefaults.factory as () =>
-      | DeepPartial<DefaultValuesShape<Form>>
-      | Promise<DeepPartial<DefaultValuesShape<Form>>>
+      | DefaultValuesInput<Form>
+      | Promise<DefaultValuesInput<Form>>
     state.defaultValuesFactory.value = factory
     if (hadPendingHydration) {
       // Server already resolved the factory; client just consumed the
@@ -576,7 +576,7 @@ function mergeWithDefaults<
   Form extends GenericForm,
   GetValueFormType extends GenericForm,
   Schema extends AbstractSchema<Form, GetValueFormType>,
-  Defaults extends DeepPartial<DefaultValuesShape<Form>>,
+  Defaults extends DefaultValuesInput<Form>,
 >(
   defaults: AttaformDefaults,
   configuration: UseFormConfiguration<Form, GetValueFormType, Schema, Defaults>
@@ -633,12 +633,7 @@ const HISTORY_MODULE_KEY = 'history'
 function buildFreshState<F extends GenericForm, G extends GenericForm = F>(
   key: FormKey,
   schema: AbstractSchema<F, G>,
-  configuration: UseFormConfiguration<
-    F,
-    G,
-    AbstractSchema<F, G>,
-    DeepPartial<DefaultValuesShape<F>>
-  >,
+  configuration: UseFormConfiguration<F, G, AbstractSchema<F, G>, DefaultValuesInput<F>>,
   registry: ReturnType<typeof useRegistry>
 ): FormStore<F, G> {
   const pending = registry.pendingHydration.get(key)

--- a/src/runtime/composables/use-form.ts
+++ b/src/runtime/composables/use-form.ts
@@ -8,7 +8,7 @@ import type {
   UseFormReturnType,
   UseFormConfiguration,
 } from '../types/types-api'
-import type { DeepPartial, DefaultValuesShape, GenericForm } from '../types/types-core'
+import type { DefaultValuesInput, GenericForm } from '../types/types-core'
 import type { TypeWithNullableDynamicKeys } from '../adapters/zod-v3/types-zod'
 import type {
   UnwrapZodObject,
@@ -39,7 +39,7 @@ export function useForm<
     Form,
     GetValueFormType,
     AbstractSchema<Form, GetValueFormType>,
-    DeepPartial<DefaultValuesShape<Form>>,
+    DefaultValuesInput<Form>,
     K
   >
 ): UseFormReturnType<Form, GetValueFormType, Form, K>
@@ -76,7 +76,7 @@ export function useForm<
 >(
   configuration: UseFormConfigurationWithZod<
     Schema,
-    DeepPartial<DefaultValuesShape<z.input<UnwrapZodObject<Schema>>>>,
+    DefaultValuesInput<z.input<UnwrapZodObject<Schema>>>,
     K
   >
 ): UseFormReturnType<
@@ -98,14 +98,10 @@ export function useForm<
         Form,
         GetValueFormType,
         AbstractSchema<Form, GetValueFormType>,
-        DeepPartial<DefaultValuesShape<Form>>,
+        DefaultValuesInput<Form>,
         K
       >
-    | UseFormConfigurationWithZod<
-        Schema,
-        DeepPartial<DefaultValuesShape<z.input<UnwrapZodObject<Schema>>>>,
-        K
-      >
+    | UseFormConfigurationWithZod<Schema, DefaultValuesInput<z.input<UnwrapZodObject<Schema>>>, K>
 ): UseFormReturnType<Form, GetValueFormType, Form, K> {
   // Foot-gun guard: catches `useForm(z.object({...}))` (raw schema as
   // the first arg — its `.schema` field is undefined), `useForm()` (no
@@ -147,7 +143,7 @@ export function useForm<
       Form,
       GetValueFormType,
       AbstractSchema<Form, GetValueFormType>,
-      DeepPartial<DefaultValuesShape<Form>>
+      DefaultValuesInput<Form>
     >),
     // `zodAdapter`'s constraint on its third generic is
     // `GetValueFormType extends TypeWithNullableDynamicKeys<FormSchema>`,
@@ -162,6 +158,6 @@ export function useForm<
     schema: abstractSchema as
       | AbstractSchema<Form, GetValueFormType>
       | ((key: FormKey, options: SchemaFactoryOptions) => AbstractSchema<Form, GetValueFormType>),
-    defaultValues: configuration.defaultValues as DeepPartial<DefaultValuesShape<Form>>,
+    defaultValues: configuration.defaultValues as DefaultValuesInput<Form>,
   }) as unknown as UseFormReturnType<Form, GetValueFormType, Form, K>
 }

--- a/src/runtime/core/build-form-api.ts
+++ b/src/runtime/core/build-form-api.ts
@@ -15,7 +15,7 @@ import type {
   ValidationResponseWithoutValue,
   WriteMeta,
 } from '../types/types-api'
-import type { DeepPartial, DefaultValuesShape, GenericForm } from '../types/types-core'
+import type { DeepPartial, DefaultValuesInput, GenericForm } from '../types/types-core'
 import { __DEV__ } from './dev'
 import type { FormStore } from './create-form-store'
 import { structuralSnapshot } from './diff-apply'
@@ -647,7 +647,7 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
   // opt-in registry is NOT touched: directives are still mounted and
   // the next user keystroke on an opted-in input re-populates the
   // entry naturally.
-  const reset = (nextDefaultValues?: DeepPartial<DefaultValuesShape<Form>>): void => {
+  const reset = (nextDefaultValues?: DefaultValuesInput<Form>): void => {
     if (nextDefaultValues === undefined) {
       state.reset()
     } else {

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -9,6 +9,7 @@ import type {
   ArrayItem,
   ArrayPath,
   DeepPartial,
+  DefaultValuesInput,
   DefaultValuesShape,
   FlatPath,
   GenericForm,
@@ -1031,7 +1032,7 @@ export type UseFormConfiguration<
   Form extends GenericForm,
   GetValueFormType,
   Schema extends AbstractSchema<Form, GetValueFormType>,
-  DefaultValues extends DeepPartial<DefaultValuesShape<Form>>,
+  DefaultValues extends DefaultValuesInput<Form>,
   K extends FormKey = FormKey,
 > = {
   /**
@@ -3522,7 +3523,7 @@ export type UseFormReturnType<
    * The next edit on a still-mounted opted-in input will start
    * persisting again automatically.
    */
-  reset: (nextDefaultValues?: DeepPartial<DefaultValuesShape<Form>>) => void
+  reset: (nextDefaultValues?: DefaultValuesInput<Form>) => void
 
   /**
    * Restore a single field (or a sub-tree like `'user'`) to its

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -2787,7 +2787,15 @@ export type FormErrorsSurface<Form> = ErrorsProxyShape<Form> & {
   (): readonly ValidationError[] | undefined
 }
 
-type ErrorsProxyShape<T> = [T] extends [
+/**
+ * Implementation-detail walker backing `form.errors` typed proxy.
+ * Exported so the bundled `.d.ts` references a single alias body
+ * rather than re-emitting the full union-aware recursion at every
+ * consumer call site that types `form.errors`. Multiple useForm
+ * instances in one scope otherwise compound this into TS2589
+ * territory. Consumers should reach for `FormErrorsSurface` instead.
+ */
+export type ErrorsProxyShape<T> = [T] extends [
   string | number | boolean | bigint | symbol | null | undefined | Date,
 ]
   ? readonly ValidationError[] | undefined

--- a/src/runtime/types/types-core.ts
+++ b/src/runtime/types/types-core.ts
@@ -482,3 +482,64 @@ export type DefaultValuesShape<T> = T extends
         : T extends object
           ? { [K in keyof T]: DefaultValuesShape<T[K]> }
           : T
+
+/**
+ * Single-walker fusion of `DeepPartial` and `DefaultValuesShape` — the
+ * type accepted at `defaultValues`, `reset()`'s parameter, and every
+ * partial-shape consumer. Every level is optional and every primitive
+ * leaf admits its supertype `| Unset`, in one tree walk where the
+ * prior `DeepPartial<DefaultValuesShape<F>>` composition walked twice.
+ *
+ * Both passes had identical topology (object → mapped, tuple →
+ * positional, array → recurse, primitive → terminal) — the doubled
+ * recursion exhausted the depth budget at consumer call sites that
+ * wire multiple complex forms into one scope. Collapsing them buys
+ * back the headroom plus a side fix: opaque leaves (`Date`, `Map`,
+ * `Set`, `RegExp`, functions) now stay intact when their containing
+ * property is optional, rather than getting structurally destructured
+ * by `DeepPartial`'s pass.
+ *
+ * Tuple positions, array elements, and discriminated-union variants
+ * all flow through unchanged from the prior semantics.
+ *
+ * ```ts
+ * type T = DefaultValuesInput<{
+ *   email: string
+ *   joinedAt: Date
+ *   profile: { name: string; age: number }
+ * }>
+ * // → {
+ * //   email?: string | Unset
+ * //   joinedAt?: Date
+ * //   profile?: { name?: string | Unset; age?: number | Unset }
+ * // }
+ * ```
+ */
+export type DefaultValuesInput<T> = T extends string
+  ? string | Unset
+  : T extends number
+    ? number | Unset
+    : T extends boolean
+      ? boolean | Unset
+      : T extends bigint
+        ? bigint | Unset
+        : T extends symbol
+          ? symbol
+          : T extends null | undefined
+            ? T
+            : T extends
+                  | Date
+                  | RegExp
+                  | Map<unknown, unknown>
+                  | Set<unknown>
+                  | ((...args: never) => unknown)
+              ? T
+              : T extends readonly [unknown, ...unknown[]]
+                ? { -readonly [K in keyof T]?: DefaultValuesInput<T[K]> }
+                : T extends ReadonlyArray<infer U>
+                  ? IsTuple<T> extends true
+                    ? { -readonly [K in keyof T]?: DefaultValuesInput<T[K]> }
+                    : Array<DefaultValuesInput<U>>
+                  : T extends object
+                    ? { [K in keyof T]?: DefaultValuesInput<T[K]> }
+                    : T

--- a/src/runtime/types/types-core.ts
+++ b/src/runtime/types/types-core.ts
@@ -14,7 +14,17 @@ export type IsObjectOrArray<T> = T extends GenericForm
     ? true
     : false
 
-type PartialFlatPath<Form, Key extends keyof Form = keyof Form> =
+/**
+ * Implementation detail backing `FlatPath` in its default
+ * (partial-path) mode. Exported so `rollup-plugin-dts` preserves it
+ * as a named alias in the bundled `.d.ts` rather than inlining the
+ * full template-literal recursion body at every reference site
+ * (`FlatPath`, `RegisterFlatPath`, every path-addressed API method).
+ * Inlining at consumer call sites compounds into TS2589 territory
+ * when multiple complex forms share a scope. Consumers should reach
+ * for `FlatPath` instead; this alias is not part of the stable surface.
+ */
+export type PartialFlatPath<Form, Key extends keyof Form = keyof Form> =
   IsObjectOrArray<Form> extends true
     ? Key extends string
       ? Form[Key] extends infer Value
@@ -265,8 +275,15 @@ export type NestedType<
           ? ValueOfUnion<_RootValue, FlattenedPath>
           : never
 
-// Helper type for primitive types (non-object and non-array)
-type Primitive = string | number | boolean | symbol | bigint | null | undefined
+/**
+ * Implementation-detail primitive-leaf marker used by `DeepPartial`
+ * and sibling structural walkers. Exported so the bundled `.d.ts`
+ * references one alias instead of re-emitting the union at every
+ * recursion branch of every walker that depends on it. Not part of
+ * the stable consumer-facing surface — reach for `DeepPartial`
+ * instead.
+ */
+export type Primitive = string | number | boolean | symbol | bigint | null | undefined
 
 /**
  * Distinguish a tuple from a regular array.

--- a/test/composables/library-hardening-probes.test.ts
+++ b/test/composables/library-hardening-probes.test.ts
@@ -5190,7 +5190,7 @@ describe('chaos — Map / Set values at leaves', () => {
           handle.api = useForm({
             schema,
             key: `chaos-set-leaf-${Math.random().toString(36).slice(2)}`,
-            defaultValues: { payload: { kind: 'seqed', tags: new Set() } },
+            defaultValues: { payload: { kind: 'seqed', tags: new Set<string>() } },
           }) as unknown as Api
           return () => h('div')
         },

--- a/test/types/default-values-input.test.ts
+++ b/test/types/default-values-input.test.ts
@@ -1,0 +1,173 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import { z } from 'zod'
+import { useForm as useFormV4 } from '../../src/zod-v4'
+import { unset } from '../../src'
+import type { DefaultValuesInput, Unset } from '../../src'
+
+/**
+ * Type-level tests for `DefaultValuesInput<F>` — the single-walker
+ * replacement for `DeepPartial<DefaultValuesShape<F>>`. Verifies
+ * surface parity with the prior composition, plus the side fix on
+ * opaque leaves (`Date`, `Map`, `Set`, `RegExp`, functions stay
+ * intact instead of getting structurally destructured).
+ *
+ * Tests run at typecheck time. `_neverInvoked` wrappers exercise
+ * call-site inference without needing a Vue app.
+ */
+
+describe('DefaultValuesInput — type-level parity tests', () => {
+  describe('primitive leaves accept value, unset, and optional', () => {
+    it('accepts string', () => {
+      function _neverInvoked() {
+        const form = useFormV4({
+          schema: z.object({ email: z.string() }),
+          defaultValues: { email: 'x' },
+        })
+        void form
+      }
+      void _neverInvoked
+    })
+
+    it('accepts unset at primitive leaf', () => {
+      function _neverInvoked() {
+        const form = useFormV4({
+          schema: z.object({ email: z.string() }),
+          defaultValues: { email: unset },
+        })
+        void form
+      }
+      void _neverInvoked
+    })
+
+    it('accepts the property being omitted', () => {
+      function _neverInvoked() {
+        const form = useFormV4({
+          schema: z.object({ email: z.string(), name: z.string() }),
+          defaultValues: { email: 'x' },
+        })
+        void form
+      }
+      void _neverInvoked
+    })
+
+    it('rejects wrong primitive type', () => {
+      function _neverInvoked() {
+        useFormV4({
+          schema: z.object({ email: z.string() }),
+          // @ts-expect-error — number not assignable to string | Unset | undefined
+          defaultValues: { email: 42 },
+        })
+      }
+      void _neverInvoked
+    })
+  })
+
+  describe('opaque leaves stay intact (Date / Map / Set / RegExp / fn)', () => {
+    it('accepts a real Date instance at a Date leaf', () => {
+      function _neverInvoked() {
+        const form = useFormV4({
+          schema: z.object({ joinedAt: z.date() }),
+          defaultValues: { joinedAt: new Date() },
+        })
+        void form
+      }
+      void _neverInvoked
+    })
+
+    it('accepts a typed Set instance at a Set<string> leaf', () => {
+      function _neverInvoked() {
+        const form = useFormV4({
+          schema: z.object({ tags: z.set(z.string()) }),
+          defaultValues: { tags: new Set<string>() },
+        })
+        void form
+      }
+      void _neverInvoked
+    })
+  })
+
+  describe('nested objects walk recursively + each level optional', () => {
+    it('accepts deep partial values', () => {
+      function _neverInvoked() {
+        const form = useFormV4({
+          schema: z.object({
+            profile: z.object({
+              name: z.string(),
+              age: z.number(),
+            }),
+          }),
+          defaultValues: { profile: { name: 'Ada' } },
+        })
+        void form
+      }
+      void _neverInvoked
+    })
+
+    it('rejects wrong nested type', () => {
+      function _neverInvoked() {
+        useFormV4({
+          schema: z.object({
+            profile: z.object({ name: z.string() }),
+          }),
+          // @ts-expect-error — boolean not assignable to string at profile.name
+          defaultValues: { profile: { name: true } },
+        })
+      }
+      void _neverInvoked
+    })
+  })
+
+  describe('tuple positions stay positional', () => {
+    it('preserves position types in a tuple value', () => {
+      function _neverInvoked() {
+        const form = useFormV4({
+          schema: z.object({
+            tup: z.tuple([z.string(), z.number()]),
+          }),
+          defaultValues: { tup: ['hello', 42] },
+        })
+        void form
+      }
+      void _neverInvoked
+    })
+
+    it('rejects swapped tuple positions', () => {
+      function _neverInvoked() {
+        useFormV4({
+          schema: z.object({
+            tup: z.tuple([z.string(), z.number()]),
+          }),
+          // @ts-expect-error — swapped positions: number → string slot, string → number slot
+          defaultValues: { tup: [42, 'hello'] },
+        })
+      }
+      void _neverInvoked
+    })
+  })
+
+  describe('arrays of objects walk through elements', () => {
+    it('walks an array-of-objects element type', () => {
+      type Walked = DefaultValuesInput<{ items: Array<{ sku: string }> }>
+      expectTypeOf<Walked>().toMatchTypeOf<{
+        items?: Array<{ sku?: string | Unset }>
+      }>()
+    })
+  })
+
+  describe('discriminated unions thread through optional', () => {
+    it('preserves union narrowing at the discriminated property', () => {
+      function _neverInvoked() {
+        const schema = z.discriminatedUnion('kind', [
+          z.object({ kind: z.literal('standard'), weight: z.number() }),
+          z.object({ kind: z.literal('oversized'), permitNumber: z.string() }),
+        ])
+        const form = useFormV4({
+          schema: z.object({ cargo: schema }),
+          defaultValues: { cargo: { kind: 'standard', weight: 10 } },
+        })
+        void form
+      }
+      void _neverInvoked
+    })
+  })
+})


### PR DESCRIPTION
## Summary

PR B of 4. Stacked on top of PR A (#204) — does not merge directly to main until A lands.

Replaces `DeepPartial<DefaultValuesShape<F>>` with a single-walker `DefaultValuesInput<F>` everywhere. The prior composition walked Form twice (DefaultValuesShape recursed for primitive widening with `| Unset`, DeepPartial recursed for property optionality) — identical topology, two complete traversals per `useForm` config.

`DefaultValuesInput<F>` does both jobs in one walk: every level optional, every primitive leaf admits `| Unset`. Saves ~1 form-walk per `useForm` config; with 4 forms in scope, that's 4 walks saved on the config side alone.

Side fix: opaque leaves (Date / Map / Set / RegExp / function) now stay intact when their containing property is optional, rather than getting structurally destructured by the prior DeepPartial pass. One existing hardening probe relied on the destructured behavior at a `new Set()` leaf (now needs the explicit generic `new Set<string>()`).

## Why DefaultValuesShape stays

`DefaultValuesShape<T>` keeps its standalone-walker form because it's still used inside `SetValuePayload<DefaultValuesShape<Leaf>, NonNullable<WriteShape<Leaf>>>` for primitive widening at setValue payloads. The DeepPartial composition is what gets fused; the standalone walker stays put.

## Type-level tests

`test/types/default-values-input.test.ts` covers the surface:

- Primitive accepts (`string` / `unset` / omitted)
- Primitive rejects (wrong kind)
- Opaque leaf preservation (`Date`, typed `Set<string>`)
- Nested-object walking + per-level optionality
- Tuple positional preservation
- Array-of-objects element walking
- Discriminated-union threading

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm vitest run` — 2651/2651 pass
- [x] `pnpm prepack` builds cleanly
- [x] `pnpm check:size` — all entries under budget
- [x] Bundled `.d.ts` carries `DefaultValuesInput` as a top-level alias

## Series overview

- PR A (#204) — Export internal recursive walkers (mechanical)
- **PR B (this)** — `DefaultValuesInput<F>` single-walker
- PR C — `LeafWalker<T, Kind>` factoring `FieldStateMapEntry` + `ErrorsProxyShape`
- PR D — Type-pressure regression suite + bundled-typecheck CI gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)