### PR TITLE
refactor(form): split field-flag tri-state by semantic group + autofocus probe

### DIFF
--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -57,14 +57,29 @@ import {
  * hydration; otherwise the state is per-component-per-form.
  */
 
-/** Per-path field status. Replaced wholesale (not mutated in place) on every change. */
+/**
+ * Per-path field status. Replaced wholesale (not mutated in place) on
+ * every change. Three semantic groups:
+ *
+ *   - `connected` — is a DOM element registered for this path?
+ *   - `focused` / `blurred` — DOM-state flags. `null` while no element
+ *     is connected (no DOM means the concepts don't apply); plain
+ *     booleans once connected, with the invariant `blurred === !focused`
+ *     enforced by `markFocused`.
+ *   - `touched` — interaction history, not DOM state. Always a plain
+ *     boolean: `false` at registration, sticky `true` after first blur,
+ *     cleared only by `form.reset()` / `form.resetField(path)`. Persists
+ *     across disconnects so v-if'd-away fields don't lose their touched
+ *     state on rehide (wizard "show review of touched fields" patterns
+ *     rely on this).
+ */
 export type FieldRecord = {
   readonly path: Path
   readonly updatedAt: string | null
   readonly connected: boolean
   readonly focused: boolean | null
   readonly blurred: boolean | null
-  readonly touched: boolean | null
+  readonly touched: boolean
 }
 
 // Hydration shape guards — defend against rolling deploys / stale cache
@@ -83,7 +98,7 @@ function isHydratedFieldRecord(value: unknown): value is FieldRecord {
     typeof r.connected === 'boolean' &&
     (typeof r.focused === 'boolean' || r.focused === null) &&
     (typeof r.blurred === 'boolean' || r.blurred === null) &&
-    (typeof r.touched === 'boolean' || r.touched === null)
+    typeof r.touched === 'boolean'
   )
 }
 
@@ -1421,7 +1436,7 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
         connected: false,
         focused: null,
         blurred: null,
-        touched: null,
+        touched: false,
       })
     })
     // No hydration — seed schemaErrors from the construction-time
@@ -1477,9 +1492,16 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
       path,
       updatedAt: patch.updatedAt ?? current?.updatedAt ?? null,
       connected: patch.connected ?? current?.connected ?? false,
-      focused: patch.focused ?? current?.focused ?? null,
-      blurred: patch.blurred ?? current?.blurred ?? null,
-      touched: patch.touched ?? current?.touched ?? null,
+      // focused/blurred use an explicit-undefined guard because
+      // patches legitimately carry `null` to mark a disconnect — the
+      // `??` operator would short-circuit on null and fall through to
+      // `current`, losing the intent. `!== undefined` honours an
+      // explicit null and preserves current only on absence.
+      focused: patch.focused !== undefined ? patch.focused : (current?.focused ?? null),
+      blurred: patch.blurred !== undefined ? patch.blurred : (current?.blurred ?? null),
+      // touched is plain `boolean`; `??` is equivalent to the explicit
+      // guard here because `false` is not nullish.
+      touched: patch.touched ?? current?.touched ?? false,
     })
   }
 
@@ -2365,7 +2387,17 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     }
     elementToFormInstance.set(element, formInstanceId)
     sortedRegistrationsCache = null
-    touchFieldRecord(key, path, { connected: true })
+    // Connect transition. Lift focused/blurred from `null`
+    // (no-element-meaningless) to optimistic booleans only when they
+    // are currently null; preserve existing booleans so a reconnect
+    // doesn't blow away DOM-truth from an autofocus event that landed
+    // before this directive's registration.
+    const current = fields.get(key)
+    touchFieldRecord(key, path, {
+      connected: true,
+      focused: current?.focused ?? false,
+      blurred: current?.blurred ?? true,
+    })
     return true
   }
 
@@ -2381,7 +2413,13 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     const remaining = record.elements.size
     if (remaining === 0) {
       elements.delete(key)
-      touchFieldRecord(key, path, { connected: false })
+      // Disconnect transition. `focused` / `blurred` are DOM-state
+      // properties — with no element to be focused or blurred, the
+      // concepts don't apply, so flip back to `null`. `touched` is
+      // interaction history and is preserved across disconnects
+      // (a v-if'd-away field that was previously blurred stays
+      // touched).
+      touchFieldRecord(key, path, { connected: false, focused: null, blurred: null })
     }
     return remaining
   }
