### PR TITLE
ci(docs): scope deploy-docs workflow to Production (Docs) environment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -30,6 +30,20 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # Scoping to the `Production (Docs)` GitHub Environment buys three
+    # things on top of a plain repo secret:
+    #   1. Activity log: each run shows up under repo → Deployments,
+    #      with timestamp + triggering user, so the docs-release ledger
+    #      lives in one obvious place.
+    #   2. Branch restriction: the environment's "Deployment branches
+    #      and tags" rules gate which refs can read the secret. Lock to
+    #      `main` so a fork or feature-branch copy of this workflow
+    #      can't reach VERCEL_DEPLOY_HOOK_URL.
+    #   3. Optional reviewer gate: the environment's "Required
+    #      reviewers" rule (configured in the repo's settings, NOT here)
+    #      adds a manual-approval click before each deploy.
+    environment:
+      name: 'Production (Docs)'
     steps:
       # Vercel Deploy Hooks are POST-only webhook URLs scoped to a
       # specific project + branch. Creating one in the Vercel


### PR DESCRIPTION
## Summary

Follow-up to #222. The `Deploy docs to Vercel` workflow now declares `environment: 'Production (Docs)'` on its `deploy` job, so `VERCEL_DEPLOY_HOOK_URL` is read from an environment-scoped secret rather than a repo-wide one.

Three properties this buys:

- **Activity log.** Each run lands in repo → Deployments with timestamp and triggering user, so the docs-release ledger has an obvious home.
- **Branch restriction.** The environment's "Deployment branches and tags" rule gates which refs can read the secret — lock to `main` from the repo settings to prevent fork or feature-branch copies of the workflow from triggering production deploys.
- **Optional reviewer gate.** The environment's "Required reviewers" rule surfaces a manual-approve click before each deploy.

## Setup checklist post-merge

1. Confirm the `Production (Docs)` environment exists in repo Settings → Environments (already done).
2. Add `VERCEL_DEPLOY_HOOK_URL` as an **environment secret** under `Production (Docs)` (not as a repo-level Actions secret).
3. Under "Deployment branches and tags", restrict to `main`.
4. Confirm "Prevent self-review" is UNCHECKED if you're the only listed reviewer (otherwise every deploy deadlocks).

## Test plan

- [x] YAML parses; `environment` field resolves to `{name: 'Production (Docs)'}` with one `deploy` step intact
- [ ] After merge: a manual run of `Deploy docs to Vercel` reaches the secret and POSTs the hook (will fail loudly with a clear error if the secret is missing in the environment)

Generated with [Claude Code](https://claude.com/claude-code)