### PR TITLE
feat(form): four-form shipment demo + v4/v3 useForm overloads

### DIFF
--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -9,6 +9,16 @@
  * The site typecheck takes ~8s. We pay it only when an apps/site
  * file is touched, which is rare on commits that don't change the
  * site.
+ *
+ * The vue-tsc pass routes through Docker (`docker compose exec -T
+ * attaform ...`) rather than running on the host. The bundled
+ * `dist/*.d.mts` stubs are absolute-path `unbuild --stub` output and
+ * point at whichever filesystem most-recently regenerated them —
+ * usually the container, since `make install` runs `pnpm dev:prepare`
+ * inside the container. Host-side vue-tsc against container-path
+ * stubs surfaces every `attaform` import as "no exported member" and
+ * fails the commit. Routing through Docker matches the
+ * "strictly Docker for dev" workflow and sidesteps the drift entirely.
  */
 export default {
   './src/**/*.{ts,vue}': 'eslint',
@@ -20,7 +30,7 @@ export default {
     // matched file list to the typecheck command.
     return [
       `eslint ${files.join(' ')}`,
-      'pnpm --filter attaform-site typecheck',
+      'docker compose exec -T attaform pnpm --filter attaform-site typecheck',
     ]
   },
   './test/**/*.{ts,vue}': 'eslint',

--- a/apps/site/components/demo/DemoReplEditor.client.vue
+++ b/apps/site/components/demo/DemoReplEditor.client.vue
@@ -185,6 +185,17 @@
     scrollBeyondLastLine: false,
     renderLineHighlight: 'gutter' as const,
     smoothScrolling: true,
+    // By default Monaco's scrollbar consumes every wheel event over its
+    // viewport — even when the editor is pinned at its top or bottom
+    // extreme. In a docs page that ends well below the REPL, that traps
+    // the reader inside the editor pane; they have to move the cursor
+    // off the editor before they can keep scrolling the page. Setting
+    // `alwaysConsumeMouseWheel: false` lets Monaco swallow the wheel
+    // only while it actually has content to scroll, then bubbles
+    // subsequent events to the parent so the page keeps moving. The
+    // preview pane doesn't have this problem because it's a plain iframe
+    // / scroll container with native wheel behavior.
+    scrollbar: { alwaysConsumeMouseWheel: false },
   }
   // `showErrorText: false` and `autoSaveText: false` opt out of the
   // "Show Error" / "Auto Save" toggle buttons @vue/repl floats in the