@@ -2395,7 +2433,22 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     const { key } = canonicalizePath(path)
     const current = fields.get(key)
     if (current?.connected === true) return
-    touchFieldRecord(key, path, { connected: true })
+    // Lift focused/blurred from `null` to optimistic booleans alongside
+    // `connected: true`. Only when currently `null` — never clobber an
+    // existing boolean, since a prior `markFocused` may have landed
+    // ahead of the optimistic mark (uncommon but possible during SSR
+    // when a custom directive flips focus state up-front). Server-
+    // rendered FieldState then matches the post-hydration optimistic
+    // state (`focused: false, blurred: true`) without a flash from
+    // `null` on the first reactive tick after hydration; real focus
+    // state lands as soon as the browser fires a focus event
+    // (autofocus / programmatic / user) — the directive's listener
+    // catches it and flips the booleans.
+    touchFieldRecord(key, path, {
+      connected: true,
+      focused: current?.focused ?? false,
+      blurred: current?.blurred ?? true,
+    })
   }
 
   function markFocused(
@@ -2409,7 +2462,7 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
       blurred: !focused,
       // `touched` flips to true on blur and stays true thereafter; while
       // a field is currently focused we keep whatever value it held.
-      touched: focused ? (fields.get(key)?.touched ?? null) : true,
+      touched: focused ? (fields.get(key)?.touched ?? false) : true,
     })
     // On blur (focused → false), `validateOn: 'blur'` fires an
     // immediate (no-debounce) validation for this path. Ignored for
@@ -2662,18 +2715,20 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     if (needsAsync) {
       queueMicrotask(() => scheduleFieldValidation([], true /* immediate */))
     }
-    // Blow away touched/focused/blurred per field. connected stays as-is
-    // (the DOM elements haven't detached — that's a separate concern from
-    // form state) and updatedAt stamps to now.
+    // Clear interaction history (`touched`) per field. `focused` /
+    // `blurred` reflect DOM-truth and stay as-is — `reset()` doesn't
+    // synthetically blur the currently-focused input, so the library
+    // shouldn't claim it did. `connected` is a separate concern from
+    // form state and is preserved. `updatedAt` stamps to now.
     const now = new Date().toISOString()
     for (const [pathKey, record] of fields) {
       fields.set(pathKey, {
         path: record.path,
         updatedAt: now,
         connected: record.connected,
-        focused: null,
-        blurred: null,
-        touched: null,
+        focused: record.focused,
+        blurred: record.blurred,
+        touched: false,
       })
     }
     // Clear submission lifecycle so a reset surface reports "nothing has
@@ -2819,13 +2874,17 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
   function clearFieldRecordFlags(pathKey: PathKey): void {
     const record = fields.get(pathKey)
     if (record === undefined) return
+    // Mirrors `resetForm`'s field-loop: clear interaction history
+    // (`touched`), preserve DOM-truth (`focused` / `blurred`) and
+    // `connected`. The function name is historical — it now clears
+    // only the history flag, not all flags.
     fields.set(pathKey, {
       path: record.path,
       updatedAt: new Date().toISOString(),
       connected: record.connected,
-      focused: null,
-      blurred: null,
-      touched: null,
+      focused: record.focused,
+      blurred: record.blurred,
+      touched: false,
     })
   }
 

