### PR TITLE
chore: cleanup sweep — lean + efficient + defensive

### DIFF
--- a/src/runtime/adapters/zod-v3/slim-primitives.ts
+++ b/src/runtime/adapters/zod-v3/slim-primitives.ts
@@ -13,27 +13,47 @@ import { isZodSchemaType } from './helpers'
  * `src/runtime/adapters/zod-v4/slim-primitives.ts`.
  */
 
-export const PERMISSIVE_V3: ReadonlySet<SlimPrimitiveKind> = new Set<SlimPrimitiveKind>([
-  'string',
-  'number',
-  'boolean',
-  'bigint',
-  'date',
-  'null',
-  'undefined',
-  'object',
-  'array',
-  'symbol',
-  'function',
-  'map',
-  'set',
-  'file',
-])
+export const PERMISSIVE_V3: ReadonlySet<SlimPrimitiveKind> =
+  /* @__PURE__ */ new Set<SlimPrimitiveKind>([
+    'string',
+    'number',
+    'boolean',
+    'bigint',
+    'date',
+    'null',
+    'undefined',
+    'object',
+    'array',
+    'symbol',
+    'function',
+    'map',
+    'set',
+    'file',
+  ])
+
+// Module-level frozen leaf singletons; see the v4 file for rationale.
+const KIND_STRING: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['string'])
+const KIND_NUMBER: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['number'])
+const KIND_BOOLEAN: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['boolean'])
+const KIND_BIGINT: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['bigint'])
+const KIND_DATE: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['date'])
+const KIND_NULL: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['null'])
+const KIND_UNDEFINED: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['undefined'])
+const KIND_OBJECT: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['object'])
+const KIND_ARRAY: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['array'])
+const KIND_SET: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['set'])
+const EMPTY_KINDS: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set()
 
 const MAX_LAZY_DEPTH_V3 = 64
 
 export function slimPrimitivesV3(schema: z.ZodTypeAny, depth = 0): Set<SlimPrimitiveKind> {
-  if (depth > MAX_LAZY_DEPTH_V3) return new Set(PERMISSIVE_V3)
+  // Clone once at the public boundary; the internal walk reuses
+  // frozen singletons for leaf kinds.
+  return new Set(walk(schema, depth))
+}
+
+function walk(schema: z.ZodTypeAny, depth: number): ReadonlySet<SlimPrimitiveKind> {
+  if (depth > MAX_LAZY_DEPTH_V3) return PERMISSIVE_V3
   const def = (
     schema as {
       _def?: {
@@ -52,15 +72,15 @@ export function slimPrimitivesV3(schema: z.ZodTypeAny, depth = 0): Set<SlimPrimi
   )._def
   const typeName = def?.typeName
 
-  if (isZodSchemaType(schema, 'ZodString')) return new Set(['string'])
-  if (isZodSchemaType(schema, 'ZodNumber')) return new Set(['number'])
-  if (isZodSchemaType(schema, 'ZodBoolean')) return new Set(['boolean'])
-  if (isZodSchemaType(schema, 'ZodBigInt')) return new Set(['bigint'])
-  if (isZodSchemaType(schema, 'ZodDate')) return new Set(['date'])
-  if (isZodSchemaType(schema, 'ZodNull')) return new Set(['null'])
-  if (isZodSchemaType(schema, 'ZodUndefined')) return new Set(['undefined'])
-  if (typeName === 'ZodVoid') return new Set(['undefined'])
-  if (typeName === 'ZodNaN') return new Set(['number'])
+  if (isZodSchemaType(schema, 'ZodString')) return KIND_STRING
+  if (isZodSchemaType(schema, 'ZodNumber')) return KIND_NUMBER
+  if (isZodSchemaType(schema, 'ZodBoolean')) return KIND_BOOLEAN
+  if (isZodSchemaType(schema, 'ZodBigInt')) return KIND_BIGINT
+  if (isZodSchemaType(schema, 'ZodDate')) return KIND_DATE
+  if (isZodSchemaType(schema, 'ZodNull')) return KIND_NULL
+  if (isZodSchemaType(schema, 'ZodUndefined')) return KIND_UNDEFINED
+  if (typeName === 'ZodVoid') return KIND_UNDEFINED
+  if (typeName === 'ZodNaN') return KIND_NUMBER
 
   if (isZodSchemaType(schema, 'ZodEnum')) {
     const options = (schema as z.ZodEnum<[string, ...string[]]>).options
@@ -69,34 +89,34 @@ export function slimPrimitivesV3(schema: z.ZodTypeAny, depth = 0): Set<SlimPrimi
       if (typeof v === 'string') out.add('string')
       else if (typeof v === 'number') out.add('number')
     }
-    return out.size === 0 ? new Set(['string']) : out
+    return out.size === 0 ? KIND_STRING : out
   }
   if (isZodSchemaType(schema, 'ZodLiteral')) {
     const value = (schema as z.ZodLiteral<unknown>).value
     return new Set([slimKindOfRawV3(value)])
   }
   if (isZodSchemaType(schema, 'ZodObject') || typeName === 'ZodRecord') {
-    return new Set(['object'])
+    return KIND_OBJECT
   }
   if (isZodSchemaType(schema, 'ZodArray') || typeName === 'ZodTuple') {
-    return new Set(['array'])
+    return KIND_ARRAY
   }
   if (isZodSchemaType(schema, 'ZodSet')) {
-    return new Set(['set'])
+    return KIND_SET
   }
   if (isZodSchemaType(schema, 'ZodOptional')) {
     const inner = def?.innerType
-    const innerSet =
-      inner === undefined ? new Set<SlimPrimitiveKind>() : slimPrimitivesV3(inner, depth + 1)
-    innerSet.add('undefined')
-    return innerSet
+    const innerSet = inner === undefined ? EMPTY_KINDS : walk(inner, depth + 1)
+    const out = new Set<SlimPrimitiveKind>(innerSet)
+    out.add('undefined')
+    return out
   }
   if (isZodSchemaType(schema, 'ZodNullable')) {
     const inner = def?.innerType
-    const innerSet =
-      inner === undefined ? new Set<SlimPrimitiveKind>() : slimPrimitivesV3(inner, depth + 1)
-    innerSet.add('null')
-    return innerSet
+    const innerSet = inner === undefined ? EMPTY_KINDS : walk(inner, depth + 1)
+    const out = new Set<SlimPrimitiveKind>(innerSet)
+    out.add('null')
+    return out
   }
   if (
     isZodSchemaType(schema, 'ZodDefault') ||
@@ -105,46 +125,45 @@ export function slimPrimitivesV3(schema: z.ZodTypeAny, depth = 0): Set<SlimPrimi
     isZodSchemaType(schema, 'ZodBranded')
   ) {
     const inner = def?.innerType ?? def?.type
-    return inner === undefined ? new Set(PERMISSIVE_V3) : slimPrimitivesV3(inner, depth + 1)
+    return inner === undefined ? PERMISSIVE_V3 : walk(inner, depth + 1)
   }
   if (isZodSchemaType(schema, 'ZodEffects')) {
     // ZodEffects wraps refinements/transforms. Use the inner schema
     // type — writes are pre-transform values.
     const inner = def?.schema
-    return inner === undefined ? new Set(PERMISSIVE_V3) : slimPrimitivesV3(inner, depth + 1)
+    return inner === undefined ? PERMISSIVE_V3 : walk(inner, depth + 1)
   }
   if (isZodSchemaType(schema, 'ZodPipeline')) {
     // Pipeline: input side ('in').
     const inner = def?.in
-    return inner === undefined ? new Set(PERMISSIVE_V3) : slimPrimitivesV3(inner, depth + 1)
+    return inner === undefined ? PERMISSIVE_V3 : walk(inner, depth + 1)
   }
   if (typeName === 'ZodLazy') {
     const getter = def?.getter
-    if (typeof getter !== 'function') return new Set(PERMISSIVE_V3)
-    return slimPrimitivesV3(getter(), depth + 1)
+    if (typeof getter !== 'function') return PERMISSIVE_V3
+    return walk(getter(), depth + 1)
   }
   if (isZodSchemaType(schema, 'ZodUnion') || isZodSchemaType(schema, 'ZodDiscriminatedUnion')) {
     const options = def?.options ?? []
     const out = new Set<SlimPrimitiveKind>()
     for (const opt of options) {
-      for (const k of slimPrimitivesV3(opt, depth + 1)) out.add(k)
+      for (const k of walk(opt, depth + 1)) out.add(k)
     }
-    return out.size === 0 ? new Set(PERMISSIVE_V3) : out
+    return out.size === 0 ? PERMISSIVE_V3 : out
   }
   if (typeName === 'ZodIntersection') {
     const left = def?.left
     const right = def?.right
-    const leftSet = left === undefined ? new Set(PERMISSIVE_V3) : slimPrimitivesV3(left, depth + 1)
-    const rightSet =
-      right === undefined ? new Set(PERMISSIVE_V3) : slimPrimitivesV3(right, depth + 1)
+    const leftSet = left === undefined ? PERMISSIVE_V3 : walk(left, depth + 1)
+    const rightSet = right === undefined ? PERMISSIVE_V3 : walk(right, depth + 1)
     const out = new Set<SlimPrimitiveKind>()
     for (const k of leftSet) if (rightSet.has(k)) out.add(k)
     return out
   }
-  if (typeName === 'ZodNever') return new Set()
-  if (typeName === 'ZodAny' || typeName === 'ZodUnknown') return new Set(PERMISSIVE_V3)
+  if (typeName === 'ZodNever') return EMPTY_KINDS
+  if (typeName === 'ZodAny' || typeName === 'ZodUnknown') return PERMISSIVE_V3
 
-  return new Set(PERMISSIVE_V3)
+  return PERMISSIVE_V3
 }
 
 function slimKindOfRawV3(value: unknown): SlimPrimitiveKind {

--- a/src/runtime/adapters/zod-v4/default-values.ts
+++ b/src/runtime/adapters/zod-v4/default-values.ts
@@ -160,7 +160,16 @@ function defaultForKind(
       // is the authority for what the seed should be at the recursive
       // boundary anyway.
       if (lazyDepth >= maxDepth) return undefined
-      const inner = unwrapLazy(schema)
+      // `z.lazy()` runs a user-supplied getter; a getter that throws
+      // (cyclic reference resolved before its target is constructed,
+      // user bug, etc.) shouldn't crash form construction. Mirror the
+      // try/catch precedent in `introspect.ts:containsAsyncRefine`.
+      let inner: z.ZodType | undefined
+      try {
+        inner = unwrapLazy(schema)
+      } catch {
+        return undefined
+      }
       return inner === undefined
         ? undefined
         : defaultForKind(kindOf(inner), inner, useDefault, maxDepth, lazyDepth + 1)

--- a/src/runtime/adapters/zod-v4/slim-primitives.ts
+++ b/src/runtime/adapters/zod-v4/slim-primitives.ts
@@ -23,22 +23,43 @@ import {
   unwrapPipe,
 } from './introspect'
 
-export const PERMISSIVE: ReadonlySet<SlimPrimitiveKind> = new Set<SlimPrimitiveKind>([
-  'string',
-  'number',
-  'boolean',
-  'bigint',
-  'date',
-  'null',
-  'undefined',
-  'object',
-  'array',
-  'symbol',
-  'function',
-  'map',
-  'set',
-  'file',
-])
+export const PERMISSIVE: ReadonlySet<SlimPrimitiveKind> =
+  /* @__PURE__ */ new Set<SlimPrimitiveKind>([
+    'string',
+    'number',
+    'boolean',
+    'bigint',
+    'date',
+    'null',
+    'undefined',
+    'object',
+    'array',
+    'symbol',
+    'function',
+    'map',
+    'set',
+    'file',
+  ])
+
+// Module-level frozen singletons for the leaf branches. Returning a
+// shared instance instead of `new Set([…])` per call cuts a hot
+// allocation when slim-primitives is reached through wrappers, and
+// collapses the inline literal Set constructions into shared
+// references for a small bundle-size win. `walk()` returns
+// `ReadonlySet`; callers that need to mutate (optional/nullable/union
+// branches, and the public `slimPrimitivesOf` boundary) clone first.
+const KIND_STRING: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['string'])
+const KIND_NUMBER: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['number'])
+const KIND_BOOLEAN: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['boolean'])
+const KIND_BIGINT: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['bigint'])
+const KIND_DATE: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['date'])
+const KIND_NULL: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['null'])
+const KIND_UNDEFINED: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['undefined'])
+const KIND_OBJECT: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['object'])
+const KIND_ARRAY: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['array'])
+const KIND_SET: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['set'])
+const KIND_FILE: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['file', 'null'])
+const EMPTY_KINDS: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set()
 
 /**
  * Walk a schema, emitting the union of slim primitive kinds it
@@ -62,23 +83,29 @@ export function slimPrimitivesOf(
   schema: z.ZodType,
   maxRecursionDepth: number
 ): Set<SlimPrimitiveKind> {
-  return walk(schema, 0, maxRecursionDepth)
+  // Clone once at the public boundary so callers get a fresh mutable
+  // Set. The internal walk reuses frozen singletons for leaf kinds.
+  return new Set(walk(schema, 0, maxRecursionDepth))
 }
 
-function walk(schema: z.ZodType, lazyDepth: number, maxDepth: number): Set<SlimPrimitiveKind> {
+function walk(
+  schema: z.ZodType,
+  lazyDepth: number,
+  maxDepth: number
+): ReadonlySet<SlimPrimitiveKind> {
   const kind = kindOf(schema)
   switch (kind) {
     case 'string':
-      return new Set(['string'])
+      return KIND_STRING
     case 'number':
     case 'nan':
-      return new Set(['number'])
+      return KIND_NUMBER
     case 'boolean':
-      return new Set(['boolean'])
+      return KIND_BOOLEAN
     case 'bigint':
-      return new Set(['bigint'])
+      return KIND_BIGINT
     case 'date':
-      return new Set(['date'])
+      return KIND_DATE
     case 'file':
       // `z.file()` accepts `File` instances at write time. `null` is
       // also accepted at the slim-primitive level so the directive's
@@ -91,12 +118,12 @@ function walk(schema: z.ZodType, lazyDepth: number, maxDepth: number): Set<SlimP
       // / `set`) makes the path a leaf via `isLeafAtPath`, so
       // `form.fields.<file-path>` returns a FieldState rather than
       // descending into the File's own keys.
-      return new Set(['file', 'null'])
+      return KIND_FILE
     case 'null':
-      return new Set(['null'])
+      return KIND_NULL
     case 'undefined':
     case 'void':
-      return new Set(['undefined'])
+      return KIND_UNDEFINED
     case 'enum': {
       // Enums in v4 may be string- or number-valued; walk entries.
       const values = getEnumValues(schema)
@@ -105,53 +132,53 @@ function walk(schema: z.ZodType, lazyDepth: number, maxDepth: number): Set<SlimP
         if (typeof v === 'string') out.add('string')
         else if (typeof v === 'number') out.add('number')
       }
-      return out.size === 0 ? new Set(['string']) : out
+      return out.size === 0 ? KIND_STRING : out
     }
     case 'literal': {
       const values = getLiteralValues(schema)
       const out = new Set<SlimPrimitiveKind>()
       for (const v of values) out.add(slimKindOfRaw(v))
-      return out.size === 0 ? new Set(PERMISSIVE) : out
+      return out.size === 0 ? PERMISSIVE : out
     }
     case 'object':
     case 'record':
-      return new Set(['object'])
+      return KIND_OBJECT
     case 'array':
     case 'tuple':
-      return new Set(['array'])
+      return KIND_ARRAY
     case 'set':
-      return new Set(['set'])
+      return KIND_SET
     case 'optional': {
       const inner = unwrapInner(schema)
-      const innerSet =
-        inner === undefined ? new Set<SlimPrimitiveKind>() : walk(inner, lazyDepth, maxDepth)
-      innerSet.add('undefined')
-      return innerSet
+      const innerSet = inner === undefined ? EMPTY_KINDS : walk(inner, lazyDepth, maxDepth)
+      const out = new Set<SlimPrimitiveKind>(innerSet)
+      out.add('undefined')
+      return out
     }
     case 'nullable': {
       const inner = unwrapInner(schema)
-      const innerSet =
-        inner === undefined ? new Set<SlimPrimitiveKind>() : walk(inner, lazyDepth, maxDepth)
-      innerSet.add('null')
-      return innerSet
+      const innerSet = inner === undefined ? EMPTY_KINDS : walk(inner, lazyDepth, maxDepth)
+      const out = new Set<SlimPrimitiveKind>(innerSet)
+      out.add('null')
+      return out
     }
     case 'default':
     case 'readonly':
     case 'catch': {
       const inner = unwrapInner(schema)
-      return inner === undefined ? new Set(PERMISSIVE) : walk(inner, lazyDepth, maxDepth)
+      return inner === undefined ? PERMISSIVE : walk(inner, lazyDepth, maxDepth)
     }
     case 'pipe': {
       // Use the INPUT side: writes are pre-transform values.
       const inner = unwrapPipe(schema)
-      return inner === undefined ? new Set(PERMISSIVE) : walk(inner, lazyDepth, maxDepth)
+      return inner === undefined ? PERMISSIVE : walk(inner, lazyDepth, maxDepth)
     }
     case 'lazy': {
       // Bump on lazy crossing only; past the cap, fall back to
       // permissive so recursive paths beyond the cap aren't gated.
-      if (lazyDepth >= maxDepth) return new Set(PERMISSIVE)
+      if (lazyDepth >= maxDepth) return PERMISSIVE
       const inner = unwrapLazy(schema)
-      return inner === undefined ? new Set(PERMISSIVE) : walk(inner, lazyDepth + 1, maxDepth)
+      return inner === undefined ? PERMISSIVE : walk(inner, lazyDepth + 1, maxDepth)
     }
     case 'union':
     case 'discriminated-union': {
@@ -160,22 +187,22 @@ function walk(schema: z.ZodType, lazyDepth: number, maxDepth: number): Set<SlimP
       for (const opt of options) {
         for (const k of walk(opt as z.ZodType, lazyDepth, maxDepth)) out.add(k)
       }
-      return out.size === 0 ? new Set(PERMISSIVE) : out
+      return out.size === 0 ? PERMISSIVE : out
     }
     case 'intersection': {
       const left = getIntersectionLeft(schema)
       const right = getIntersectionRight(schema)
-      const leftSet = left === undefined ? new Set(PERMISSIVE) : walk(left, lazyDepth, maxDepth)
-      const rightSet = right === undefined ? new Set(PERMISSIVE) : walk(right, lazyDepth, maxDepth)
+      const leftSet = left === undefined ? PERMISSIVE : walk(left, lazyDepth, maxDepth)
+      const rightSet = right === undefined ? PERMISSIVE : walk(right, lazyDepth, maxDepth)
       const out = new Set<SlimPrimitiveKind>()
       for (const k of leftSet) if (rightSet.has(k)) out.add(k)
       return out
     }
     case 'never':
-      return new Set()
+      return EMPTY_KINDS
     case 'any':
     case 'unknown':
-      return new Set(PERMISSIVE)
+      return PERMISSIVE
     // Kinds we don't understand at the slim level: be permissive to
     // avoid false-rejecting legitimate writes against schema shapes
     // we haven't characterised.
@@ -183,9 +210,9 @@ function walk(schema: z.ZodType, lazyDepth: number, maxDepth: number): Set<SlimP
     case 'custom':
     case 'template-literal':
     case 'transform':
-      return new Set(PERMISSIVE)
+      return PERMISSIVE
     default:
-      return new Set(PERMISSIVE)
+      return PERMISSIVE
   }
 }
 

--- a/src/runtime/core/dev-stack-trace.ts
+++ b/src/runtime/core/dev-stack-trace.ts
@@ -68,7 +68,7 @@ export function captureUserCallSite(): string | undefined {
  * the original trimmed frame is returned unchanged — better to
  * surface something than nothing.
  */
