### PR TITLE
fix(vite): forward attaform/zod rewrite + devtools meta

### DIFF
--- a/src/nuxt.ts
+++ b/src/nuxt.ts
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module'
 import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import {
@@ -10,6 +11,14 @@ import {
 } from '@nuxt/kit'
 import type { AttaformDefaults } from './runtime/types/types-api'
 import { attaform as attaformVitePlugin } from './vite'
+
+// Read the published version from the package's own package.json so the
+// module's DevTools panel surfaces the live version pill without a
+// build-time string injection. `createRequire` reads sync at module load —
+// run once, free at steady state. Works under unbuild's Rollup output
+// without bundler-specific JSON-import handling.
+const pkgVersion = (createRequire(import.meta.url)('../package.json') as { version: string })
+  .version
 
 /**
  * Options accepted by `attaform/nuxt` under the `attaform`
@@ -92,8 +101,10 @@ function canResolve(specifier: string, fromURL: string): boolean {
 
 export default defineNuxtModule<AttaformModuleOptions>({
   meta: {
-    name: 'attaform',
+    name: 'Attaform',
     configKey: 'attaform',
+    version: pkgVersion,
+    docs: 'https://www.attaform.com/docs',
     compatibility: {
       nuxt: '>=3.0.0',
     },

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -218,7 +218,7 @@ export function attaform(options: AttaformVitePluginOptions = {}): Plugin {
       }
       aliasTarget = detection.major === 4 ? ZOD_V4_SPECIFIER : ZOD_V3_SPECIFIER
     },
-    resolveId(source) {
+    async resolveId(source, importer) {
       // Intercept ONLY the exact unified specifier. Explicit subpaths
       // (`attaform/zod-v3`, `attaform/zod-v4`) and the root entry
       // (`attaform`) pass through unchanged — that's the documented
@@ -226,7 +226,14 @@ export function attaform(options: AttaformVitePluginOptions = {}): Plugin {
       if (!resolveZodAlias) return null
       if (aliasTarget === null) return null
       if (source !== ZOD_UNIFIED_SPECIFIER) return null
-      return aliasTarget
+      // Returning the bare specifier directly would freeze it as the
+      // resolved id — Vite then ships `/@id/attaform/zod-v4` to the
+      // browser and 404s because no plugin loads that virtual URL.
+      // Re-run the new specifier through the resolver chain so the
+      // matching subpath export lands as a real file path.
+      // `skipSelf: true` is defensive — our filter rejects the rewritten
+      // target anyway, but keeps the hook reentrant under future edits.
+      return this.resolve(aliasTarget, importer, { skipSelf: true })
     },
   }
 }

--- a/test/vite/resolve-alias.test.ts
+++ b/test/vite/resolve-alias.test.ts
@@ -86,26 +86,34 @@ async function callResolveId(
   // `{ handler, order }`. The plugin we authored uses the function
   // form, but support both shapes for forward-compat.
   const handler = typeof hook === 'function' ? hook : hook.handler
-  // The `this` context isn't strictly needed here — our hook reads
-  // closure state — but bind a stub so calls don't blow up if a
-  // future iteration uses `this.resolve`.
+  // The hook now calls `this.resolve(newSpec, importer, { skipSelf })`
+  // to forward the rewritten specifier through Vite's resolver chain.
+  // Stub `resolve` to echo back an `{ id }` object so the test can
+  // assert the chosen subpath without spinning a real Vite resolver.
+  const context = {
+    resolve: async (id: string) => ({ id, external: false }),
+  }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (handler as any).call({}, source, importer)
+  return (handler as any).call(context, source, importer)
 }
 
 describe('attaform/vite — resolveId alias for `attaform/zod`', () => {
   it('rewrites `attaform/zod` to `attaform/zod-v4` when zod@4 is installed', async () => {
     const config = await resolveWithRoot([vue(), attaform()], zodV4Root)
     const plugin = findAttaformPlugin(config)
-    const resolved = await callResolveId(plugin, 'attaform/zod', undefined)
-    expect(resolved).toBe('attaform/zod-v4')
+    const resolved = (await callResolveId(plugin, 'attaform/zod', undefined)) as {
+      id: string
+    } | null
+    expect(resolved?.id).toBe('attaform/zod-v4')
   })
 
   it('rewrites `attaform/zod` to `attaform/zod-v3` when zod@3 is installed', async () => {
     const config = await resolveWithRoot([vue(), attaform()], zodV3Root)
     const plugin = findAttaformPlugin(config)
-    const resolved = await callResolveId(plugin, 'attaform/zod', undefined)
-    expect(resolved).toBe('attaform/zod-v3')
+    const resolved = (await callResolveId(plugin, 'attaform/zod', undefined)) as {
+      id: string
+    } | null
+    expect(resolved?.id).toBe('attaform/zod-v3')
   })
 
   it('throws at configResolved when zod is not installed', async () => {


### PR DESCRIPTION
## Summary

`attaform/vite`'s `resolveId` hook returned the rewritten specifier (`'attaform/zod-v4'` / `'attaform/zod-v3'`) as a bare string. Vite freezes that as the resolved id, ships `/@id/attaform/zod-v4` to the browser, and 404s — the page never mounts, even though the subpath export resolves cleanly under a plain `import`.

Forwarding the new specifier through `this.resolve(target, importer, { skipSelf: true })` runs it through the standard resolver chain so it lands as a real file path.

The existing unit test pinned the wrong contract (asserted the hook returned the bare specifier string). Updated to stub `this.resolve` with a pass-through echo and assert against the resolved object's `.id` — same semantic intent, but now checking the contract Vite actually consumes.

## Discovery

Invisible to the existing unit test, which never exercised the resolve chain. Surfaced by spinning up a real Nuxt 4 consumer outside the monorepo (`pnpm create nuxt@latest`, install attaform from a `pnpm pack` tarball, wire `attaform/nuxt` + a username/password form) — the page failed to load with a clear `attaform/zod-v4` 404.

Once fixed, the consumer renders cleanly and the Vue DevTools "Attaform" inspector + timeline both light up.

## Test plan

- [x] `test/vite/resolve-alias.test.ts` — 9 tests, all passing (test updated to match new contract)
- [x] `test/packaging/*` — 21 tests, all passing
- [x] `test/vite/*` + `test/packaging/*` combined — 30 tests, all passing
- [x] Manual verification: Nuxt 4 consumer with `attaform/nuxt` loads cleanly, `<input v-register>` mounts, Vue DevTools panel shows the Attaform inspector with redacted-password panel + timeline events

🤖 Generated with [Claude Code](https://claude.com/claude-code)