### PR TITLE
docs(perf): surface measured bench numbers

### DIFF
--- a/docs/perf.md
+++ b/docs/perf.md
@@ -9,6 +9,35 @@ and what to look at if a form starts feeling slow. CI runs the
 benchmark suite under `bench/` on every PR with thresholds tracked
 in [`bench/`](https://github.com/attaform/attaform/tree/main/bench).
 
+## Measured numbers
+
+Real-browser numbers from `pnpm bench`, single-threaded on
+contemporary hardware. Your machine will land elsewhere on the
+number line; the orders of magnitude won't.
+
+| Operation                                                      | Cost    |
+| -------------------------------------------------------------- | ------- |
+| Single-field keystroke, 100-leaf form                          | 6 µs    |
+| Single-field keystroke, 500-leaf form                          | 30 µs   |
+| Validation overhead per keystroke (`validateOn: 'change'`)     | 5 µs    |
+| Submit lifecycle (validate → submit → parse → setFieldErrors)  | 3.4 µs  |
+| Path canonicalisation (cache hit)                              | 60 ns   |
+| Sensitive-name check (common pattern, early hit)               | 70 ns   |
+| Persistence write — `'local'` / `'session'` (100-leaf payload) | 2.8 µs  |
+| Persistence write — `'indexeddb'` (100-leaf payload)           | 62 µs   |
+| Debounced-writer schedule (steady-state typing)                | 0.18 µs |
+| Discriminated union — write into active variant                | 19 µs   |
+| Discriminated union — cross-variant flip                       | 25 µs   |
+| Reset, 100-leaf object form                                    | 678 µs  |
+| Field-array append, 100-item                                   | 2.5 ms  |
+| Field-array append, 1000-item                                  | 9 ms    |
+| Field-array swap on 500-item                                   | 3.9 ms  |
+
+A 60 fps frame is **16.7 ms**. Single-keystroke work clears the
+budget by three orders of magnitude on a 100-leaf form and by
+two on a 500-leaf form — Vue's render gets the rest of the frame
+to itself.
+
 ## Hot-path characteristics
 
 - **Keystrokes** — the `register` → form-state path runs against a
@@ -69,9 +98,9 @@ const isEmailDirty = computed(() => form.fields.email.dirty)
 
 ## Reset cost
 
-`reset()` is sub-millisecond on a 100-leaf form and a few
-milliseconds at 500 leaves. `resetField(path)` scales with the
-subtree — prefer it for localised reversions.
+`reset()` is sub-millisecond on a 100-leaf form (~680 µs in the
+suite — see Measured numbers above). `resetField(path)` scales with
+the subtree — prefer it for localised reversions.
 
 ## Benching your own form
 

--- a/docs/recipes/persistence-backends.md
+++ b/docs/recipes/persistence-backends.md
@@ -23,6 +23,12 @@ clone algorithm, so those leaves round-trip cleanly.
 Only the backend you choose is bundled. Pick `'local'`, don't pay
 for the IndexedDB code.
 
+Write latency on a 100-leaf form: `'local'` and `'session'` land in
+**~3 µs**, `'indexeddb'` in **~62 µs**. Both are well under one
+frame; the gap matters only for backends doing async hydration —
+see [Async backends + the "flash of default state"](#async-backends--the-flash-of-default-state) below.
+The full bench is in [Performance](/docs/perf#measured-numbers).
+
 ## Full options
 
 ```ts


### PR DESCRIPTION
## Summary

`docs/perf.md` framed the hot paths narratively but didn't quote concrete costs — readers had to clone and run `pnpm bench` to see a magnitude. This PR pulls the bench numbers up into a table at the top of the perf doc and adds a latency note to the persistence-backend picker, where the 22× `'local'` vs `'indexeddb'` gap actually informs a decision.

Changes:

- **`docs/perf.md`** — new **Measured numbers** section at the top, with absolute costs for keystroke (100-leaf, 500-leaf), validation overhead, submit lifecycle, persistence writes (per backend), debounced-writer schedule, discriminated-union flips, reset, and field-array helpers. Anchored against the 60 fps / 16.7 ms frame budget so a reader gets the shape of the numbers, not just the digits.
- **`docs/perf.md` reset section** — tightened the "few milliseconds at 500 leaves" line (the bench suite doesn't actually measure 500-leaf reset) to cite the measured 680 µs at 100 leaves instead.
- **`docs/recipes/persistence-backends.md`** — small write-latency paragraph under the picker table (~3 µs local/session, ~62 µs indexeddb) with a deep link to the new perf-doc anchor.

No code changes, no API changes, no test changes.

## Test plan

- [x] Vercel preview renders the new section + table correctly
- [x] In-page anchor `/docs/perf#measured-numbers` resolves from the persistence-backends cross-link
- [x] Anchor for the "Async backends" section on persistence-backends.md resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)