### PR TITLE
feat: v-register on <input type="file"> (picker plumbing + persistence carve-out)

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -171,7 +171,24 @@ export default [
     //     replace-on-mount in use-stepper.ts
     //   - StepperHistoryConfig + getServerActiveStep option types
     // Measured at 38.30 KB.
-    limit: '39 KB',
+    //
+    // Raised 39 → 40 KB on the file-input v-register branch:
+    //   - vRegisterFile variant in directive.ts (real change-handler,
+    //     blank-marking on register / clear, DOM-clear via el.value = '',
+    //     scoped storage watcher for programmatic clears, persisted-file
+    //     dev warn dedup via WeakMap<PersistOptInRegistry, Set<PathKey>>)
+    //   - 'file' kind plumbing across the v4 adapter (ZodKind, kindOf,
+    //     defaultForKind, slim-primitives with 'null' acceptance, plus
+    //     case additions in assertSupportedKinds, fingerprint,
+    //     path-walker, strip, adapter.walkForMeta)
+    //   - cross-adapter SlimPrimitiveKind 'file' + slimKindOf File
+    //     branch, v3 PERMISSIVE_V3 'file' entry
+    //   - LeafWalker 'File' primitive so form.fields.<file-path>
+    //     resolves to FieldState
+    //   - syncPersistOptIn carve-out reads vnode.props.type to dodge
+    //     the el.type pre-patch timing window
+    // Measured at 38.78 KB.
+    limit: '40 KB',
     gzip: true,
     modifyEsbuildConfig: asEsm,
   },
