### PR TITLE
ci: manual-trigger docs deploy + exact-version publish mode

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,77 @@
+name: Deploy docs to Vercel
+run-name: Deploy docs to Vercel${{ github.event.inputs.reason != '' && format(' — {0}', github.event.inputs.reason) || '' }}
+
+# Manual-only production deployment for the docs site at apps/site.
+# Vercel's git-push auto-deploys from `main` are disabled in
+# apps/site/vercel.json (`git.deploymentEnabled.main = false`), so
+# this workflow is the ONLY path that ships the production site.
+#
+# Why manual: the docs reference symbols, types, and behavior shipped
+# by the `attaform` npm package. Auto-publishing docs on every merge
+# to main risks the published docs page referencing an API that
+# isn't on npm yet. The release order is now strictly:
+#
+#   1. Run `Publish to NPM and Version Bump` (publish-npm.yml)
+#   2. Wait for `npm install attaform@<version>` to resolve the new
+#      tarball (registry usually serves new versions within a minute)
+#   3. Run THIS workflow to ship the matching docs
+#
+# Preview deploys for non-main branches and PRs continue to fire
+# automatically — `deploymentEnabled` only gates the production
+# branch, so PR previews still help review docs changes pre-merge.
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for this deploy (e.g. "0.18.0 release", "fix broken link"). Shown in the workflow run name; optional but useful for the activity log.'
+        required: false
+        default: ''
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      # Vercel Deploy Hooks are POST-only webhook URLs scoped to a
+      # specific project + branch. Creating one in the Vercel
+      # dashboard:
+      #   Project → Settings → Git → Deploy Hooks → Create Hook
+      #   Name:   "Manual production deploy"
+      #   Branch: main
+      # The resulting URL goes into the `VERCEL_DEPLOY_HOOK_URL` repo
+      # secret. The URL itself is the auth token — anyone with the URL
+      # can trigger a production deploy, so it lives only as a secret
+      # and never in the repo.
+      #
+      # Hitting the hook bypasses `deploymentEnabled.main = false`
+      # (that flag governs git-push auto-deploys, not hook-triggered
+      # ones) and queues a production build from the current `main`
+      # tip on Vercel's side. The response carries the queued job's
+      # id + state; the human-visible deployment URL only appears
+      # after Vercel builds, so we surface the dashboard link instead.
+      - name: Trigger Vercel production deploy
+        env:
+          VERCEL_DEPLOY_HOOK_URL: ${{ secrets.VERCEL_DEPLOY_HOOK_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${VERCEL_DEPLOY_HOOK_URL:-}" ]; then
+            echo "::error::VERCEL_DEPLOY_HOOK_URL secret is not set. Create a Deploy Hook in Vercel (Project Settings → Git → Deploy Hooks, branch: main), then add the URL as a repo secret named VERCEL_DEPLOY_HOOK_URL."
+            exit 1
+          fi
+          RESPONSE=$(curl --fail-with-body -sS -X POST "$VERCEL_DEPLOY_HOOK_URL")
+          echo "Vercel response: $RESPONSE"
+          {
+            echo "### Vercel deploy queued"
+            echo ""
+            echo "Triggered by: @${{ github.actor }}"
+            if [ -n "${{ github.event.inputs.reason }}" ]; then
+              echo "Reason: ${{ github.event.inputs.reason }}"
+            fi
+            echo ""
+            echo "Hook response:"
+            echo ""
+            echo '```json'
+            echo "$RESPONSE"
+            echo '```'
+            echo ""
+            echo "Track the build at https://vercel.com/dashboard — Vercel will publish to the production domain once the build succeeds."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,14 +1,22 @@
 name: Publish to NPM and Version Bump
-run-name: Publish ${{ github.event.inputs.prerelease_id != '' && format('{0} ({1})', github.event.inputs.version_type, github.event.inputs.prerelease_id) || github.event.inputs.version_type }} release to NPM
+run-name: ${{ github.event.inputs.exact_version != '' && format('Publish v{0} to NPM{1}', github.event.inputs.exact_version, github.event.inputs.dist_tag != '' && format(' @ {0}', github.event.inputs.dist_tag) || '') || format('Publish {0} release to NPM', github.event.inputs.prerelease_id != '' && format('{0} ({1})', github.event.inputs.version_type, github.event.inputs.prerelease_id) || github.event.inputs.version_type) }}
 on:
   workflow_dispatch:
     inputs:
       version_type:
-        description: 'Version type (major, minor, patch). For prereleases, this is the base bump that the prerelease attaches to (used only when starting a NEW prerelease cycle).'
+        description: 'Version type (major, minor, patch). For prereleases, this is the base bump that the prerelease attaches to (used only when starting a NEW prerelease cycle). Ignored when `exact_version` is set.'
         required: true
         default: 'patch'
       prerelease_id:
-        description: 'Prerelease identifier (alpha, beta, rc, next, ...). Leave EMPTY for a stable release. Example flow: 0.2.1 → 0.2.2-beta.0 → 0.2.2-beta.1 → 0.2.2.'
+        description: 'Prerelease identifier (alpha, beta, rc, next, ...). Leave EMPTY for a stable release. Example flow: 0.2.1 → 0.2.2-beta.0 → 0.2.2-beta.1 → 0.2.2. Ignored when `exact_version` is set.'
+        required: false
+        default: ''
+      exact_version:
+        description: 'Override mode: publish this EXACT semver (e.g. "1.16.3" or "1.16.3-hotfix.0") instead of computing from version_type / prerelease_id. Use for hotfixes to an older major line while a newer major holds the current `latest` tag. Pair with `dist_tag` so the publish does not clobber `latest`.'
+        required: false
+        default: ''
+      dist_tag:
+        description: 'npm dist-tag override. Leave EMPTY in normal flows — the workflow derives `latest` for stable releases and the preid for prereleases. Set this when publishing an off-latest version (e.g. "v1" for a v1.x hotfix while 2.x is current) so `npm install attaform` still resolves to the current major.'
         required: false
         default: ''
 jobs:
@@ -28,7 +36,29 @@ jobs:
         env:
           VERSION_TYPE: ${{ github.event.inputs.version_type }}
           PRERELEASE_ID: ${{ github.event.inputs.prerelease_id }}
+          EXACT_VERSION: ${{ github.event.inputs.exact_version }}
         run: |
+          # exact_version short-circuit: caller dictates the version
+          # verbatim, skipping version_type / prerelease_id math. Used
+          # for hotfix releases to older major lines (e.g. publishing
+          # 1.16.3 while 2.x is current). The publish step uses
+          # `dist_tag` to keep the off-latest tarball from shadowing
+          # the current `latest` — pair them together.
+          if [ -n "$EXACT_VERSION" ]; then
+            if ! echo "$EXACT_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?(\+[A-Za-z0-9.-]+)?$'; then
+              echo "::error::exact_version='$EXACT_VERSION' is not a valid semver string. Examples: 1.16.3, 1.16.3-hotfix.0"
+              exit 1
+            fi
+            CURRENT=$(node -p "require('./package.json').version")
+            if [ "$EXACT_VERSION" = "$CURRENT" ]; then
+              echo "::error::exact_version='$EXACT_VERSION' matches the current package.json version — pnpm version would reject the bump. Pick a distinct version or use a regular bump path."
+              exit 1
+            fi
+            echo "next_version=$EXACT_VERSION" >> $GITHUB_OUTPUT
+            echo "WORKFLOW_TITLE=Publish exact version $EXACT_VERSION to NPM" >> $GITHUB_ENV
+            exit 0
+          fi
+
           # Computed in Node so we can handle prerelease semantics without
           # depending on `semver` being installed (this step runs BEFORE
           # `pnpm install`). Pure-JS version inc, matching `semver.inc`:
@@ -155,8 +185,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION_TYPE: ${{ github.event.inputs.version_type }}
           PRERELEASE_ID: ${{ github.event.inputs.prerelease_id }}
+          EXACT_VERSION: ${{ github.event.inputs.exact_version }}
         run: |
-          if [ -n "$PRERELEASE_ID" ]; then
+          if [ -n "$EXACT_VERSION" ]; then
+            # Override mode: `pnpm version <exact-semver>` writes the
+            # version verbatim. npm/pnpm accept arbitrary semver here
+            # with no monotonic check, so hotfix-of-older-major bumps
+            # (e.g. 2.0.0 → 1.16.3 for a v1.x security patch) work.
+            pnpm version "$EXACT_VERSION"
+          elif [ -n "$PRERELEASE_ID" ]; then
             # Prerelease modes match the calculate-next-version logic.
             #   Already on a prerelease (any preid) → `prerelease --preid <id>`:
             #     this either bumps the counter (same preid) or switches
@@ -193,11 +230,20 @@ jobs:
         # resolves to `latest` (the stable line), and consumers opt in
         # via `npm install attaform@beta`. Without `--tag`, pnpm publish
         # defaults to `latest`, which would shadow the stable release.
+        #
+        # `dist_tag` input wins over prerelease_id when set — used in
+        # the exact_version override mode to publish a v1.x hotfix
+        # under a non-latest tag (e.g. "v1") so the older-major
+        # tarball does not shadow the current major on the default
+        # `npm install attaform`.
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           PRERELEASE_ID: ${{ github.event.inputs.prerelease_id }}
+          DIST_TAG: ${{ github.event.inputs.dist_tag }}
         run: |
-          if [ -n "$PRERELEASE_ID" ]; then
+          if [ -n "$DIST_TAG" ]; then
+            pnpm publish --access public --provenance --tag "$DIST_TAG"
+          elif [ -n "$PRERELEASE_ID" ]; then
             pnpm publish --access public --provenance --tag "$PRERELEASE_ID"
           else
             pnpm publish --access public --provenance
@@ -264,8 +310,17 @@ jobs:
           # above would short-circuit here rather than produce an
           # orphan release. Stable releases use `--latest` (primary on
           # the repo's releases page); prereleases use `--prerelease`
-          # so they don't shadow the stable line.
-          if [ -n "${{ github.event.inputs.prerelease_id }}" ]; then
+          # so they don't shadow the stable line. Off-latest stable
+          # hotfixes (any non-empty, non-`latest` dist_tag) get neither
+          # flag — they appear in the release list but don't claim
+          # the "Latest" badge that the current major's release holds.
+          DIST_TAG_INPUT="${{ github.event.inputs.dist_tag }}"
+          if [ -n "$DIST_TAG_INPUT" ] && [ "$DIST_TAG_INPUT" != "latest" ]; then
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --notes-file "$RUNNER_TEMP/release-body.md" \
+              --verify-tag
+          elif [ -n "${{ github.event.inputs.prerelease_id }}" ]; then
             gh release create "$TAG" \
               --title "$TAG" \
               --notes-file "$RUNNER_TEMP/release-body.md" \

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ pnpm-debug.log*
 
 # Generated dirs
 dist
+apps/site/.repl-cache
 apps/site/public/lib
 apps/site/public/_pagefind
 

--- a/apps/site/vercel.json
+++ b/apps/site/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "main": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Three CI/release-engineering changes:

1. **Vercel docs auto-deploy on main is gone.** Vercel now only ships the docs site when the new `Deploy docs to Vercel` workflow is manually triggered. Reason: docs reference symbols/types/behavior that must already be on npm — auto-publishing docs on every merge risked publishing pages that reference an API not yet shipped.
2. **`exact_version` + `dist_tag` modes on the npm publish workflow.** Override path for hotfix releases to older major lines (e.g. a v1.x security patch while 2.x holds `latest`) without clobbering the `latest` dist-tag.
3. **`apps/site/.repl-cache` gitignored on main.** The rule already exists on downstream branches (added in `d09cb4e` on the lazy-activation stack); landing it here keeps `git status` clean for anyone running the dev server.

## What ships

### Vercel docs deploy gate

- `apps/site/vercel.json` sets `git.deploymentEnabled.main = false`. Preview deploys for other branches and PRs continue to fire automatically.
- `.github/workflows/deploy-docs.yml` is a `workflow_dispatch`-only workflow that POSTs a Vercel Deploy Hook URL. Optional `reason` input is reflected in the run name (e.g. for the activity log).

**Setup step required after merge:**
1. Vercel dashboard → Project → Settings → Git → Deploy Hooks → Create Hook (name: `Manual production deploy`, branch: `main`) → copy URL.
2. GitHub repo → Settings → Secrets and variables → Actions → add `VERCEL_DEPLOY_HOOK_URL` with that URL.

New release order:
1. Run `Publish to NPM and Version Bump`.
2. Wait for `npm install attaform@<version>` to resolve the new tarball.
3. Run `Deploy docs to Vercel` to ship the matching docs.

### `exact_version` + `dist_tag` on publish-npm

Two new optional `workflow_dispatch` inputs:

- `exact_version` — when set, skips `version_type` / `prerelease_id` math and runs `pnpm version <exact-semver>` verbatim. Validates the semver shape and refuses an exact_version equal to the current `package.json` version. Existing `version_type` + `prerelease_id` flows are untouched.
- `dist_tag` — overrides the publish dist-tag. Without it, the workflow still defaults to `latest` (stable) or the preid (prereleases). With it, the publish and GitHub Release respect it.

**Off-latest GitHub Releases**: when `dist_tag` is set and is NOT `latest`, the `gh release create` call skips both `--latest` and `--prerelease`. The release appears in the list but doesn't claim the "Latest" badge currently held by the active major.

Example: a v1.x hotfix while 2.x is current —

```
exact_version = 1.16.3
dist_tag      = v1
```

→ publishes `attaform@1.16.3` to `@v1`. `npm install attaform` still resolves to the 2.x `latest`; 1.x users opt in via `npm install attaform@v1`.

### `.gitignore`

One-line addition: `apps/site/.repl-cache` next to the existing `apps/site/public/*` entries under \"Generated dirs\".

## Test plan

- [x] `apps/site/vercel.json` validates as JSON
- [x] `.github/workflows/deploy-docs.yml` and the updated `publish-npm.yml` both parse as valid YAML
- [x] Inputs on `publish-npm.yml` confirmed (`version_type`, `prerelease_id`, `exact_version`, `dist_tag`); all 16 existing steps still present
- [ ] After merge: add the `VERCEL_DEPLOY_HOOK_URL` secret in the repo settings
- [ ] After merge: first push to main triggers ONE last Vercel auto-deploy (the one that picks up the new `vercel.json`); subsequent main pushes are silent
- [ ] Smoke-test the new `Deploy docs to Vercel` workflow once the secret is set — manually triggered run should POST the hook and surface the queued job in the run summary
- [ ] Smoke-test the `exact_version` path can wait until an actual hotfix is needed; the override is additive over existing flows

Generated with [Claude Code](https://claude.com/claude-code)