### PR TITLE
refactor(types): fuse ErrorsProxyShape into LeafWalker (wave 2 — PR E)

### DIFF
--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -2846,25 +2846,19 @@ export type FormErrorsSurface<Form> = ErrorsProxyShape<Form> & {
 
 /**
  * Implementation-detail walker backing `form.errors` typed proxy.
+ * Thin alias over `LeafWalker<T, 'errors', false>` — the shared walker
+ * topology is defined once at `LeafWalker` and parameterized via
+ * `LeafSchemeFor`. `false` preserves optional-key modifiers (errors
+ * proxy mirrors the input shape including `?`); contrast with the
+ * fields proxy alias which strips them via the default `true`.
+ *
  * Exported so the bundled `.d.ts` references a single alias body
  * rather than re-emitting the full union-aware recursion at every
  * consumer call site that types `form.errors`. Multiple useForm
  * instances in one scope otherwise compound this into TS2589
  * territory. Consumers should reach for `FormErrorsSurface` instead.
  */
-export type ErrorsProxyShape<T> = [T] extends [
-  string | number | boolean | bigint | symbol | null | undefined | Date,
-]
-  ? readonly ValidationError[] | undefined
-  : [T] extends [ReadonlyArray<infer U>]
-    ? { readonly [K: number]: ErrorsProxyShape<U> }
-    : [T] extends [object]
-      ? [IsUnion<T>] extends [true]
-        ? {
-            readonly [K in KeyofUnion<T>]: ErrorsProxyShape<ValueOfUnion<T, K>>
-          }
-        : { readonly [K in keyof T]: ErrorsProxyShape<T[K]> }
-      : readonly ValidationError[] | undefined
+export type ErrorsProxyShape<T> = LeafWalker<T, 'errors', false>
 
 /**
  * Type of `form.values`. Drillable readonly callable proxy. Unlike


### PR DESCRIPTION
## Summary

- Replaces the duplicated `ErrorsProxyShape` body at `types-api.ts:2855` with the alias the surrounding machinery was designed to support: `LeafWalker<T, 'errors', false>`.
- The wave-1 refactor (#206) introduced `LeafWalker<T, Kind, StripOptional>` specifically to factor both `FieldStateMapEntry` and `ErrorsProxyShape` against a shared walk topology. `FieldStateMapEntry` landed as a one-line alias; `ErrorsProxyShape`'s body was preserved inline. This PR finishes the fusion.
- `StripOptional=false` preserves the prior errors-proxy semantics (mirrors input `?` modifiers); contrast with `FieldStateMapEntry`'s default `true`. `LeafSchemeFor['errors']` was already declared.

## Why

Keeps `LeafWalker` load-bearing as the shared topology for future walker kinds. Wave 2's next stretch goal (PR J — `WriteShape`/`DefaultValuesShape` fusion) hinges on `LeafWalker` being the canonical walk; this PR removes the parallel inline body that would otherwise drift.

## Bundle size

Modest by itself — the body was already on one minified line in the bundle:

| File | Before | After | Δ |
| --- | ---:| ---:| ---:|
| `dist/shared/*` (all chunks) | 214,317 | 214,236 | **−81 B** |
| `dist/index.d.ts` | 25,529 | 25,529 | 0 |
| `dist/zod*.d.ts` | unchanged | unchanged | 0 |

Entry files unchanged (they're re-export shells; bodies live in shared chunks).

## Wave 2 context

PR E of six (E → F → G → H → I → J). E is the mechanical opener; the bigger wins land at G (drop `LiftedValueShape` after F unblocks the v3 useForm overload coupling) and H (memoize `WriteShape<ReadForm>` in `UseFormReturnType`). Plan in `/Users/ozzy/.claude/plans/sounds-good-please-plan-swirling-pancake.md` for the full sequencing.

## Test plan

- [x] `pnpm typecheck` — green
- [x] `pnpm lint` — green (eslint + prettier)
- [x] `pnpm vitest run` — 2,642 passed / 16 skipped
- [x] `pnpm prepack` — clean build
- [x] `pnpm check:bundled-types` — 4-form fixture still typechecks against bundled `.d.ts`
- [x] Verified bundle: `dist/shared/attaform.CodDFgpX.d.ts:3000` now reads `type ErrorsProxyShape<T> = LeafWalker<T, 'errors', false>;`

🤖 Generated with [Claude Code](https://claude.com/claude-code)