@@ -244,7 +261,11 @@ export default [
     // unified `attaform/zod` entry. The full stepper surface
     // (composable + registry + statuses proxy + history primitive)
     // now ships through this bundle too. Measured at 50.40 KB.
-    limit: '51 KB',
+    //
+    // Raised 51 → 52 KB tracking index.mjs's file-input v-register
+    // bump (same shared core chunk: vRegisterFile variant, 'file'
+    // ZodKind plumbing, persistence carve-out). Measured at 50.99 KB.
+    limit: '52 KB',
     gzip: true,
     ignore: ['zod'],
     modifyEsbuildConfig: asEsm,
@@ -271,7 +292,12 @@ export default [
     // Raised 43 → 45 KB when `useStepper` was re-exported from the
     // `attaform/zod-v4` subpath. Same surface addition as the
     // `attaform/zod` unified entry. Measured at 44.46 KB.
-    limit: '45 KB',
+    //
+    // Raised 45 → 46 KB tracking index.mjs's file-input v-register
+    // bump (same shared core chunk + v4-side 'file' ZodKind plumbing
+    // across kindOf / defaultForKind / slim-primitives / fingerprint /
+    // path-walker / strip / walkForMeta). Measured at 45.02 KB.
+    limit: '46 KB',
     gzip: true,
     ignore: ['zod'],
     modifyEsbuildConfig: asEsm,
@@ -324,7 +350,11 @@ export default [
     // Raised 42 → 44 KB when `useStepper` was re-exported from the
     // `attaform/zod-v3` subpath. Same surface addition as the
     // `attaform/zod` unified entry. Measured at 43.86 KB.
-    limit: '44 KB',
+    //
+    // Raised 44 → 45 KB tracking index.mjs's file-input v-register
+    // bump (same shared core chunk + v3 PERMISSIVE_V3 'file' entry).
+    // Measured at 44.41 KB.
+    limit: '45 KB',
     gzip: true,
     ignore: ['zod', 'lodash-es'],
     modifyEsbuildConfig: asEsm,

--- a/docs/recipes/file-uploads.md
+++ b/docs/recipes/file-uploads.md
@@ -1,0 +1,203 @@
+---
+title: 'File uploads'
+description: 'How Attaform binds `<input type="file">` to form state — picking, clearing, validation, and the production pattern for persisting uploads across reloads.'
+---
+
+# `<input type="file" v-register>`
+
+`v-register` binds `<input type="file">` to form state the same way it
+binds every other native input. Picks flow into storage as `File | null`
+(single) or `File[]` (multiple). Required-file fields surface
+"No value supplied" through the same `derivedBlankErrors` channel as
+required numbers or bigints. The schema author writes `z.file()` (Zod 4)
+or `z.instanceof(File)` (Zod 3) and gets typed inference back without
+any plumbing.
+
+```vue
+<script setup lang="ts">
+  import { z } from 'zod'
+  import { useForm } from 'attaform/zod'
+
+  const schema = z.object({
+    avatar: z.file().nullable(),
+    docs: z.array(z.file()),
+  })
+
+  const form = useForm({ schema, key: 'profile' })
+</script>
+
+<template>
+  <form @submit="form.handleSubmit((data) => upload(data))">
+    <input v-register="form.register('avatar')" type="file" accept="image/*" />
+    <input v-register="form.register('docs')" type="file" multiple />
+  </form>
+</template>
+```
+
+## Storage shape
+
+| Element                        | Storage value  | Blank state                   |
+| ------------------------------ | -------------- | ----------------------------- |
+| `<input type="file">`          | `File \| null` | `null` + path in `blankPaths` |
+| `<input type="file" multiple>` | `File[]`       | `[]` + path in `blankPaths`   |
+
+The directive canonicalises blank storage to `null` / `[]` regardless of
+how you expressed "optional file" in the schema — `z.file()`,
+`z.file().nullable()`, or `z.file().optional()` all settle to the same
+runtime shape on register and on clear.
+
+## What the directive owns
+
+The variant takes care of:
+
+- Reading `event.target.files` on change → writing `File` / `File[]` /
+  `null` to storage.
+- Detecting `multiple` from the DOM (`el.multiple`) so the right shape
+  lands.
+- Marking the path in `blankPaths` whenever storage transitions to the
+  blank shape — on register, on user clear, on `form.clear(path)`, on
+  `form.reset()`, and on hydration. The friendly "No value supplied"
+  error stays accurate without any consumer code.
+- Clearing the DOM input (`el.value = ''`) when storage goes blank.
+  The browser blocks every other programmatic write to `input.files`
+  for security, but the empty-string assignment is permitted.
+- Refusing to opt the path into persistence regardless of
+  `register(path, { persist: true })` — see below.
+
+## Files don't persist
+
+`File` objects are transient browser-side handles. They can't survive a
+reload by design:
+
+- `JSON.stringify(new File([...], 'x'))` returns `"{}"`. The browser
+  doesn't expose the bytes to serialization.
+- `input.files` is read-only at the browser layer. Even if you
+  serialized the bytes elsewhere and rehydrated, you couldn't push a
+  reconstructed `File` back into the DOM input.
+- `localStorage` caps at ~5 MB anyway. A single phone photo blows past
+  that.
+
+So Attaform carves file paths out of the persistence opt-in registry
+entirely. A file input registered with `{ persist: true }` is silently
+ignored at the persistence boundary, and a one-time dev warning fires
+to surface the gap during development:
+
+```
+[attaform] register('avatar', { persist: true }) on <input type="file"> —
+files can't ride a refresh (browsers block programmatic writes to
+<input type="file">), so this path won't be saved. For long-lived
+flows, upload on selection and persist the resulting URL or ID in a
+sibling string field.
+```
+
+The warning fires once per `(form, path)` so it surfaces during dev
+without flooding the console. In production builds it's tree-shaken
+out.
+
+## The production pattern — upload on selection
+
+For long-running forms (SAAS onboarding, multi-step uploads, anything
+non-trivial), pair an **ephemeral File field** with a **persisted URL
+field**. The File ride the picker UI; the URL rides the form state
+across refreshes.
+
+```vue
+<script setup lang="ts">
+  import { watch } from 'vue'
+  import { z } from 'zod'
+  import { useForm } from 'attaform/zod'
+
+  const schema = z.object({
+    // Ephemeral handle for the picker UI — never persists.
+    idFile: z.file().nullable(),
+
+    // The "real" field your backend cares about. Survives refresh.
+    idUrl: z.string().url(),
+  })
+
+  const form = useForm({ schema, key: 'shipment', persist: 'local' })
+
+  watch(
+    () => form.values.idFile,
+    async (file) => {
+      if (file === null) return
+      const url = await uploadToBackend(file)
+      form.setValue('idUrl', url)
+    }
+  )
+</script>
+
+<template>
+  <input v-register="form.register('idFile')" type="file" accept="application/pdf" />
+  <span v-if="form.values.idUrl">Already uploaded ✓</span>
+</template>
+```
+
+After a refresh: `idFile` is back at `null` (correctly — can't persist),
+but `idUrl` survives. The form remembers the upload already happened
+and the user doesn't have to redo it.
+
+## What happens on a refresh without the URL pattern
+
+Short-lived forms can skip the URL plumbing and accept the trade-off:
+on refresh, the file is gone and the user re-picks. Validation makes
+the gap obvious — the required-file error surfaces immediately:
+
+```ts
+const schema = z.object({ id: z.file() })
+const form = useForm({ schema, key: 'contact', persist: 'local' })
+
+// On reload: form.values.id === null, fields.id.blank === true,
+// errors.id includes "No value supplied". The user re-picks the file
+// to satisfy the schema before submit.
+```
+
+Perfectly fine for a 30-second contact form. For anything where losing
+a file is painful (an ID upload mid-stepper, a draft document, a
+multi-photo gallery), use the upload-on-select pattern above.
+
+## Validation
+
+Schema-level constraints on files work the way you'd expect:
+
+```ts
+const schema = z.object({
+  avatar: z
+    .file()
+    .max(2 * 1024 * 1024)
+    .mime(['image/png', 'image/jpeg']),
+  docs: z
+    .array(z.file().max(5 * 1024 * 1024))
+    .min(1)
+    .max(10),
+})
+```
+
+Refinement errors surface through `form.errors.<path>` and per-field
+`fields.<path>.errors`. The "No value supplied" error (from the blank
+channel) wins display priority over schema errors so users see the
+relevant message first — _"upload an ID"_ instead of
+_"Expected File, received null"_.
+
+## Zod 3 vs Zod 4
+
+Both work the same through the directive — file events flow into form
+state identically regardless of which schema major produced the field.
+The schema-level idiom differs:
+
+- **Zod 4**: `z.file()` is native, with `.min(size)` / `.max(size)` /
+  `.mime([...])` constraints.
+- **Zod 3**: `z.instanceof(File)` (single) and
+  `z.array(z.instanceof(File))` (multiple). Custom refinements via
+  `.refine((f) => f.size <= MAX, ...)`.
+
+Use whichever your project's adapter is on. The Attaform plumbing
+treats both the same once the value lands in storage.
+
+## SSR
+
+The directive's listener-attachment is client-only — Vue skips
+directive lifecycle hooks during SSR, so server renders emit an empty
+file input and hydration takes over from there. There's nothing
+file-specific to configure for SSR; the same `useForm` + `v-register`
+that works for text inputs works here.

--- a/src/runtime/adapters/zod-v3/slim-primitives.ts
+++ b/src/runtime/adapters/zod-v3/slim-primitives.ts
@@ -27,6 +27,7 @@ export const PERMISSIVE_V3: ReadonlySet<SlimPrimitiveKind> = new Set<SlimPrimiti
   'function',
   'map',
   'set',
+  'file',
 ])
 
 const MAX_LAZY_DEPTH_V3 = 64

--- a/src/runtime/adapters/zod-v4/adapter.ts
+++ b/src/runtime/adapters/zod-v4/adapter.ts
@@ -920,6 +920,7 @@ function walkForMeta(
       case 'custom':
       case 'template-literal':
       case 'transform':
+      case 'file':
         return
     }
   } finally {

--- a/src/runtime/adapters/zod-v4/assert-supported.ts
+++ b/src/runtime/adapters/zod-v4/assert-supported.ts
@@ -150,6 +150,7 @@ export function assertSupportedKinds(
     case 'custom':
     case 'template-literal':
     case 'transform':
+    case 'file':
       return
     default: {
       const _exhaustive: never = kind

--- a/src/runtime/adapters/zod-v4/default-values.ts
+++ b/src/runtime/adapters/zod-v4/default-values.ts
@@ -212,6 +212,13 @@ function defaultForKind(
       // Kept for exhaustive switch safety when `deriveDefault` is
       // called directly in tests.
       return undefined
+    case 'file':
+      // `z.file()` has no canonical "empty file" — the user picks one
+      // through the directive's change handler. `null` is the storage
+      // blank value the directive canonicalises to on register / clear;
+      // emitting `null` here keeps `getEmptyValueAtPath` aligned with
+      // what `form.clear(path)` writes.
+      return null
     default: {
       const _exhaustive: never = kind
       throw new Error(`deriveDefault: unhandled ZodKind '${_exhaustive as string}'`)

--- a/src/runtime/adapters/zod-v4/fingerprint.ts
+++ b/src/runtime/adapters/zod-v4/fingerprint.ts
@@ -229,6 +229,7 @@ function computeFingerprint(
     case 'custom':
     case 'template-literal':
     case 'transform':
+    case 'file':
       return `${kind}:*`
 
     default: {

--- a/src/runtime/adapters/zod-v4/introspect.ts
+++ b/src/runtime/adapters/zod-v4/introspect.ts
@@ -49,6 +49,7 @@ export type ZodKind =
   | 'custom'
   | 'template-literal'
   | 'transform'
+  | 'file'
 
 // Narrow accessor for the unstable `def` surface. All reads from this
 // object go through helpers below — never inline.
@@ -170,6 +171,8 @@ export function kindOf(schema: unknown): ZodKind {
     case 'template_literal':
     case 'templateLiteral':
       return 'template-literal'
+    case 'file':
+      return 'file'
     default:
       return 'unknown'
   }

--- a/src/runtime/adapters/zod-v4/path-walker.ts
+++ b/src/runtime/adapters/zod-v4/path-walker.ts
@@ -153,9 +153,10 @@ function walkSegments(
     case 'custom':
     case 'template-literal':
     case 'transform':
+    case 'file':
       // ZodTransform is the input side of `z.preprocess(fn, inner)` and
       // not directly walkable; callers reach `inner` through the
-      // surrounding pipe.
+      // surrounding pipe. `file` is a leaf with no sub-paths.
       return []
     default: {
       const _exhaustive: never = kind

--- a/src/runtime/adapters/zod-v4/slim-primitives.ts
+++ b/src/runtime/adapters/zod-v4/slim-primitives.ts
@@ -37,6 +37,7 @@ export const PERMISSIVE: ReadonlySet<SlimPrimitiveKind> = new Set<SlimPrimitiveK
   'function',
   'map',
   'set',
+  'file',
 ])
 
 /**
@@ -78,6 +79,19 @@ function walk(schema: z.ZodType, lazyDepth: number, maxDepth: number): Set<SlimP
       return new Set(['bigint'])
     case 'date':
       return new Set(['date'])
+    case 'file':
+      // `z.file()` accepts `File` instances at write time. `null` is
+      // also accepted at the slim-primitive level so the directive's
+      // canonical blank value (the "no file selected" sentinel) lands
+      // even on required-file schemas — the blank-path channel + the
+      // derived "No value supplied" error already gates submission, so
+      // permitting `null` storage here doesn't loosen schema enforcement.
+      //
+      // The set's lack of container kinds (`object` / `array` / `map`
+      // / `set`) makes the path a leaf via `isLeafAtPath`, so
+      // `form.fields.<file-path>` returns a FieldState rather than
+      // descending into the File's own keys.
+      return new Set(['file', 'null'])
     case 'null':
       return new Set(['null'])
     case 'undefined':

--- a/src/runtime/adapters/zod-v4/strip.ts
+++ b/src/runtime/adapters/zod-v4/strip.ts
@@ -174,6 +174,7 @@ export function stripRefinements(schema: z.ZodType): z.ZodType {
     case 'custom':
     case 'template-literal':
     case 'transform':
+    case 'file':
       return schema
     default: {
       // Compile-time exhaustiveness pin. If `ZodKind` grows a new
@@ -342,6 +343,7 @@ export function stripAsyncChecks(schema: z.ZodType): z.ZodType {
       case 'custom':
       case 'template-literal':
       case 'transform':
+      case 'file':
         return s
       default: {
         const _exhaustive: never = kind
@@ -565,10 +567,12 @@ function walkSlim(
       return (slimmedInner as z.ZodType).catch(getCatchDefault(schema) as never)
     }
     case 'transform':
+    case 'file':
       // ZodTransform is the input side of `z.preprocess(fn, inner)` and
       // never appears as a top-level schema reachable from the slim path
       // (the surrounding pipe descends into `.out` for the inner shape).
-      // Pass through unchanged for exhaustive switch safety.
+      // `file` has no refinements to strip beyond what the leaf schema
+      // already represents. Pass through unchanged.
       return schema
     default: {
       const _exhaustive: never = kind

--- a/src/runtime/core/directive.ts
+++ b/src/runtime/core/directive.ts
@@ -25,7 +25,7 @@ import {
   looseToNumber,
 } from './vue-shared-shim'
 import type { DirectiveBinding, DirectiveHook, ObjectDirective, VNode } from 'vue'
-import { isRef, nextTick, warn } from 'vue'
+import { effectScope, isRef, nextTick, warn, watch } from 'vue'
 import { REGISTER_OWNER_MARKER } from '../composables/use-register'
 import { __DEV__ } from './dev'
 import type {
@@ -415,7 +415,12 @@ const getModelAssigner = (
  * cross-form / cross-SFC case where `register()` returns a value bound
  * to a different FormStore (different `persistOptIns` instance).
  */
-function syncPersistOptIn(el: HTMLElement, value: unknown, oldValue: unknown): void {
+function syncPersistOptIn(
+  el: HTMLElement,
+  value: unknown,
+  oldValue: unknown,
+  vnodeType: unknown
+): void {
   const wasOptedIn = isRegisterValue(oldValue) && oldValue.persist === true
   // File inputs can't survive a reload — `input.files` is read-only at
   // the browser layer, so even a perfect base64 round-trip couldn't
@@ -423,7 +428,14 @@ function syncPersistOptIn(el: HTMLElement, value: unknown, oldValue: unknown): v
   // path never enters `optedInPaths`, never reaches the serializer, and
   // a separate `vRegisterFile` hook can surface the one-time dev warn
   // pointing consumers at the upload-on-select pattern.
-  const isFileInput = el.tagName === 'INPUT' && (el as HTMLInputElement).type === 'file'
+  //
+  // Detection consults `vnode.props.type` (passed in) first, then
+  // `el.type` as a fallback. During `created`, Vue may not have
+  // patched the `type` property onto the element yet — the vnode's
+  // prop is the authoritative pre-patch source. On `beforeUpdate` the
+  // element is fully patched and `el.type` agrees.
+  const isFileInput =
+    el.tagName === 'INPUT' && (vnodeType === 'file' || (el as HTMLInputElement).type === 'file')
   const wantsOptIn = !isFileInput && isRegisterValue(value) && value.persist === true
   if (!wasOptedIn && !wantsOptIn) return
   const elementId = getOrAssignElementId(el)
@@ -1355,7 +1367,7 @@ const vRegisterDynamic: RegisterModelDynamicCustomDirective = {
   created(el, binding, vnode) {
     // Per-element persist opt-in is reconciled at the dynamic level so
     // the per-tag variants stay focused on their input semantics.
-    syncPersistOptIn(el, binding.value, undefined)
+    syncPersistOptIn(el, binding.value, undefined, vnode.props?.['type'])
     // Per-path multi-tab opt-out lives at the dynamic level too —
     // ref-counted on the FormStore so multiple bindings on the same
     // path balance correctly across conditional renders.
@@ -1405,7 +1417,7 @@ const vRegisterDynamic: RegisterModelDynamicCustomDirective = {
     // re-evaluates on every parent render. `binding.oldValue` holds the
     // prior RegisterValue so the helper can diff persist / path / registry
     // and migrate the entry without thrashing.
-    syncPersistOptIn(el, binding.value, binding.oldValue)
+    syncPersistOptIn(el, binding.value, binding.oldValue, vnode.props?.['type'])
     // Reactive multi-tab opt-out toggling — same diff strategy.
     syncMultiTabOptOut(binding.value, binding.oldValue)
     // Same diff for the form's element map. Catches the
@@ -1518,6 +1530,13 @@ function maybeWarnPersistedFile(value: RegisterValue): void {
 // `beforeUpdate` hook keeps the DOM in lockstep with storage by
 // clearing `el.value` when storage transitions to blank — the only
 // programmatic write browsers permit on file inputs.
+// Symbol slot for the per-element effect-scope teardown function. The
+// blank-resync watcher inside `created` runs in its own scope so we
+// can stop it on `beforeUnmount` without depending on the surrounding
+// component still being alive.
+const fileScopeKey: unique symbol = Symbol.for('attaform:file-scope')
+type FileScopeCarrier = { [fileScopeKey]?: () => void }
+
 const vRegisterFile: RegisterModelDynamicCustomDirective = {
   created(el, { value }) {
     if (!isRegisterValue(value)) return
@@ -1544,22 +1563,58 @@ const vRegisterFile: RegisterModelDynamicCustomDirective = {
       const blank = isBlankFileValue(next)
       value.setValueWithInternalPath(next, blank ? { blank: true } : undefined)
     })
+
+    // Watch storage for programmatic transitions to the blank shape
+    // (`form.clear(path)` / `form.reset()` / hydrate). Re-mark the
+    // path blank and clear the DOM input. `beforeUpdate` covers the
+    // common parent-re-render case; this watcher catches storage
+    // mutations that don't trigger a parent re-render. Runs in its
+    // own effect scope so we can stop it from `beforeUnmount`
+    // independent of the surrounding component.
+    const scope = effectScope(true)
+    scope.run(() => {
+      watch(
+        value.innerRef,
+        (next) => {
+          if (!isBlankFileValue(next)) return
+          value.setValueWithInternalPath(next, { blank: true })
+          if (input.value !== '') input.value = ''
+        },
+        { flush: 'post' }
+      )
+    })
+    ;(input as FileScopeCarrier)[fileScopeKey] = (): void => scope.stop()
   },
   beforeUpdate(el, { value }) {
     if (!isRegisterValue(value)) return
     const input = el as HTMLInputElement
-    // Storage → DOM sync. The only programmatic mutation browsers allow
-    // on a file input is `el.value = ''` (the clear path). Drive that
-    // from the blank-shape predicate so `form.clear(path)` and
-    // `form.reset()` visibly empty the input without coupling the
-    // directive to the storage container's specific empty value.
+    // Storage → DOM + blankPaths sync. Two responsibilities:
+    //
+    //   1. Clear the DOM input when storage went blank
+    //      (`form.clear(path)` / `form.reset()` / hydrate). `el.value
+    //      = ''` is the one programmatic mutation browsers allow on
+    //      `<input type="file">`.
+    //
+    //   2. Re-mark the path blank in the store so `derivedBlankErrors`
+    //      keeps firing the friendly "No value supplied" message after
+    //      programmatic clears. `form.clear` writes the schema's empty
+    //      value (`null`) but doesn't propagate `meta.blank: true`, so
+    //      the path would otherwise drift out of `blankPaths`. The
+    //      store's `Set.add` is idempotent, and identity-equal writes
+    //      don't trigger re-renders — safe to call on every update.
     const currentRaw = value.innerRef.value
-    if (isBlankFileValue(currentRaw) && input.value !== '') {
-      input.value = ''
+    if (isBlankFileValue(currentRaw)) {
+      value.setValueWithInternalPath(currentRaw, { blank: true })
+      if (input.value !== '') input.value = ''
     }
   },
   beforeUnmount(el, { value }) {
     removeTrackedListeners(el)
+    const stop = (el as FileScopeCarrier)[fileScopeKey]
+    if (stop !== undefined) {
+      stop()
+      delete (el as FileScopeCarrier)[fileScopeKey]
+    }
     if (!isRegisterValue(value)) return
     value.deregisterElement(el)
   },

--- a/src/runtime/core/directive.ts
+++ b/src/runtime/core/directive.ts
@@ -41,6 +41,7 @@ import type {
   WriteMeta,
 } from '../types/types-api'
 import type { PathKey } from './paths'
+import type { PersistOptInRegistry } from './persistence/opt-in-registry'
 import { getOrAssignElementId } from './persistence/opt-in-registry'
 import { enforceSensitiveCheck } from './persistence/sensitive-names'
 
@@ -416,7 +417,14 @@ const getModelAssigner = (
  */
 function syncPersistOptIn(el: HTMLElement, value: unknown, oldValue: unknown): void {
   const wasOptedIn = isRegisterValue(oldValue) && oldValue.persist === true
-  const wantsOptIn = isRegisterValue(value) && value.persist === true
+  // File inputs can't survive a reload — `input.files` is read-only at
+  // the browser layer, so even a perfect base64 round-trip couldn't
+  // restore the picked file. The registry carve-out lives here so the
+  // path never enters `optedInPaths`, never reaches the serializer, and
+  // a separate `vRegisterFile` hook can surface the one-time dev warn
+  // pointing consumers at the upload-on-select pattern.
+  const isFileInput = el.tagName === 'INPUT' && (el as HTMLInputElement).type === 'file'
+  const wantsOptIn = !isFileInput && isRegisterValue(value) && value.persist === true
   if (!wasOptedIn && !wantsOptIn) return
   const elementId = getOrAssignElementId(el)
   // Detach the old opt-in unless every dimension matches (persist still
@@ -1443,27 +1451,114 @@ const vRegisterDynamic: RegisterModelDynamicCustomDirective = {
   },
 }
 
-// No-op variant for <input type="file">. Setting el.value on a file input
-// throws a DOMException for security reasons; the compile-time transform
-// skips this case, and this runtime directive routes reactive type="file"
-// (e.g. `:type="isUpload ? 'file' : 'text'"`) to a no-op too, still tracking
-// the element for focus-state purposes.
-const vRegisterFileNoop: RegisterModelDynamicCustomDirective = {
+// True for any value the file directive treats as "no file selected":
+// `null`, `undefined`, the empty array (multi-input cleared), and an
+// empty `FileList`. Strict equality short-circuits the common cases;
+// the FileList check covers the case where a host wrote the live DOM
+// FileList back into storage (rare, but cheap to handle).
+function isBlankFileValue(value: unknown): boolean {
+  if (value === null || value === undefined) return true
+  if (Array.isArray(value) && value.length === 0) return true
+  if (typeof FileList !== 'undefined' && value instanceof FileList && value.length === 0)
+    return true
+  return false
+}
+
+// Read the current selection off a file input and reshape to the
+// directive's canonical storage form: `File[]` when the element has the
+// `multiple` attribute, `File | null` otherwise. `el.files` is `null`
+// on programmatically-detached inputs and the FileList is empty when
+// the user picked nothing — both collapse to the blank shape.
+function readFilesFromInput(el: HTMLInputElement): File[] | File | null {
+  const files = el.files
+  if (el.multiple) {
+    return files === null ? [] : Array.from(files)
+  }
+  if (files === null || files.length === 0) return null
+  return files.item(0)
+}
+
+// Per-form dedupe for the persisted-file-input dev warning. Keyed on
+// the form's `PersistOptInRegistry` (every form has its own instance)
+// so the warning fires once per (form, path) — a single noisy hint
+// during development rather than per-mount, per-keystroke noise.
+const warnedPersistedFileForms: WeakMap<PersistOptInRegistry, Set<PathKey>> | null = __DEV__
+  ? new WeakMap<PersistOptInRegistry, Set<PathKey>>()
+  : null
+
+function maybeWarnPersistedFile(value: RegisterValue): void {
+  if (!__DEV__ || warnedPersistedFileForms === null) return
+  if (value.persist !== true) return
+  let warnedPaths = warnedPersistedFileForms.get(value.persistOptIns)
+  if (warnedPaths === undefined) {
+    warnedPaths = new Set<PathKey>()
+    warnedPersistedFileForms.set(value.persistOptIns, warnedPaths)
+  }
+  if (warnedPaths.has(value.path)) return
+  warnedPaths.add(value.path)
+  warn(
+    `[attaform] register('${value.path}', { persist: true }) on <input type="file"> — ` +
+      `files can't ride a refresh (browsers block programmatic writes to ` +
+      `<input type="file">), so this path won't be saved. For long-lived ` +
+      `flows, upload on selection and persist the resulting URL or ID in a ` +
+      `sibling string field.`
+  )
+}
+
+// Real `v-register` variant for `<input type="file">`. Reads
+// `event.target.files` into form state as `File | null` (single) or
+// `File[]` (multiple). Storage is the canonical blank shape (`null` /
+// `[]`) when no file is selected, with the path marked in
+// `blankPaths` so the friendly "No value supplied" error surfaces
+// through `derivedBlankErrors` on required-file fields — same channel
+// as required numbers / bigints.
+//
+// The persistence carve-out lives in `syncPersistOptIn`: file paths
+// never enter `persistOptIns`, never serialize, never rehydrate. The
+// `beforeUpdate` hook keeps the DOM in lockstep with storage by
+// clearing `el.value` when storage transitions to blank — the only
+// programmatic write browsers permit on file inputs.
+const vRegisterFile: RegisterModelDynamicCustomDirective = {
   created(el, { value }) {
     if (!isRegisterValue(value)) return
-    value.registerElement(el)
-    if (__DEV__) {
-      warn(
-        '[attaform] v-register on <input type="file"> is not supported. ' +
-          'Handle uploads with a manual @change listener.'
-      )
+    // `resolveDynamicModel` routes here only when `el.tagName === 'INPUT'`
+    // and `el.type === 'file'`. The variant union type widens to include
+    // select/textarea, so narrow once per hook.
+    const input = el as HTMLInputElement
+    value.registerElement(input)
+    maybeWarnPersistedFile(value)
+
+    // Seed the blank-path channel on register. Storage shape gets
+    // canonicalised to `null` / `[]` whenever the consumer's default
+    // is loosely blank (e.g. `undefined` for a non-nullable
+    // `z.file()` schema), so reads return a uniform shape regardless
+    // of how the user expressed "optional file" in their schema.
+    const currentRaw = value.innerRef.value
+    if (isBlankFileValue(currentRaw)) {
+      const blankShape: File[] | null = input.multiple ? [] : null
+      value.setValueWithInternalPath(blankShape, { blank: true })
+    }
+
+    addEventListener(input, 'change', () => {
+      const next = readFilesFromInput(input)
+      const blank = isBlankFileValue(next)
+      value.setValueWithInternalPath(next, blank ? { blank: true } : undefined)
+    })
+  },
+  beforeUpdate(el, { value }) {
+    if (!isRegisterValue(value)) return
+    const input = el as HTMLInputElement
+    // Storage → DOM sync. The only programmatic mutation browsers allow
+    // on a file input is `el.value = ''` (the clear path). Drive that
+    // from the blank-shape predicate so `form.clear(path)` and
+    // `form.reset()` visibly empty the input without coupling the
+    // directive to the storage container's specific empty value.
+    const currentRaw = value.innerRef.value
+    if (isBlankFileValue(currentRaw) && input.value !== '') {
+      input.value = ''
     }
   },
   beforeUnmount(el, { value }) {
-    // The file-input variant attaches no listeners, but we still drain
-    // the bag defensively — a runtime-typed `:type` binding that flipped
-    // from 'text' to 'file' on a reused element would have left the text
-    // variant's listeners attached.
     removeTrackedListeners(el)
     if (!isRegisterValue(value)) return
     value.deregisterElement(el)
@@ -1477,7 +1572,7 @@ function resolveDynamicModel(tagName: string, type: unknown) {
   if (tagName === 'SELECT') return vRegisterSelect
   if (tagName === 'TEXTAREA') return vRegisterText
   if (typeof type !== 'string') return vRegisterText
-  if (type === 'file') return vRegisterFileNoop
+  if (type === 'file') return vRegisterFile
   if (type === 'checkbox') return vRegisterCheckbox
   if (type === 'radio') return vRegisterRadio
   return vRegisterText

--- a/src/runtime/core/slim-primitive-gate.ts
+++ b/src/runtime/core/slim-primitive-gate.ts
@@ -56,6 +56,10 @@ export function slimKindOf(value: unknown): SlimPrimitiveKind {
   if (value instanceof Date) return 'date'
   if (value instanceof Map) return 'map'
   if (value instanceof Set) return 'set'
+  // Guard the global access — File is browser/Node-21+ only; falling
+  // through to 'object' on platforms where it's not defined leaves
+  // server-side rendering uncoupled from the DOM globals.
+  if (typeof File !== 'undefined' && value instanceof File) return 'file'
   const t = typeof value
   switch (t) {
     case 'string':

--- a/src/runtime/lib/core/transforms/input-text-area-transform.ts
+++ b/src/runtime/lib/core/transforms/input-text-area-transform.ts
@@ -206,12 +206,15 @@ export const inputTextAreaNodeTransform: NodeTransform = (node) => {
     const registerSummarizedProp = elementProps[registerIndex]
     if (!registerSummarizedProp) return // no v-register directive; nothing to transform
 
-    // <input type="file" v-register="..."> silently skipped — at runtime the
-    // directive routes to a no-op variant. Trying to set el.value on a file
-    // input throws a DOMException for security reasons. We must skip not just
-    // the static type="file" case but any dynamic binding (`:type="x"`,
-    // template-literal expressions, etc.) that COULD resolve to "file" at
-    // runtime — `couldResolveToFileType` errs on the conservative side.
+    // <input type="file" v-register="..."> bypasses the value-binding
+    // injection — the runtime `vRegisterFile` variant owns the DOM
+    // contract for file inputs (read `el.files` on change; clear via
+    // `el.value = ''` only). Skipping at compile-time avoids the
+    // `:value=""` binding browsers would otherwise reject on a file
+    // input. We must skip not just the static `type="file"` case but any
+    // dynamic binding (`:type="x"`, template-literal expressions, etc.)
+    // that COULD resolve to "file" at runtime — `couldResolveToFileType`
+    // errs on the conservative side.
     const typeIndex = elementProps.findIndex((p) => isExactKey(p.key, 'type'))
     const typeProp = elementProps[typeIndex]
     if (typeProp !== undefined && couldResolveToFileType(typeProp.value)) return

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -613,6 +613,7 @@ export type SlimPrimitiveKind =
   | 'function'
   | 'map'
   | 'set'
+  | 'file'
 
 /**
  * The "no result yet" status returned by the reactive `validate()` ref
@@ -2702,7 +2703,7 @@ export type LeafWalker<
   T,
   Kind extends keyof LeafSchemeFor<unknown>,
   StripOptional extends boolean = true,
-> = [T] extends [string | number | boolean | bigint | symbol | null | undefined | Date]
+> = [T] extends [string | number | boolean | bigint | symbol | null | undefined | Date | File]
   ? LeafSchemeFor<T>[Kind]
   : [T] extends [ReadonlyArray<infer U>]
     ? { readonly [K: number]: LeafWalker<U, Kind, StripOptional> }

--- a/test/composables/file.test.ts
+++ b/test/composables/file.test.ts
@@ -1,0 +1,488 @@
+// @vitest-environment jsdom
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, withDirectives, type App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import type { UseFormReturn } from '../../src/zod'
+import { vRegister } from '../../src/runtime/core/directive'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import { waitUntil } from '../utils/form-harness'
+
+/**
+ * `<input type="file" v-register>` end-to-end coverage.
+ *
+ * The variant reads `el.files` on change and writes the canonical
+ * storage shape: `File | null` (single) or `File[]` (multiple). Blank
+ * paths are marked through `setValueWithInternalPath`'s `{ blank:
+ * true }` meta so required-file fields surface "No value supplied"
+ * via `derivedBlankErrors`. Persistence is carved out at
+ * `syncPersistOptIn` — file paths never enter `optedInPaths`.
+ *
+ * Tests use `z.file().nullable()` (v4 native). The directive itself is
+ * DOM-driven, not schema-driven — v3's `z.instanceof(File)` flows
+ * through the same code paths.
+ */
+
+function dispatchChange(el: HTMLInputElement): void {
+  el.dispatchEvent(new Event('change', { bubbles: true }))
+}
+
+// jsdom marks `el.files` read-only. Override with a `defineProperty`
+// stand-in so tests can simulate user picks without driving the
+// native file-picker (which doesn't exist in jsdom).
+function setFiles(el: HTMLInputElement, files: File[]): void {
+  // FileList isn't constructible; use a typed array-like that mimics
+  // the `length` + indexed access + `item(i)` surface.
+  const list = {
+    ...files,
+    length: files.length,
+    item(index: number) {
+      return files[index] ?? null
+    },
+    [Symbol.iterator]() {
+      let i = 0
+      return {
+        next: () =>
+          i < files.length
+            ? { value: files[i++] as File, done: false as const }
+            : { value: undefined as unknown as File, done: true as const },
+      }
+    },
+  } as unknown as FileList
+  Object.defineProperty(el, 'files', { value: list, configurable: true })
+}
+
+function makeFile(name = 'photo.png', size = 1024, type = 'image/png'): File {
+  const buf = new Uint8Array(size)
+  return new File([buf], name, { type })
+}
+
+describe('<input type="file" v-register> — single file', () => {
+  let app: App | undefined
+
+  afterEach(() => {
+    app?.unmount()
+    app = undefined
+    document.body.innerHTML = ''
+  })
+
+  it('picking a file writes the File to storage and drops the path from blankPaths', async () => {
+    const schema = z.object({ avatar: z.file().nullable() })
+    const captured: { api?: UseFormReturn<typeof schema> } = {}
+
+    const Parent = defineComponent({
+      setup() {
+        const form = useForm({ schema, key: 'file-single', strict: false })
+        captured.api = form
+        return () =>
+          withDirectives(h('input', { type: 'file', class: 'avatar' }), [
+            [vRegister, form.register('avatar')],
+          ])
+      },
+    })
+
+    app = createApp(Parent).use(createAttaform())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await waitUntil(() => (captured.api?.fields.avatar.blank === true ? true : null))
+
+    if (captured.api === undefined) throw new Error('unreachable')
+    const input = root.querySelector('input.avatar') as HTMLInputElement
+    expect(input.type).toBe('file')
+    expect(captured.api.values.avatar).toBeNull()
+    expect(captured.api.fields.avatar.blank).toBe(true)
+
+    const picked = makeFile()
+    setFiles(input, [picked])
+    dispatchChange(input)
+
+    await waitUntil(() => (captured.api?.values.avatar instanceof File ? true : null))
+    expect(captured.api.values.avatar).toBe(picked)
+    expect(captured.api.fields.avatar.blank).toBe(false)
+  })
+
+  it('clearing (empty FileList) writes null and re-marks blank', async () => {
+    const schema = z.object({ avatar: z.file().nullable() })
+    const captured: { api?: UseFormReturn<typeof schema> } = {}
+
+    const Parent = defineComponent({
+      setup() {
+        const form = useForm({ schema, key: 'file-clear', strict: false })
+        captured.api = form
+        return () =>
+          withDirectives(h('input', { type: 'file', class: 'avatar' }), [
+            [vRegister, form.register('avatar')],
+          ])
+      },
+    })
+
+    app = createApp(Parent).use(createAttaform())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await waitUntil(() => (captured.api?.fields.avatar.blank === true ? true : null))
+
+    if (captured.api === undefined) throw new Error('unreachable')
+    const input = root.querySelector('input.avatar') as HTMLInputElement
+
+    setFiles(input, [makeFile()])
+    dispatchChange(input)
+    await waitUntil(() => (captured.api?.values.avatar instanceof File ? true : null))
+    expect(captured.api.fields.avatar.blank).toBe(false)
+
+    setFiles(input, [])
+    dispatchChange(input)
+    await waitUntil(() => (captured.api?.values.avatar === null ? true : null))
+    expect(captured.api.values.avatar).toBeNull()
+    expect(captured.api.fields.avatar.blank).toBe(true)
+  })
+})
+
+describe('<input type="file" multiple v-register>', () => {
+  let app: App | undefined
+
+  afterEach(() => {
+    app?.unmount()
+    app = undefined
+    document.body.innerHTML = ''
+  })
+
+  it('picking multiple writes File[] of correct length and order', async () => {
+    const schema = z.object({ docs: z.array(z.file()) })
+    const captured: { api?: UseFormReturn<typeof schema> } = {}
+
+    const Parent = defineComponent({
+      setup() {
+        const form = useForm({ schema, key: 'file-multi', strict: false })
+        captured.api = form
+        return () =>
+          withDirectives(h('input', { type: 'file', multiple: true, class: 'docs' }), [
+            [vRegister, form.register('docs')],
+          ])
+      },
+    })
+
+    app = createApp(Parent).use(createAttaform())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await waitUntil(() =>
+      Array.isArray(captured.api?.values.docs) && captured.api.values.docs.length === 0
+        ? true
+        : null
+    )
+
+    if (captured.api === undefined) throw new Error('unreachable')
+    const input = root.querySelector('input.docs') as HTMLInputElement
+    expect(captured.api.values.docs).toEqual([])
+    expect(captured.api.fields('docs').blank).toBe(true)
+
+    const a = makeFile('a.pdf', 10, 'application/pdf')
+    const b = makeFile('b.pdf', 20, 'application/pdf')
+    setFiles(input, [a, b])
+    dispatchChange(input)
+
+    await waitUntil(() => (captured.api?.values.docs.length === 2 ? true : null))
+    expect(captured.api.values.docs).toEqual([a, b])
+    expect(captured.api.fields('docs').blank).toBe(false)
+  })
+
+  it('clearing all selections writes [] and re-marks blank', async () => {
+    const schema = z.object({ docs: z.array(z.file()) })
+    const captured: { api?: UseFormReturn<typeof schema> } = {}
+
+    const Parent = defineComponent({
+      setup() {
+        const form = useForm({ schema, key: 'file-multi-clear', strict: false })
+        captured.api = form
+        return () =>
+          withDirectives(h('input', { type: 'file', multiple: true, class: 'docs' }), [
+            [vRegister, form.register('docs')],
+          ])
+      },
+    })
+
+    app = createApp(Parent).use(createAttaform())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await waitUntil(() => (captured.api?.fields('docs').blank === true ? true : null))
+
+    if (captured.api === undefined) throw new Error('unreachable')
+    const input = root.querySelector('input.docs') as HTMLInputElement
+
+    setFiles(input, [makeFile()])
+    dispatchChange(input)
+    await waitUntil(() => (captured.api?.values.docs.length === 1 ? true : null))
+
+    setFiles(input, [])
+    dispatchChange(input)
+    await waitUntil(() =>
+      captured.api?.fields('docs').blank === true && captured.api.values.docs.length === 0
+        ? true
+        : null
+    )
+    expect(captured.api.values.docs).toEqual([])
+    expect(captured.api.fields('docs').blank).toBe(true)
+  })
+})
+
+describe('<input type="file" v-register> — required-file error', () => {
+  let app: App | undefined
+
+  afterEach(() => {
+    app?.unmount()
+    app = undefined
+    document.body.innerHTML = ''
+  })
+
+  it('surfaces "No value supplied" through derivedBlankErrors when required', async () => {
+    const schema = z.object({ id: z.file() })
+    const captured: { api?: UseFormReturn<typeof schema> } = {}
+
+    const Parent = defineComponent({
+      setup() {
+        const form = useForm({ schema, key: 'file-required', strict: false })
+        captured.api = form
+        return () =>
+          withDirectives(h('input', { type: 'file', class: 'id' }), [
+            [vRegister, form.register('id')],
+          ])
+      },
+    })
+
+    app = createApp(Parent).use(createAttaform())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await waitUntil(() => (captured.api?.fields.id.blank === true ? true : null))
+
+    if (captured.api === undefined) throw new Error('unreachable')
+    const errs = captured.api.errors.id
+    expect(Array.isArray(errs) && errs.length > 0).toBe(true)
+  })
+})
+
+describe('<input type="file" v-register> — persistence carve-out', () => {
+  const apps: App[] = []
+
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+    document.body.innerHTML = ''
+    localStorage.clear()
+  })
+
+  it('never persists file values regardless of register({ persist: true })', async () => {
+    const schema = z.object({
+      avatar: z.file().nullable(),
+      title: z.string(),
+    })
+    const captured: { api?: UseFormReturn<typeof schema> } = {}
+
+    const Parent = defineComponent({
+      setup() {
+        const form = useForm({
+          schema,
+          key: 'file-persist-carveout',
+          persist: { storage: 'local', key: 'file-persist-test', debounceMs: 5 },
+          strict: false,
+        })
+        captured.api = form
+        return () =>
+          h('div', [
+            withDirectives(h('input', { type: 'file', class: 'avatar' }), [
+              [vRegister, form.register('avatar', { persist: true })],
+            ]),
+            withDirectives(h('input', { type: 'text', class: 'title' }), [
+              [vRegister, form.register('title', { persist: true })],
+            ]),
+          ])
+      },
+    })
+
+    const app = createApp(Parent).use(createAttaform())
+    apps.push(app)
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await waitUntil(() => (captured.api?.fields.avatar.blank === true ? true : null))
+
+    if (captured.api === undefined) throw new Error('unreachable')
+    const fileInput = root.querySelector('input.avatar') as HTMLInputElement
+    const textInput = root.querySelector('input.title') as HTMLInputElement
+
+    setFiles(fileInput, [makeFile()])
+    dispatchChange(fileInput)
+    textInput.value = 'release notes'
+    textInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    await waitUntil(() => (localStorage.getItem('file-persist-test') !== null ? true : null), 200)
+
+    const raw = Object.keys(localStorage).find((k) => k.startsWith('file-persist-test:'))
+    expect(raw).toBeDefined()
+    if (raw === undefined) throw new Error('unreachable')
+    const payload = JSON.parse(localStorage.getItem(raw) ?? '{}') as {
+      data?: { form?: Record<string, unknown> }
+    }
+    expect(payload.data?.form).toBeDefined()
+    expect('avatar' in (payload.data?.form ?? {})).toBe(false)
+    expect(payload.data?.form?.['title']).toBe('release notes')
+  })
+
+  it('emits a one-time dev warn when persist is set on a file input', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    const schema = z.object({
+      avatar: z.file().nullable(),
+      banner: z.file().nullable(),
+    })
+
+    const Parent = defineComponent({
+      setup() {
+        const form = useForm({
+          schema,
+          key: 'file-warn-dedup',
+          persist: { storage: 'local', key: 'file-warn-test', debounceMs: 5 },
+          strict: false,
+        })
+        return () =>
+          h('div', [
+            withDirectives(h('input', { type: 'file', class: 'avatar' }), [
+              [vRegister, form.register('avatar', { persist: true })],
+            ]),
+            withDirectives(h('input', { type: 'file', class: 'avatar-dup' }), [
+              [vRegister, form.register('avatar', { persist: true })],
+            ]),
+            withDirectives(h('input', { type: 'file', class: 'banner' }), [
+              [vRegister, form.register('banner', { persist: true })],
+            ]),
+          ])
+      },
+    })
+
+    const app = createApp(Parent).use(createAttaform())
+    apps.push(app)
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+
+    await waitUntil(
+      () =>
+        warnSpy.mock.calls.filter((c: unknown[]) =>
+          String(c[0] ?? '').includes('on <input type="file">')
+        ).length > 0
+          ? true
+          : null,
+      200
+    )
+
+    const fileWarns = warnSpy.mock.calls.filter((c: unknown[]) =>
+      String(c[0] ?? '').includes('on <input type="file">')
+    )
+    const avatarWarns = fileWarns.filter((c: unknown[]) => String(c[0] ?? '').includes('avatar'))
+    const bannerWarns = fileWarns.filter((c: unknown[]) => String(c[0] ?? '').includes('banner'))
+    expect(avatarWarns.length).toBe(1)
+    expect(bannerWarns.length).toBe(1)
+
+    warnSpy.mockRestore()
+  })
+})
+
+describe('<input type="file" v-register> — programmatic clear', () => {
+  let app: App | undefined
+
+  afterEach(() => {
+    app?.unmount()
+    app = undefined
+    document.body.innerHTML = ''
+  })
+
+  it('form.clear(path) resets storage to null and clears the DOM input', async () => {
+    const schema = z.object({ avatar: z.file().nullable() })
+    const captured: { api?: UseFormReturn<typeof schema> } = {}
+
+    const Parent = defineComponent({
+      setup() {
+        const form = useForm({ schema, key: 'file-prog-clear', strict: false })
+        captured.api = form
+        return () =>
+          withDirectives(h('input', { type: 'file', class: 'avatar' }), [
+            [vRegister, form.register('avatar')],
+          ])
+      },
+    })
+
+    app = createApp(Parent).use(createAttaform())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await waitUntil(() => (captured.api?.fields.avatar.blank === true ? true : null))
+
+    if (captured.api === undefined) throw new Error('unreachable')
+    const input = root.querySelector('input.avatar') as HTMLInputElement
+
+    setFiles(input, [makeFile()])
+    dispatchChange(input)
+    await waitUntil(() => (captured.api?.values.avatar instanceof File ? true : null))
+    expect(captured.api.values.avatar).toBeInstanceOf(File)
+
+    captured.api.clear('avatar')
+    await waitUntil(() => (captured.api?.values.avatar === null ? true : null))
+    expect(captured.api.values.avatar).toBeNull()
+    expect(captured.api.fields.avatar.blank).toBe(true)
+    expect(input.value).toBe('')
+  })
+})
+
+describe('<input type="file" v-register> — listener cleanup', () => {
+  let app: App | undefined
+
+  afterEach(() => {
+    app?.unmount()
+    app = undefined
+    document.body.innerHTML = ''
+  })
+
+  it('removes the change listener on unmount', async () => {
+    const schema = z.object({ avatar: z.file().nullable() })
+    const captured: { api?: UseFormReturn<typeof schema> } = {}
+
+    const Parent = defineComponent({
+      setup() {
+        const form = useForm({ schema, key: 'file-cleanup', strict: false })
+        captured.api = form
+        return () =>
+          withDirectives(h('input', { type: 'file', class: 'avatar' }), [
+            [vRegister, form.register('avatar')],
+          ])
+      },
+    })
+
+    app = createApp(Parent).use(createAttaform())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await waitUntil(() => (captured.api?.fields.avatar.blank === true ? true : null))
+
+    const input = root.querySelector('input.avatar') as HTMLInputElement
+    app.unmount()
+    app = undefined
+
+    // After unmount, dispatching change must not flow into storage.
+    setFiles(input, [makeFile()])
+    dispatchChange(input)
+    expect(captured.api?.values.avatar).toBeNull()
+  })
+})
+
+// Restore the platform localStorage for the file-suite block that
+// touched it — sibling suites observing jsdom's default get a clean
+// slate.
+afterAll(() => {
+  localStorage.clear()
+})


### PR DESCRIPTION
## Summary

Promote `<input type="file">` from a no-op variant to a first-class
`v-register` target. Picks land in form state as `File | null` (single)
or `File[]` (multiple), wired through the same blank-path + required-
error machinery every other input uses. Persistence is carved out at
the registry level — file paths can't survive a reload (browser
security), so the library refuses to pretend otherwise and emits a
one-time dev warn pointing at the upload-on-select pattern.

## Commits

- `feat(directive)` — `vRegisterFile` replaces `vRegisterFileNoop`.
  Reads `event.target.files` on change, handles single + multiple,
  marks blank on register / clear, syncs DOM via `el.value = ''` (the
  one programmatic write browsers permit on file inputs). Persistence
  carve-out at `syncPersistOptIn` checks `vnode.props.type` (the
  authoritative pre-patch source during `created`) before consulting
  `el.type`.
- `feat(adapter)` — promote `'file'` to a recognised `ZodKind` in v4
  so `z.file()` paths register as leaves through `form.fields.<path>`.
  Touches every exhaustive switch (`kindOf`, `assertSupportedKinds`,
  `defaultForKind` returns `null`, slim-primitives, fingerprint,
  path-walker, strip, `walkForMeta`). Slim accept set at the file leaf
  includes `'null'` so blank-marking writes land on required-file
  schemas. `LeafWalker` adds `File` to the primitive type set so the
  proxy returns a `FieldState`, not a descent. v3 mirror: `'file'`
  joins `PERMISSIVE_V3` for value-level pass-through.
- `test(file)` — 9-case suite covering single + multi pick / clear,
  required-file error via `derivedBlankErrors`, persistence carve-out
  (spy on storage adapter), one-time warn dedup per `(form, path)`,
  `form.clear` round-trip, unmount listener drain. Plus a scoped
  watcher inside `created` so programmatic `form.clear` / `form.reset`
  re-mark blank even when the parent doesn't re-render.
- `docs(recipes)` — `docs/recipes/file-uploads.md`. Picker plumbing,
  the upload-on-select production pattern (ephemeral `z.file()` paired
  with a persisted URL field), validation snippet, zod 3 vs 4 idiom
  table.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm vitest run` — 192 files / 2667 tests pass (+9 new)
- [x] `pnpm prepack` — bundle clean
- [x] `pnpm check:bundled-types` — 4-form-stepper fixture still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)