--- a/apps/site/components/demo/DemoReplEditor.client.vue
+++ b/apps/site/components/demo/DemoReplEditor.client.vue
@@ -117,19 +117,34 @@
   // never reassign it, but the type still demands a Ref wrapper.
   const resourceLinks = ref({
     pkgFileTextUrl: (pkgName: string, _pkgVersion: string | undefined, pkgPath: string) => {
-      if (pkgName === 'attaform' || pkgName === 'vue' || pkgName === 'zod') {
+      if (
+        pkgName === 'attaform' ||
+        pkgName === 'vue' ||
+        pkgName === 'zod' ||
+        pkgName === 'zod-v3'
+      ) {
         return `/lib/types/${pkgName}/${pkgPath}`
       }
       return `https://cdn.jsdelivr.net/npm/${pkgName}/${pkgPath}`
     },
     pkgDirUrl: (pkgName: string, _pkgVersion: string | undefined, _pkgPath: string) => {
-      if (pkgName === 'attaform' || pkgName === 'vue' || pkgName === 'zod') {
+      if (
+        pkgName === 'attaform' ||
+        pkgName === 'vue' ||
+        pkgName === 'zod' ||
+        pkgName === 'zod-v3'
+      ) {
         return `/lib/types/${pkgName}/meta.json`
       }
       return `https://unpkg.com/${pkgName}@${_pkgVersion || 'latest'}/${_pkgPath}/?meta`
     },
     pkgLatestVersionUrl: (pkgName: string) => {
-      if (pkgName === 'attaform' || pkgName === 'vue' || pkgName === 'zod') {
+      if (
+        pkgName === 'attaform' ||
+        pkgName === 'vue' ||
+        pkgName === 'zod' ||
+        pkgName === 'zod-v3'
+      ) {
         return `/lib/types/${pkgName}/package.json`
       }
       return `https://unpkg.com/${pkgName}@latest/package.json`

--- a/apps/site/nuxt.config.ts
+++ b/apps/site/nuxt.config.ts
@@ -1,3 +1,5 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { logger as nuxtKitLogger } from '@nuxt/kit'
 import tailwindcss from '@tailwindcss/vite'
 import { rendererRich, transformerTwoslash } from '@shikijs/twoslash'
@@ -5,6 +7,18 @@ import type { Logger, LogOptions } from 'vite'
 import attaformPkg from '../../package.json'
 import vuePkg from 'vue/package.json'
 import zodPkg from 'zod/package.json'
+// `zod-v3` is an npm-aliased package — pnpm installs zod@3.x under
+// the directory name `zod-v3` (see root package.json:
+// `"zod-v3": "npm:zod@^3.24"`). The aliased path resolves to its
+// own package.json, whose version field is the v3.x release.
+import zodV3Pkg from 'zod-v3/package.json'
+
+// Compute the on-disk path to the monorepo root (two levels up from
+// `apps/site`). Used to broaden Vite's `server.fs.allow` so the
+// dev server can stream files from the workspace's hoisted
+// `node_modules/.pnpm/...` tree (see the `vite.server.fs.allow`
+// block below for the full rationale).
+const monorepoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 
 // Two warning families fire on every build, are not ours to fix,
 // and add nothing actionable for a maintainer reading the logs:
@@ -312,6 +326,7 @@ export default defineNuxtConfig({
         attaform: attaformPkg.version,
         vue: vuePkg.version,
         zod: zodPkg.version,
+        'zod-v3': zodV3Pkg.version,
       },
     },
   },
@@ -446,8 +461,27 @@ export default defineNuxtConfig({
     // expects you to use the top-level `devServer.host`), but Vite
     // itself accepts the value and devtools needs it set on Vite's
     // own config, so we suppress the type error.
-    // @ts-expect-error see comment above — Nuxt-typed Omit, Vite-accepted runtime field
-    server: { host: '0.0.0.0' },
+    server: {
+      // @ts-expect-error Nuxt's `vite.server` type Omits `host`; the
+      // runtime accepts it (see comment above for why devtools needs
+      // this set on Vite's own config).
+      host: '0.0.0.0',
+      // Vite's strict `fs.allow` defaults to the workspace root, but
+      // requests to `/@fs/app/node_modules/.pnpm/...` for modules in
+      // `optimizeDeps.exclude` arrive BEFORE the importer is analyzed
+      // — so the target file never lands in `config.safeModulePaths`
+      // via the import-analysis pass, and `fs.allow` is the only gate
+      // that lets the static-serve middleware emit the file. The
+      // symptom is a 404 on `@vue/repl/monaco-editor` (7.2 MB) on
+      // first page load while smaller siblings in the same directory
+      // (already-analyzed) serve cleanly. Explicitly listing the
+      // monorepo root (two levels up from `apps/site`) here makes the
+      // allowance unambiguous and survives any Vite-detected-root
+      // drift across pnpm-workspace layouts.
+      fs: {
+        allow: [monorepoRoot],
+      },
+    },
     // Vite's startup crawl scans index.html + statically discoverable
     // imports; it misses imports inside `.client.vue` components (which
     // SSR skips) and inside Nuxt's lazy page chunks. When those land

--- a/apps/site/repl-demos/shipment-demo.vue
+++ b/apps/site/repl-demos/shipment-demo.vue
@@ -1,22 +1,20 @@
 <script setup lang="ts">
   // ─────────────────────────────────────────────────────────────────
-  // Cargo shipment booking — a stress test for Attaform. Exercises:
-  // discriminated unions, enums, field arrays, async field + aggregate
-  // validation, transforms, the unset sentinel, persistence, multi-step
-  // navigation, meta + field valid/validating flags, and the
-  // `field.showErrors` / `field.firstError` error-display primitives.
+  // Cargo shipment booking — multistep wizard built on `useStepper`
+  // composing four `useForm` instances. Each step owns its own schema,
+  // history, and persistence; the stepper orchestrates navigation,
+  // status aggregation, and the cross-form submit.
   //
-  // Error display: every field reads `showErrors` (heuristic-gated:
-  // show after submit OR after touched + dirty) plus `firstError` (the
-  // top error in schema order). Override the heuristic globally via
-  // `createAttaform({ defaults: { shouldShowErrors } })` or per-form
-  // via `useForm({ shouldShowErrors })`. Library default kicks in
-  // here — see the `errorMessage` helper below.
+  // Stresses: discriminated unions, enums, field arrays, async field +
+  // aggregate validation, transforms, the unset sentinel, the
+  // `field.showErrors` / `field.firstError` error-display primitives.
+  // Per-form `history` and `persist` configs round out the wiring —
+  // each step has its own undo stack and namespaced storage key.
   // ─────────────────────────────────────────────────────────────────
 
   import { computed, nextTick, ref, watch } from 'vue'
   import { z } from 'zod'
-  import { fieldMeta, useForm, unset, withMeta } from 'attaform/zod'
+  import { fieldMeta, useForm, useStepper, unset, withMeta } from 'attaform/zod'
   import type { FieldState } from 'attaform'
 
   // ─── Mock async services ─────────────────────────────────────────
@@ -68,14 +66,20 @@
     })
   }
 
-  // ─── Schemas ─────────────────────────────────────────────────────
+  // ─── Constants ───────────────────────────────────────────────────
   const COUNTRIES = ['US', 'CA', 'MX', 'GB', 'DE', 'FR', 'JP', 'CN', 'AU'] as const
   const HAZARD_CLASSES = ['1', '2', '3', '4', '5', '6', '7', '8', '9'] as const
   const TRUCK_TYPES = ['box', 'flatbed', 'reefer', 'tanker'] as const
   const CONTAINER_SIZES = ['20FT', '40FT', '40FTHC', '45FTHC'] as const
   const COVERAGES = ['none', 'basic', 'full'] as const
   const CURRENCIES = ['USD', 'EUR', 'GBP', 'JPY'] as const
+  const ACKNOWLEDGEMENTS = [
+    'I confirm the cargo description is accurate.',
+    'I authorize handling fees for hazmat or oversized items.',
+    "I accept the carrier's terms of service and rate schedule.",
+  ] as const
 
+  // ─── Step 1 — reference + pickup + delivery ──────────────────────
   const addressSchema = z.object({
     line1: z
       .string()
@@ -104,6 +108,21 @@
     country: z.enum(COUNTRIES).register(fieldMeta, { label: 'Country' }),
   })
 
+  const referenceSchema = z.object({
+    reference: z
+      .string()
+      .regex(/^SHP-\d{6}$/, 'Reference looks like SHP-123456 — SHP plus 6 digits.')
+      .register(fieldMeta, {
+        label: 'Reference',
+        placeholder: 'SHP-123456',
+        description: 'Tracking ID for this shipment.',
+      }),
+    pickup: withMeta(addressSchema, { label: 'Pickup address' }),
+    delivery: withMeta(addressSchema, { label: 'Delivery address' }),
+    useSameDeliveryAddress: z.boolean().register(fieldMeta, { label: 'Same as pickup address' }),
+  })
+
+  // ─── Step 2 — cargo line items + discriminated details ───────────
   const lineItemSchema = z.object({
     sku: z
       .string()
@@ -131,7 +150,7 @@
   // "dry → hazmat" reclassification keeps whatever items the user
   // already typed instead of resetting items: [] on each variant
   // reshape. The async .superRefine attaches the capacity error at
-  // this array's path (cargo.items), surfaced via cargoItemsArrayError.
+  // this array's path (cargoForm: items), surfaced via cargoItemsArrayError.
   const lineItemArraySchema = z
     .array(lineItemSchema)
     .min(1, 'Add at least one line item to ship.')
@@ -210,6 +229,7 @@
       .register(fieldMeta, { label: 'Cargo details' }),
   })
 
+  // ─── Step 3 — service mode + dates + insurance + notes ───────────
   const truckServiceSchema = z.object({
     mode: z.literal('truck'),
     truckType: z.enum(TRUCK_TYPES).register(fieldMeta, { label: 'Truck type' }),
@@ -237,29 +257,10 @@
     containerSize: z.enum(CONTAINER_SIZES).register(fieldMeta, { label: 'Container' }),
   })
 
-  const serviceSchema = z.discriminatedUnion('mode', [
-    truckServiceSchema,
-    airServiceSchema,
-    oceanServiceSchema,
-  ])
-
-  const schema = z.object({
-    reference: z
-      .string()
-      .regex(/^SHP-\d{6}$/, 'Reference looks like SHP-123456 — SHP plus 6 digits.')
-      .register(fieldMeta, {
-        label: 'Reference',
-        placeholder: 'SHP-123456',
-        description: 'Tracking ID for this shipment.',
-      }),
-    pickup: withMeta(addressSchema, { label: 'Pickup address' }),
-    delivery: withMeta(addressSchema, { label: 'Delivery address' }),
-    // Schema-modeled toggle so the flag is persisted + restored
-    // alongside the rest of the draft. The watch below keeps
-    // delivery in sync with pickup whenever it's true.
-    useSameDeliveryAddress: z.boolean().register(fieldMeta, { label: 'Same as pickup address' }),
-    cargo: cargoSchema.register(fieldMeta, { label: 'Cargo' }),
-    service: serviceSchema.register(fieldMeta, { label: 'Service' }),
+  const serviceSchema = z.object({
+    service: z
+      .discriminatedUnion('mode', [truckServiceSchema, airServiceSchema, oceanServiceSchema])
+      .register(fieldMeta, { label: 'Service' }),
     desiredPickupDate: z
       .string()
       .min(1, 'Pick a pickup date.')
@@ -269,10 +270,10 @@
       .min(1, 'Pick a delivery date.')
       .register(fieldMeta, { label: 'Delivery date' }),
     // Inference stress test: `.transform()`-wrapped object with a
-    // `.default()`-ed leaf inside. The read view (form.values.insurance)
-    // recurses through the pipe so `currency` types as `string` — not
-    // `string | undefined`. The transform fires at submit, so
-    // handleSubmit's payload also carries the derived `tier`.
+    // `.default()`-ed leaf inside. The read view recurses through the
+    // pipe so `currency` types as `string` — not `string | undefined`.
+    // The transform fires at submit, so handleSubmit's payload also
+    // carries the derived `tier`.
     insurance: z
       .object({
         declaredValueUSD: z
@@ -305,40 +306,95 @@
       .register(fieldMeta, { label: 'Notes', description: 'Optional handling instructions.' }),
   })
 
-  // ─── Form ────────────────────────────────────────────────────────
-  const form = useForm({
-    schema,
-    key: 'shipment',
-    persist: 'local',
+  // ─── Step 4 — review form (terms + signature + acknowledgements) ─
+  const reviewSchema = z.object({
+    termsAccepted: z
+      .literal(true, { message: 'Accept the terms to book the shipment.' })
+      .register(fieldMeta, { label: 'I accept the terms' }),
+    signature: z.string().min(2, 'Type your name to sign.').register(fieldMeta, {
+      label: 'Signature',
+      description: 'Type your name as it appears on your shipping account.',
+    }),
+    acknowledgements: z
+      .array(z.enum(ACKNOWLEDGEMENTS))
+      .min(ACKNOWLEDGEMENTS.length, 'Confirm every acknowledgement above to continue.')
+      .register(fieldMeta, { label: 'Acknowledgements' }),
+  })
+
+  // ─── Forms ──────────────────────────────────────────────────────
+  const refForm = useForm({
+    schema: referenceSchema,
+    key: 'reference',
+    persist: { storage: 'local', key: 'attaform:shipment.reference' },
     history: { max: 50 },
     validateOn: 'change',
     debounceMs: 200,
     defaultValues: {
       reference: 'SHP-100001',
-      cargo: { items: [], details: { type: 'dry', fragile: false } },
+      pickup: { country: 'US' },
+      delivery: { country: 'US' },
+      useSameDeliveryAddress: false,
+    },
+  })
+
+  const cargoForm = useForm({
+    schema: cargoSchema,
+    key: 'cargo',
+    persist: { storage: 'local', key: 'attaform:shipment.cargo' },
+    history: { max: 50 },
+    validateOn: 'change',
+    debounceMs: 200,
+    defaultValues: {
+      items: [],
+      details: { type: 'dry', fragile: false },
+    },
+  })
+
+  const serviceForm = useForm({
+    schema: serviceSchema,
+    key: 'service',
+    persist: { storage: 'local', key: 'attaform:shipment.service' },
+    history: { max: 50 },
+    validateOn: 'change',
+    debounceMs: 200,
+    defaultValues: {
       service: { mode: 'truck', truckType: 'box', liftgate: false },
       // unset = "show empty until the user commits a value". $0
       // declared insurance is a meaningful choice, so we don't paint
       // it until they type it.
       insurance: { declaredValueUSD: unset, coverage: 'basic' },
-      pickup: { country: 'US' },
-      delivery: { country: 'US' },
-      useSameDeliveryAddress: false,
       // unset on an optional string keeps "untouched" distinguishable
-      // from "intentionally empty". Watch form.fields.notes.blank.
+      // from "intentionally empty". Watch serviceForm.fields.notes.blank.
       notes: unset,
     },
   })
 
+  const reviewForm = useForm({
+    schema: reviewSchema,
+    key: 'review',
+    persist: { storage: 'local', key: 'attaform:shipment.review' },
+    history: { max: 50 },
+    validateOn: 'change',
+    debounceMs: 200,
+    defaultValues: {
+      acknowledgements: [],
+    },
+  })
+
+  // Compose the four into a wizard. `useStepper` picks up the form
+  // keys for `current`, derives statuses from form meta, and threads
+  // the active step through browser back/forward via window.history.
+  const stepper = useStepper([refForm, cargoForm, serviceForm, reviewForm])
+
   // ─── Pickup → delivery live mirror ───────────────────────────────
   // While the flag is on, copy pickup → delivery via the whole-form
-  // callback variant of setValue. Un-ticking leaves the snapshot in
-  // place for the user to edit.
+  // callback variant of setValue. Both fields live in refForm so this
+  // mirror is self-contained — no cross-form plumbing.
   watch(
-    [() => form.values.useSameDeliveryAddress, () => form.values.pickup],
+    [() => refForm.values.useSameDeliveryAddress, () => refForm.values.pickup],
     ([same]) => {
       if (!same) return
-      form.setValue((v) => ({ ...v, delivery: v.pickup }))
+      refForm.setValue((v) => ({ ...v, delivery: v.pickup }))
     },
     { deep: true, immediate: true }
   )
@@ -347,83 +403,76 @@
     (raw: unknown) => (typeof raw === 'string' ? raw.toUpperCase().replace(/\s+/g, '') : raw),
   ]
 
-  // ─── Step navigation ─────────────────────────────────────────────
-  const STEPS = [
-    { id: 1, title: 'Origin & destination' },
-    { id: 2, title: 'Cargo' },
-    { id: 3, title: 'Service & insurance' },
-    { id: 4, title: 'Review & submit' },
-  ] as const
-  type StepId = (typeof STEPS)[number]['id']
-  const step = ref<StepId>(1)
-
-  // Step 4 owns no fields, so it's never independently "done" — its
-  // completion is the submit itself, not a validity check.
-  const STEP_PATHS = {
-    1: ['reference', 'pickup', 'delivery'],
-    2: ['cargo'],
-    3: ['service', 'insurance', 'desiredPickupDate', 'desiredDeliveryDate', 'notes'],
-    4: [],
+  // ─── Step metadata ───────────────────────────────────────────────
+  // Stepper drives the nav — `current` is the active form's key, and
+  // `statuses[key].isValid` is what gates the Next button.
+  const STEP_TITLES = {
+    reference: 'Origin & destination',
+    cargo: 'Cargo',
+    service: 'Service & insurance',
+    review: 'Review & submit',
   } as const
-  function isStepValid(id: StepId) {
-    const paths = STEP_PATHS[id]
-    if (paths.length === 0) return false
-    return paths.every((p) => form.fields(p).valid)
-  }
-  const currentStepValid = computed(() => isStepValid(step.value))
+  type FormKey = keyof typeof STEP_TITLES
 
-  function goNext() {
-    if (step.value < 4) step.value = (step.value + 1) as StepId
-  }
-  function goBack() {
-    if (step.value > 1) step.value = (step.value - 1) as StepId
-  }
+  const formByKey = {
+    reference: refForm,
+    cargo: cargoForm,
+    service: serviceForm,
+    review: reviewForm,
+  } as const
 
   // ─── Error summary (review step) ────────────────────────────────
-  // Group form.meta.errors by top-level segment so the Review step
-  // renders one panel per section. Each row jumps to the owning step.
-  // Section / leaf labels read straight from the schema's registered
-  // metadata via form.fields(path).label — the schema is the single
-  // source of truth for both structure and presentation.
+  // `stepper.allErrors` is the flat aggregate across all four forms.
+  // Group by formKey × top-level path so each section renders a tidy
+  // panel. Each row jumps to the owning step via `stepper.goTo`.
   type ErrorGroup = {
-    rootKey: string
+    formKey: FormKey
+    stepTitle: string
     rootLabel: string
-    items: { leafLabel: string | null; message: string; path: ReadonlyArray<string | number> }[]
+    rootKey: string
+    items: {
+      leafLabel: string | null
+      message: string
+      path: ReadonlyArray<string | number>
+    }[]
   }
+
+  function safeLabelAtPath(formKey: FormKey, path: ReadonlyArray<string | number>): string | null {
+    try {
+      return formByKey[formKey].fields(path).label || null
+    } catch {
+      return null
+    }
+  }
+
   const groupedErrors = computed(() => {
     const groups = new Map<string, ErrorGroup>()
-    for (const e of form.meta.errors) {
+    for (const e of stepper.allErrors.value) {
+      const formKey = e.formKey as FormKey
       const root = String(e.path[0] ?? '(root)')
-      let group = groups.get(root)
+      const key = `${formKey}:${root}`
+      let group = groups.get(key)
       if (!group) {
+        const rootLabel = safeLabelAtPath(formKey, [root]) ?? root
         group = {
+          formKey,
+          stepTitle: STEP_TITLES[formKey],
           rootKey: root,
-          rootLabel: form.fields(root).label || root,
+          rootLabel,
           items: [],
         }
-        groups.set(root, group)
+        groups.set(key, group)
       }
-      let leaf: string | null = null
-      if (e.path.length > 1) {
-        leaf = form.fields(e.path).label || null
-      }
+      const leaf = e.path.length > 1 ? safeLabelAtPath(formKey, e.path) : null
       group.items.push({ leafLabel: leaf, message: e.message, path: e.path })
     }
     return [...groups.values()]
   })
-  function pathToStep(path: ReadonlyArray<string | number>) {
-    const root = String(path[0] ?? '')
-    for (const id of [1, 2, 3] as const) {
-      if ((STEP_PATHS[id] as ReadonlyArray<string>).includes(root)) return id
-    }
-    return 4
-  }
-  function goToError(path: ReadonlyArray<string | number>) {
-    step.value = pathToStep(path)
-    // nextTick so v-show paints the active step body before we focus.
-    // `form.fields(path)` resolves the FieldState directly (call-form);
-    // `.element` is the first DOM node bound at that path.
-    nextTick(() => form.fields(path).element?.focus())
+
+  function goToError(formKey: FormKey, path: ReadonlyArray<string | number>) {
+    stepper.goTo(formKey)
+    // nextTick so the active step body paints before we try to focus.
+    nextTick(() => formByKey[formKey].fields(path).element?.focus())
   }
 
   // ─── Cargo / service variant switching ───────────────────────────
@@ -462,20 +511,20 @@
     full: 'Full',
   }
 
-  const cargoType = computed(() => form.values.cargo.details.type)
-  const serviceMode = computed(() => form.values.service.mode)
+  const cargoType = computed(() => cargoForm.values.details.type)
+  const serviceMode = computed(() => serviceForm.values.service.mode)
 
   function setCargoType(type: (typeof CARGO_TYPES)[number]) {
-    form.setValue('cargo.details.type', type)
+    cargoForm.setValue('details.type', type)
   }
 
   function setServiceMode(mode: (typeof SERVICE_MODES)[number]) {
-    form.setValue('service.mode', mode)
+    serviceForm.setValue('service.mode', mode)
   }
 
   // ─── Line items (field array) ────────────────────────────────────
   function addLineItem() {
-    form.append('cargo.items', {
+    cargoForm.append('items', {
       sku: '',
       description: '',
       quantity: 1,
@@ -483,35 +532,56 @@
     })
   }
   function removeLineItem(idx: number) {
-    form.remove('cargo.items', idx)
+    cargoForm.remove('items', idx)
   }
 
   const totalLb = computed(() =>
-    form.values.cargo.items.reduce(
+    cargoForm.values.items.reduce(
       (sum, it) => sum + (Number(it.quantity) || 0) * (Number(it.unitWeightLb) || 0),
       0
     )
   )
 
   // ─── Submit ──────────────────────────────────────────────────────
-  // handleSubmit awaits every async refinement (postal lookups, SKU
-  // checks, capacity) before deciding success vs failure.
+  // `handleSubmit` on the review form awaits every async refinement
+  // (postal lookups, SKU checks, capacity, signature). Before
+  // surfacing success we re-check the prior three forms' statuses —
+  // the user can edit upstream steps after reaching review, so the
+  // stepper.statuses gate is what catches "looks valid but pickup
+  // dropped invalid after the user came back here".
   const submitError = ref<string | null>(null)
-  const onSubmit = form.handleSubmit(
-    (values) => {
+  const onSubmit = reviewForm.handleSubmit(
+    (review) => {
+      const upstreamValid =
+        stepper.statuses.reference.isValid &&
+        stepper.statuses.cargo.isValid &&
+        stepper.statuses.service.isValid
+      if (!upstreamValid) {
+        submitError.value =
+          'One or more earlier steps need fixes. Use the summary below to jump to the offending field.'
+        return
+      }
       submitError.value = null
-      alert('Booked!\n\n' + JSON.stringify(values, null, 2))
-      form.reset()
-      step.value = 1
+      const payload = {
+        reference: refForm.values(),
+        cargo: cargoForm.values(),
+        service: serviceForm.values(),
+        review,
+      }
+      alert('Booked!\n\n' + JSON.stringify(payload, null, 2))
+      resetAll()
     },
     () => {
-      submitError.value = 'Please fix the highlighted fields above.'
+      submitError.value = 'Please fix the highlighted fields on this step before booking.'
     }
   )
 
   function resetAll() {
-    form.reset()
-    step.value = 1
+    refForm.reset()
+    cargoForm.reset()
+    serviceForm.reset()
+    reviewForm.reset()
+    stepper.goTo('reference')
     submitError.value = null
   }
 
@@ -532,25 +602,44 @@
     return field?.showErrors ? (field.firstError?.message ?? '') : ''
   }
 
-  // Array-level error at cargo.items (min(1) + async capacity refine).
-  // Filtered to path.length === 2 so per-row errors at
-  // cargo.items.${i}.${leaf} don't bleed into the array banner.
+  // Array-level error at cargoForm: items (min(1) + async capacity refine).
+  // Filtered to path.length === 1 so per-row errors at
+  // items.${i}.${leaf} don't bleed into the array banner.
   const cargoItemsArrayError = computed(
-    () => form.errors('cargo.items')?.find((e) => e.path.length === 2)?.message ?? ''
+    () => cargoForm.errors('items')?.find((e) => e.path.length === 1)?.message ?? ''
   )
 
   const addressBlocks = computed(() => [
     {
       prefix: 'pickup' as const,
-      label: form.fields('pickup').label,
+      label: refForm.fields('pickup').label,
       mirrored: false,
     },
     {
       prefix: 'delivery' as const,
-      label: form.fields('delivery').label,
-      mirrored: form.values.useSameDeliveryAddress,
+      label: refForm.fields('delivery').label,
+      mirrored: refForm.values.useSameDeliveryAddress,
     },
   ])
+
+  // Undo/redo targets the form that owns the active step — each form
+  // has its own history stack so an undo on cargo doesn't roll back
+  // an address edit.
+  const activeForm = computed(() => formByKey[stepper.current.value])
+  const canGoNext = computed(() => stepper.statuses[stepper.current.value].isValid)
+  const isAnyValidating = computed(() => stepper.forms.some((f) => f.meta.validating))
+
+  // Acknowledgement multi-checkbox helper — read / write the array via
+  // setValue. `register()` doesn't bind multi-checkboxes natively in
+  // the demo's HTML; managing it imperatively keeps the surface tight.
+  function toggleAcknowledgement(ack: (typeof ACKNOWLEDGEMENTS)[number], checked: boolean) {
+    const current = reviewForm.values.acknowledgements ?? []
+    const next = checked ? [...current, ack] : current.filter((a) => a !== ack)
+    reviewForm.setValue('acknowledgements', next)
+  }
+  function isAcknowledged(ack: (typeof ACKNOWLEDGEMENTS)[number]) {
+    return (reviewForm.values.acknowledgements ?? []).includes(ack)
+  }
 </script>
 
 <template>
@@ -564,37 +653,37 @@
       <!-- ─── Stepper ─── -->
       <nav class="stepper" aria-label="Form progress">
         <button
-          v-for="s in STEPS"
-          :key="s.id"
+          v-for="(form, idx) in stepper.forms"
+          :key="form.key"
           type="button"
           class="step"
           :class="{
-            active: step === s.id,
-            done: isStepValid(s.id),
+            active: stepper.current.value === form.key,
+            done: stepper.statuses[form.key as FormKey].isValid,
           }"
-          :aria-current="step === s.id ? 'step' : undefined"
-          @click="step = s.id"
+          :aria-current="stepper.current.value === form.key ? 'step' : undefined"
+          @click="stepper.goTo(form.key as FormKey)"
         >
-          <span class="step-num">{{ s.id }}</span>
-          <span class="step-title">{{ s.title }}</span>
+          <span class="step-num">{{ idx + 1 }}</span>
+          <span class="step-title">{{ STEP_TITLES[form.key as FormKey] }}</span>
         </button>
       </nav>
 
       <!-- ─── Step 1: addresses ─── -->
-      <section v-show="step === 1" class="step-body">
-        <div class="field" :class="fieldClasses(form.fields.reference)">
-          <label for="reference">{{ form.fields.reference.label }}</label>
-          <small v-if="form.fields.reference.description" class="help">
-            {{ form.fields.reference.description }}
+      <section v-if="stepper.current.value === 'reference'" class="step-body">
+        <div class="field" :class="fieldClasses(refForm.fields.reference)">
+          <label for="reference">{{ refForm.fields.reference.label }}</label>
+          <small v-if="refForm.fields.reference.description" class="help">
+            {{ refForm.fields.reference.description }}
           </small>
           <input
             id="reference"
-            v-register="form.register('reference')"
-            :placeholder="form.fields.reference.placeholder"
+            v-register="refForm.register('reference')"
+            :placeholder="refForm.fields.reference.placeholder"
           />
-          <small v-if="form.fields.reference.validating" class="hint">Checking…</small>
+          <small v-if="refForm.fields.reference.validating" class="hint">Checking…</small>
           <small v-else class="error">
-            {{ errorMessage(form.fields.reference) }}
+            {{ errorMessage(refForm.fields.reference) }}
           </small>
         </div>
 
@@ -606,84 +695,84 @@
         >
           <legend>{{ block.label }}</legend>
           <label v-if="block.prefix === 'delivery'" class="checkbox">
-            <input v-register="form.register('useSameDeliveryAddress')" type="checkbox" />
-            {{ form.fields.useSameDeliveryAddress.label }}
+            <input v-register="refForm.register('useSameDeliveryAddress')" type="checkbox" />
+            {{ refForm.fields.useSameDeliveryAddress.label }}
           </label>
           <div class="grid-2">
-            <div class="field" :class="fieldClasses(form.fields[block.prefix].line1)">
-              <label>{{ form.fields[block.prefix].line1.label }}</label>
-              <small v-if="form.fields[block.prefix].line1.description" class="help">
-                {{ form.fields[block.prefix].line1.description }}
+            <div class="field" :class="fieldClasses(refForm.fields[block.prefix].line1)">
+              <label>{{ refForm.fields[block.prefix].line1.label }}</label>
+              <small v-if="refForm.fields[block.prefix].line1.description" class="help">
+                {{ refForm.fields[block.prefix].line1.description }}
               </small>
               <input
-                v-register="form.register([block.prefix, 'line1'])"
+                v-register="refForm.register([block.prefix, 'line1'])"
                 :disabled="block.mirrored"
               />
-              <small class="error">{{ errorMessage(form.fields[block.prefix].line1) }}</small>
+              <small class="error">{{ errorMessage(refForm.fields[block.prefix].line1) }}</small>
             </div>
             <div class="field">
-              <label>{{ form.fields[block.prefix].line2.label }}</label>
-              <small v-if="form.fields[block.prefix].line2.description" class="help">
-                {{ form.fields[block.prefix].line2.description }}
+              <label>{{ refForm.fields[block.prefix].line2.label }}</label>
+              <small v-if="refForm.fields[block.prefix].line2.description" class="help">
+                {{ refForm.fields[block.prefix].line2.description }}
               </small>
               <input
-                v-register="form.register([block.prefix, 'line2'])"
+                v-register="refForm.register([block.prefix, 'line2'])"
                 :disabled="block.mirrored"
               />
             </div>
           </div>
           <div class="grid-3">
-            <div class="field" :class="fieldClasses(form.fields[block.prefix].city)">
-              <label>{{ form.fields[block.prefix].city.label }}</label>
+            <div class="field" :class="fieldClasses(refForm.fields[block.prefix].city)">
+              <label>{{ refForm.fields[block.prefix].city.label }}</label>
               <input
-                v-register="form.register([block.prefix, 'city'])"
+                v-register="refForm.register([block.prefix, 'city'])"
                 :disabled="block.mirrored"
               />
-              <small class="error">{{ errorMessage(form.fields[block.prefix].city) }}</small>
+              <small class="error">{{ errorMessage(refForm.fields[block.prefix].city) }}</small>
             </div>
-            <div class="field" :class="fieldClasses(form.fields[block.prefix].region)">
-              <label>{{ form.fields[block.prefix].region.label }}</label>
-              <small v-if="form.fields[block.prefix].region.description" class="help">
-                {{ form.fields[block.prefix].region.description }}
+            <div class="field" :class="fieldClasses(refForm.fields[block.prefix].region)">
+              <label>{{ refForm.fields[block.prefix].region.label }}</label>
+              <small v-if="refForm.fields[block.prefix].region.description" class="help">
+                {{ refForm.fields[block.prefix].region.description }}
               </small>
               <input
-                v-register="form.register([block.prefix, 'region'])"
+                v-register="refForm.register([block.prefix, 'region'])"
                 :disabled="block.mirrored"
               />
-              <small class="error">{{ errorMessage(form.fields[block.prefix].region) }}</small>
+              <small class="error">{{ errorMessage(refForm.fields[block.prefix].region) }}</small>
             </div>
-            <div class="field" :class="fieldClasses(form.fields[block.prefix].country)">
-              <label>{{ form.fields[block.prefix].country.label }}</label>
+            <div class="field" :class="fieldClasses(refForm.fields[block.prefix].country)">
+              <label>{{ refForm.fields[block.prefix].country.label }}</label>
               <select
-                v-register="form.register([block.prefix, 'country'])"
+                v-register="refForm.register([block.prefix, 'country'])"
                 :disabled="block.mirrored"
               >
                 <option v-for="c in COUNTRIES" :key="c" :value="c">{{ c }}</option>
               </select>
             </div>
           </div>
-          <div class="field" :class="fieldClasses(form.fields[block.prefix].postalCode)">
-            <label>{{ form.fields[block.prefix].postalCode.label }}</label>
-            <small v-if="form.fields[block.prefix].postalCode.description" class="help">
-              {{ form.fields[block.prefix].postalCode.description }}
+          <div class="field" :class="fieldClasses(refForm.fields[block.prefix].postalCode)">
+            <label>{{ refForm.fields[block.prefix].postalCode.label }}</label>
+            <small v-if="refForm.fields[block.prefix].postalCode.description" class="help">
+              {{ refForm.fields[block.prefix].postalCode.description }}
             </small>
             <input
-              v-register="form.register([block.prefix, 'postalCode'])"
+              v-register="refForm.register([block.prefix, 'postalCode'])"
               placeholder="Try 10xxx, M5xxx, SWxxx…"
               :disabled="block.mirrored"
             />
-            <small v-if="form.fields[block.prefix].postalCode.validating" class="hint">
+            <small v-if="refForm.fields[block.prefix].postalCode.validating" class="hint">
               Looking up postal code…
             </small>
             <small v-else class="error">
-              {{ errorMessage(form.fields[block.prefix].postalCode) }}
+              {{ errorMessage(refForm.fields[block.prefix].postalCode) }}
             </small>
           </div>
         </fieldset>
       </section>
 
       <!-- ─── Step 2: cargo ─── -->
-      <section v-show="step === 2" class="step-body">
+      <section v-else-if="stepper.current.value === 'cargo'" class="step-body">
         <div class="variant-picker">
           <label>Cargo class</label>
           <div class="chip-row">
@@ -703,85 +792,85 @@
         <!-- Per-variant fields -->
         <div v-if="cargoType === 'dry'" class="row">
           <label class="checkbox">
-            <input v-register="form.register('cargo.details.fragile')" type="checkbox" />
+            <input v-register="cargoForm.register('details.fragile')" type="checkbox" />
             Mark as fragile
           </label>
         </div>
 
         <div v-else-if="cargoType === 'refrigerated'" class="grid-2">
-          <div class="field" :class="fieldClasses(form.fields.cargo.details.tempMinF)">
-            <label>{{ form.fields.cargo.details.tempMinF.label }}</label>
+          <div class="field" :class="fieldClasses(cargoForm.fields.details.tempMinF)">
+            <label>{{ cargoForm.fields.details.tempMinF.label }}</label>
             <input
-              v-register.number="form.register('cargo.details.tempMinF')"
+              v-register.number="cargoForm.register('details.tempMinF')"
               type="number"
               step="0.5"
             />
-            <small class="error">{{ errorMessage(form.fields.cargo.details.tempMinF) }}</small>
+            <small class="error">{{ errorMessage(cargoForm.fields.details.tempMinF) }}</small>
           </div>
-          <div class="field" :class="fieldClasses(form.fields.cargo.details.tempMaxF)">
-            <label>{{ form.fields.cargo.details.tempMaxF.label }}</label>
+          <div class="field" :class="fieldClasses(cargoForm.fields.details.tempMaxF)">
+            <label>{{ cargoForm.fields.details.tempMaxF.label }}</label>
             <input
-              v-register.number="form.register('cargo.details.tempMaxF')"
+              v-register.number="cargoForm.register('details.tempMaxF')"
               type="number"
               step="0.5"
             />
-            <small class="error">{{ errorMessage(form.fields.cargo.details.tempMaxF) }}</small>
+            <small class="error">{{ errorMessage(cargoForm.fields.details.tempMaxF) }}</small>
           </div>
         </div>
 
         <div v-else-if="cargoType === 'hazmat'" class="hazmat">
           <div class="grid-2">
-            <div class="field" :class="fieldClasses(form.fields.cargo.details.unNumber)">
-              <label>{{ form.fields.cargo.details.unNumber.label }}</label>
-              <small v-if="form.fields.cargo.details.unNumber.description" class="help">
-                {{ form.fields.cargo.details.unNumber.description }}
+            <div class="field" :class="fieldClasses(cargoForm.fields.details.unNumber)">
+              <label>{{ cargoForm.fields.details.unNumber.label }}</label>
+              <small v-if="cargoForm.fields.details.unNumber.description" class="help">
+                {{ cargoForm.fields.details.unNumber.description }}
               </small>
-              <input v-register="form.register('cargo.details.unNumber')" placeholder="UN1234" />
-              <small class="error">{{ errorMessage(form.fields.cargo.details.unNumber) }}</small>
+              <input v-register="cargoForm.register('details.unNumber')" placeholder="UN1234" />
+              <small class="error">{{ errorMessage(cargoForm.fields.details.unNumber) }}</small>
             </div>
-            <div class="field" :class="fieldClasses(form.fields.cargo.details.hazardClass)">
-              <label>{{ form.fields.cargo.details.hazardClass.label }}</label>
-              <small v-if="form.fields.cargo.details.hazardClass.description" class="help">
-                {{ form.fields.cargo.details.hazardClass.description }}
+            <div class="field" :class="fieldClasses(cargoForm.fields.details.hazardClass)">
+              <label>{{ cargoForm.fields.details.hazardClass.label }}</label>
+              <small v-if="cargoForm.fields.details.hazardClass.description" class="help">
+                {{ cargoForm.fields.details.hazardClass.description }}
               </small>
-              <select v-register="form.register('cargo.details.hazardClass')">
+              <select v-register="cargoForm.register('details.hazardClass')">
                 <option v-for="c in HAZARD_CLASSES" :key="c" :value="c"> Class {{ c }} </option>
               </select>
-              <small class="error">{{ errorMessage(form.fields.cargo.details.hazardClass) }}</small>
+              <small class="error">{{ errorMessage(cargoForm.fields.details.hazardClass) }}</small>
             </div>
           </div>
           <label class="checkbox">
-            <input v-register="form.register('cargo.details.acknowledged')" type="checkbox" />
+            <input v-register="cargoForm.register('details.acknowledged')" type="checkbox" />
             I have read and acknowledge the dangerous-goods handling rules.
           </label>
-          <small class="error">{{ errorMessage(form.fields.cargo.details.acknowledged) }}</small>
+          <small class="error">{{ errorMessage(cargoForm.fields.details.acknowledged) }}</small>
         </div>
 
         <div v-else-if="cargoType === 'oversized'" class="oversized">
           <div class="grid-3">
-            <div class="field" :class="fieldClasses(form.fields.cargo.details.lengthIn)">
-              <label>{{ form.fields.cargo.details.lengthIn.label }}</label>
-              <input v-register.number="form.register('cargo.details.lengthIn')" type="number" />
-              <small class="error">{{ errorMessage(form.fields.cargo.details.lengthIn) }}</small>
+            <div class="field" :class="fieldClasses(cargoForm.fields.details.lengthIn)">
+              <label>{{ cargoForm.fields.details.lengthIn.label }}</label>
+              <input v-register.number="cargoForm.register('details.lengthIn')" type="number" />
+              <small class="error">{{ errorMessage(cargoForm.fields.details.lengthIn) }}</small>
             </div>
-            <div class="field" :class="fieldClasses(form.fields.cargo.details.widthIn)">
-              <label>{{ form.fields.cargo.details.widthIn.label }}</label>
-              <input v-register.number="form.register('cargo.details.widthIn')" type="number" />
-              <small class="error">{{ errorMessage(form.fields.cargo.details.widthIn) }}</small>
+            <div class="field" :class="fieldClasses(cargoForm.fields.details.widthIn)">
+              <label>{{ cargoForm.fields.details.widthIn.label }}</label>
+              <input v-register.number="cargoForm.register('details.widthIn')" type="number" />
+              <small class="error">{{ errorMessage(cargoForm.fields.details.widthIn) }}</small>
             </div>
-            <div class="field" :class="fieldClasses(form.fields.cargo.details.heightIn)">
-              <label>{{ form.fields.cargo.details.heightIn.label }}</label>
-              <input v-register.number="form.register('cargo.details.heightIn')" type="number" />
-              <small class="error">{{ errorMessage(form.fields.cargo.details.heightIn) }}</small>
+            <div class="field" :class="fieldClasses(cargoForm.fields.details.heightIn)">
+              <label>{{ cargoForm.fields.details.heightIn.label }}</label>
+              <input v-register.number="cargoForm.register('details.heightIn')" type="number" />
+              <small class="error">{{ errorMessage(cargoForm.fields.details.heightIn) }}</small>
             </div>
           </div>
           <div class="field">
-            <label>{{ form.fields.cargo.details.permitNumber.label }}</label>
-            <small v-if="form.fields.cargo.details.permitNumber.description" class="help">
-              {{ form.fields.cargo.details.permitNumber.description }}
+            <label>{{ cargoForm.fields.details.permitNumber.label }}</label>
+            <small v-if="cargoForm.fields.details.permitNumber.description" class="help">
+              {{ cargoForm.fields.details.permitNumber.description }}
             </small>
-            <input v-register="form.register('cargo.details.permitNumber')" />
-            <small v-if="!form.values.cargo.details.permitNumber" class="muted">
+            <input v-register="cargoForm.register('details.permitNumber')" />
+            <small v-if="!cargoForm.values.details.permitNumber" class="muted">
               No permit on file — start typing to add one.
             </small>
           </div>
@@ -795,18 +884,16 @@
             >
             <button type="button" class="ghost" @click="addLineItem">+ Add item</button>
           </div>
-          <div v-if="form.values.cargo.items.length === 0" class="empty">
+          <div v-if="cargoForm.values.items.length === 0" class="empty">
             No line items yet. Try
             <code>SKU-1001</code>, <code>SKU-2001</code>, or <code>PALLET-A</code>.
           </div>
-          <div v-for="(item, idx) in form.fields.cargo.items" :key="idx" class="line-item">
+          <div v-for="(item, idx) in cargoForm.fields.items" :key="idx" class="line-item">
             <div class="li-grid">
               <div class="field" :class="fieldClasses(item.sku)">
                 <label>{{ item.sku.label }}</label>
                 <input
-                  v-register="
-                    form.register(`cargo.items.${idx}.sku`, { transforms: skuTransforms })
-                  "
+                  v-register="cargoForm.register(`items.${idx}.sku`, { transforms: skuTransforms })"
                   placeholder="SKU-1001"
                 />
                 <small v-if="item.sku.validating" class="hint"> Checking SKU… </small>
@@ -816,13 +903,13 @@
               </div>
               <div class="field" :class="fieldClasses(item.description)">
                 <label>{{ item.description.label }}</label>
-                <input v-register="form.register(`cargo.items.${idx}.description`)" />
+                <input v-register="cargoForm.register(`items.${idx}.description`)" />
                 <small class="error">{{ errorMessage(item.description) }}</small>
               </div>
               <div class="field qty" :class="fieldClasses(item.quantity)">
                 <label>{{ item.quantity.label }}</label>
                 <input
-                  v-register.number="form.register(`cargo.items.${idx}.quantity`)"
+                  v-register.number="cargoForm.register(`items.${idx}.quantity`)"
                   type="number"
                   min="1"
                 />
@@ -831,7 +918,7 @@
               <div class="field qty" :class="fieldClasses(item.unitWeightLb)">
                 <label>{{ item.unitWeightLb.label }}</label>
                 <input
-                  v-register.number="form.register(`cargo.items.${idx}.unitWeightLb`)"
+                  v-register.number="cargoForm.register(`items.${idx}.unitWeightLb`)"
                   type="number"
                   step="0.01"
                   min="0"
@@ -853,7 +940,7 @@
       </section>
 
       <!-- ─── Step 3: service & insurance ─── -->
-      <section v-show="step === 3" class="step-body">
+      <section v-else-if="stepper.current.value === 'service'" class="step-body">
         <div class="variant-picker">
           <label>Service mode</label>
           <div class="chip-row">
@@ -871,45 +958,45 @@
         </div>
 
         <div v-if="serviceMode === 'truck'" class="grid-2">
-          <div class="field" :class="fieldClasses(form.fields.service.truckType)">
-            <label>{{ form.fields.service.truckType.label }}</label>
-            <select v-register="form.register('service.truckType')">
+          <div class="field" :class="fieldClasses(serviceForm.fields.service.truckType)">
+            <label>{{ serviceForm.fields.service.truckType.label }}</label>
+            <select v-register="serviceForm.register('service.truckType')">
               <option v-for="t in TRUCK_TYPES" :key="t" :value="t">{{
                 TRUCK_TYPE_LABELS[t]
               }}</option>
             </select>
           </div>
           <label class="checkbox align-end">
-            <input v-register="form.register('service.liftgate')" type="checkbox" />
-            {{ form.fields.service.liftgate.label }}
+            <input v-register="serviceForm.register('service.liftgate')" type="checkbox" />
+            {{ serviceForm.fields.service.liftgate.label }}
           </label>
         </div>
 
         <div v-else-if="serviceMode === 'air'" class="grid-2">
-          <div class="field" :class="fieldClasses(form.fields.service.airline)">
-            <label>{{ form.fields.service.airline.label }}</label>
-            <input v-register="form.register('service.airline')" placeholder="Lufthansa" />
-            <small class="error">{{ errorMessage(form.fields.service.airline) }}</small>
+          <div class="field" :class="fieldClasses(serviceForm.fields.service.airline)">
+            <label>{{ serviceForm.fields.service.airline.label }}</label>
+            <input v-register="serviceForm.register('service.airline')" placeholder="Lufthansa" />
+            <small class="error">{{ errorMessage(serviceForm.fields.service.airline) }}</small>
           </div>
-          <div class="field" :class="fieldClasses(form.fields.service.awbPrefix)">
-            <label>{{ form.fields.service.awbPrefix.label }}</label>
-            <small v-if="form.fields.service.awbPrefix.description" class="help">
-              {{ form.fields.service.awbPrefix.description }}
+          <div class="field" :class="fieldClasses(serviceForm.fields.service.awbPrefix)">
+            <label>{{ serviceForm.fields.service.awbPrefix.label }}</label>
+            <small v-if="serviceForm.fields.service.awbPrefix.description" class="help">
+              {{ serviceForm.fields.service.awbPrefix.description }}
             </small>
-            <input v-register="form.register('service.awbPrefix')" placeholder="220" />
-            <small class="error">{{ errorMessage(form.fields.service.awbPrefix) }}</small>
+            <input v-register="serviceForm.register('service.awbPrefix')" placeholder="220" />
+            <small class="error">{{ errorMessage(serviceForm.fields.service.awbPrefix) }}</small>
           </div>
         </div>
 
         <div v-else-if="serviceMode === 'ocean'" class="grid-2">
-          <div class="field" :class="fieldClasses(form.fields.service.vessel)">
-            <label>{{ form.fields.service.vessel.label }}</label>
-            <input v-register="form.register('service.vessel')" placeholder="MSC Aurelia" />
-            <small class="error">{{ errorMessage(form.fields.service.vessel) }}</small>
+          <div class="field" :class="fieldClasses(serviceForm.fields.service.vessel)">
+            <label>{{ serviceForm.fields.service.vessel.label }}</label>
+            <input v-register="serviceForm.register('service.vessel')" placeholder="MSC Aurelia" />
+            <small class="error">{{ errorMessage(serviceForm.fields.service.vessel) }}</small>
           </div>
-          <div class="field" :class="fieldClasses(form.fields.service.containerSize)">
-            <label>{{ form.fields.service.containerSize.label }}</label>
-            <select v-register="form.register('service.containerSize')">
+          <div class="field" :class="fieldClasses(serviceForm.fields.service.containerSize)">
+            <label>{{ serviceForm.fields.service.containerSize.label }}</label>
+            <select v-register="serviceForm.register('service.containerSize')">
               <option v-for="s in CONTAINER_SIZES" :key="s" :value="s">{{
                 CONTAINER_SIZE_LABELS[s]
               }}</option>
@@ -918,47 +1005,47 @@
         </div>
 
         <div class="grid-2">
-          <div class="field" :class="fieldClasses(form.fields.desiredPickupDate)">
-            <label>{{ form.fields.desiredPickupDate.label }}</label>
-            <input v-register="form.register('desiredPickupDate')" type="date" />
-            <small class="error">{{ errorMessage(form.fields.desiredPickupDate) }}</small>
+          <div class="field" :class="fieldClasses(serviceForm.fields.desiredPickupDate)">
+            <label>{{ serviceForm.fields.desiredPickupDate.label }}</label>
+            <input v-register="serviceForm.register('desiredPickupDate')" type="date" />
+            <small class="error">{{ errorMessage(serviceForm.fields.desiredPickupDate) }}</small>
           </div>
-          <div class="field" :class="fieldClasses(form.fields.desiredDeliveryDate)">
-            <label>{{ form.fields.desiredDeliveryDate.label }}</label>
-            <input v-register="form.register('desiredDeliveryDate')" type="date" />
-            <small class="error">{{ errorMessage(form.fields.desiredDeliveryDate) }}</small>
+          <div class="field" :class="fieldClasses(serviceForm.fields.desiredDeliveryDate)">
+            <label>{{ serviceForm.fields.desiredDeliveryDate.label }}</label>
+            <input v-register="serviceForm.register('desiredDeliveryDate')" type="date" />
+            <small class="error">{{ errorMessage(serviceForm.fields.desiredDeliveryDate) }}</small>
           </div>
         </div>
 
         <fieldset class="address">
-          <legend>{{ form.fields('insurance').label }}</legend>
+          <legend>{{ serviceForm.fields('insurance').label }}</legend>
           <div class="grid-3">
-            <div class="field" :class="fieldClasses(form.fields.insurance.declaredValueUSD)">
-              <label>{{ form.fields.insurance.declaredValueUSD.label }}</label>
-              <small v-if="form.fields.insurance.declaredValueUSD.description" class="help">
-                {{ form.fields.insurance.declaredValueUSD.description }}
+            <div class="field" :class="fieldClasses(serviceForm.fields.insurance.declaredValueUSD)">
+              <label>{{ serviceForm.fields.insurance.declaredValueUSD.label }}</label>
+              <small v-if="serviceForm.fields.insurance.declaredValueUSD.description" class="help">
+                {{ serviceForm.fields.insurance.declaredValueUSD.description }}
               </small>
               <input
-                v-register.number="form.register('insurance.declaredValueUSD')"
+                v-register.number="serviceForm.register('insurance.declaredValueUSD')"
                 type="number"
                 min="0"
               />
               <small class="error">{{
-                errorMessage(form.fields.insurance.declaredValueUSD)
+                errorMessage(serviceForm.fields.insurance.declaredValueUSD)
               }}</small>
             </div>
             <div class="field">
-              <label>{{ form.fields.insurance.coverage.label }}</label>
-              <select v-register="form.register('insurance.coverage')">
+              <label>{{ serviceForm.fields.insurance.coverage.label }}</label>
+              <select v-register="serviceForm.register('insurance.coverage')">
                 <option v-for="c in COVERAGES" :key="c" :value="c">{{ COVERAGE_LABELS[c] }}</option>
               </select>
             </div>
             <div class="field">
-              <label>{{ form.fields.insurance.currency.label }}</label>
-              <small v-if="form.fields.insurance.currency.description" class="help">
-                {{ form.fields.insurance.currency.description }}
+              <label>{{ serviceForm.fields.insurance.currency.label }}</label>
+              <small v-if="serviceForm.fields.insurance.currency.description" class="help">
+                {{ serviceForm.fields.insurance.currency.description }}
               </small>
-              <select v-register="form.register('insurance.currency')">
+              <select v-register="serviceForm.register('insurance.currency')">
                 <option v-for="c in CURRENCIES" :key="c" :value="c">{{ c }}</option>
               </select>
             </div>
@@ -966,48 +1053,65 @@
         </fieldset>
 
         <div class="field">
-          <label>{{ form.fields.notes.label }}</label>
-          <small v-if="form.fields.notes.description" class="help">
-            {{ form.fields.notes.description }}
+          <label>{{ serviceForm.fields.notes.label }}</label>
+          <small v-if="serviceForm.fields.notes.description" class="help">
+            {{ serviceForm.fields.notes.description }}
           </small>
           <textarea
-            v-register="form.register('notes')"
+            v-register="serviceForm.register('notes')"
             rows="3"
             placeholder="Special handling instructions…"
           />
-          <small v-if="!form.values.notes" class="muted">
+          <small v-if="!serviceForm.values.notes" class="muted">
             No notes recorded — start typing to add some.
           </small>
-          <small class="error">{{ errorMessage(form.fields.notes) }}</small>
+          <small class="error">{{ errorMessage(serviceForm.fields.notes) }}</small>
         </div>
       </section>
 
       <!-- ─── Step 4: review ─── -->
-      <section v-show="step === 4" class="step-body review">
-        <h3>Review</h3>
-        <pre>{{ JSON.stringify(form.values(), null, 2) }}</pre>
-        <!-- `form.meta.showErrors` runs the configured heuristic against
-             the root container's aggregated state — same gate as every
-             per-field error site, so the summary only appears when the
-             user is ready to see issues. -->
-        <aside v-if="form.meta.showErrors" class="errors-summary" aria-live="polite">
+      <section v-else-if="stepper.current.value === 'review'" class="step-body review">
+        <h3>Review your manifest</h3>
+        <p class="muted">Everything looks accurate? Sign and book below.</p>
+        <pre>{{
+          JSON.stringify(
+            {
+              reference: refForm.values(),
+              cargo: cargoForm.values(),
+              service: serviceForm.values(),
+            },
+            null,
+            2
+          )
+        }}</pre>
+
+        <!-- Aggregate error summary across all forms. `stepper.allErrors`
+             is the load-bearing aggregate; each row jumps via
+             stepper.goTo(formKey). -->
+        <aside v-if="groupedErrors.length > 0" class="errors-summary" aria-live="polite">
           <header class="errors-summary-head">
             <span class="errors-summary-icon" aria-hidden="true">⚠</span>
             <div>
               <h3 class="errors-summary-title">
-                {{ form.meta.errors.length }}
-                {{ form.meta.errors.length === 1 ? 'item' : 'items' }} on the manifest before it
-                ships.
+                {{ stepper.allErrors.value.length }}
+                {{ stepper.allErrors.value.length === 1 ? 'item' : 'items' }} on the manifest before
+                it ships.
               </h3>
               <p class="errors-summary-hint">Tap any line to jump to the field.</p>
             </div>
           </header>
           <ol class="errors-summary-groups">
-            <li v-for="group in groupedErrors" :key="group.rootKey">
-              <h4 class="errors-summary-group-head">{{ group.rootLabel }}</h4>
+            <li v-for="group in groupedErrors" :key="`${group.formKey}:${group.rootKey}`">
+              <h4 class="errors-summary-group-head">
+                {{ group.stepTitle }} · {{ group.rootLabel }}
+              </h4>
               <ul class="errors-summary-items">
                 <li v-for="(item, i) in group.items" :key="i">
-                  <button type="button" class="errors-summary-row" @click="goToError(item.path)">
+                  <button
+                    type="button"
+                    class="errors-summary-row"
+                    @click="goToError(group.formKey, item.path)"
+                  >
                     <span v-if="item.leafLabel" class="errors-summary-leaf">{{
                       item.leafLabel
                     }}</span>
@@ -1019,6 +1123,42 @@
             </li>
           </ol>
         </aside>
+
+        <fieldset class="address">
+          <legend>Sign & accept</legend>
+          <div class="field" :class="fieldClasses(reviewForm.fields.signature)">
+            <label>{{ reviewForm.fields.signature.label }}</label>
+            <small v-if="reviewForm.fields.signature.description" class="help">
+              {{ reviewForm.fields.signature.description }}
+            </small>
+            <input v-register="reviewForm.register('signature')" placeholder="Ada Lovelace" />
+            <small class="error">{{ errorMessage(reviewForm.fields.signature) }}</small>
+          </div>
+          <div class="field">
+            <label>Acknowledgements</label>
+            <div class="row" style="flex-direction: column; gap: 0.375rem">
+              <label v-for="ack in ACKNOWLEDGEMENTS" :key="ack" class="checkbox">
+                <input
+                  type="checkbox"
+                  :checked="isAcknowledged(ack)"
+                  @change="
+                    toggleAcknowledgement(
+                      ack,
+                      ($event.target as HTMLInputElement | null)?.checked ?? false
+                    )
+                  "
+                />
+                {{ ack }}
+              </label>
+            </div>
+            <small class="error">{{ errorMessage(reviewForm.fields('acknowledgements')) }}</small>
+          </div>
+          <label class="checkbox">
+            <input v-register="reviewForm.register('termsAccepted')" type="checkbox" />
+            {{ reviewForm.fields.termsAccepted.label }}
+          </label>
+          <small class="error">{{ errorMessage(reviewForm.fields.termsAccepted) }}</small>
+        </fieldset>
       </section>
 
       <!-- ─── Submit-row error (form-level) ─── -->
@@ -1030,40 +1170,47 @@
           <button
             type="button"
             class="ghost"
-            :disabled="!form.history.canUndo"
-            @click="form.history.undo()"
+            :disabled="!activeForm.history.canUndo"
+            @click="activeForm.history.undo()"
           >
             ↶ Undo
           </button>
           <button
             type="button"
             class="ghost"
-            :disabled="!form.history.canRedo"
-            @click="form.history.redo()"
+            :disabled="!activeForm.history.canRedo"
+            @click="activeForm.history.redo()"
           >
             ↷ Redo
           </button>
           <button type="button" class="ghost danger" @click="resetAll">Reset</button>
         </div>
         <div class="nav-right">
-          <button v-if="step > 1" type="button" class="secondary" @click="goBack"> Back </button>
           <button
-            v-if="step < 4"
+            v-if="stepper.current.value !== 'reference'"
+            type="button"
+            class="secondary"
+            @click="stepper.back()"
+          >
+            Back
+          </button>
+          <button
+            v-if="stepper.current.value !== 'review'"
             type="button"
             class="primary"
-            :disabled="!currentStepValid"
-            @click="goNext"
+            :disabled="!canGoNext"
+            @click="stepper.next()"
           >
             Next
-            <span v-if="form.meta.validating" class="badge">…</span>
+            <span v-if="isAnyValidating" class="badge">…</span>
           </button>
           <button
             v-else
             type="submit"
             class="primary"
-            :disabled="form.meta.submitting || !form.meta.valid"
+            :disabled="reviewForm.meta.submitting || !reviewForm.meta.valid"
           >
-            {{ form.meta.submitting ? 'Booking…' : 'Book shipment' }}
+            {{ reviewForm.meta.submitting ? 'Booking…' : 'Book shipment' }}
           </button>
         </div>
       </div>

--- a/apps/site/scripts/bundle-repl-deps.mjs
+++ b/apps/site/scripts/bundle-repl-deps.mjs
@@ -46,6 +46,11 @@ const typesDir = resolve(outDir, 'types')
 const requireFromHere = createRequire(import.meta.url)
 const vuePkg = requireFromHere('vue/package.json')
 const zodPkg = requireFromHere('zod/package.json')
+// `zod-v3` is an npm-aliased package: pnpm installs zod@3.x under the
+// directory name `zod-v3` so v3 and v4 can coexist. The package.json's
+// own `name` field still says "zod", but `requireFromHere('zod-v3/...')`
+// resolves to the v3 install via the alias.
+const zodV3Pkg = requireFromHere('zod-v3/package.json')
 // attaform's package.json sits at the monorepo root, not in
 // node_modules — resolve it by absolute path so we don't rely on a
 // hoisting layout that the workspace might restructure later.
@@ -316,6 +321,19 @@ const packageManifests = {
     types: './index.d.ts',
     main: './index.js',
   },
+  // `zod-v3` is consumed by the unified `attaform/zod` entry's type
+  // bundle (the V3 overload references `z as zV3 from 'zod-v3'`).
+  // Volar's LSP resolves that bare import against the package manifest
+  // here — without this, the LSP falls back to fetching from unpkg
+  // (which 404s + CORS-blocks the request, polluting the console).
+  // The runtime side doesn't need a `/lib/zod-v3.js` because esbuild
+  // inlines zod-v3 into `attaform-zod.js` (no external marker).
+  'zod-v3': {
+    name: 'zod-v3',
+    version: zodV3Pkg.version,
+    types: './index.d.ts',
+    main: './index.js',
+  },
 }
 
 // Just attaform's two .d.ts entry points. Re-run on every src/ change
@@ -346,6 +364,7 @@ async function emitTypeBundles() {
     mkdir(resolve(typesDir, 'attaform'), { recursive: true }),
     mkdir(resolve(typesDir, 'vue'), { recursive: true }),
     mkdir(resolve(typesDir, 'zod'), { recursive: true }),
+    mkdir(resolve(typesDir, 'zod-v3'), { recursive: true }),
   ])
   await Promise.all([
     emitAttaformTypeBundles(),
@@ -359,6 +378,22 @@ async function emitTypeBundles() {
       input: resolve(repoRoot, 'node_modules/zod/index.d.ts'),
       output: resolve(typesDir, 'zod/index.d.ts'),
       name: 'zod',
+      respectExternal: true,
+    }),
+    bundleDts({
+      // zod-v3's root `index.d.ts` re-exports through an `import * as
+      // z` / `export { z }` namespace shape that rollup-plugin-dts
+      // chokes on (it emits getter syntax in its namespace fixer that
+      // its own parser can't re-parse — UnsupportedSyntaxError). The
+      // `v3/external.d.ts` sub-entry has the same surface (everything
+      // the public `z` namespace contains) via plain `export *`
+      // statements, which bundles cleanly. We then rewrite a fresh
+      // `index.d.ts` below that re-exports the bundle as the `z`
+      // namespace, matching the consumer-facing shape
+      // `import { z } from 'zod-v3'`.
+      input: resolve(repoRoot, 'node_modules/zod-v3/v3/external.d.ts'),
+      output: resolve(typesDir, 'zod-v3/external.d.ts'),
+      name: 'zod-v3',
       respectExternal: true,
     }),
   ])
@@ -381,6 +416,17 @@ async function emitTypeBundles() {
     writeFile(resolve(typesDir, 'attaform/zod.js'), ''),
     writeFile(resolve(typesDir, 'vue/index.js'), ''),
     writeFile(resolve(typesDir, 'zod/index.js'), ''),
+    writeFile(resolve(typesDir, 'zod-v3/index.js'), ''),
+    // zod-v3 root entry: re-exports the bundled v3 surface as both
+    // the `z` namespace (matching `import { z } from 'zod-v3'`) and
+    // as plain named re-exports (matching `import { ZodObject } from
+    // 'zod-v3'`). Mirrors the shape zod-v3's published `index.d.ts`
+    // exposes, minus the namespace-fixer syntax that rollup-plugin-dts
+    // can't handle (see the bundleDts call above for context).
+    writeFile(
+      resolve(typesDir, 'zod-v3/index.d.ts'),
+      `import * as z from './external'\nexport * from './external'\nexport { z }\nexport default z\n`
+    ),
   ])
   // Sidecar `.d.ts` next to each `.js` runtime bundle so Nuxt/IDE
   // tooling (vue-tsc, Volar, vtsls) sees types when resolving an
@@ -438,6 +484,14 @@ async function emitTypeBundles() {
     writeFile(
       resolve(typesDir, 'zod/meta.json'),
       JSON.stringify(dirMeta(['package.json', 'index.d.ts', 'index.js']), null, 2)
+    ),
+    writeFile(
+      resolve(typesDir, 'zod-v3/meta.json'),
+      JSON.stringify(
+        dirMeta(['package.json', 'index.d.ts', 'index.js', 'external.d.ts']),
+        null,
+        2
+      )
     ),
   ])
 }

--- a/src/runtime/adapters/unified/types-unified.ts
+++ b/src/runtime/adapters/unified/types-unified.ts
@@ -1,0 +1,144 @@
+/**
+ * Type-level helpers for the unified `attaform/zod` entry. These give
+ * tests and other type-query call sites a deterministic projection
+ * over an arbitrary v4 OR v3 schema, sidestepping the brittle
+ * instantiation-expression resolution rules TypeScript applies to
+ * overloaded functions (`typeof useForm<X>` can pick the wrong
+ * overload or the impl signature, depending on whether the type
+ * argument is a concrete schema, a generic, or a constraint).
+ *
+ * The helpers dispatch ONCE per use site via a binary conditional —
+ * no stacking, no amplification across the return type. Equivalent
+ * to writing `ReturnType<typeof useForm<S>>` but cache-stable across
+ * call patterns.
+ *
+ * Per `inference-first DX`, these helpers are test- and
+ * internal-facing. Consumer code shouldn't reach for them — the
+ * overloaded `useForm` already gives full inference at call sites.
+ */
+import type { z } from 'zod'
+import type { z as zV3 } from 'zod-v3'
+import type { StorageShape as StorageShapeV4 } from '../zod-v4/types-storage-shape'
+import type { StorageShape as StorageShapeV3 } from '../zod-v3/types-storage-shape'
+import type { UnwrapZodObject } from '../zod-v3/types-zod-adapter'
+import type {
+  AbstractSchema,
+  FormKey,
+  UseFormConfiguration,
+  UseFormReturnType,
+  ValidateOnConfig,
+} from '../../types/types-api'
+import type { DefaultValuesInput, GenericForm } from '../../types/types-core'
+
+type V4FormOf<S extends z.ZodObject> = z.input<S> extends GenericForm ? z.input<S> : never
+type V4OutOf<S extends z.ZodObject> = z.output<S> extends GenericForm ? z.output<S> : never
+type V4ReadOf<S extends z.ZodObject> =
+  StorageShapeV4<S> extends GenericForm ? StorageShapeV4<S> : never
+
+type V3FormOf<S extends zV3.ZodObject<zV3.ZodRawShape>> =
+  zV3.input<UnwrapZodObject<S>> extends GenericForm ? zV3.input<UnwrapZodObject<S>> : never
+type V3OutOf<S extends zV3.ZodObject<zV3.ZodRawShape>> =
+  zV3.output<UnwrapZodObject<S>> extends GenericForm ? zV3.output<UnwrapZodObject<S>> : never
+type V3ReadOf<S extends zV3.ZodObject<zV3.ZodRawShape>> =
+  StorageShapeV3<UnwrapZodObject<S>> extends GenericForm
+    ? StorageShapeV3<UnwrapZodObject<S>>
+    : never
+
+/**
+ * Direct V4 projection — no major-dispatch. Use when the schema's
+ * Zod major is known statically (typical for V4 generic helpers like
+ * `function setup<S extends z.ZodObject>(s: S)`). TS simplifies the
+ * helper cleanly under generic constraints because no conditional
+ * is present.
+ */
+export type UseFormReturnV4<
+  Schema extends z.ZodObject,
+  K extends FormKey = FormKey,
+> = UseFormReturnType<V4FormOf<Schema>, V4OutOf<Schema>, V4ReadOf<Schema>, K>
+
+/**
+ * Direct V4 configuration projection. Mirrors `UseFormReturnV4`.
+ */
+export type UseFormConfigV4<Schema extends z.ZodObject, K extends FormKey = FormKey> = Omit<
+  UseFormConfiguration<
+    V4FormOf<Schema>,
+    V4OutOf<Schema>,
+    AbstractSchema<V4FormOf<Schema>, V4OutOf<Schema>>,
+    DefaultValuesInput<V4FormOf<Schema>>,
+    K
+  >,
+  'schema' | 'validateOn' | 'debounceMs'
+> & { schema: Schema } & ValidateOnConfig
+
+/**
+ * Direct V3 projection — no major-dispatch. Use when the schema's
+ * Zod major is known statically.
+ */
+export type UseFormReturnV3<
+  Schema extends zV3.ZodObject<zV3.ZodRawShape>,
+  K extends FormKey = FormKey,
+> = UseFormReturnType<V3FormOf<Schema>, V3OutOf<Schema>, V3ReadOf<Schema>, K>
+
+/**
+ * Direct V3 configuration projection. Mirrors `UseFormReturnV3`.
+ */
+export type UseFormConfigV3<
+  Schema extends zV3.ZodObject<zV3.ZodRawShape>,
+  K extends FormKey = FormKey,
+> = Omit<
+  UseFormConfiguration<
+    V3FormOf<Schema>,
+    V3OutOf<Schema>,
+    AbstractSchema<V3FormOf<Schema>, V3OutOf<Schema>>,
+    DefaultValuesInput<V3FormOf<Schema>>,
+    K
+  >,
+  'schema' | 'validateOn' | 'debounceMs'
+> & { schema: Schema } & ValidateOnConfig
+
+/**
+ * The return shape of `useForm` for a given Zod schema. Dispatches
+ * once on the schema's major version and projects to the matching
+ * adapter's `Form` / `Out` / `Read` slots.
+ *
+ * Replaces `ReturnType<typeof useForm<Schema, K>>` in test code with
+ * concrete schemas. For generic helpers (`<S extends z.ZodObject>`),
+ * use `UseFormReturnV4<S>` directly — TS doesn't simplify
+ * conditional types under generic constraints, so the dispatch in
+ * this helper stays deferred and TS can't prove return-type
+ * compatibility.
+ */
+export type UseFormReturn<Schema, K extends FormKey = FormKey> = Schema extends z.ZodObject
+  ? UseFormReturnType<V4FormOf<Schema>, V4OutOf<Schema>, V4ReadOf<Schema>, K>
+  : Schema extends zV3.ZodObject<zV3.ZodRawShape>
+    ? UseFormReturnType<V3FormOf<Schema>, V3OutOf<Schema>, V3ReadOf<Schema>, K>
+    : never
+
+/**
+ * The configuration parameter shape of `useForm` for a given Zod
+ * schema. Mirrors `UseFormReturn`'s dispatch — replaces
+ * `Parameters<typeof useForm<Schema, K>>[0]` in test code.
+ */
+export type UseFormConfig<Schema, K extends FormKey = FormKey> = Schema extends z.ZodObject
+  ? Omit<
+      UseFormConfiguration<
+        V4FormOf<Schema>,
+        V4OutOf<Schema>,
+        AbstractSchema<V4FormOf<Schema>, V4OutOf<Schema>>,
+        DefaultValuesInput<V4FormOf<Schema>>,
+        K
+      >,
+      'schema' | 'validateOn' | 'debounceMs'
+    > & { schema: Schema } & ValidateOnConfig
+  : Schema extends zV3.ZodObject<zV3.ZodRawShape>
+    ? Omit<
+        UseFormConfiguration<
+          V3FormOf<Schema>,
+          V3OutOf<Schema>,
+          AbstractSchema<V3FormOf<Schema>, V3OutOf<Schema>>,
+          DefaultValuesInput<V3FormOf<Schema>>,
+          K
+        >,
+        'schema' | 'validateOn' | 'debounceMs'
+      > & { schema: Schema } & ValidateOnConfig
+    : never

--- a/src/runtime/adapters/unified/use-form.ts
+++ b/src/runtime/adapters/unified/use-form.ts
@@ -5,21 +5,18 @@
  * to the v3 wrapper, which already accepts both Zod v3 input and
  * `AbstractSchema` directly via its built-in shape branch.
  *
- * Type-level dispatch happens through a single signature with a
- * union constraint — `Schema extends z.ZodObject |
- * zV3.ZodObject<zV3.ZodRawShape>`. The configuration parameter and
- * return type both dispatch conditionally on whether `Schema` is a
- * v4 or v3 object. The two majors don't structurally satisfy each
- * other's `ZodObject` constraints (v4 has `loose` / `safeExtend` /
- * `def` / `type` members v3 lacks), so neither alone is enough — the
- * union accepts both, and the conditional return type routes through
- * the matching adapter's `StorageShape` / `z.input` / `z.output`.
+ * Type-level dispatch happens via TWO typed overloads — v4 first, v3
+ * second — plus an untyped impl. Each overload mirrors the matching
+ * direct adapter's signature exactly, so a v4-schema call site pays
+ * the same per-call depth cost as importing from `attaform/zod-v4`
+ * directly. Overload resolution at concrete call sites commits to one
+ * overload immediately on argument shape — no type-level dispatch tax.
  *
- * A single signature (rather than overloads) keeps `typeof
- * useForm<X>` instantiation expressions in test code unambiguous:
- * TypeScript's overload-resolution rules for these expressions are
- * brittle when multiple overloads partially match, so we collapse to
- * one signature.
+ * Tests and other call sites that need the equivalent of
+ * `typeof useForm<X>` should reach for the `UseFormReturn<X>` /
+ * `UseFormConfig<X>` helpers in `types-api.ts` — instantiation
+ * expressions on overloaded functions follow brittle resolution rules,
+ * and the helper types give a deterministic projection.
  *
  * This module is the FALLBACK path. Vite consumers see the
  * `attaform/vite` plugin's `resolveId` hook rewrite `attaform/zod`
@@ -53,84 +50,28 @@ import type {
 import type { DefaultValuesInput, GenericForm } from '../../types/types-core'
 
 // ───────────────────────────────────────────────────────────────────
-// Per-major projections. Each dispatches a single Schema to the
-// matching adapter's input / output / storage-shape slot. The
-// trailing `never` arms catch the "other major" case so an isolated
-// instantiation stays well-formed; the union constraint on the
-// public signature guarantees one arm always fires.
+// Per-major projection helpers. Each overload's constraint scopes the
+// Schema to one Zod major, so the projection is a direct read — no
+// dispatch in the type body. Mirrors the direct adapter shapes so the
+// unified entry pays the same per-call depth cost as a direct import.
 // ───────────────────────────────────────────────────────────────────
 
-// Per-major helpers. Naming each variant keeps `rollup-plugin-dts`
-// from inlining the `z.input<X> extends GenericForm ? z.input<X> :
-// never` conditional twice inside each branch of the unified
-// `FormInput` / `FormOutput` / `FormStorageShape` aliases — the
-// bundled `.d.ts` preserves the helper as a single alias rather
-// than re-evaluating it at every consumer call site. Critical for
-// TS2589 headroom in setups that wire several `useForm` calls in
-// one scope (multistep wizards, parallel inline pickers, etc.).
-type FormInputV4<S extends z.ZodObject> = z.input<S> extends GenericForm ? z.input<S> : never
-type FormOutputV4<S extends z.ZodObject> = z.output<S> extends GenericForm ? z.output<S> : never
-type FormStorageShapeV4<S extends z.ZodObject> =
+type V4FormOf<S extends z.ZodObject> = z.input<S> extends GenericForm ? z.input<S> : never
+type V4OutOf<S extends z.ZodObject> = z.output<S> extends GenericForm ? z.output<S> : never
+type V4ReadOf<S extends z.ZodObject> =
   StorageShapeV4<S> extends GenericForm ? StorageShapeV4<S> : never
 
-type FormInputV3<S extends zV3.ZodObject<zV3.ZodRawShape>> =
+type V3FormOf<S extends zV3.ZodObject<zV3.ZodRawShape>> =
   zV3.input<UnwrapZodObject<S>> extends GenericForm ? zV3.input<UnwrapZodObject<S>> : never
-type FormOutputV3<S extends zV3.ZodObject<zV3.ZodRawShape>> =
+type V3OutOf<S extends zV3.ZodObject<zV3.ZodRawShape>> =
   zV3.output<UnwrapZodObject<S>> extends GenericForm ? zV3.output<UnwrapZodObject<S>> : never
-type FormStorageShapeV3<S extends zV3.ZodObject<zV3.ZodRawShape>> =
+type V3ReadOf<S extends zV3.ZodObject<zV3.ZodRawShape>> =
   StorageShapeV3<UnwrapZodObject<S>> extends GenericForm
     ? StorageShapeV3<UnwrapZodObject<S>>
     : never
 
-type FormInput<Schema> = Schema extends z.ZodObject
-  ? FormInputV4<Schema>
-  : Schema extends zV3.ZodObject<zV3.ZodRawShape>
-    ? FormInputV3<Schema>
-    : never
-
-type FormOutput<Schema> = Schema extends z.ZodObject
-  ? FormOutputV4<Schema>
-  : Schema extends zV3.ZodObject<zV3.ZodRawShape>
-    ? FormOutputV3<Schema>
-    : never
-
-type FormStorageShape<Schema> = Schema extends z.ZodObject
-  ? FormStorageShapeV4<Schema>
-  : Schema extends zV3.ZodObject<zV3.ZodRawShape>
-    ? FormStorageShapeV3<Schema>
-    : never
-
-// Single unified configuration shape. The outer structure is
-// non-conditional (so TS can resolve it for any Schema satisfying
-// the union constraint, including generic `F extends z.ZodObject`
-// helpers in test code); only the field-level types dispatch on
-// Schema kind via `FormInput` / `FormOutput`. The runtime cast
-// passes the configuration through unchanged — each adapter's own
-// signature absorbs the residual structural drift.
-type UnifiedConfiguration<Schema, K extends FormKey = FormKey> = Omit<
-  UseFormConfiguration<
-    FormInput<Schema>,
-    FormOutput<Schema>,
-    AbstractSchema<FormInput<Schema>, FormOutput<Schema>>,
-    DefaultValuesInput<FormInput<Schema>>,
-    K
-  >,
-  'schema' | 'validateOn' | 'debounceMs'
-> & { schema: Schema } & ValidateOnConfig
-
 /**
- * Create a form bound to a Zod schema. Accepts both Zod v3 and Zod v4
- * schemas; the runtime picks the right adapter from the schema's
- * shape.
- *
- * Type inference works transparently for both Zod v3 and Zod v4
- * schemas — the adapter is selected from the schema's shape at both
- * runtime and type-check time. `form.values`, `form.fields`,
- * `register`, and the `handleSubmit` callback data type all resolve
- * against the matching adapter's storage shape; consumers don't need
- * to reach for `attaform/zod-v3` or `attaform/zod-v4` to get full
- * inference. Those subpath entries remain as lean-bundle escape
- * hatches for non-Vite tooling, not correctness escape hatches.
+ * Create a form bound to a Zod v4 schema.
  *
  * ```ts
  * import { useForm } from 'attaform/zod'
@@ -143,14 +84,54 @@ type UnifiedConfiguration<Schema, K extends FormKey = FormKey> = Omit<
  *   }),
  * })
  * ```
+ *
+ * v4 schemas match this overload first via their structural `def`
+ * field. v3 schemas fall through to the v3 overload below.
  */
-export function useForm<
-  Schema extends z.ZodObject | zV3.ZodObject<zV3.ZodRawShape>,
-  K extends FormKey = FormKey,
->(
-  configuration: UnifiedConfiguration<Schema, K>
-): UseFormReturnType<FormInput<Schema>, FormOutput<Schema>, FormStorageShape<Schema>, K> {
-  // Foot-gun guard mirrors the typed wrappers'.
+export function useForm<Schema extends z.ZodObject, K extends FormKey = FormKey>(
+  configuration: Omit<
+    UseFormConfiguration<
+      V4FormOf<Schema>,
+      V4OutOf<Schema>,
+      AbstractSchema<V4FormOf<Schema>, V4OutOf<Schema>>,
+      DefaultValuesInput<V4FormOf<Schema>>,
+      K
+    >,
+    'schema' | 'validateOn' | 'debounceMs'
+  > & { schema: Schema } & ValidateOnConfig
+): UseFormReturnType<V4FormOf<Schema>, V4OutOf<Schema>, V4ReadOf<Schema>, K>
+/**
+ * Create a form bound to a Zod v3 schema.
+ *
+ * ```ts
+ * import { useForm } from 'attaform/zod'
+ * import { z } from 'zod-v3'
+ *
+ * const form = useForm({
+ *   schema: z.object({
+ *     username: z.string().min(2, 'At least 2 characters'),
+ *     password: z.string().min(8, 'At least 8 characters'),
+ *   }),
+ * })
+ * ```
+ *
+ * v3 schemas match this overload; v4 schemas hit the v4 overload
+ * above first and never reach here.
+ */
+export function useForm<Schema extends zV3.ZodObject<zV3.ZodRawShape>, K extends FormKey = FormKey>(
+  configuration: Omit<
+    UseFormConfiguration<
+      V3FormOf<Schema>,
+      V3OutOf<Schema>,
+      AbstractSchema<V3FormOf<Schema>, V3OutOf<Schema>>,
+      DefaultValuesInput<V3FormOf<Schema>>,
+      K
+    >,
+    'schema' | 'validateOn' | 'debounceMs'
+  > & { schema: Schema } & ValidateOnConfig
+): UseFormReturnType<V3FormOf<Schema>, V3OutOf<Schema>, V3ReadOf<Schema>, K>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function useForm(configuration: any): any {
   if (
     configuration === undefined ||
     configuration === null ||
@@ -158,28 +139,9 @@ export function useForm<
   ) {
     throw new InvalidUseFormConfigError()
   }
-
   const { schema } = configuration as { schema: unknown }
   if (isZodV4SchemaShape(schema)) {
-    return useFormV4(
-      configuration as Parameters<typeof useFormV4>[0]
-    ) as unknown as UseFormReturnType<
-      FormInput<Schema>,
-      FormOutput<Schema>,
-      FormStorageShape<Schema>,
-      K
-    >
+    return useFormV4(configuration as Parameters<typeof useFormV4>[0])
   }
-  // Anything else (Zod v3 schema, custom AbstractSchema, schema
-  // factory) goes through the v3 wrapper, which already accepts both
-  // Zod v3 input and AbstractSchema directly via its existing shape
-  // branch.
-  return useFormV3(
-    configuration as Parameters<typeof useFormV3>[0]
-  ) as unknown as UseFormReturnType<
-    FormInput<Schema>,
-    FormOutput<Schema>,
-    FormStorageShape<Schema>,
-    K
-  >
+  return useFormV3(configuration as Parameters<typeof useFormV3>[0])
 }

--- a/src/runtime/core/stepper-history.ts
+++ b/src/runtime/core/stepper-history.ts
@@ -65,14 +65,37 @@ export function createStepperHistory(param: string): StepperHistoryHandle {
 
   window.addEventListener('popstate', handlePopstate)
 
+  // Some embedded contexts can't accept a same-document URL rewrite —
+  // most commonly `about:srcdoc` iframes (e.g. Vue REPL previews),
+  // sandboxed iframes, and data: URLs. In those, `buildUrl(key)`
+  // resolves to a URL whose origin doesn't match the document's
+  // (the document inherits the parent's origin, but the synthesized
+  // URL keeps the scheme), and `history.pushState` / `replaceState`
+  // throw `SecurityError`. The user-visible step state still works
+  // — `current` / `goTo()` drive the form via the in-memory stepper
+  // — they just won't appear in the URL bar. Silently swallowing
+  // keeps the preview functional without coupling the library to
+  // embed-detection logic.
+  function safeWriteState(key: string, op: 'push' | 'replace'): void {
+    try {
+      const fn = op === 'push' ? window.history.pushState : window.history.replaceState
+      fn.call(window.history, {}, '', buildUrl(key))
+    } catch {
+      // SecurityError or similar — origin mismatch, sandboxed history,
+      // or a host that's locked down the History API. No remediation
+      // possible here; the in-memory stepper state remains the source
+      // of truth.
+    }
+  }
+
   return {
     push(key) {
       if (disposed) return
-      window.history.pushState({}, '', buildUrl(key))
+      safeWriteState(key, 'push')
     },
     replace(key) {
       if (disposed) return
-      window.history.replaceState({}, '', buildUrl(key))
+      safeWriteState(key, 'replace')
     },
     read() {
       const url = new URL(window.location.href)

--- a/src/zod.ts
+++ b/src/zod.ts
@@ -46,6 +46,14 @@
  */
 
 export { useForm } from './runtime/adapters/unified/use-form'
+export type {
+  UseFormConfig,
+  UseFormConfigV3,
+  UseFormConfigV4,
+  UseFormReturn,
+  UseFormReturnV3,
+  UseFormReturnV4,
+} from './runtime/adapters/unified/types-unified'
 export type { PathInput, PathOutput } from './runtime/adapters/zod-v4'
 export { injectForm } from './runtime/composables/use-form-context'
 export { useRegister } from './runtime/composables/use-register'

--- a/test/adapters/zod-v4/recursion-depth.test.ts
+++ b/test/adapters/zod-v4/recursion-depth.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../../src/zod'
+import type { UseFormReturn } from '../../../src/zod'
 import { createAttaform } from '../../../src/runtime/core/plugin'
 import {
   deriveDefault,
@@ -253,7 +254,7 @@ describe('maxRecursionDepth — counter bumps on lazy only', () => {
           country: z.string(),
         }),
       })
-      type Api = ReturnType<typeof useForm<typeof schema>>
+      type Api = UseFormReturn<typeof schema>
       const handle: { api?: Api } = {}
       const App = defineComponent({
         setup() {
@@ -277,7 +278,7 @@ describe('maxRecursionDepth — counter bumps on lazy only', () => {
       const schema = z.object({
         a: z.object({ b: z.object({ c: z.object({ d: z.string() }) }) }),
       })
-      type Api = ReturnType<typeof useForm<typeof schema>>
+      type Api = UseFormReturn<typeof schema>
       const handle: { api?: Api } = {}
       const App = defineComponent({
         setup() {
@@ -312,7 +313,7 @@ describe('useForm — passes sanitised maxRecursionDepth into walks', () => {
     type Node = { value: string; child: Node }
     const Node: z.ZodType<Node> = z.lazy(() => z.object({ value: z.string(), child: Node }))
     const schema = z.object({ root: Node })
-    type Api = ReturnType<typeof useForm<typeof schema>>
+    type Api = UseFormReturn<typeof schema>
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const handle: { api?: Api } = {}
     const App = defineComponent({
@@ -351,7 +352,7 @@ describe('useForm — passes sanitised maxRecursionDepth into walks', () => {
     const schema = z.object({
       name: z.string(),
     })
-    type Api = ReturnType<typeof useForm<typeof schema>>
+    type Api = UseFormReturn<typeof schema>
     const handle: { api?: Api } = {}
     const App = defineComponent({
       setup() {

--- a/test/composables/app-defaults.test.ts
+++ b/test/composables/app-defaults.test.ts
@@ -7,6 +7,7 @@ import { ANONYMOUS_FORM_KEY_PREFIX } from '../../src/runtime/core/defaults'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import type { UseFormReturnType } from '../../src/runtime/types/types-api'
 import { useForm } from '../../src/zod'
+import type { UseFormConfig, UseFormReturn } from '../../src/zod'
 import { z as zV3 } from 'zod-v3'
 
 /**
@@ -32,7 +33,7 @@ const tightSchema = z.object({
 })
 
 type Tight = z.infer<typeof tightSchema>
-type API = ReturnType<typeof useForm<typeof tightSchema>>
+type API = UseFormReturn<typeof tightSchema>
 
 function mountWithDefaults(
   defaults: Parameters<typeof createAttaform>[0] extends infer T
@@ -60,7 +61,7 @@ function mountWithDefaults(
         ...(formOptions.defaultValues !== undefined
           ? { defaultValues: formOptions.defaultValues }
           : {}),
-      } as Parameters<typeof useForm<typeof tightSchema>>[0])
+      } as UseFormConfig<typeof tightSchema>)
       return () => h('div')
     },
   })
@@ -211,8 +212,8 @@ describe('app-level defaults — anonymous + multi-form', () => {
     type FormA = typeof tightSchema
     type FormB = typeof tightSchema
     const handles: {
-      a?: ReturnType<typeof useForm<FormA>>
-      b?: ReturnType<typeof useForm<FormB>>
+      a?: UseFormReturn<FormA>
+      b?: UseFormReturn<FormB>
     } = {}
     const App = defineComponent({
       setup() {

--- a/test/composables/array-index-paths.test.ts
+++ b/test/composables/array-index-paths.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormConfigV4 } from '../../src/zod'
 import { attachRegistryToApp, createRegistry } from '../../src/runtime/core/registry'
 import type { UseFormReturnType } from '../../src/runtime/types/types-api'
 
@@ -17,7 +18,7 @@ import type { UseFormReturnType } from '../../src/runtime/types/types-api'
 
 function setupForm<F extends z.ZodObject<Record<string, z.ZodType>>>(
   schema: F,
-  defaultValues?: Parameters<typeof useForm<F>>[0]['defaultValues']
+  defaultValues?: UseFormConfigV4<F>['defaultValues']
 ) {
   let captured!: UseFormReturnType<z.output<F> & Record<string, unknown>>
   const Probe = defineComponent({

--- a/test/composables/async-validation.test.ts
+++ b/test/composables/async-validation.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, nextTick, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { createAttaform } from '../../src/runtime/core/plugin'
 
 /**
@@ -31,8 +32,8 @@ const signupSchema = z.object({
   password: z.string().min(8),
 })
 
-function mountForm(onCreated: (form: ReturnType<typeof useForm<typeof signupSchema>>) => void) {
-  type Returned = ReturnType<typeof useForm<typeof signupSchema>>
+function mountForm(onCreated: (form: UseFormReturn<typeof signupSchema>) => void) {
+  type Returned = UseFormReturn<typeof signupSchema>
   const handle: { api?: Returned } = {}
   const App = defineComponent({
     setup() {
@@ -63,7 +64,7 @@ describe('async validation — handleSubmit awaits async refinements', () => {
   })
 
   it('dispatches to onSubmit when an async refinement passes', async () => {
-    let api!: ReturnType<typeof useForm<typeof signupSchema>>
+    let api!: UseFormReturn<typeof signupSchema>
     const { app } = mountForm((a) => (api = a))
     apps.push(app)
     api.setValue('email', 'alice@example.com')
@@ -77,7 +78,7 @@ describe('async validation — handleSubmit awaits async refinements', () => {
   })
 
   it('routes async refinement failures into fieldErrors + onError', async () => {
-    let api!: ReturnType<typeof useForm<typeof signupSchema>>
+    let api!: UseFormReturn<typeof signupSchema>
     const { app } = mountForm((a) => (api = a))
     apps.push(app)
     api.setValue('email', 'taken@example.com')
@@ -98,7 +99,7 @@ describe('async validation — handleSubmit awaits async refinements', () => {
   })
 
   it('validating flips true during submit validation, false after', async () => {
-    let api!: ReturnType<typeof useForm<typeof signupSchema>>
+    let api!: UseFormReturn<typeof signupSchema>
     const { app } = mountForm((a) => (api = a))
     apps.push(app)
     api.setValue('email', 'alice@example.com')
@@ -120,7 +121,7 @@ describe('validateAsync — imperative one-shot', () => {
   })
 
   it('resolves to success when the current form state satisfies the schema', async () => {
-    let api!: ReturnType<typeof useForm<typeof signupSchema>>
+    let api!: UseFormReturn<typeof signupSchema>
     const { app } = mountForm((a) => (api = a))
     apps.push(app)
     api.setValue('email', 'ok@example.com')
@@ -131,7 +132,7 @@ describe('validateAsync — imperative one-shot', () => {
   })
 
   it('resolves to failure when the async refinement rejects', async () => {
-    let api!: ReturnType<typeof useForm<typeof signupSchema>>
+    let api!: UseFormReturn<typeof signupSchema>
     const { app } = mountForm((a) => (api = a))
     apps.push(app)
     api.setValue('email', 'taken@x.com')
@@ -150,7 +151,7 @@ describe('per-field validating — `form.fields.<path>.validating`', () => {
   })
 
   it('flips true synchronously after setValue, back to false once the per-field run settles', async () => {
-    let api!: ReturnType<typeof useForm<typeof signupSchema>>
+    let api!: UseFormReturn<typeof signupSchema>
     const { app } = mountForm((a) => (api = a))
     apps.push(app)
 
@@ -173,7 +174,7 @@ describe('per-field validating — `form.fields.<path>.validating`', () => {
   })
 
   it('sibling paths flip independently — email validating does not affect password', async () => {
-    let api!: ReturnType<typeof useForm<typeof signupSchema>>
+    let api!: UseFormReturn<typeof signupSchema>
     const { app } = mountForm((a) => (api = a))
     apps.push(app)
 
@@ -200,7 +201,7 @@ describe('per-field validating — `form.fields.<path>.validating`', () => {
     // Per-field `validating` reflects field-LEVEL scheduled runs only,
     // by design. Whole-form validation drives the form-wide flag and the
     // per-field flag stays at its prior value (here, `false`).
-    let api!: ReturnType<typeof useForm<typeof signupSchema>>
+    let api!: UseFormReturn<typeof signupSchema>
     const { app } = mountForm((a) => (api = a))
     apps.push(app)
 
@@ -233,7 +234,7 @@ describe('per-field validating — `form.fields.<path>.validating`', () => {
     // accessor reports `true` continuously until both runs settle. A
     // Set-based regression would briefly read `false` between the
     // aborted run's delete and the fresh run's add.
-    let api!: ReturnType<typeof useForm<typeof signupSchema>>
+    let api!: UseFormReturn<typeof signupSchema>
     const { app } = mountForm((a) => (api = a))
     apps.push(app)
 
@@ -257,7 +258,7 @@ describe('per-field valid — `form.fields.<path>.valid`', () => {
   })
 
   it('false during a per-field run, true after settle when there are no errors', async () => {
-    let api!: ReturnType<typeof useForm<typeof signupSchema>>
+    let api!: UseFormReturn<typeof signupSchema>
     const { app } = mountForm((a) => (api = a))
     apps.push(app)
 
@@ -275,7 +276,7 @@ describe('per-field valid — `form.fields.<path>.valid`', () => {
   })
 
   it('false after a failed async refinement settles (no in-flight, errors present)', async () => {
-    let api!: ReturnType<typeof useForm<typeof signupSchema>>
+    let api!: UseFormReturn<typeof signupSchema>
     const { app } = mountForm((a) => (api = a))
     apps.push(app)
 
@@ -297,7 +298,7 @@ describe('form.meta.valid — `valid && !validating`', () => {
   })
 
   it('flips false during validateAsync, true after settle when no errors', async () => {
-    let api!: ReturnType<typeof useForm<typeof signupSchema>>
+    let api!: UseFormReturn<typeof signupSchema>
     const { app } = mountForm((a) => (api = a))
     apps.push(app)
 
@@ -327,7 +328,7 @@ describe('form.meta.valid — `valid && !validating`', () => {
   })
 
   it('false after a failed validateAsync (errors land, no in-flight)', async () => {
-    let api!: ReturnType<typeof useForm<typeof signupSchema>>
+    let api!: UseFormReturn<typeof signupSchema>
     const { app } = mountForm((a) => (api = a))
     apps.push(app)
 
@@ -348,7 +349,7 @@ describe('validate() reactive ref — pending + cancellation', () => {
   })
 
   it('starts pending, then settles on the first form mutation after mount', async () => {
-    let api!: ReturnType<typeof useForm<typeof signupSchema>>
+    let api!: UseFormReturn<typeof signupSchema>
     const { app } = mountForm((a) => (api = a))
     apps.push(app)
     const status = api.validate()
@@ -367,7 +368,7 @@ describe('validate() reactive ref — pending + cancellation', () => {
     // clobber the newer "alice@" result after it resolves. With the
     // generation counter, only the newest run writes — the test
     // confirms the settled status reflects the *latest* form value.
-    let api!: ReturnType<typeof useForm<typeof signupSchema>>
+    let api!: UseFormReturn<typeof signupSchema>
     const { app } = mountForm((a) => (api = a))
     apps.push(app)
     api.setValue('email', 'taken@example.com')

--- a/test/composables/blank-numeric-blur-preservation.test.ts
+++ b/test/composables/blank-numeric-blur-preservation.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, withDirectives, type App } from 'vue'
 import { z } from 'zod'
 import { unset, useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { canonicalizePath } from '../../src/runtime/core/paths'
 import { vRegister } from '../../src/runtime/core/directive'
 import { createAttaform } from '../../src/runtime/core/plugin'
@@ -143,7 +144,7 @@ describe('blank-marked number leaf — blank flag survives blur', () => {
   it('blankPaths still contains the leaf after focus + blur', async () => {
     const root = document.createElement('div')
     document.body.appendChild(root)
-    let captured: ReturnType<typeof useForm<typeof numericLeafSchema>> | undefined
+    let captured: UseFormReturn<typeof numericLeafSchema> | undefined
     const App = defineComponent({
       setup() {
         const form = useForm({

--- a/test/composables/blank-persistence.test.ts
+++ b/test/composables/blank-persistence.test.ts
@@ -3,6 +3,7 @@ import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vites
 import { createApp, defineComponent, h, withDirectives, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { vRegister } from '../../src/runtime/core/directive'
 import { AttaformErrorCode } from '../../src/runtime/core/error-codes'
 import { canonicalizePath } from '../../src/runtime/core/paths'
@@ -135,7 +136,7 @@ describe('persistence — blank round-trips across mount', () => {
       })
     )
 
-    let captured: ReturnType<typeof useForm<typeof schema>> | undefined
+    let captured: UseFormReturn<typeof schema> | undefined
     const App = defineComponent({
       setup() {
         const form = useForm({
@@ -251,7 +252,7 @@ describe('persistence — blank round-trips across mount', () => {
       })
     )
 
-    let captured: ReturnType<typeof useForm<typeof schema>> | undefined
+    let captured: UseFormReturn<typeof schema> | undefined
     const App = defineComponent({
       setup() {
         const form = useForm({

--- a/test/composables/blank.test.ts
+++ b/test/composables/blank.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, type App } from 'vue'
 import { z } from 'zod'
 import { unset, useForm } from '../../src/zod'
+import type { UseFormConfigV4 } from '../../src/zod'
 import { canonicalizePath } from '../../src/runtime/core/paths'
 import { attachRegistryToApp, createRegistry } from '../../src/runtime/core/registry'
 import type { UseFormReturnType } from '../../src/runtime/types/types-api'
@@ -17,7 +18,7 @@ import type { UseFormReturnType } from '../../src/runtime/types/types-api'
 
 function setupForm<F extends z.ZodObject<Record<string, z.ZodType>>>(
   schema: F,
-  defaultValues?: Parameters<typeof useForm<F>>[0]['defaultValues']
+  defaultValues?: UseFormConfigV4<F>['defaultValues']
 ) {
   let captured!: UseFormReturnType<z.output<F> & Record<string, unknown>>
   const Probe = defineComponent({

--- a/test/composables/checkbox-mid-click.test.ts
+++ b/test/composables/checkbox-mid-click.test.ts
@@ -14,6 +14,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, withDirectives, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { vRegister } from '../../src/runtime/core/directive'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import { waitUntil } from '../utils/form-harness'
@@ -33,7 +34,7 @@ describe('<input type="checkbox" v-register> — sibling re-render mid-click', (
   })
 
   it('a sibling re-render between mousedown and change MUST NOT clobber the user-toggled checkbox (array model)', async () => {
-    const handle: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const handle: { api?: UseFormReturn<typeof schema> } = {}
 
     const Parent = defineComponent({
       setup() {
@@ -131,7 +132,7 @@ describe('<input type="checkbox" v-register> — sibling re-render mid-click', (
     // We instrument `el.checked`'s setter with `Object.defineProperty`
     // to count writes — pre-fix the count grew with every sibling
     // keystroke; post-fix it stays at zero after mount.
-    const handle: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const handle: { api?: UseFormReturn<typeof schema> } = {}
 
     const Parent = defineComponent({
       setup() {
@@ -207,7 +208,7 @@ describe('<input type="checkbox" v-register> — sibling re-render mid-click', (
     // Counterpart to the skip test — confirm the identity guard
     // doesn't get stuck. After a programmatic `setValue` moves the
     // model, the next render must re-apply.
-    const handle: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const handle: { api?: UseFormReturn<typeof schema> } = {}
 
     const Parent = defineComponent({
       setup() {

--- a/test/composables/checkbox.test.ts
+++ b/test/composables/checkbox.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, withDirectives, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { vRegister } from '../../src/runtime/core/directive'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import { waitUntil } from '../utils/form-harness'
@@ -42,7 +43,7 @@ describe('<input type="checkbox" v-register> — single boolean', () => {
 
   it('checking the box writes true; unchecking writes false', async () => {
     const schema = z.object({ agreed: z.boolean() })
-    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const captured: { api?: UseFormReturn<typeof schema> } = {}
 
     const Parent = defineComponent({
       setup() {
@@ -79,7 +80,7 @@ describe('<input type="checkbox" v-register> — single boolean', () => {
 
   it('mounts with el.checked synced to the form value', async () => {
     const schema = z.object({ agreed: z.boolean() })
-    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const captured: { api?: UseFormReturn<typeof schema> } = {}
 
     const Parent = defineComponent({
       setup() {
@@ -123,7 +124,7 @@ describe('<input type="checkbox" v-register> — array group', () => {
 
   it('toggles add/remove the option value from the array', async () => {
     const schema = z.object({ fruits: z.array(z.string()) })
-    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const captured: { api?: UseFormReturn<typeof schema> } = {}
 
     const Parent = defineComponent({
       setup() {
@@ -194,7 +195,7 @@ describe('<input type="checkbox" v-register> — array group', () => {
 
   it('mounts with each checkbox checked iff its value is in the array', async () => {
     const schema = z.object({ fruits: z.array(z.string()) })
-    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const captured: { api?: UseFormReturn<typeof schema> } = {}
 
     const Parent = defineComponent({
       setup() {
@@ -247,7 +248,7 @@ describe('<input type="checkbox" v-register> — array group', () => {
     // _value) and then deleting `_value` before dispatching change —
     // the post-hydration state in a real Nuxt app.
     const schema = z.object({ fruits: z.array(z.string()) })
-    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const captured: { api?: UseFormReturn<typeof schema> } = {}
 
     const Parent = defineComponent({
       setup() {
@@ -289,7 +290,7 @@ describe('<input type="checkbox" v-register> — array group', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     try {
       const schema = z.object({ fruits: z.array(z.string()) })
-      const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+      const captured: { api?: UseFormReturn<typeof schema> } = {}
 
       const Parent = defineComponent({
         setup() {
@@ -347,7 +348,7 @@ describe('<input type="checkbox" v-register> — Set group', () => {
 
   it('toggles add/delete the option value through Set semantics', async () => {
     const schema = z.object({ tags: z.set(z.string()) })
-    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const captured: { api?: UseFormReturn<typeof schema> } = {}
 
     const Parent = defineComponent({
       setup() {
@@ -418,7 +419,7 @@ describe('<input type="checkbox" v-register> — :true-value / :false-value', ()
 
   it('binds a single checkbox to one of two strings', async () => {
     const schema = z.object({ newsletter: z.enum(['subscribe', 'unsubscribe']) })
-    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const captured: { api?: UseFormReturn<typeof schema> } = {}
 
     const Parent = defineComponent({
       setup() {
@@ -486,7 +487,7 @@ describe('checkbox slim-primitive gate interactions', () => {
 
   it('rejects a string write to a boolean checkbox path', async () => {
     const schema = z.object({ agreed: z.boolean() })
-    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const captured: { api?: UseFormReturn<typeof schema> } = {}
 
     const Parent = defineComponent({
       setup() {
@@ -509,7 +510,7 @@ describe('checkbox slim-primitive gate interactions', () => {
 
   it('rejects a string write to an array checkbox path', async () => {
     const schema = z.object({ fruits: z.array(z.string()) })
-    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const captured: { api?: UseFormReturn<typeof schema> } = {}
 
     const Parent = defineComponent({
       setup() {

--- a/test/composables/coerce.test.ts
+++ b/test/composables/coerce.test.ts
@@ -15,6 +15,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, withDirectives, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormConfigV4, UseFormReturnV4 } from '../../src/zod'
 import { vRegister, isRegisterValue, assignKey } from '../../src/runtime/core/directive'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import { defineCoercion, defaultCoercionRules } from '../../src/runtime/core/schema-coerce'
@@ -31,17 +32,17 @@ afterEach(() => {
 function mount<S extends z.ZodObject>(
   schema: S,
   defaultValues: z.infer<S>,
-  body: (api: ReturnType<typeof useForm<S>>) => unknown,
+  body: (api: UseFormReturnV4<S>) => unknown,
   pluginOpts?: Parameters<typeof createAttaform>[0]
-): { api: ReturnType<typeof useForm<S>>; root: HTMLDivElement } {
-  const handle: { api?: ReturnType<typeof useForm<S>> } = {}
+): { api: UseFormReturnV4<S>; root: HTMLDivElement } {
+  const handle: { api?: UseFormReturnV4<S> } = {}
   const Parent = defineComponent({
     setup() {
       const api = useForm({
         schema,
         defaultValues,
         key: `coerce-${Math.random().toString(36).slice(2)}`,
-      } as Parameters<typeof useForm<S>>[0])
+      } as UseFormConfigV4<S>)
       handle.api = api
       return () => body(api)
     },
@@ -531,7 +532,7 @@ describe('plugin-default off', () => {
 describe('per-form override beats plugin default (both directions)', () => {
   it('plugin off + useForm({ coerce: true }) → coerce runs', async () => {
     const schema = z.object({ age: z.number() })
-    const handle: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const handle: { api?: UseFormReturnV4<typeof schema> } = {}
     const Parent = defineComponent({
       setup() {
         const api = useForm({
@@ -564,7 +565,7 @@ describe('per-form override beats plugin default (both directions)', () => {
   it('plugin on + useForm({ coerce: false }) → coerce off', async () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {})
     const schema = z.object({ age: z.number() })
-    const handle: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const handle: { api?: UseFormReturnV4<typeof schema> } = {}
     const Parent = defineComponent({
       setup() {
         const api = useForm({
@@ -718,7 +719,7 @@ describe('consumer-extended registry — string->bigint', () => {
         },
       }),
     ]
-    const handle: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const handle: { api?: UseFormReturnV4<typeof schema> } = {}
     const Parent = defineComponent({
       setup() {
         const api = useForm({

--- a/test/composables/custom-defaults-e2e.test.ts
+++ b/test/composables/custom-defaults-e2e.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormReturnV4 } from '../../src/zod'
 import { createAttaform } from '../../src/runtime/core/plugin'
 
 /**
@@ -31,9 +32,9 @@ function harness<S extends z.ZodObject>(
   schema: S
 ): {
   app: App
-  form: ReturnType<typeof useForm<S>>
+  form: UseFormReturnV4<S>
 } {
-  let captured!: ReturnType<typeof useForm<S>>
+  let captured!: UseFormReturnV4<S>
   const Probe = defineComponent({
     setup() {
       captured = useForm({

--- a/test/composables/default-values-async-function.test.ts
+++ b/test/composables/default-values-async-function.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormConfigV4 } from '../../src/zod'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import type { UseFormReturnType } from '../../src/runtime/types/types-api'
 import { waitUntil } from '../utils/form-harness'
@@ -24,7 +25,7 @@ type ApiFor<Schema extends z.ZodObject> = UseFormReturnType<z.output<Schema>>
 
 function mountForm<Schema extends z.ZodObject>(
   schema: Schema,
-  defaultValues: NonNullable<Parameters<typeof useForm<Schema>>[0]['defaultValues']>
+  defaultValues: NonNullable<UseFormConfigV4<Schema>['defaultValues']>
 ): { app: App; api: ApiFor<Schema> } {
   const handle: { api?: ApiFor<Schema> } = {}
   const App = defineComponent({

--- a/test/composables/default-values-async-rejection.test.ts
+++ b/test/composables/default-values-async-rejection.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormConfigV4 } from '../../src/zod'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import type { UseFormReturnType } from '../../src/runtime/types/types-api'
 import { waitUntil } from '../utils/form-harness'
@@ -22,7 +23,7 @@ type ApiFor<Schema extends z.ZodObject> = UseFormReturnType<z.output<Schema>>
 
 function mountForm<Schema extends z.ZodObject>(
   schema: Schema,
-  defaultValues: NonNullable<Parameters<typeof useForm<Schema>>[0]['defaultValues']>
+  defaultValues: NonNullable<UseFormConfigV4<Schema>['defaultValues']>
 ): { app: App; api: ApiFor<Schema> } {
   const handle: { api?: ApiFor<Schema> } = {}
   const App = defineComponent({

--- a/test/composables/default-values-history-skip.test.ts
+++ b/test/composables/default-values-history-skip.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormConfigV4 } from '../../src/zod'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import type { UseFormReturnType } from '../../src/runtime/types/types-api'
 import { waitUntil } from '../utils/form-harness'
@@ -23,7 +24,7 @@ type ApiFor<Schema extends z.ZodObject> = UseFormReturnType<z.output<Schema>>
 
 function mountForm<Schema extends z.ZodObject>(
   schema: Schema,
-  defaultValues: NonNullable<Parameters<typeof useForm<Schema>>[0]['defaultValues']>
+  defaultValues: NonNullable<UseFormConfigV4<Schema>['defaultValues']>
 ): { app: App; api: ApiFor<Schema> } {
   const handle: { api?: ApiFor<Schema> } = {}
   const App = defineComponent({

--- a/test/composables/default-values-rehydrate.test.ts
+++ b/test/composables/default-values-rehydrate.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormConfigV4 } from '../../src/zod'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import type { UseFormReturnType } from '../../src/runtime/types/types-api'
 import { waitUntil } from '../utils/form-harness'
@@ -29,7 +30,7 @@ type ApiFor<Schema extends z.ZodObject> = UseFormReturnType<z.output<Schema>>
 
 function mountForm<Schema extends z.ZodObject>(
   schema: Schema,
-  defaultValues: NonNullable<Parameters<typeof useForm<Schema>>[0]['defaultValues']>
+  defaultValues: NonNullable<UseFormConfigV4<Schema>['defaultValues']>
 ): { app: App; api: ApiFor<Schema> } {
   const handle: { api?: ApiFor<Schema> } = {}
   const App = defineComponent({

--- a/test/composables/derived-blank-errors.test.ts
+++ b/test/composables/derived-blank-errors.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, nextTick, type App } from 'vue'
 import { z } from 'zod'
 import { unset } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { useForm } from '../../src/zod'
 import { AttaformErrorCode } from '../../src/runtime/core/error-codes'
 import { createAttaform } from '../../src/runtime/core/plugin'
@@ -35,7 +36,7 @@ const numericSchema = z.object({
   income: z.number(),
   netWorth: z.bigint(),
 })
-type NumericApi = ReturnType<typeof useForm<typeof numericSchema>>
+type NumericApi = UseFormReturn<typeof numericSchema>
 
 function mountNumeric(): { app: App; api: NumericApi } {
   const handle: { api?: NumericApi } = {}
@@ -132,7 +133,7 @@ describe('derivedBlankErrors — string / boolean leaves do NOT auto-mark', () =
 
   it("required string leaf is blank-free at mount (storage `''` matches DOM `''`)", () => {
     const schema = z.object({ name: z.string() })
-    type Api = ReturnType<typeof useForm<typeof schema>>
+    type Api = UseFormReturn<typeof schema>
     const handle: { api?: Api } = {}
     const App = defineComponent({
       setup() {
@@ -151,7 +152,7 @@ describe('derivedBlankErrors — string / boolean leaves do NOT auto-mark', () =
 
   it('required boolean leaf is blank-free at mount (storage `false` matches unchecked)', () => {
     const schema = z.object({ agreed: z.boolean() })
-    type Api = ReturnType<typeof useForm<typeof schema>>
+    type Api = UseFormReturn<typeof schema>
     const handle: { api?: Api } = {}
     const App = defineComponent({
       setup() {
@@ -170,7 +171,7 @@ describe('derivedBlankErrors — string / boolean leaves do NOT auto-mark', () =
 
   it('user typing then deleting a string does NOT re-blank (schema is authority)', async () => {
     const schema = z.object({ name: z.string() })
-    type Api = ReturnType<typeof useForm<typeof schema>>
+    type Api = UseFormReturn<typeof schema>
     const handle: { api?: Api } = {}
     const App = defineComponent({
       setup() {
@@ -206,7 +207,7 @@ describe('derivedBlankErrors — string / boolean leaves do NOT auto-mark', () =
 
   it('explicit `unset` opts a string into blank (universal opt-in)', () => {
     const schema = z.object({ note: z.string() })
-    type Api = ReturnType<typeof useForm<typeof schema>>
+    type Api = UseFormReturn<typeof schema>
     const handle: { api?: Api } = {}
     const App = defineComponent({
       setup() {
@@ -228,7 +229,7 @@ describe('derivedBlankErrors — string / boolean leaves do NOT auto-mark', () =
 
   it('explicit `unset` opts a boolean into blank (universal opt-in)', () => {
     const schema = z.object({ agreed: z.boolean() })
-    type Api = ReturnType<typeof useForm<typeof schema>>
+    type Api = UseFormReturn<typeof schema>
     const handle: { api?: Api } = {}
     const App = defineComponent({
       setup() {
@@ -250,7 +251,7 @@ describe('derivedBlankErrors — string / boolean leaves do NOT auto-mark', () =
 
   it('schema-level non-empty rule (`.min(1)`) fires through schemaErrors, not blank', async () => {
     const schema = z.object({ name: z.string().min(1, 'name required') })
-    type Api = ReturnType<typeof useForm<typeof schema>>
+    type Api = UseFormReturn<typeof schema>
     const handle: { api?: Api } = {}
     const App = defineComponent({
       setup() {
@@ -279,7 +280,7 @@ describe('derivedBlankErrors — schema modifiers gate the synthesis', () => {
 
   it('does NOT synthesise for `.optional()` numeric leaves', () => {
     const schema = z.object({ income: z.number().optional() })
-    type Api = ReturnType<typeof useForm<typeof schema>>
+    type Api = UseFormReturn<typeof schema>
     const handle: { api?: Api } = {}
     const App = defineComponent({
       setup() {
@@ -297,7 +298,7 @@ describe('derivedBlankErrors — schema modifiers gate the synthesis', () => {
 
   it('does NOT synthesise for `.nullable()` numeric leaves', () => {
     const schema = z.object({ income: z.number().nullable() })
-    type Api = ReturnType<typeof useForm<typeof schema>>
+    type Api = UseFormReturn<typeof schema>
     const handle: { api?: Api } = {}
     const App = defineComponent({
       setup() {
@@ -315,7 +316,7 @@ describe('derivedBlankErrors — schema modifiers gate the synthesis', () => {
 
   it('does NOT synthesise for `.default(N)` numeric leaves', () => {
     const schema = z.object({ income: z.number().default(0) })
-    type Api = ReturnType<typeof useForm<typeof schema>>
+    type Api = UseFormReturn<typeof schema>
     const handle: { api?: Api } = {}
     const App = defineComponent({
       setup() {
@@ -332,7 +333,7 @@ describe('derivedBlankErrors — schema modifiers gate the synthesis', () => {
   })
 
   it('does NOT synthesise when the consumer provides an explicit value', () => {
-    type Api = ReturnType<typeof useForm<typeof numericSchema>>
+    type Api = UseFormReturn<typeof numericSchema>
     const handle: { api?: Api } = {}
     const App = defineComponent({
       setup() {
@@ -400,7 +401,7 @@ describe('derivedBlankErrors — independent of imperative writers', () => {
     const refineSchema = z.object({
       income: z.number().refine((v) => v > 1000, 'must be > 1000'),
     })
-    type Api = ReturnType<typeof useForm<typeof refineSchema>>
+    type Api = UseFormReturn<typeof refineSchema>
     const handle: { api?: Api } = {}
     const App = defineComponent({
       setup() {

--- a/test/composables/discriminated-union-lift.test.ts
+++ b/test/composables/discriminated-union-lift.test.ts
@@ -6,7 +6,7 @@ import type {
   FieldStateMapEntry,
   ValidationError,
 } from '../../src/runtime/types/types-api'
-import type { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 
 /**
  * Type-level coverage for the discriminated-union "lift" applied to
@@ -139,7 +139,7 @@ const _cargoSchema = z.object({
   ]),
 })
 
-type CargoForm = ReturnType<typeof useForm<typeof _cargoSchema>>
+type CargoForm = UseFormReturn<typeof _cargoSchema>
 
 // Recursive Proxy stand-in (same pattern as type-inference.test.ts):
 // the file never invokes useForm because there's no Vue app context;

--- a/test/composables/discriminated-union-variant-switch.test.ts
+++ b/test/composables/discriminated-union-variant-switch.test.ts
@@ -4,6 +4,7 @@ import { createApp, defineComponent, h, nextTick, type App } from 'vue'
 import { z } from 'zod'
 import { z as zV3 } from 'zod-v3'
 import { isUnset, unset, useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { useForm as useFormV3 } from '../../src/zod-v3'
 import { AttaformErrorCode } from '../../src/runtime/core/error-codes'
 import { createAttaform } from '../../src/runtime/core/plugin'
@@ -1521,7 +1522,7 @@ const cargoLiftSchema = z.object({
   ]),
 })
 
-type CargoLiftApi = ReturnType<typeof useForm<typeof cargoLiftSchema>>
+type CargoLiftApi = UseFormReturn<typeof cargoLiftSchema>
 
 function mountCargoLift(): { app: App; api: CargoLiftApi } {
   const handle: { api?: CargoLiftApi } = {}

--- a/test/composables/du-variant-error-regressions.test.ts
+++ b/test/composables/du-variant-error-regressions.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, type App } from 'vue'
 import { z } from 'zod'
 import { unset, useForm } from '../../src/zod'
+import type { UseFormConfig } from '../../src/zod'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import type { UseFormReturnType, ValidationError } from '../../src/runtime/types/types-api'
 import { waitUntil } from '../utils/form-harness'
@@ -66,7 +67,7 @@ type MountResult = {
 }
 
 function mount(
-  defaultValues: NonNullable<Parameters<typeof useForm<typeof profileSchema>>[0]['defaultValues']>
+  defaultValues: NonNullable<UseFormConfig<typeof profileSchema>['defaultValues']>
 ): MountResult {
   const handle: { api?: ProfileApi } = {}
   const warnings: string[] = []

--- a/test/composables/errors-at.test.ts
+++ b/test/composables/errors-at.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { computed, createApp, defineComponent, h, nextTick, type App } from 'vue'
 import { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { z } from 'zod'
 import { createAttaform } from '../../src/runtime/core/plugin'
 
@@ -29,7 +30,7 @@ const schema = z.object({
   }),
 })
 
-type Api = ReturnType<typeof useForm<typeof schema>>
+type Api = UseFormReturn<typeof schema>
 type ErrorsCallForm = (path?: string | readonly (string | number)[]) =>
   | readonly {
       message: string

--- a/test/composables/field-errors-view.test.ts
+++ b/test/composables/field-errors-view.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, nextTick, type App } from 'vue'
 import { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { z } from 'zod'
 import { parseApiErrors } from '../../src/runtime/core/parse-api-errors'
 import { createAttaform } from '../../src/runtime/core/plugin'
@@ -26,7 +27,7 @@ const schema = z.object({
   password: z.string().min(8, 'min 8 chars'),
 })
 
-type Api = ReturnType<typeof useForm<typeof schema>>
+type Api = UseFormReturn<typeof schema>
 
 function mount(): { app: App; api: Api } {
   const handle: { api?: Api } = {}

--- a/test/composables/field-state-proxy.test.ts
+++ b/test/composables/field-state-proxy.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, watch, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import { waitUntil } from '../utils/form-harness'
 
@@ -25,10 +26,10 @@ const schema = z.object({
 })
 
 function mountForm(): {
-  api: ReturnType<typeof useForm<typeof schema>>
+  api: UseFormReturn<typeof schema>
   app: App
 } {
-  let captured: ReturnType<typeof useForm<typeof schema>> | undefined
+  let captured: UseFormReturn<typeof schema> | undefined
   const App = defineComponent({
     setup() {
       captured = useForm({

--- a/test/composables/field-validation.test.ts
+++ b/test/composables/field-validation.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, nextTick, type App } from 'vue'
 import { useForm } from '../../src/zod'
+import type { UseFormConfig, UseFormReturn } from '../../src/zod'
 import { z } from 'zod'
 import { createAttaform } from '../../src/runtime/core/plugin'
 
@@ -26,7 +27,7 @@ const baseSchema = z.object({
 })
 
 function mountWith(options: { validateOn?: 'change' | 'blur' | 'submit'; debounceMs?: number }) {
-  type Returned = ReturnType<typeof useForm<typeof baseSchema>>
+  type Returned = UseFormReturn<typeof baseSchema>
   const handle: { api?: Returned } = {}
   const App = defineComponent({
     setup() {
@@ -41,7 +42,7 @@ function mountWith(options: { validateOn?: 'change' | 'blur' | 'submit'; debounc
         strict: false,
         ...(options.validateOn !== undefined ? { validateOn: options.validateOn } : {}),
         ...(options.debounceMs !== undefined ? { debounceMs: options.debounceMs } : {}),
-      } as Parameters<typeof useForm<typeof baseSchema>>[0])
+      } as UseFormConfig<typeof baseSchema>)
       return () => h('div')
     },
   })

--- a/test/composables/form-level-errors.test.ts
+++ b/test/composables/form-level-errors.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, type App } from 'vue'
 import { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { z } from 'zod'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import type { ValidationError } from '../../src/runtime/types/types-api'
@@ -31,7 +32,7 @@ const schema = z.object({
   password: z.string().min(8, 'min 8 chars'),
 })
 
-type Api = ReturnType<typeof useForm<typeof schema>>
+type Api = UseFormReturn<typeof schema>
 
 function mount(): { app: App; api: Api } {
   const handle: { api?: Api } = {}

--- a/test/composables/form-meta-error-count.test.ts
+++ b/test/composables/form-meta-error-count.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormConfigV4 } from '../../src/zod'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import type { UseFormReturnType } from '../../src/runtime/types/types-api'
 import { waitUntil } from '../utils/form-harness'
@@ -27,7 +28,7 @@ type ApiFor<Schema extends z.ZodObject> = Omit<UseFormReturnType<z.output<Schema
 
 function mountForm<Schema extends z.ZodObject>(
   schema: Schema,
-  defaultValues: NonNullable<Parameters<typeof useForm<Schema>>[0]['defaultValues']>
+  defaultValues: NonNullable<UseFormConfigV4<Schema>['defaultValues']>
 ): { app: App; api: ApiFor<Schema> } {
   const handle: { api?: ApiFor<Schema> } = {}
   const App = defineComponent({

--- a/test/composables/form-meta-is-submitted.test.ts
+++ b/test/composables/form-meta-is-submitted.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormConfigV4 } from '../../src/zod'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import type { UseFormReturnType } from '../../src/runtime/types/types-api'
 import { waitUntil } from '../utils/form-harness'
@@ -22,7 +23,7 @@ type ApiFor<Schema extends z.ZodObject> = UseFormReturnType<z.output<Schema>>
 
 function mountForm<Schema extends z.ZodObject>(
   schema: Schema,
-  defaultValues: NonNullable<Parameters<typeof useForm<Schema>>[0]['defaultValues']>
+  defaultValues: NonNullable<UseFormConfigV4<Schema>['defaultValues']>
 ): { app: App; api: ApiFor<Schema> } {
   const handle: { api?: ApiFor<Schema> } = {}
   const App = defineComponent({

--- a/test/composables/history.test.ts
+++ b/test/composables/history.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, type App } from 'vue'
 import { z } from 'zod'
 import { unset, useForm } from '../../src/zod'
+import type { UseFormConfig, UseFormReturn } from '../../src/zod'
 import { canonicalizePath } from '../../src/runtime/core/paths'
 import { createAttaform } from '../../src/runtime/core/plugin'
 
@@ -22,9 +23,9 @@ const schema = z.object({
   password: z.string(),
 })
 
-type ApiReturn = ReturnType<typeof useForm<typeof schema>>
+type ApiReturn = UseFormReturn<typeof schema>
 
-function mountForm(history: Parameters<typeof useForm<typeof schema>>[0]['history']): {
+function mountForm(history: UseFormConfig<typeof schema>['history']): {
   app: App
   api: ApiReturn
 } {
@@ -185,7 +186,7 @@ describe('history — blankPaths preservation', () => {
   // the value). History snapshots have to carry both halves — replaying
   // the form value alone would pin a cleared field to '0' on the screen.
   const numericSchema = z.object({ count: z.number() })
-  type NumericApi = ReturnType<typeof useForm<typeof numericSchema>>
+  type NumericApi = UseFormReturn<typeof numericSchema>
   const countKey = canonicalizePath('count').key
 
   function mountNumericForm(): { app: App; api: NumericApi } {
@@ -276,7 +277,7 @@ describe('history — delta round-trip', () => {
     }),
     email: z.string(),
   })
-  type NestedApi = ReturnType<typeof useForm<typeof nestedSchema>>
+  type NestedApi = UseFormReturn<typeof nestedSchema>
 
   function mountNested(): { app: App; api: NestedApi } {
     const handle: { api?: NestedApi } = {}

--- a/test/composables/initial-validation-seed.test.ts
+++ b/test/composables/initial-validation-seed.test.ts
@@ -6,6 +6,7 @@ import { createFormStore } from '../../src/runtime/core/create-form-store'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import { canonicalizePath } from '../../src/runtime/core/paths'
 import { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { fakeSchema } from '../utils/fake-schema'
 import { waitUntil } from '../utils/form-harness'
 
@@ -32,9 +33,9 @@ type Tight = z.infer<typeof tightSchema>
 
 function mountWithZod(options: { strict?: boolean; defaultValues?: Partial<Tight> }): {
   app: App
-  api: ReturnType<typeof useForm<typeof tightSchema>>
+  api: UseFormReturn<typeof tightSchema>
 } {
-  type API = ReturnType<typeof useForm<typeof tightSchema>>
+  type API = UseFormReturn<typeof tightSchema>
   const handle: { api?: API } = {}
   const App = defineComponent({
     setup() {
@@ -77,7 +78,7 @@ describe('initial validation seed — strict mode', () => {
     const asyncSchema = z.object({
       email: z.email().refine(async () => Promise.resolve(true), 'taken'),
     })
-    type AsyncApi = ReturnType<typeof useForm<typeof asyncSchema>>
+    type AsyncApi = UseFormReturn<typeof asyncSchema>
     const handle: { api?: AsyncApi } = {}
     const App = defineComponent({
       setup() {
@@ -166,7 +167,7 @@ describe('initial validation seed — async-refine schema', () => {
         .email()
         .refine(async (v) => v !== 'taken@example.com', 'That email is already registered.'),
     })
-    type AsyncApi = ReturnType<typeof useForm<typeof asyncSchema>>
+    type AsyncApi = UseFormReturn<typeof asyncSchema>
     const handle: { api?: AsyncApi } = {}
     const App = defineComponent({
       setup() {
@@ -202,7 +203,7 @@ describe('initial validation seed — async-refine schema', () => {
         .email()
         .refine(async (v) => v !== 'taken@example.com', 'That email is already registered.'),
     })
-    type AsyncApi = ReturnType<typeof useForm<typeof asyncSchema>>
+    type AsyncApi = UseFormReturn<typeof asyncSchema>
     const handle: { api?: AsyncApi } = {}
     const App = defineComponent({
       setup() {
@@ -244,7 +245,7 @@ describe('initial validation seed — async-refine schema', () => {
     const asyncSchema = z.object({
       email: z.email().refine(async (v) => v !== 'taken@example.com', 'taken'),
     })
-    type AsyncApi = ReturnType<typeof useForm<typeof asyncSchema>>
+    type AsyncApi = UseFormReturn<typeof asyncSchema>
     const handle: { api?: AsyncApi } = {}
     const App = defineComponent({
       setup() {
@@ -289,7 +290,7 @@ describe('initial validation seed — async-refine schema', () => {
     const asyncSchema = z.object({
       email: z.email().refine(async (v) => v !== 'taken@example.com', 'taken'),
     })
-    type AsyncApi = ReturnType<typeof useForm<typeof asyncSchema>>
+    type AsyncApi = UseFormReturn<typeof asyncSchema>
     const handle: { api?: AsyncApi } = {}
     const App = defineComponent({
       setup() {
@@ -336,7 +337,7 @@ describe('initial validation seed — async-refine schema', () => {
         .email()
         .refine(async (v) => v !== 'taken@example.com', 'That email is already registered.'),
     })
-    type MixedApi = ReturnType<typeof useForm<typeof mixedSchema>>
+    type MixedApi = UseFormReturn<typeof mixedSchema>
     const handle: { api?: MixedApi } = {}
     const App = defineComponent({
       setup() {
@@ -383,7 +384,7 @@ describe('initial validation seed — async-refine schema', () => {
         .email()
         .refine(async (v) => v !== 'taken@example.com', 'That email is already registered.'),
     })
-    type MixedApi = ReturnType<typeof useForm<typeof mixedSchema>>
+    type MixedApi = UseFormReturn<typeof mixedSchema>
     const handle: { api?: MixedApi } = {}
     const App = defineComponent({
       setup() {
@@ -425,7 +426,7 @@ describe('initial validation seed — async-refine schema', () => {
         .email()
         .refine(async (v) => v !== 'taken@example.com', 'That email is already registered.'),
     })
-    type MixedApi = ReturnType<typeof useForm<typeof mixedSchema>>
+    type MixedApi = UseFormReturn<typeof mixedSchema>
     const handle: { api?: MixedApi } = {}
     const App = defineComponent({
       setup() {
@@ -463,7 +464,7 @@ describe('initial validation seed — async-refine schema', () => {
     // actually pending. Skipping the schedule for sync schemas keeps
     // `validating` honestly false at construction.
     const syncSchema = z.object({ email: z.email('Invalid email') })
-    type SyncApi = ReturnType<typeof useForm<typeof syncSchema>>
+    type SyncApi = UseFormReturn<typeof syncSchema>
     const handle: { api?: SyncApi } = {}
     const App = defineComponent({
       setup() {

--- a/test/composables/initial-validity.test.ts
+++ b/test/composables/initial-validity.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, nextTick, type App } from 'vue'
 import { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { z } from 'zod'
 import { createAttaform } from '../../src/runtime/core/plugin'
 
@@ -46,8 +47,8 @@ const syncSchema = z.object({ reference: z.string() }).refine((data) => data.ref
   message: 'reference must be OK',
 })
 
-type AsyncApi = ReturnType<typeof useForm<typeof asyncSchema>>
-type SyncApi = ReturnType<typeof useForm<typeof syncSchema>>
+type AsyncApi = UseFormReturn<typeof asyncSchema>
+type SyncApi = UseFormReturn<typeof syncSchema>
 
 // Convenience wrapper for the multi-path "all subtrees valid" read.
 // Each path goes through `form.fields(p).valid` — same per-path
@@ -222,7 +223,7 @@ describe('initial validity gating — asymmetry between isValid and field.valid'
     }),
   })
 
-  type MixedApi = ReturnType<typeof useForm<typeof mixedSchema>>
+  type MixedApi = UseFormReturn<typeof mixedSchema>
   const apps: App[] = []
   afterEach(() => {
     while (apps.length > 0) apps.pop()?.unmount()

--- a/test/composables/is-valid.test.ts
+++ b/test/composables/is-valid.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { computed, createApp, defineComponent, h, nextTick, type App } from 'vue'
 import { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { z } from 'zod'
 import { attachRegistryToApp, createRegistry } from '../../src/runtime/core/registry'
 import { canonicalizePath } from '../../src/runtime/core/paths'
@@ -33,7 +34,7 @@ const schema = z.object({
   }),
 })
 
-type Api = ReturnType<typeof useForm<typeof schema>>
+type Api = UseFormReturn<typeof schema>
 
 type FieldStateLike = {
   valid: boolean

--- a/test/composables/library-hardening-probes.test.ts
+++ b/test/composables/library-hardening-probes.test.ts
@@ -4,6 +4,7 @@ import { createApp, defineComponent, h, nextTick, watch, type App } from 'vue'
 import { z } from 'zod'
 import { z as zV3 } from 'zod-v3'
 import { unset, useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { useForm as useFormV3 } from '../../src/zod-v3'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import type { UseFormReturnType } from '../../src/runtime/types/types-api'
@@ -3044,7 +3045,7 @@ describe('chaos — z.transform() at a leaf changes the output type', () => {
     // Inside the form API, the same asymmetry threads through. Type-
     // assert directly off `useForm`'s return without any `as Api` cast
     // so the public TS surface is what's under test.
-    type FormApi = ReturnType<typeof useForm<typeof _schema>>
+    type FormApi = UseFormReturn<typeof _schema>
 
     // form.values reflects storage — the pre-transform z.input view.
     type FlagAtValues = FormApi['values']['isLongEmail']
@@ -5421,7 +5422,7 @@ describe('chaos — two <input> elements registered to the same path', () => {
 
   it('typing in either input keeps both in sync via the shared form value', async () => {
     const schema = z.object({ shared: z.string() })
-    type Api = ReturnType<typeof useForm<typeof schema>>
+    type Api = UseFormReturn<typeof schema>
     const handle: { api?: Api; el1?: HTMLInputElement; el2?: HTMLInputElement } = {}
 
     // Use the directive interface that the existing persistence test
@@ -6044,7 +6045,7 @@ describe('chaos — empty z.object({}) schema', () => {
 
   it('mounts a form with z.object({}) and accepts validateAsync', async () => {
     const schema = z.object({})
-    let api: ReturnType<typeof useForm<typeof schema>> | undefined
+    let api: UseFormReturn<typeof schema> | undefined
     const App = defineComponent({
       setup() {
         api = useForm({
@@ -6095,7 +6096,7 @@ describe('crash — BigInt-in-DU surfaces as a thrown error to the Vue app', () 
     // Vue's errorHandler captures uncaught errors that escape render
     // / handlers. Wire a spy to detect any.
     const captured: unknown[] = []
-    const handle: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const handle: { api?: UseFormReturn<typeof schema> } = {}
     const App = defineComponent({
       setup() {
         handle.api = useForm({
@@ -6112,7 +6113,7 @@ describe('crash — BigInt-in-DU surfaces as a thrown error to the Vue app', () 
     }
     app.mount(document.createElement('div'))
     apps.push(app)
-    const api = handle.api as ReturnType<typeof useForm<typeof schema>>
+    const api = handle.api as UseFormReturn<typeof schema>
 
     // The user clicks "switch to small". The synchronous setValue
     // triggers reshape → JSON.stringify(BigInt) → throws → propagates
@@ -6195,7 +6196,7 @@ describe('crash — infinite reactivity loop via setValue inside a computed', ()
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
-    const handle: { api?: ReturnType<typeof useForm<typeof schema>>; iterations?: number } = {
+    const handle: { api?: UseFormReturn<typeof schema>; iterations?: number } = {
       iterations: 0,
     }
     let crashed = false

--- a/test/composables/meta-errors-order-stability.test.ts
+++ b/test/composables/meta-errors-order-stability.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormConfigV4 } from '../../src/zod'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import type { UseFormReturnType } from '../../src/runtime/types/types-api'
 import { waitUntil } from '../utils/form-harness'
@@ -35,7 +36,7 @@ type ApiFor<Schema extends z.ZodObject> = Omit<UseFormReturnType<z.output<Schema
 
 function mountForm<Schema extends z.ZodObject>(
   schema: Schema,
-  defaultValues: NonNullable<Parameters<typeof useForm<Schema>>[0]['defaultValues']>
+  defaultValues: NonNullable<UseFormConfigV4<Schema>['defaultValues']>
 ): { app: App; api: ApiFor<Schema> } {
   const handle: { api?: ApiFor<Schema> } = {}
   const App = defineComponent({

--- a/test/composables/multi-select-cmd-click.test.ts
+++ b/test/composables/multi-select-cmd-click.test.ts
@@ -17,6 +17,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, withDirectives, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { vRegister } from '../../src/runtime/core/directive'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import { waitUntil } from '../utils/form-harness'
@@ -39,7 +40,7 @@ describe('<select multiple v-register> — Cmd+click adds selection', () => {
   })
 
   it('after Cmd+click on a third option, DOM shows all three selected (matches model)', async () => {
-    const handle: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const handle: { api?: UseFormReturn<typeof schema> } = {}
 
     const Parent = defineComponent({
       setup() {
@@ -154,7 +155,7 @@ describe('<select multiple v-register> — Cmd+click adds selection', () => {
     // `setSelected` from `updated` when the model hasn't changed since
     // the last application — mirroring the spirit of `setChecked`'s
     // `originalValue === oldValue` short-circuit.
-    const handle: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const handle: { api?: UseFormReturn<typeof schema> } = {}
 
     const Parent = defineComponent({
       setup() {

--- a/test/composables/path-tuples-runtime.test.ts
+++ b/test/composables/path-tuples-runtime.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, type App } from 'vue'
 import { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { z } from 'zod'
 import { createAttaform } from '../../src/runtime/core/plugin'
 
@@ -27,7 +28,7 @@ const schema = z.object({
   ),
 })
 
-type Api = ReturnType<typeof useForm<typeof schema>>
+type Api = UseFormReturn<typeof schema>
 
 function mount(): { app: App; api: Api } {
   const handle: { api?: Api } = {}

--- a/test/composables/persist-hydration-validate.test.ts
+++ b/test/composables/persist-hydration-validate.test.ts
@@ -6,6 +6,7 @@ import { fingerprintZodSchema } from '../../src/runtime/adapters/zod-v4/fingerpr
 import { hashStableString } from '../../src/runtime/core/hash'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { waitUntil } from '../utils/form-harness'
 
 /**
@@ -91,8 +92,8 @@ type SyncForm = z.infer<typeof syncSchema>
 const ASYNC_FP = hashStableString(fingerprintZodSchema(asyncSchema))
 const SYNC_FP = hashStableString(fingerprintZodSchema(syncSchema))
 
-type AsyncApi = ReturnType<typeof useForm<typeof asyncSchema>>
-type SyncApi = ReturnType<typeof useForm<typeof syncSchema>>
+type AsyncApi = UseFormReturn<typeof asyncSchema>
+type SyncApi = UseFormReturn<typeof syncSchema>
 
 function mountAsyncForm(persistKey: string, strict: boolean = true): { app: App; api: AsyncApi } {
   const handle: { api?: AsyncApi } = {}

--- a/test/composables/persistence.test.ts
+++ b/test/composables/persistence.test.ts
@@ -4,6 +4,7 @@ import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vites
 import { createApp, defineComponent, h, withDirectives, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormConfig, UseFormReturn } from '../../src/zod'
 import { vRegister } from '../../src/runtime/core/directive'
 import { AnonPersistError } from '../../src/runtime/core/errors'
 import { __resetIndexedDbForTests } from '../../src/runtime/core/persistence/indexeddb'
@@ -96,10 +97,10 @@ const schema = z.object({
 const FP = hashStableString(fingerprintZodSchema(schema))
 const fpKey = (base: string): string => `${base}:${FP}`
 
-type ApiReturn = ReturnType<typeof useForm<typeof schema>>
+type ApiReturn = UseFormReturn<typeof schema>
 type Field = 'email' | 'password'
 
-function mountForm(persist: Parameters<typeof useForm<typeof schema>>[0]['persist']): {
+function mountForm(persist: UseFormConfig<typeof schema>['persist']): {
   app: App
   api: ApiReturn
   /**
@@ -329,7 +330,7 @@ describe('persistence — non-opted-in blank paths survive hydration', () => {
       })
     )
 
-    const captured: { api?: ReturnType<typeof useForm<typeof customSchema>> } = {}
+    const captured: { api?: UseFormReturn<typeof customSchema> } = {}
     const App = defineComponent({
       setup() {
         const api = useForm({
@@ -1454,7 +1455,7 @@ describe('persistence — cross-store cleanup at mount', () => {
     __resetIndexedDbForTests()
   })
 
-  function mountMinimal(persist: Parameters<typeof useForm<typeof schema>>[0]['persist']): App {
+  function mountMinimal(persist: UseFormConfig<typeof schema>['persist']): App {
     const App = defineComponent({
       setup() {
         useForm({

--- a/test/composables/radio-mid-click.test.ts
+++ b/test/composables/radio-mid-click.test.ts
@@ -13,6 +13,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, withDirectives, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { vRegister } from '../../src/runtime/core/directive'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import { waitUntil } from '../utils/form-harness'
@@ -32,7 +33,7 @@ describe('<input type="radio" v-register> — sibling re-render mid-click', () =
   })
 
   it('a sibling re-render between mousedown and change MUST NOT clobber the user-selected radio', async () => {
-    const handle: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const handle: { api?: UseFormReturn<typeof schema> } = {}
 
     const Parent = defineComponent({
       setup() {
@@ -118,7 +119,7 @@ describe('<input type="radio" v-register> — sibling re-render mid-click', () =
   })
 
   it('subsequent renders with model-identity-unchanged are no-ops on the DOM (skip path)', async () => {
-    const handle: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const handle: { api?: UseFormReturn<typeof schema> } = {}
 
     const Parent = defineComponent({
       setup() {
@@ -187,7 +188,7 @@ describe('<input type="radio" v-register> — sibling re-render mid-click', () =
   })
 
   it('a real model change still drives the DOM (post-skip resync)', async () => {
-    const handle: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const handle: { api?: UseFormReturn<typeof schema> } = {}
 
     const Parent = defineComponent({
       setup() {

--- a/test/composables/radio.test.ts
+++ b/test/composables/radio.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, withDirectives, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { vRegister } from '../../src/runtime/core/directive'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import { waitUntil } from '../utils/form-harness'
@@ -36,7 +37,7 @@ describe('<input type="radio" v-register> — single-group selection', () => {
 
   it('selecting a radio writes its option-value to the model', async () => {
     const schema = z.object({ tier: z.enum(['free', 'pro', 'enterprise']) })
-    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const captured: { api?: UseFormReturn<typeof schema> } = {}
 
     const Parent = defineComponent({
       setup() {
@@ -103,7 +104,7 @@ describe('<input type="radio" v-register> — single-group selection', () => {
 
   it('mounts with el.checked synced to the model', async () => {
     const schema = z.object({ tier: z.enum(['free', 'pro', 'enterprise']) })
-    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const captured: { api?: UseFormReturn<typeof schema> } = {}
 
     const Parent = defineComponent({
       setup() {
@@ -151,7 +152,7 @@ describe('<input type="radio" v-register> — single-group selection', () => {
     // latter: include the form's value in the render function so a
     // setValue call triggers a re-render → `beforeUpdate` → setChecked.
     const schema = z.object({ tier: z.enum(['free', 'pro', 'enterprise']) })
-    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const captured: { api?: UseFormReturn<typeof schema> } = {}
 
     const Parent = defineComponent({
       setup() {
@@ -203,7 +204,7 @@ describe('<input type="radio" v-register> — single-group selection', () => {
     // group should leave every option unchecked rather than picking
     // an arbitrary one.
     const schema = z.object({ tier: z.enum(['free', 'pro', 'enterprise']) })
-    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const captured: { api?: UseFormReturn<typeof schema> } = {}
 
     const Parent = defineComponent({
       setup() {
@@ -254,7 +255,7 @@ describe('<input type="radio" v-register> — hydration with static value attrib
     // The directive must still resolve the option-value via the DOM
     // attribute (el.value) so el.checked reflects the model.
     const schema = z.object({ tier: z.enum(['free', 'pro', 'enterprise']) })
-    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const captured: { api?: UseFormReturn<typeof schema> } = {}
 
     const Parent = defineComponent({
       setup() {
@@ -324,7 +325,7 @@ describe('<input type="radio" v-register> — slim-gate interactions', () => {
   it('rejects a non-string write to a string-enum-bound radio path', async () => {
     warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const schema = z.object({ tier: z.enum(['free', 'pro']) })
-    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const captured: { api?: UseFormReturn<typeof schema> } = {}
 
     const Parent = defineComponent({
       setup() {
@@ -354,7 +355,7 @@ describe('<input type="radio" v-register> — slim-gate interactions', () => {
 
   it('accepts an out-of-enum string (refinement check, not a write-time gate)', async () => {
     const schema = z.object({ tier: z.enum(['free', 'pro']) })
-    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const captured: { api?: UseFormReturn<typeof schema> } = {}
 
     const Parent = defineComponent({
       setup() {

--- a/test/composables/register-display-value.test.ts
+++ b/test/composables/register-display-value.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormConfigV4 } from '../../src/zod'
 import { canonicalizePath } from '../../src/runtime/core/paths'
 import { attachRegistryToApp, createRegistry } from '../../src/runtime/core/registry'
 import type {
@@ -32,7 +33,7 @@ function asInternal<V>(rv: RegisterValue<V>): InternalRegisterValue<V> {
 
 function setupForm<F extends z.ZodObject<Record<string, z.ZodType>>>(
   schema: F,
-  defaultValues?: Parameters<typeof useForm<F>>[0]['defaultValues']
+  defaultValues?: UseFormConfigV4<F>['defaultValues']
 ) {
   let captured!: UseFormReturnType<z.output<F> & Record<string, unknown>>
   const Probe = defineComponent({

--- a/test/composables/reset.test.ts
+++ b/test/composables/reset.test.ts
@@ -4,6 +4,7 @@ import { createApp, defineComponent, h, type App } from 'vue'
 import { useForm } from '../../src'
 import { attachRegistryToApp, createRegistry } from '../../src/runtime/core/registry'
 import type { UseFormReturnType } from '../../src/runtime/types/types-api'
+import type { UseFormReturn } from '../../src/zod'
 import { fakeSchema } from '../utils/fake-schema'
 
 /**
@@ -238,7 +239,7 @@ describe('useForm — reset() re-derives schema errors against the post-reset st
       email: z.email(),
     })
 
-    let captured!: ReturnType<typeof useForm<typeof schema>>
+    let captured!: UseFormReturn<typeof schema>
     const Probe = defineComponent({
       setup() {
         captured = useForm({
@@ -297,7 +298,7 @@ describe('useForm — reset() re-derives schema errors against the post-reset st
       email: z.email(),
     })
 
-    let captured!: ReturnType<typeof useForm<typeof schema>>
+    let captured!: UseFormReturn<typeof schema>
     const Probe = defineComponent({
       setup() {
         captured = useForm({
@@ -351,7 +352,7 @@ describe('useForm — reset() re-derives schema errors against the post-reset st
       delivery: addressSchema,
     })
 
-    let captured!: ReturnType<typeof useForm<typeof schema>>
+    let captured!: UseFormReturn<typeof schema>
     const Probe = defineComponent({
       setup() {
         captured = useForm({
@@ -443,7 +444,7 @@ describe('useForm — reset() re-derives schema errors against the post-reset st
       }),
     })
 
-    let captured!: ReturnType<typeof useForm<typeof schema>>
+    let captured!: UseFormReturn<typeof schema>
     const Probe = defineComponent({
       setup() {
         captured = useForm({
@@ -519,7 +520,7 @@ describe('useForm — reset() re-derives schema errors against the post-reset st
         .refine(async (v) => v !== 'taken@example.com', 'That email is already registered.'),
     })
 
-    let captured!: ReturnType<typeof useForm<typeof schema>>
+    let captured!: UseFormReturn<typeof schema>
     const Probe = defineComponent({
       setup() {
         captured = useForm({
@@ -574,7 +575,7 @@ describe('useForm — reset() re-derives schema errors against the post-reset st
         .refine(async (v) => v !== 'taken@example.com', 'That email is already registered.'),
     })
 
-    let captured!: ReturnType<typeof useForm<typeof schema>>
+    let captured!: UseFormReturn<typeof schema>
     const Probe = defineComponent({
       setup() {
         captured = useForm({
@@ -615,7 +616,7 @@ describe('useForm — reset() re-derives schema errors against the post-reset st
 
     const schema = z.object({ name: z.string().min(1) })
 
-    let captured!: ReturnType<typeof useForm<typeof schema>>
+    let captured!: UseFormReturn<typeof schema>
     const Probe = defineComponent({
       setup() {
         captured = useForm({

--- a/test/composables/schema-errors-edge-cases.test.ts
+++ b/test/composables/schema-errors-edge-cases.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, nextTick, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormConfigV4 } from '../../src/zod'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import type { UseFormReturnType, ValidationError } from '../../src/runtime/types/types-api'
 import { waitUntil } from '../utils/form-harness'
@@ -30,7 +31,7 @@ type LooseApi<Schema extends z.ZodObject> = Omit<
 
 function mountForm<Schema extends z.ZodObject>(
   schema: Schema,
-  defaultValues: NonNullable<Parameters<typeof useForm<Schema>>[0]['defaultValues']>
+  defaultValues: NonNullable<UseFormConfigV4<Schema>['defaultValues']>
 ): { app: App; api: LooseApi<Schema> } {
   const handle: { api?: LooseApi<Schema> } = {}
   const App = defineComponent({

--- a/test/composables/select-out-of-enum.test.ts
+++ b/test/composables/select-out-of-enum.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, withDirectives, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { vRegister } from '../../src/runtime/core/directive'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import { waitUntil } from '../utils/form-harness'
@@ -38,7 +39,7 @@ describe('<select v-register> with out-of-enum option', () => {
   })
 
   it('selecting an out-of-enum option writes the string value (slim-type match)', async () => {
-    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const captured: { api?: UseFormReturn<typeof schema> } = {}
 
     const Parent = defineComponent({
       setup() {
@@ -95,7 +96,7 @@ describe('<select v-register> with out-of-enum option', () => {
   it('programmatic setValue with a wrong-primitive-type value is REJECTED + dev-warned', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const captured: { api?: UseFormReturn<typeof schema> } = {}
 
     const Parent = defineComponent({
       setup() {
@@ -142,7 +143,7 @@ describe('<select v-register> with out-of-enum option', () => {
   })
 
   it('programmatic setValue with a wrong-enum-member writes (string slim accepted)', async () => {
-    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const captured: { api?: UseFormReturn<typeof schema> } = {}
 
     const Parent = defineComponent({
       setup() {

--- a/test/composables/set-value-schema-fill-regression.test.ts
+++ b/test/composables/set-value-schema-fill-regression.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { createAttaform } from '../../src/runtime/core/plugin'
 
 /**
@@ -48,7 +49,7 @@ const formSchema = z.object({
 type Form = z.output<typeof formSchema>
 
 function harness(initialPeople: Form['people']) {
-  let captured!: ReturnType<typeof useForm<typeof formSchema>>
+  let captured!: UseFormReturn<typeof formSchema>
   const Probe = defineComponent({
     setup() {
       captured = useForm({
@@ -217,7 +218,7 @@ const profileSchema = z.object({
 type ProfileForm = z.output<typeof profileSchema>
 
 function profileHarness(initial: Partial<ProfileForm['user']>) {
-  let captured!: ReturnType<typeof useForm<typeof profileSchema>>
+  let captured!: UseFormReturn<typeof profileSchema>
   const Probe = defineComponent({
     setup() {
       captured = useForm({
@@ -312,7 +313,7 @@ const addressSchema = z.object({
 type AddressForm = z.output<typeof addressSchema>
 
 function addressHarness(initialPeople: AddressForm['address']['people']) {
-  let captured!: ReturnType<typeof useForm<typeof addressSchema>>
+  let captured!: UseFormReturn<typeof addressSchema>
   const Probe = defineComponent({
     setup() {
       captured = useForm({
@@ -400,7 +401,7 @@ const cascadeSchema = z.object({
 type CascadeForm = z.output<typeof cascadeSchema>
 
 function cascadeHarness() {
-  let captured!: ReturnType<typeof useForm<typeof cascadeSchema>>
+  let captured!: UseFormReturn<typeof cascadeSchema>
   const Probe = defineComponent({
     setup() {
       captured = useForm({
@@ -520,7 +521,7 @@ const tupleSchema = z.object({
 type TupleForm = z.output<typeof tupleSchema>
 
 function tupleHarness(initial: TupleForm['coords']) {
-  let captured!: ReturnType<typeof useForm<typeof tupleSchema>>
+  let captured!: UseFormReturn<typeof tupleSchema>
   const Probe = defineComponent({
     setup() {
       captured = useForm({

--- a/test/composables/slim-primitive-defaults.test.ts
+++ b/test/composables/slim-primitive-defaults.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormReturnV4 } from '../../src/zod'
 import { createAttaform } from '../../src/runtime/core/plugin'
 
 /**
@@ -32,8 +33,8 @@ function mountWith<S extends z.ZodObject>(
   schema: S,
   defaults: Partial<z.infer<S>>,
   strict: boolean = false
-): { api: ReturnType<typeof useForm<S>>; app: App } {
-  const captured: { api?: ReturnType<typeof useForm<S>> } = {}
+): { api: UseFormReturnV4<S>; app: App } {
+  const captured: { api?: UseFormReturnV4<S> } = {}
   const App = defineComponent({
     setup() {
       const config = {
@@ -42,7 +43,7 @@ function mountWith<S extends z.ZodObject>(
         strict,
         defaultValues: defaults,
       }
-      captured.api = (useForm as unknown as (cfg: unknown) => ReturnType<typeof useForm<S>>)(config)
+      captured.api = (useForm as unknown as (cfg: unknown) => UseFormReturnV4<S>)(config)
       return () => h('div')
     },
   })
@@ -50,7 +51,7 @@ function mountWith<S extends z.ZodObject>(
   const root = document.createElement('div')
   document.body.appendChild(root)
   app.mount(root)
-  return { api: captured.api as ReturnType<typeof useForm<S>>, app }
+  return { api: captured.api as UseFormReturnV4<S>, app }
 }
 
 describe('slim-primitive defaults — refinement-invalid passes through', () => {

--- a/test/composables/slim-primitive-write-gate.test.ts
+++ b/test/composables/slim-primitive-write-gate.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormReturnV4 } from '../../src/zod'
 import { makeMounter as makeMounterShared, waitUntil } from '../utils/form-harness'
 
 /**
@@ -32,7 +33,7 @@ import { makeMounter as makeMounterShared, waitUntil } from '../utils/form-harne
 // `path` parameter) so we narrow back from the harness's `any` here.
 function makeMounter<S extends z.ZodObject>(schema: S) {
   return makeMounterShared(useForm, schema) as () => {
-    api: ReturnType<typeof useForm<S>>
+    api: UseFormReturnV4<S>
     app: App
   }
 }

--- a/test/composables/spike-no-debounce.test.ts
+++ b/test/composables/spike-no-debounce.test.ts
@@ -16,6 +16,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, withDirectives, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormConfig, UseFormReturn } from '../../src/zod'
 import { vRegister } from '../../src/runtime/core/directive'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import { waitUntil } from '../utils/form-harness'
@@ -33,7 +34,7 @@ describe('spike — debounceMs: 0 disables the debounce timer', () => {
   })
 
   it('explicit positive debounce: post-keystroke errors do NOT surface until the timer fires', async () => {
-    const handle: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const handle: { api?: UseFormReturn<typeof schema> } = {}
     const Parent = defineComponent({
       setup() {
         handle.api = useForm({
@@ -83,7 +84,7 @@ describe('spike — debounceMs: 0 disables the debounce timer', () => {
   })
 
   it('debounceMs: 0: errors surface on the next microtask — no timer wait', async () => {
-    const handle: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const handle: { api?: UseFormReturn<typeof schema> } = {}
     const Parent = defineComponent({
       setup() {
         handle.api = useForm({
@@ -121,7 +122,7 @@ describe('spike — debounceMs: 0 disables the debounce timer', () => {
   })
 
   it('debounceMs: 0: per-keystroke errors track the live value with no lag', async () => {
-    const handle: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const handle: { api?: UseFormReturn<typeof schema> } = {}
     const Parent = defineComponent({
       setup() {
         handle.api = useForm({
@@ -176,7 +177,7 @@ describe('spike — debounceMs: 0 disables the debounce timer', () => {
     // directives below fail the build if the constraint regresses. The
     // body executes nothing meaningful at runtime — vitest accepts the
     // empty test, the build is the gate.
-    type Opts = Parameters<typeof useForm<typeof schema>>[0]
+    type Opts = UseFormConfig<typeof schema>
     const ok1: Opts = { schema, validateOn: 'change', debounceMs: 50 }
     const ok2: Opts = { schema, validateOn: 'blur' }
     const ok3: Opts = { schema, validateOn: 'submit' }
@@ -211,7 +212,7 @@ describe('spike — persist.debounceMs: 0 writes immediately on every form chang
       },
     }
 
-    const handle: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const handle: { api?: UseFormReturn<typeof schema> } = {}
     const Parent = defineComponent({
       setup() {
         handle.api = useForm({
@@ -267,7 +268,7 @@ describe('spike — persist.debounceMs: 0 writes immediately on every form chang
       },
     }
 
-    const handle: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const handle: { api?: UseFormReturn<typeof schema> } = {}
     const Parent = defineComponent({
       setup() {
         handle.api = useForm({

--- a/test/composables/surface-proxy.test.ts
+++ b/test/composables/surface-proxy.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, type App } from 'vue'
 import { z } from 'zod'
 import { unset, useForm } from '../../src/zod'
+import type { UseFormConfigV4, UseFormReturnV4 } from '../../src/zod'
 import { createAttaform } from '../../src/runtime/core/plugin'
 
 /**
@@ -23,8 +24,8 @@ afterEach(() => {
 
 function mount<Schema extends z.ZodObject>(
   schema: Schema,
-  defaultValues: Parameters<typeof useForm<Schema>>[0]['defaultValues']
-): ReturnType<typeof useForm<Schema>> {
+  defaultValues: UseFormConfigV4<Schema>['defaultValues']
+): UseFormReturnV4<Schema> {
   let captured: unknown
   const App = defineComponent({
     setup() {
@@ -42,7 +43,7 @@ function mount<Schema extends z.ZodObject>(
   app.mount(root)
   apps.push(app)
   if (captured === undefined) throw new Error('useForm did not return')
-  return captured as ReturnType<typeof useForm<Schema>>
+  return captured as UseFormReturnV4<Schema>
 }
 
 describe('form.fields — shadowing immunity (FIELD_STATE_KEYS only inject at leaves)', () => {

--- a/test/composables/surface-serialization.test.ts
+++ b/test/composables/surface-serialization.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, nextTick, toDisplayString, type App } from 'vue'
 import { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { z } from 'zod'
 import { createAttaform } from '../../src/runtime/core/plugin'
 
@@ -41,7 +42,7 @@ describe('form.values / form.errors / form.fields — template + JSON.stringify 
       email: z.email(),
       password: z.string().min(1, 'pw required'),
     })
-    type Api = ReturnType<typeof useForm<typeof schema>>
+    type Api = UseFormReturn<typeof schema>
     const handle: { api?: Api } = {}
     const App = defineComponent({
       setup() {
@@ -168,7 +169,7 @@ describe('form.values / form.errors / form.fields — template + JSON.stringify 
           z.object({ channel: z.literal('sms'), number: z.string().min(10) }),
         ]),
       })
-      type Api = ReturnType<typeof useForm<typeof schema>>
+      type Api = UseFormReturn<typeof schema>
       const handle: { api?: Api } = {}
       const App = defineComponent({
         setup() {

--- a/test/composables/transform-clamp-dom-sync.test.ts
+++ b/test/composables/transform-clamp-dom-sync.test.ts
@@ -26,6 +26,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, withDirectives, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { vRegister } from '../../src/runtime/core/directive'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import { waitUntil } from '../utils/form-harness'
@@ -46,7 +47,7 @@ describe('spike 18c — `<input type="number">` + clamp transform DOM/storage pa
 
   it('typing past the clamp cap snaps the DOM back to the clamped value', async () => {
     const schema = z.object({ bounded: z.number() })
-    const handle: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const handle: { api?: UseFormReturn<typeof schema> } = {}
     const Parent = defineComponent({
       setup() {
         const api = useForm({
@@ -107,7 +108,7 @@ describe('spike 18c — `<input type="number">` + clamp transform DOM/storage pa
 
   it('typing below the clamp cap snaps the DOM back to the clamped value', async () => {
     const schema = z.object({ bounded: z.number() })
-    const handle: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const handle: { api?: UseFormReturn<typeof schema> } = {}
     const Parent = defineComponent({
       setup() {
         const api = useForm({
@@ -150,7 +151,7 @@ describe('spike 18c — `<input type="number">` + clamp transform DOM/storage pa
     // The user gets to keep typing the scientific-notation form mid-edit;
     // blur normalizes it.
     const schema = z.object({ bounded: z.number() })
-    const handle: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const handle: { api?: UseFormReturn<typeof schema> } = {}
     const Parent = defineComponent({
       setup() {
         const api = useForm({

--- a/test/composables/transform-no-op-write-dom-sync.test.ts
+++ b/test/composables/transform-no-op-write-dom-sync.test.ts
@@ -14,6 +14,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, withDirectives, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { vRegister } from '../../src/runtime/core/directive'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import { waitUntil } from '../utils/form-harness'
@@ -35,7 +36,7 @@ describe('no-op-write DOM-sync bug class — probes for non-text directives', ()
     // stays at false (no patch) → no render → setChecked doesn't fire
     // → DOM checkbox stays visibly checked, divorced from storage.
     const schema = z.object({ agreed: z.boolean() })
-    const handle: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const handle: { api?: UseFormReturn<typeof schema> } = {}
     const Parent = defineComponent({
       setup() {
         const api = useForm({
@@ -79,7 +80,7 @@ describe('no-op-write DOM-sync bug class — probes for non-text directives', ()
     // storage stays 'a' (no patch, no render) → setSelected doesn't
     // fire to revert → DOM <select> stays on 'b', diverged.
     const schema = z.object({ pick: z.enum(['a', 'b', 'c']) })
-    const handle: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const handle: { api?: UseFormReturn<typeof schema> } = {}
     const Parent = defineComponent({
       setup() {
         const api = useForm({

--- a/test/composables/transforms-all-elements.test.ts
+++ b/test/composables/transforms-all-elements.test.ts
@@ -10,6 +10,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, withDirectives, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { vRegister } from '../../src/runtime/core/directive'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import { waitUntil } from '../utils/form-harness'
@@ -42,7 +43,7 @@ describe('register({ transforms }) — applies to all four element variants', ()
       radio: z.string(),
     })
 
-    const handle: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const handle: { api?: UseFormReturn<typeof schema> } = {}
     const Parent = defineComponent({
       setup() {
         const api = useForm({

--- a/test/composables/type-inference.test.ts
+++ b/test/composables/type-inference.test.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, it } from 'vitest'
 import { z } from 'zod'
 import type { FormMeta } from '../../src'
-import type { useForm } from '../../src/zod'
+import type { UseFormConfig, UseFormReturn } from '../../src/zod'
 
 /**
  * Type-inference tests for `useForm` via the Zod v4 adapter.
@@ -55,11 +55,11 @@ type ExpectedForm = {
 // `useForm({ schema, key })`. We bind the generic to our Schema to
 // exercise the full inference pipeline (Schema → z.output<Schema> →
 // Form → FlatPath/NestedType).
-type Form = ReturnType<typeof useForm<Schema>>
+type Form = UseFormReturn<Schema>
 
 // The public factory's *parameter* type — used to test the type-level
 // requirement on `key` without actually invoking useForm at runtime.
-type UseFormOptions = Parameters<typeof useForm<Schema>>[0]
+type UseFormOptions = UseFormConfig<Schema>
 
 // `expectTypeOf` evaluates its argument at runtime even though it only
 // cares about the type. We can't call the real `useForm` here (no Vue
@@ -267,7 +267,7 @@ describe('useForm type inference — primitive-array register paths', () => {
     multiBooleans: z.array(z.boolean()),
     multiBigints: z.array(z.bigint()),
   })
-  type MultiForm = ReturnType<typeof useForm<typeof _multiSchema>>
+  type MultiForm = UseFormReturn<typeof _multiSchema>
   const multiForm = (() => {
     const handler: ProxyHandler<() => unknown> = { get: () => proxy, apply: () => proxy }
     const proxy: unknown = new Proxy(() => undefined, handler)
@@ -452,7 +452,7 @@ describe('useForm type inference — setValue at honest-input paths', () => {
     anyThing: z.any(),
   })
   type HonestSchema = typeof _honestSchema
-  type HonestForm = ReturnType<typeof useForm<HonestSchema>>
+  type HonestForm = UseFormReturn<HonestSchema>
   const honestForm: HonestForm = (() => {
     const handler: ProxyHandler<() => unknown> = { get: () => proxy, apply: () => proxy }
     const proxy: unknown = new Proxy(() => undefined, handler)

--- a/test/composables/use-register-template.test.ts
+++ b/test/composables/use-register-template.test.ts
@@ -5,6 +5,7 @@ import { createApp, defineComponent, type App } from 'vue'
 import * as VueRuntime from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { useRegister } from '../../src/runtime/composables/use-register'
 import { vRegister } from '../../src/runtime/core/directive'
 import { createAttaform } from '../../src/runtime/core/plugin'
@@ -95,7 +96,7 @@ describe('useRegister — template-compiled v-register reaches inner input', () 
     // injects `:value` and `:registerValue` props. At runtime,
     // useRegister captures registerValue and strips both bridge keys
     // from instance.attrs (no DOM leak on the wrapper).
-    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const captured: { api?: UseFormReturn<typeof schema> } = {}
     const Parent = defineComponent({
       components: { Child },
       setup() {
@@ -148,7 +149,7 @@ describe('useRegister — template-compiled v-register reaches inner input', () 
       ),
     })
 
-    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const captured: { api?: UseFormReturn<typeof schema> } = {}
     const Parent = defineComponent({
       components: { Child },
       setup() {

--- a/test/composables/use-register.test.ts
+++ b/test/composables/use-register.test.ts
@@ -13,6 +13,7 @@ import {
 } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { useRegister } from '../../src/runtime/composables/use-register'
 import { vRegister } from '../../src/runtime/core/directive'
 import { createAttaform } from '../../src/runtime/core/plugin'
@@ -226,7 +227,7 @@ describe('useRegister — inside child setup', () => {
 
   it("with parent registerValue → returns ComputedRef whose .value === parent's RV (referential)", async () => {
     const captured: {
-      parentRV?: ReturnType<ReturnType<typeof useForm<typeof schema>>['register']>
+      parentRV?: ReturnType<UseFormReturn<typeof schema>['register']>
       childRegister?: ReturnType<typeof useRegister>
     } = {}
 
@@ -615,7 +616,7 @@ describe('useRegister — sentinel suppresses parent-directive warn', () => {
     // input doesn't reach the wrapper's listener with a write
     // attempt, so the form value isn't clobbered with `el.value`
     // (the wrapper's, which is junk).
-    let formApi: ReturnType<typeof useForm<typeof schema>> | undefined
+    let formApi: UseFormReturn<typeof schema> | undefined
     const Child = defineComponent({
       name: 'NoBailChild',
       inheritAttrs: false,
@@ -676,7 +677,7 @@ describe('useRegister — inner v-register receives full directive lifecycle', (
   })
 
   it('FormStore element registry tracks the inner input + focus listeners attach', async () => {
-    const captured: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const captured: { api?: UseFormReturn<typeof schema> } = {}
 
     const Child = defineComponent({
       name: 'InnerRegisterChild',

--- a/test/composables/v-register-component-runtime.test.ts
+++ b/test/composables/v-register-component-runtime.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, onMounted, ref, withDirectives, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { assignKey, vRegister } from '../../src/runtime/core/directive'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import { useRegister } from '../../src/runtime/composables/use-register'
@@ -27,7 +28,7 @@ import { waitUntil } from '../utils/form-harness'
  */
 
 const schema = z.object({ email: z.string(), name: z.string() })
-type ApiReturn = ReturnType<typeof useForm<typeof schema>>
+type ApiReturn = UseFormReturn<typeof schema>
 
 type MountReturn = {
   app: App
@@ -504,7 +505,7 @@ describe('pattern 3: @update:registerValue prop on a component', () => {
       rv.setValueWithInternalPath(String(value ?? '').toUpperCase())
     }
 
-    const handle: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const handle: { api?: UseFormReturn<typeof schema> } = {}
     const Parent = defineComponent({
       setup() {
         const api = useForm({ schema, key: `compiler-${Math.random().toString(36).slice(2)}` })
@@ -695,7 +696,7 @@ describe('register({ transforms: [...] }) — sync user-input pipeline', () => {
   it('11. failure isolation — one path throwing does not affect others', async () => {
     // Mount a parent with two RegisterValue bindings; one throws, one normalizes.
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
-    const handle: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const handle: { api?: UseFormReturn<typeof schema> } = {}
     const Parent = defineComponent({
       setup() {
         const api = useForm({ schema, key: `iso-${Math.random().toString(36).slice(2)}` })
@@ -748,7 +749,7 @@ describe('register({ transforms: [...] }) — sync user-input pipeline', () => {
     // upper, typing in B writes raw. No cross-element leakage at the
     // transform layer; form state at the path is still a single shared
     // slot (last-write-wins), so we can read it back to verify.
-    const handle: { api?: ReturnType<typeof useForm<typeof schema>> } = {}
+    const handle: { api?: UseFormReturn<typeof schema> } = {}
     const Parent = defineComponent({
       setup() {
         const api = useForm({ schema, key: `per-bind-${Math.random().toString(36).slice(2)}` })

--- a/test/composables/values-proxy.test.ts
+++ b/test/composables/values-proxy.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, isReactive, isReadonly, isRef, watch } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import { waitUntil } from '../utils/form-harness'
 
@@ -26,10 +27,10 @@ const schema = z.object({
 type Form = z.infer<typeof schema>
 
 function mountForm(): {
-  api: ReturnType<typeof useForm<typeof schema>>
+  api: UseFormReturn<typeof schema>
   unmount: () => void
 } {
-  let captured: ReturnType<typeof useForm<typeof schema>> | undefined
+  let captured: UseFormReturn<typeof schema> | undefined
   const App = defineComponent({
     setup() {
       captured = useForm({

--- a/test/composables/values-storage-shape-v3.test.ts
+++ b/test/composables/values-storage-shape-v3.test.ts
@@ -21,7 +21,7 @@ import { createAttaform } from '../../src/runtime/core/plugin'
  * depth bounded — see the doc on `ReadShape` for the rationale.
  *
  * v3's `useForm` has multiple overloads, so the proxy-based
- * `ReturnType<typeof useForm<...>>` pattern used by the v4 matrix
+ * `UseFormReturn<...>` pattern used by the v4 matrix
  * doesn't resolve consistently. We mount each scenario and run both
  * type-level (`expectTypeOf(api.values.X)`) and runtime
  * (`expect(api.values.X)`) assertions against the live API instance.

--- a/test/composables/values-storage-shape.test.ts
+++ b/test/composables/values-storage-shape.test.ts
@@ -3,6 +3,7 @@ import { createApp, defineComponent, h } from 'vue'
 import { describe, expect, expectTypeOf, it } from 'vitest'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import type { ValidationError } from '../../src/runtime/types/types-api'
 
@@ -84,7 +85,7 @@ const defaultsSchema = z.object({
 })
 
 describe('ZodDefault — type peels `| undefined`, runtime resolves the default', () => {
-  type Form = ReturnType<typeof useForm<typeof defaultsSchema>>
+  type Form = UseFormReturn<typeof defaultsSchema>
   const formT = makeFormProxy<Form>()
 
   it('z.boolean().default(true) → boolean (type)', () => {
@@ -191,7 +192,7 @@ const bareRequiredSchema = z.object({
 })
 
 describe('Synthesis — bare-required fields resolve to a falsy concrete value', () => {
-  type Form = ReturnType<typeof useForm<typeof bareRequiredSchema>>
+  type Form = UseFormReturn<typeof bareRequiredSchema>
   const formT = makeFormProxy<Form>()
 
   it('z.string() (no default) → string (type)', () => {
@@ -276,7 +277,7 @@ const deepSchema = z.object({
 })
 
 describe('Synthesis — deep nested objects resolve recursively', () => {
-  type Form = ReturnType<typeof useForm<typeof deepSchema>>
+  type Form = UseFormReturn<typeof deepSchema>
   const formT = makeFormProxy<Form>()
 
   it('two-level descent — type stays strict', () => {
@@ -367,7 +368,7 @@ const arrSchema = z.object({ tags: z.array(z.string()) })
 
 describe('Genuinely uncertain — invariant does NOT promise to peel', () => {
   it('z.string().optional() keeps `| undefined` at the type level', () => {
-    type Form = ReturnType<typeof useForm<typeof optionalSchema>>
+    type Form = UseFormReturn<typeof optionalSchema>
     const formT = makeFormProxy<Form>()
     expectTypeOf(formT.values.bio).toEqualTypeOf<string | undefined>()
   })
@@ -387,7 +388,7 @@ describe('Genuinely uncertain — invariant does NOT promise to peel', () => {
   })
 
   it('z.string().nullable() keeps `| null` at the type level', () => {
-    type Form = ReturnType<typeof useForm<typeof nullableSchema>>
+    type Form = UseFormReturn<typeof nullableSchema>
     const formT = makeFormProxy<Form>()
     expectTypeOf(formT.values.ref).toEqualTypeOf<string | null>()
   })
@@ -407,7 +408,7 @@ describe('Genuinely uncertain — invariant does NOT promise to peel', () => {
   })
 
   it('array element past length is `T | undefined` — noUncheckedIndexedAccess, not storage', () => {
-    type Form = ReturnType<typeof useForm<typeof arrSchema>>
+    type Form = UseFormReturn<typeof arrSchema>
     const formT = makeFormProxy<Form>()
     expectTypeOf(formT.values.tags[0]).toEqualTypeOf<string | undefined>()
   })
@@ -438,7 +439,7 @@ const transformSchema = z.object({
 
 describe('preprocess / transform — write-boundary vs parse-time semantics', () => {
   it('z.preprocess(fn, z.string()) — type peels to inner-schema input', () => {
-    type Form = ReturnType<typeof useForm<typeof preprocessSchema>>
+    type Form = UseFormReturn<typeof preprocessSchema>
     const formT = makeFormProxy<Form>()
     expectTypeOf(formT.values.trimmed).toEqualTypeOf<string>()
   })
@@ -487,7 +488,7 @@ describe('preprocess / transform — write-boundary vs parse-time semantics', ()
   })
 
   it('z.string().transform(fn) — storage holds PRE-transform input (existing rationale)', () => {
-    type Form = ReturnType<typeof useForm<typeof transformSchema>>
+    type Form = UseFormReturn<typeof transformSchema>
     const formT = makeFormProxy<Form>()
     // Transforms run at parse, not at write. The storage view stays the
     // input shape — string here, not number. This is the case the §1.1
@@ -519,7 +520,7 @@ describe('preprocess / transform — write-boundary vs parse-time semantics', ()
         })
         .transform((o) => ({ ...o, sealed: true })),
     })
-    type Form = ReturnType<typeof useForm<typeof _schema>>
+    type Form = UseFormReturn<typeof _schema>
     const formT = makeFormProxy<Form>()
     expectTypeOf(formT.values.meta.tag).toEqualTypeOf<string>()
     expectTypeOf(formT.values.meta.retries).toEqualTypeOf<number>()
@@ -537,7 +538,7 @@ describe('preprocess / transform — write-boundary vs parse-time semantics', ()
         })
       ),
     })
-    type Form = ReturnType<typeof useForm<typeof _schema>>
+    type Form = UseFormReturn<typeof _schema>
     const formT = makeFormProxy<Form>()
     expectTypeOf(formT.values.meta.tag).toEqualTypeOf<string>()
   })
@@ -635,7 +636,7 @@ describe('Depth pressure — multi-step booking schema (shipment-demo shape)', (
     notes: z.string().max(500).optional(),
   })
 
-  type Form = ReturnType<typeof useForm<typeof shipmentSchema>>
+  type Form = UseFormReturn<typeof shipmentSchema>
   const formT = makeFormProxy<Form>()
 
   it('top-level scalars resolve without TS2589', () => {

--- a/test/composables/whole-form-setvalue-loop-regression.test.ts
+++ b/test/composables/whole-form-setvalue-loop-regression.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, defineComponent, h, nextTick, watch, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 import { createAttaform } from '../../src/runtime/core/plugin'
 
 /**
@@ -38,7 +39,7 @@ const schema = z.object({
   }),
 })
 
-type Api = ReturnType<typeof useForm<typeof schema>>
+type Api = UseFormReturn<typeof schema>
 
 function mount(): { app: App; api: Api } {
   let captured: Api | undefined

--- a/test/composables/write-shape.test.ts
+++ b/test/composables/write-shape.test.ts
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, it } from 'vitest'
 import { z } from 'zod'
-import type { useForm } from '../../src/zod'
+import type { UseFormConfig, UseFormReturn } from '../../src/zod'
 import type { WriteShape } from '../../src/runtime/types/types-core'
 
 /**
@@ -102,7 +102,7 @@ const _setValueSchema = z.object({
   age: z.number().int(),
   email: z.string().email(),
 })
-const setValueForm = makeFormProxy<ReturnType<typeof useForm<typeof _setValueSchema>>>()
+const setValueForm = makeFormProxy<UseFormReturn<typeof _setValueSchema>>()
 
 describe('WriteShape — applied to setValue', () => {
   const form = setValueForm
@@ -139,7 +139,7 @@ describe('WriteShape — applied to setValue', () => {
 describe('WriteShape — applied to defaultValues', () => {
   it('refinement-invalid string defaults are accepted', () => {
     const _schema = z.object({ color: z.enum(['red', 'green', 'blue']) })
-    type Defaults = Parameters<typeof useForm<typeof _schema>>[0]['defaultValues']
+    type Defaults = UseFormConfig<typeof _schema>['defaultValues']
 
     // 'teal' is not in the enum, but it's a string — slim-correct.
     expectTypeOf<{ color: 'teal' }>().toMatchTypeOf<NonNullable<Defaults>>()
@@ -147,7 +147,7 @@ describe('WriteShape — applied to defaultValues', () => {
 
   it('wrong-primitive defaults are TS errors (compile error)', () => {
     const _schema = z.object({ color: z.enum(['red', 'green', 'blue']) })
-    type Defaults = Parameters<typeof useForm<typeof _schema>>[0]['defaultValues']
+    type Defaults = UseFormConfig<typeof _schema>['defaultValues']
 
     // @ts-expect-error: number is not a string — slim-mismatch
     const _bad: Defaults = { color: 1 }
@@ -156,7 +156,7 @@ describe('WriteShape — applied to defaultValues', () => {
 })
 
 const _submitSchema = z.object({ color: z.enum(['red', 'green', 'blue']) })
-const _submitForm = makeFormProxy<ReturnType<typeof useForm<typeof _submitSchema>>>()
+const _submitForm = makeFormProxy<UseFormReturn<typeof _submitSchema>>()
 
 describe('WriteShape — handleSubmit stays strict', () => {
   it('handleSubmit data is the strict zod-output type, not WriteShape', () => {
@@ -173,7 +173,7 @@ const _readSchema = z.object({
   age: z.number().int(),
   email: z.string().email(),
 })
-const _readForm = makeFormProxy<ReturnType<typeof useForm<typeof _readSchema>>>()
+const _readForm = makeFormProxy<UseFormReturn<typeof _readSchema>>()
 
 /**
  * Read-side widening: storage holds slim-primitive-correct values

--- a/test/devtools/plugin.test.ts
+++ b/test/devtools/plugin.test.ts
@@ -6,6 +6,7 @@ import { setupAttaformDevtools } from '../../src/runtime/core/devtools'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import { createRegistry, attachRegistryToApp } from '../../src/runtime/core/registry'
 import { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
 
 /**
  * Phase 5.10 — Vue DevTools plugin contract tests.
@@ -164,7 +165,7 @@ describe('DevTools plugin — inspector + timeline wiring', () => {
   })
 
   it('emits a timeline event on submit success', async () => {
-    const handle: { api?: ReturnType<typeof useForm<z.ZodObject<{ email: z.ZodString }>>> } = {}
+    const handle: { api?: UseFormReturn<z.ZodObject<{ email: z.ZodString }>> } = {}
     const App = defineComponent({
       setup() {
         handle.api = useForm({
@@ -255,7 +256,7 @@ describe('DevTools plugin — sensitive-name redaction (B5)', () => {
 
   it('redacts sensitive leaves in form.change timeline events', async () => {
     const handle: {
-      api?: ReturnType<typeof useForm<z.ZodObject<{ email: z.ZodString; password: z.ZodString }>>>
+      api?: UseFormReturn<z.ZodObject<{ email: z.ZodString; password: z.ZodString }>>
     } = {}
     const App = defineComponent({
       setup() {


### PR DESCRIPTION
## Summary

- **Library** — Split the unified `attaform/zod` `useForm` into v4 + v3 overloads (plus an untyped impl) so concrete call sites pay the same depth budget as importing directly from `attaform/zod-v4`. New `UseFormReturn` / `UseFormConfig` helpers (with explicit `…V4` / `…V3` variants) give tests a deterministic projection where `typeof useForm<X>` instantiation expressions would otherwise resolve brittly under overloads. Four-form scopes now fit cleanly under vue-tsc.
- **Demo** — Restructured `apps/site/repl-demos/shipment-demo.vue` into four `useStepper`-driven forms (reference / cargo / service / review). Each step owns its own schema, history, and namespaced persist key; the review form's `handleSubmit` aggregates across `stepper.forms`.
- **Tests** — Migrated 61 tests from `typeof useForm<X>` queries to the new helpers.
- **Stepper history** — No-op on SecurityError when `history.pushState` / `replaceState` fires in opaque-origin embeds (Vue REPL previews, sandboxed iframes). In-memory stepper state stays authoritative; the URL bar just doesn't reflect active step inside the embed.
- **REPL infra** — Bundle zod-v3 types into the playground (Volar resolves locally instead of round-tripping unpkg), raise Vite's `server.fs.allow` to the monorepo root so dev-mode Monaco worker chunks resolve, release Monaco wheel events to the parent at editor scroll extremes.
- **Pre-commit** — Route the site's vue-tsc through `docker compose exec` so host-vs-container `unbuild --stub` absolute-path drift can't fail commits.

## Test plan

- [x] `make typecheck` passes (root + site)
- [x] `make test` — full vitest suite green
- [x] `make check` — lint + format + typecheck
- [x] `pnpm prepack && pnpm check:bundled-types` — bundled-type CI gate stays green
- [x] `make up`, visit http://localhost:3000/play, navigate the four shipment steps, verify back/forward steps through forms, submit shows aggregated payload
- [x] Monaco editor wheel releases to the parent at scroll extremes

🤖 Generated with [Claude Code](https://claude.com/claude-code)