--- a/src/runtime/core/field-state-api.ts
+++ b/src/runtime/core/field-state-api.ts
@@ -177,7 +177,7 @@ function buildLeafFieldStateBase<F extends GenericForm>(
     dirty: !pristine,
     focused: record?.focused ?? null,
     blurred: record?.blurred ?? null,
-    touched: record?.touched ?? null,
+    touched: record?.touched ?? false,
     connected: record?.connected ?? false,
     element: firstElement,
     elements: elementsArr,

--- a/src/runtime/core/register-api.ts
+++ b/src/runtime/core/register-api.ts
@@ -79,6 +79,22 @@ function attachFocusListeners<F extends GenericForm>(
   element.addEventListener('focus', handleFocus)
   element.addEventListener('blur', handleBlur)
   target[attaformListenersSymbol] = { handleFocus, handleBlur }
+  // Catch-up probe: the browser applies `autofocus` and dispatches the
+  // resulting `focus` event during HTML parse, BEFORE Vue's directive
+  // lifecycle runs and we attach the listeners above. Programmatic
+  // `.focus()` from a parent component's `onMounted` has the same race.
+  // In both cases, by the time we wire up, the focus event has come and
+  // gone and our handler never runs. Probe `document.activeElement`
+  // (ShadowRoot-aware, mirroring the lookup at directive.ts:881) once
+  // immediately after attaching, so the freshly-rendered field's
+  // FieldState reflects DOM truth instead of the optimistic
+  // `focused: false` seeded at registration.
+  const rootNode = element.getRootNode()
+  const activeElement =
+    rootNode instanceof Document || rootNode instanceof ShadowRoot ? rootNode.activeElement : null
+  if (activeElement === element) {
+    state.markFocused(segments, true, focusMeta)
+  }
 }
 
 function detachFocusListeners(element: HTMLElement): void {

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -2427,21 +2427,25 @@ export type PathSetValuePayload<Leaf> =
 /**
  * Focus / blur / touched flags for a registered field.
  *
- * - `focused` — `true` while the user is interacting with the field;
- *   `false` after blur. `null` until the field has ever been focused.
- * - `blurred` — `true` after the field has lost focus at least once.
- *   `null` before any blur event.
- * - `touched` — flips to `true` on the first blur after a focus and
- *   stays `true` thereafter. Useful for "show errors only after the
- *   user has interacted" UX.
+ * - `focused` — `true` while the user is interacting with the field,
+ *   `false` after blur. `null` while no DOM element is connected for
+ *   this path (the DOM-state concept doesn't apply with no element).
+ * - `blurred` — strictly the inverse of `focused` when an element is
+ *   connected: `true` while not focused, `false` while focused. `null`
+ *   while no element is connected.
+ * - `touched` — interaction history. Plain `boolean`: `false` at
+ *   registration, flips to `true` on the first blur, stays `true`
+ *   thereafter, and is preserved across disconnects. Cleared only by
+ *   `form.reset()` / `form.resetField(path)`. Useful for "show errors
+ *   only after the user has interacted" UX.
  */
 export type DOMFieldState = {
-  /** `true` while focused; `false` after blur; `null` before first focus. */
+  /** `true` while focused; `false` while connected but not focused; `null` while no element is connected. */
   focused: boolean | null
-  /** `true` once the field has lost focus at least once; `null` before. */
+  /** Inverse of `focused` when connected; `null` while no element is connected. */
   blurred: boolean | null
-  /** Flips to `true` on the first blur after a focus and stays there. */
-  touched: boolean | null
+  /** `true` after the first blur; persists across disconnects until `reset()`. */
+  touched: boolean
 }
 /**
  * Per-field reactive shape returned by `form.fields.<leaf-path>` and
@@ -2464,7 +2468,7 @@ export type FieldState<Value = unknown> = {
   readonly dirty: boolean
   readonly focused: boolean | null
   readonly blurred: boolean | null
-  readonly touched: boolean | null
+  readonly touched: boolean
   readonly connected: boolean
   /**
    * The first DOM element bound to this path via `v-register`, or

--- a/test/composables/api-surface-contract.test.ts
+++ b/test/composables/api-surface-contract.test.ts
@@ -179,11 +179,12 @@ describe('API surface contract — actions on `api`, status on `api.meta`, histo
 
     expect(typeof emailField.dirty).toBe('boolean')
     expect(typeof emailField.valid).toBe('boolean')
-    expect(typeof emailField.touched === 'boolean' || emailField.touched === null).toBe(true)
+    expect(typeof emailField.touched).toBe('boolean')
     expect(typeof emailField.showErrors).toBe('boolean')
 
     expectTypeOf(emailField.dirty).toEqualTypeOf<boolean>()
     expectTypeOf(emailField.valid).toEqualTypeOf<boolean>()
+    expectTypeOf(emailField.touched).toEqualTypeOf<boolean>()
     expectTypeOf(emailField.showErrors).toEqualTypeOf<boolean>()
   })
 

--- a/test/composables/field-state-proxy.test.ts
+++ b/test/composables/field-state-proxy.test.ts
@@ -68,7 +68,7 @@ describe('form.fields — top-level leaf reads', () => {
     expect(fs.dirty).toBe(false)
     expect(fs.pristine).toBe(true)
     expect(fs.errors).toEqual([])
-    expect(fs.touched).toBe(null)
+    expect(fs.touched).toBe(false)
   })
 
   it('reflects setValue mutations on subsequent reads', () => {

--- a/test/composables/should-show-errors.test.ts
+++ b/test/composables/should-show-errors.test.ts
@@ -59,7 +59,7 @@ type FieldStateLike = {
   readonly errors: readonly ValidationError[]
   readonly showErrors: boolean
   readonly firstError: ValidationError | undefined
-  readonly touched: boolean | null
+  readonly touched: boolean
   readonly dirty: boolean
 }
 
@@ -225,7 +225,7 @@ function describeOverrideTier(
       await form.handleSubmit(() => {})()
       await nextTick()
       expect(form.meta.submitCount).toBeGreaterThan(0)
-      // touched is still null (no DOM blur, no programmatic touch)
+      // touched is still false (no DOM blur, no programmatic touch)
       expect(form.fields('email').showErrors).toBe(false)
       form.touch('email')
       await nextTick()
@@ -476,7 +476,7 @@ describe('shouldShowErrors — type-level guards', () => {
 
     // Every other FieldState key still reaches through, so authors keep
     // full IDE access to touched / dirty / errors / path / etc.
-    expectTypeOf<Field['touched']>().toEqualTypeOf<boolean | null>()
+    expectTypeOf<Field['touched']>().toEqualTypeOf<boolean>()
     expectTypeOf<Field['dirty']>().toEqualTypeOf<boolean>()
     expectTypeOf<Meta['submitCount']>().toEqualTypeOf<number>()
   })

--- a/test/composables/surface-proxy.test.ts
+++ b/test/composables/surface-proxy.test.ts
@@ -855,10 +855,11 @@ describe('surface materialisation — predictable representations + complex erro
 
     // Every schema-leaf carries the full FieldState surface — `value`
     // matches storage, `path` is the absolute path, `pristine` reflects
-    // the un-mutated initial state. Pre-interaction interaction flags
-    // (`focused`, `blurred`, `touched`) start as `null` (the sentinel
-    // for "no directive signal yet"); `updatedAt` is the construction
-    // timestamp until the first write.
+    // the un-mutated initial state. `focused` / `blurred` start as
+    // `null` (no DOM connected, so the DOM-state concepts don't apply
+    // yet); `touched` starts as `false` (interaction history is a
+    // boolean — no event yet means `false`, not "unknown");
+    // `updatedAt` is the construction timestamp until the first write.
     const expectedLeafShape = {
       value: expect.anything(),
       original: expect.anything(),
@@ -866,7 +867,7 @@ describe('surface materialisation — predictable representations + complex erro
       dirty: false,
       focused: null,
       blurred: null,
-      touched: null,
+      touched: false,
       connected: false,
       updatedAt: expect.anything(),
       errors: [],

--- a/test/composables/surface-serialization.test.ts
+++ b/test/composables/surface-serialization.test.ts
@@ -275,7 +275,7 @@ describe('form.values / form.errors / form.fields — template + JSON.stringify 
       // FieldState terminal includes the usual keys.
       expect(snapshot['value']).toBe('a@b.co')
       expect(typeof snapshot['dirty']).toBe('boolean')
-      expect(typeof snapshot['touched'] === 'boolean' || snapshot['touched'] === null).toBe(true)
+      expect(typeof snapshot['touched']).toBe('boolean')
     })
   })
 })

--- a/test/composables/touch.test.ts
+++ b/test/composables/touch.test.ts
@@ -61,7 +61,7 @@ async function flushValidations(form: { meta: { validating: boolean } }): Promis
 
 type FormWithTouch = {
   touch: (path?: string | readonly (string | number)[]) => void
-  fields: (path?: string | readonly (string | number)[]) => { touched: boolean | null }
+  fields: (path?: string | readonly (string | number)[]) => { touched: boolean }
   meta: { validating: boolean }
   setValue: (path: string, value: unknown) => boolean
   values: (path?: string | readonly (string | number)[]) => unknown
@@ -97,7 +97,7 @@ describe('form.touch — zod-v3 adapter', () => {
 
   it('marks a leaf path touched', async () => {
     const form = asTouchable(makeForm())
-    expect(form.fields('email').touched).toBe(null)
+    expect(form.fields('email').touched).toBe(false)
     form.touch('email')
     await nextTick()
     expect(form.fields('email').touched).toBe(true)
@@ -119,7 +119,7 @@ describe('form.touch — zod-v3 adapter', () => {
     expect(form.fields('profile.name').touched).toBe(true)
     expect(form.fields('profile.age').touched).toBe(true)
     // Sibling leaf untouched
-    expect(form.fields('email').touched).toBe(null)
+    expect(form.fields('email').touched).toBe(false)
   })
 
   it('no-arg form marks every leaf in the form', async () => {
@@ -136,7 +136,7 @@ describe('form.touch — zod-v3 adapter', () => {
     form.touch(['profile', 'name'])
     await nextTick()
     expect(form.fields('profile.name').touched).toBe(true)
-    expect(form.fields('profile.age').touched).toBe(null)
+    expect(form.fields('profile.age').touched).toBe(false)
   })
 
   it('does not modify value', async () => {
@@ -200,7 +200,7 @@ describe('form.touch — zod-v4 adapter', () => {
 
   it('marks a leaf path touched', async () => {
     const form = asTouchable(makeForm())
-    expect(form.fields('email').touched).toBe(null)
+    expect(form.fields('email').touched).toBe(false)
     form.touch('email')
     await nextTick()
     expect(form.fields('email').touched).toBe(true)
@@ -212,7 +212,7 @@ describe('form.touch — zod-v4 adapter', () => {
     await nextTick()
     expect(form.fields('profile.name').touched).toBe(true)
     expect(form.fields('profile.age').touched).toBe(true)
-    expect(form.fields('email').touched).toBe(null)
+    expect(form.fields('email').touched).toBe(false)
   })
 
   it('no-arg form marks every leaf in the form', async () => {

--- a/test/composables/v-register-component-runtime.test.ts
+++ b/test/composables/v-register-component-runtime.test.ts
@@ -327,7 +327,7 @@ describe('non-pattern: v-register on a non-form root WITHOUT useRegister/assignK
     const fs = mounted.api.fields.email
     expect(fs.focused).toBeNull()
     expect(fs.blurred).toBeNull()
-    expect(fs.touched).toBeNull()
+    expect(fs.touched).toBe(false)
   })
 })
 

--- a/test/composables/values-storage-shape.test.ts
+++ b/test/composables/values-storage-shape.test.ts
@@ -788,15 +788,15 @@ describe('Depth pressure — multi-step booking schema (shipment-demo shape)', (
   // Pinning a sampling here keeps the aggregation surface honest
   // alongside the leaf-value pin above.
   it('FieldState aggregation flags expose the typed surface at every depth', () => {
-    // `touched` carries `null` for never-focused fields; `dirty` /
-    // `valid` / `blank` are strict booleans. Aggregations at container
-    // paths are reachable through the callable form (the proxy at a
-    // container path returns a sub-proxy, not a FieldState).
-    expectTypeOf(formT.fields.reference.touched).toEqualTypeOf<boolean | null>()
+    // `touched` / `dirty` / `valid` / `blank` are all strict booleans.
+    // Aggregations at container paths are reachable through the
+    // callable form (the proxy at a container path returns a sub-proxy,
+    // not a FieldState).
+    expectTypeOf(formT.fields.reference.touched).toEqualTypeOf<boolean>()
     expectTypeOf(formT.fields.reference.dirty).toEqualTypeOf<boolean>()
     expectTypeOf(formT.fields.reference.valid).toEqualTypeOf<boolean>()
     expectTypeOf(formT.fields.reference.blank).toEqualTypeOf<boolean>()
-    expectTypeOf(formT.fields.pickup.city.touched).toEqualTypeOf<boolean | null>()
+    expectTypeOf(formT.fields.pickup.city.touched).toEqualTypeOf<boolean>()
     // Root no-arg call returns the root FieldState (aggregated across
     // every active-variant leaf).
     expectTypeOf(formT.fields().dirty).toEqualTypeOf<boolean>()

--- a/test/core/create-form-store.test.ts
+++ b/test/core/create-form-store.test.ts
@@ -55,7 +55,7 @@ describe('createFormStore', () => {
       expect(emailField?.connected).toBe(false)
       expect(emailField?.focused).toBe(null)
       expect(emailField?.blurred).toBe(null)
-      expect(emailField?.touched).toBe(null)
+      expect(emailField?.touched).toBe(false)
     })
   })
 
@@ -337,10 +337,10 @@ describe('createFormStore', () => {
       expect(field?.touched).toBe(true)
     })
 
-    it('markFocused(true) on a never-touched field preserves touched=null', () => {
+    it('markFocused(true) on a never-touched field preserves touched=false', () => {
       const state = makeState()
       state.markFocused(['email'], true)
-      expect(state.getFieldRecord(['email'])?.touched).toBe(null)
+      expect(state.getFieldRecord(['email'])?.touched).toBe(false)
     })
 
     it('markFocused(true) after a blur keeps touched=true', () => {

--- a/test/core/field-state-api.test.ts
+++ b/test/core/field-state-api.test.ts
@@ -62,12 +62,12 @@ describe('buildFieldStateAccessor', () => {
     expect(getFieldState(['email']).value.errors).toHaveLength(1)
   })
 
-  it('focused/blurred/touched default to null until focus events fire', () => {
+  it('focused/blurred default to null while no element is connected; touched defaults to false', () => {
     const { getFieldState } = makeAccessor()
     const s = getFieldState(['email']).value
     expect(s.focused).toBe(null)
     expect(s.blurred).toBe(null)
-    expect(s.touched).toBe(null)
+    expect(s.touched).toBe(false)
   })
 
   it('connected flips to true when an element registers, back to false when all deregister', () => {

--- a/test/core/register-api.test.ts
+++ b/test/core/register-api.test.ts
@@ -154,6 +154,62 @@ describe('buildRegister', () => {
       document.body.removeChild(input)
     })
 
+    it('catches autofocus that fired before the listener was attached', () => {
+      // The browser applies `<input autofocus>` during HTML parse and
+      // dispatches the resulting `focus` event BEFORE Vue's directive
+      // lifecycle runs. By the time `attachFocusListeners` wires up,
+      // the focus event has already come and gone. The probe inside
+      // `attachFocusListeners` exists to close that race: if the
+      // element is already `document.activeElement` at attach-time,
+      // call `markFocused(true)` synchronously so FieldState reflects
+      // DOM truth instead of the optimistic `focused: false` seeded
+      // at registration. Simulates the race by focusing the input
+      // BEFORE calling `registerElement` (the call order inside the
+      // directive `created` hook for an autofocused element).
+      const { state, register } = makeRegister()
+      const rv = register(['email'])
+      const input = document.createElement('input')
+      document.body.appendChild(input)
+      input.focus()
+      expect(document.activeElement).toBe(input)
+      // Sanity: the FormStore has not seen any focus signal yet — the
+      // listener isn't attached and `input.focus()` above only fired a
+      // native DOM event no one was listening to.
+      expect(state.getFieldRecord(['email'])?.focused).toBe(null)
+
+      rv.registerElement(input)
+      // After registration, the probe inside `attachFocusListeners`
+      // sees `document.activeElement === input` and flips focused.
+      expect(state.getFieldRecord(['email'])?.focused).toBe(true)
+      expect(state.getFieldRecord(['email'])?.blurred).toBe(false)
+      expect(state.getFieldRecord(['email'])?.connected).toBe(true)
+
+      document.body.removeChild(input)
+    })
+
+    it('does not flip focused when registering an element that is NOT the active one', () => {
+      // Negative case for the autofocus probe — pin that we don't
+      // false-positive when a sibling input happens to be focused.
+      const { state, register } = makeRegister()
+      const rv = register(['email'])
+      const sibling = document.createElement('input')
+      const target = document.createElement('input')
+      document.body.appendChild(sibling)
+      document.body.appendChild(target)
+      sibling.focus()
+      expect(document.activeElement).toBe(sibling)
+
+      rv.registerElement(target)
+      // `target` was not the active element at attach-time, so the
+      // probe leaves the optimistic `focused: false` in place.
+      expect(state.getFieldRecord(['email'])?.focused).toBe(false)
+      expect(state.getFieldRecord(['email'])?.blurred).toBe(true)
+      expect(state.getFieldRecord(['email'])?.connected).toBe(true)
+
+      document.body.removeChild(sibling)
+      document.body.removeChild(target)
+    })
+
     it('removes focus/blur listeners on deregister', () => {
       const { state, register } = makeRegister()
       const rv = register(['email'])
@@ -165,11 +221,14 @@ describe('buildRegister', () => {
       expect(state.getFieldRecord(['email'])?.focused).toBe(true)
 
       rv.deregisterElement(input)
-      // After deregister, re-dispatch: if a listener still fires, focused flips.
+      // After deregister, re-dispatch: if a listener still fires,
+      // `markFocused(blur)` would flip the record to `focused: false,
+      // blurred: true`. Instead the disconnect transition has set
+      // both flags to `null` (no element ⇒ DOM-state concepts don't
+      // apply) and the missing listener leaves them at `null`.
       input.dispatchEvent(new FocusEvent('blur'))
-      // markFocused isn't called post-deregister — the record still reflects
-      // the last value before deregister.
-      expect(state.getFieldRecord(['email'])?.focused).toBe(true)
+      expect(state.getFieldRecord(['email'])?.focused).toBe(null)
+      expect(state.getFieldRecord(['email'])?.blurred).toBe(null)
       expect(state.getFieldRecord(['email'])?.connected).toBe(false)
       document.body.removeChild(input)
     })

--- a/test/core/serialize.test.ts
+++ b/test/core/serialize.test.ts
@@ -156,7 +156,7 @@ describe('hydration shape guard', () => {
       connected: true,
       focused: null,
       blurred: null,
-      touched: null,
+      touched: false,
     }
     const hydration = buildPayload({
       fields: [


### PR DESCRIPTION
## Summary

- `FieldRecord.touched` becomes plain `boolean` (was `boolean | null`); `focused` / `blurred` stay `boolean | null` but are now strictly `null` only while no element is connected. The invariant `blurred === !focused` holds when not null.
- `markConnectedOptimistically` seeds optimistic booleans at SSR (`focused: false, blurred: true`) alongside `connected: true`, so SSR markup stops claiming "we don't know" while the element is demonstrably rendered.
- `registerElement` lifts focused/blurred from null on connect; `deregisterElement` flips them back to null on full detach. `touched` is preserved across disconnects (interaction history isn't a DOM property).
- New catch-up probe in `attachFocusListeners`: if the element is already `document.activeElement` when the listener is wired up, synchronously call `markFocused(path, true)`. Closes the autofocus race where the browser fires the focus event during HTML parse, before Vue's directive lifecycle runs. Same ShadowRoot-aware lookup the directive already uses for lazy/trim gating.
- `form.reset()` / `resetField()` now only flip `touched`, preserving DOM-truth on focused/blurred (reset doesn't synthetically blur the input, so the library shouldn't claim it did).
- Two red-green tests pin the autofocus probe — positive case (focus-before-register → flips) and negative (sibling-focused → stays false).

## Why

Surfaced during the Nuxt DevTools overlay work: SSR-rendered FieldState was claiming `connected: true, focused: null, blurred: null, touched: null` for v-register'd inputs. The element is demonstrably rendered and the user demonstrably hasn't touched it, yet every flag said "unknown." The fix splits the three flags by semantic group: DOM-state (focused/blurred) genuinely is meaningless without a DOM, but interaction history (touched) is a property of the form lifecycle, not the element lifecycle.

A compile-time autofocus detection path was considered and rejected — browsers pick the LAST autofocus winner across the assembled DOM, which a per-SFC transform has no visibility into. The runtime probe queries `document.activeElement` after the browser has resolved arbitration, so it's not just simpler, it's the only structurally correct option.

## Test plan

- [x] `pnpm typecheck` clean (inside Docker)
- [x] `pnpm vitest run` — 2666 tests passing (was 2664; +2 new autofocus tests)
- [x] Red-green-green cycle verified for the autofocus probe (probe disabled → positive test fails as expected, negative still passes; probe restored → both pass)
- [x] Manual lab verification (`~/Projects/attaform-devtools-lab`): SSR markup ships `focused: false, blurred: true, touched: false, connected: true` and post-hydration the JSON stays honest through type / blur / re-focus cycles
- [x] Autofocus verified end-to-end: adding `autofocus` to the username input flips `focused: true` after hydration via the catch-up probe

🤖 Generated with [Claude Code](https://claude.com/claude-code)