-export function shortenSourceFrame(frame: string): string {
+function shortenSourceFrame(frame: string): string {
   const match = /(?:^|\s|\()([^\s()]+):(\d+):\d+\)?$/.exec(frame)
   if (match === null) return frame
   const [, urlOrPath, line] = match

--- a/src/runtime/core/vue-shared-shim.ts
+++ b/src/runtime/core/vue-shared-shim.ts
@@ -30,10 +30,6 @@ export function isSet(value: unknown): value is Set<unknown> {
   return toTypeString(value) === '[object Set]'
 }
 
-export function isMap(value: unknown): value is Map<unknown, unknown> {
-  return toTypeString(value) === '[object Map]'
-}
-
 export function isDate(value: unknown): value is Date {
   return toTypeString(value) === '[object Date]'
 }

--- a/test/core/vue-shared-shim.test.ts
+++ b/test/core/vue-shared-shim.test.ts
@@ -3,7 +3,6 @@ import {
   invokeArrayFns,
   isArray,
   isFunction,
-  isMap,
   isObject,
   isSet,
   isSymbol,
@@ -33,11 +32,6 @@ describe('vue-shared shim', () => {
       expect(isSet(new Set([1, 2]))).toBe(true)
       expect(isSet(new Map())).toBe(false)
       expect(isSet({})).toBe(false)
-    })
-
-    it('isMap distinguishes Map', () => {
-      expect(isMap(new Map())).toBe(true)
-      expect(isMap(new Set())).toBe(false)
     })
 
     it('isSymbol', () => {


### PR DESCRIPTION
## Summary

Audit-driven cleanup pass — three parallel angles (lean, efficient, defensive) collapsed into a single tight PR. Pre-1.0, no users; subtraction is welcome.

Three logical commits:

- **chore(lean)**: drop dead `isMap` from `vue-shared-shim` + the matching test block; unexport `shortenSourceFrame` (single internal call site).
- **perf(adapters)**: lift each slim-primitive leaf kind to a module-level frozen singleton across the v3 + v4 adapters; collapse 24+ `new Set([…])` allocations into shared references. `walk()` now returns `ReadonlySet` internally; `slimPrimitivesOf` clones once at the public boundary. `/* @__PURE__ */` annotations on the singleton initialisers.
- **fix(adapter)**: wrap `unwrapLazy(schema)` in try/catch inside `defaultForKind`'s `lazy` branch, matching the precedent in `introspect.ts:containsAsyncRefine`. A user-supplied `z.lazy()` getter that throws no longer crashes default-value derivation.

No public API surface added or removed. No schema, persistence, or directive behaviour changes.

## Verification

- ✅ `pnpm typecheck` — clean.
- ✅ `pnpm lint` — clean.
- ✅ `pnpm vitest run` — 2666 / 2666 passing across 192 test files.
- ✅ `pnpm prepack` — bundles clean.
- ✅ `pnpm check:bundled-types` — gate green.
- ✅ `pnpm check:size` — all bundles under their existing budgets (no size-limit bumps).

## Test plan

- [ ] CI green
- [ ] Bundle sizes within their existing caps

## Deferred (separate PRs)

The audit surfaced several larger items intentionally left for future passes — v3/v4 adapter consolidation (~800 lines of structural duplication), `isLeafAtPath` + `getSlimPrimitiveTypesAtPath` shared-walk refactor, persistence payload-size cap with `QuotaExceededError` handling, `as any` audit, and a few smaller efficiency wins. Each sized too large or too uncertain for a single tight PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)