### PR TITLE
[13/14] docs(multistep): section walk

### DIFF
--- a/apps/site/docs-demos/use-wizard.vue
+++ b/apps/site/docs-demos/use-wizard.vue
@@ -51,8 +51,10 @@
           current: wizard.current === form.key,
         }"
       >
-        <span class="step-num">{{ i + 1 }}</span>
-        <span class="step-label">{{ form.key.replace('docs-demo-wizard-', '') }}</span>
+        <button type="button" class="step-button" @click="wizard.goTo(form.key)">
+          <span class="step-num">{{ i + 1 }}</span>
+          <span class="step-label">{{ form.key.replace('docs-demo-wizard-', '') }}</span>
+        </button>
       </li>
     </ol>
 
@@ -150,21 +152,38 @@
   .rail li {
     flex: 1;
     display: flex;
+  }
+  .step-button {
+    flex: 1;
+    display: flex;
     align-items: center;
     gap: 0.375rem;
     padding: 0.375rem 0.5rem;
     background: #f3f4f6;
+    border: 0;
     border-radius: 0.375rem;
     font-size: 0.75rem;
+    font-weight: 400;
     color: #6b7280;
     text-transform: capitalize;
+    cursor: pointer;
+    font-family: inherit;
+    text-align: left;
+    transition: filter 120ms ease;
   }
-  .rail li.current {
+  .step-button:hover {
+    filter: brightness(0.95);
+  }
+  .step-button:focus-visible {
+    outline: 2px solid #2563eb;
+    outline-offset: 2px;
+  }
+  .rail li.current .step-button {
     background: #dbeafe;
     color: #1e40af;
     font-weight: 500;
   }
-  .rail li.done {
+  .rail li.done .step-button {
     background: #ecfdf5;
     color: #047857;
   }

--- a/docs/multistep/aggregates.md
+++ b/docs/multistep/aggregates.md
@@ -94,11 +94,11 @@ Sort order: wizard's `forms` order, then each form's internal error order. The s
 </template>
 ```
 
-A click on any summary row jumps the wizard to the step that produced the error. The consumer wires the focus / scroll behaviour from there.
+A click on any summary row jumps the wizard to the step that produced the error. The consumer wires the focus / scroll behavior from there.
 
 ## Dormant steps contribute nothing
 
-`wizard.allErrors` deliberately skips steps whose forms have not been activated. A non-current step with an async `defaultValues` factory does NOT fire on the server just because the consumer reads the summary list:
+`wizard.allErrors` deliberately skips steps whose forms have not been activated. A non-current step with an async `defaultValues` factory does **not** fire on the server just because the consumer reads the summary list:
 
 ```ts
 const wizard = useWizard([account, profile, review] as const)
@@ -106,7 +106,7 @@ const wizard = useWizard([account, profile, review] as const)
 // wizard.allErrors only includes errors from account, not profile or review.
 ```
 
-That keeps the [SSR privacy invariant](/docs/multistep/ssr) intact. A summary panel rendered on the server reports the current step's errors without disturbing dormant steps.
+That keeps the [SSR privacy invariant](/docs/multistep/ssr#the-stated-invariant) intact. A summary panel rendered on the server reports the current step's errors without disturbing dormant steps.
 
 On the client, navigating to a step activates that step's factory and its errors join the aggregate naturally.
 

--- a/docs/multistep/history.md
+++ b/docs/multistep/history.md
@@ -36,11 +36,11 @@ const review = useForm({ schema: reviewSchema, key: 'signup-review' })
 const wizard = useWizard([account, profile, review] as const)
 ```
 
-With no `history` option, the wizard:
+With no `history` option:
 
-- Calls `wizard.next()` → URL becomes `?step=signup-profile`. `pushState` adds a new history entry.
-- Calls `wizard.back()` → URL becomes `?step=signup-account`. The browser's back button walks the wizard.
-- Reload at `?step=signup-review` → wizard opens on the `signup-review` step (the form's resolved or seeded values populate normally).
+- `wizard.next()` pushes `?step=signup-profile`; the browser's back button retreats one step.
+- `wizard.back()` pushes `?step=signup-account`; forward advances again.
+- A reload at `?step=signup-review` opens the wizard on `signup-review`; the form's resolved or seeded values populate normally.
 - Other search params on the URL are preserved across navigations.
 
 ## Disabling history

--- a/docs/multistep/lazy-activation.md
+++ b/docs/multistep/lazy-activation.md
@@ -37,7 +37,7 @@ The rule is "all or nothing, except `form.key`." Any reactive interaction with t
 
 Observing factory state (`form.ready`, `form.hydrating`, `form.hydrateError`) activates the factory deliberately. Reading these implies the consumer is about to gate UI on the answer; firing the factory is the only way to produce a real answer.
 
-The wizard's `wizard.statuses` proxy is the deliberate exception. Reading a step's status does NOT activate it. See [Statuses](/docs/multistep/statuses).
+The wizard's `wizard.statuses` proxy is the deliberate exception. Reading a step's status does **not** activate it. See [Statuses](/docs/multistep/statuses).
 
 ## `form.activate()` for the explicit kickoff
 
@@ -45,6 +45,7 @@ For SSR prefetch, or when the consumer wants to start fetching ahead of the firs
 
 ```ts
 import { useForm } from 'attaform/zod'
+import { z } from 'zod'
 
 const userSchema = z.object({ email: z.email(), name: z.string() })
 const userForm = useForm({
@@ -54,9 +55,9 @@ const userForm = useForm({
 void userForm.activate()
 ```
 
-`activate()` returns a `Promise<void>` that resolves when the factory settles (or rejects normalised into `hydrateError`). Consumers may ignore the promise (`void form.activate()`) when they don't need to await.
+`activate()` returns a `Promise<void>` that resolves when the factory settles (or rejects normalized into `hydrateError`). Consumers may ignore the promise (`void form.activate()`) when they don't need to await.
 
-The method is idempotent in the strongest sense: every call against the same form returns the SAME in-flight promise until the factory settles. Two consumers (a parent's `useForm` and a descendant's `injectForm`) calling `activate()` concurrently share one factory run. SSR consumers reading the same store all await the same fetch.
+The method is idempotent in the strongest sense: every call against the same form returns the **same** in-flight promise until the factory settles. Two consumers (a parent's `useForm` and a descendant's `injectForm`) calling `activate()` concurrently share one factory run. SSR consumers reading the same store all await the same fetch.
 
 A previously-rejected factory leaves `activate()` as a no-op (the consumer's [`form.rehydrate()`](/docs/schemas/defaults#loading-defaults-asynchronously) is the explicit replay). That keeps a reactive read of `form.hydrateError` from accidentally retrying a broken fetch in an effect loop.
 
@@ -86,6 +87,9 @@ The three signals fall into clean UI patterns:
 ```vue
 <script setup lang="ts">
   import { useForm } from 'attaform/zod'
+  import { z } from 'zod'
+
+  const userSchema = z.object({ email: z.email(), name: z.string() })
   const userForm = useForm({
     schema: userSchema,
     defaultValues: async () => api.fetchUser(),
@@ -112,12 +116,12 @@ Read each guard left-to-right:
 
 ## Privacy follows activation
 
-A form that no one touches never fires its factory. That is the load-bearing property behind the [SSR privacy invariant](/docs/multistep/ssr): a non-current step of a `useWizard` is not just "skipped on the server." It is genuinely dormant. No fetch fires. No PII fields leave the browser's network tab.
+A form that no one touches never fires its factory. That is the load-bearing property behind the [SSR privacy invariant](/docs/multistep/ssr#the-stated-invariant): a non-current step of a `useWizard` is not just "skipped on the server." It is genuinely dormant. No fetch fires. No PII fields leave the browser's network tab.
 
 The lazy default is what makes `attaform/vite`'s compile-time `__ssrAccessed` injection meaningful. The transform's whole job is to mark forms whose template references prove "this consumer wants this fetched on the server." Without lazy-by-default, every form would fetch and the transform would have nothing to opt-in to.
 
 ## Cross-reference
 
 - [SSR & the privacy invariant](/docs/multistep/ssr) for the server-side implications.
-- [Statuses](/docs/multistep/statuses) for the read surface that does NOT activate (`wizard.statuses`).
+- [Statuses](/docs/multistep/statuses) for the read surface that does **not** activate (`wizard.statuses`).
 - [Defaults from the schema](/docs/schemas/defaults) for `rehydrate()` and the async-factory contract.

--- a/docs/multistep/patterns.md
+++ b/docs/multistep/patterns.md
@@ -24,6 +24,7 @@ The default shape: walk the forms array in order. `wizard.next()` advances; `wiz
 
 ```ts
 import { useForm, useWizard } from 'attaform/zod'
+import { z } from 'zod'
 
 const accountSchema = z.object({ email: z.email() })
 const profileSchema = z.object({ name: z.string().min(1) })
@@ -40,7 +41,7 @@ function onAccountNext(): void {
 }
 ```
 
-Each step gates on its own `form.handleSubmit` to advance: validation fails locally on the active step, then the wizard advances.
+Each step gates on its own `form.handleSubmit` to advance. Validation runs locally on the active step; the wizard advances only on success.
 
 ## Branching wizards
 
@@ -72,7 +73,7 @@ If a step doesn't apply for the entire flow, omit it from the array:
 
 ```ts
 const visible = computed(() =>
-  user.value.kind === 'organisation' ? [account, organisation, review] : [account, profile, review]
+  user.value.kind === 'organization' ? [account, organization, review] : [account, profile, review]
 )
 const wizard = useWizard(visible.value as const)
 ```
@@ -86,8 +87,8 @@ If applicability depends on values entered during the flow, keep the step in the
 ```ts
 function onAccountNext(): void {
   account.handleSubmit((data) => {
-    if (data.kind === 'organisation') {
-      wizard.goTo('signup-organisation')
+    if (data.kind === 'organization') {
+      wizard.goTo('signup-organization')
     } else {
       wizard.goTo('signup-profile')
     }
@@ -95,7 +96,7 @@ function onAccountNext(): void {
 }
 ```
 
-The skipped step's form still exists. The aggregator gates on `defaultsResolved`, so a skipped step contributes `PENDING_STATUS` to `wizard.statuses` and nothing to `wizard.allErrors` until something activates it.
+The skipped step's form still exists. The aggregator gates on `defaultsResolved`, so a skipped step contributes a pending `FormStatus` to `wizard.statuses` and nothing to `wizard.allErrors` until something activates it.
 
 ## Per-step persistence
 

--- a/docs/multistep/ssr.md
+++ b/docs/multistep/ssr.md
@@ -122,7 +122,7 @@ const wizard = useWizard([account, profile, review] as const, {
 })
 ```
 
-The wizard consults `getServerActiveStep()` BEFORE deciding which form's factory to mark for prefetch. The fallback chain:
+The wizard consults `getServerActiveStep()` **before** deciding which form's factory to mark for prefetch. The fallback chain:
 
 1. `getServerActiveStep()` returns a known key. The wizard marks that form.
 2. Returns `undefined` and the request URL carries `?step=<key>` (matched against `history.param`). The wizard marks that form.
@@ -130,7 +130,7 @@ The wizard consults `getServerActiveStep()` BEFORE deciding which form's factory
 
 The getter runs on both server and client. The consumer's route source must be available on both. Returning a key that doesn't appear in `forms` dev-warns and falls back to `forms[0]`.
 
-## Async factories the framework decides about
+## Letting the framework own slow factories
 
 The library does not special-case slow factories. A request timeout, a `<Suspense>` boundary with a fallback, or a Nuxt-level cache header is the framework's job. When the consumer specifically wants client-only fetching for a slow factory:
 

--- a/docs/multistep/ssr.md
+++ b/docs/multistep/ssr.md
@@ -32,7 +32,7 @@ That last sentence is the privacy backstop. Even if the transform marks every st
 
 ## Three positive triggers
 
-The three triggers reflect three different consumer intents. The library treats them as equally valid signals that "this form is part of what the server should render."
+The three triggers reflect three different consumer intents. Attaform treats them as equally valid signals that "this form is part of what the server should render."
 
 ### 1. Explicit `form.activate()`
 
@@ -102,11 +102,11 @@ Non-current steps of a `useWizard` are added to the registry's skip set on the s
 - Other steps' factories: dormant. The hydration transfer state carries the schema's slim defaults for those keys.
 - Client: navigating to a non-current step activates that step's factory on the client (lazy activation handles the rest).
 
-The skip overrides marks even when the consumer explicitly calls `form.activate()` on a non-current step from inside a wizard. The library treats the wizard's privacy contract as load-bearing.
+The skip overrides marks even when the consumer explicitly calls `form.activate()` on a non-current step from inside a wizard. Attaform treats the wizard's privacy contract as load-bearing.
 
 ## `getServerActiveStep`
 
-The library is framework-agnostic. It does not import a router or read a session. The consumer reads the request's route, query, header, cookie, or wherever the active step lives, and returns it from a getter:
+Attaform is framework-agnostic. It does not import a router or read a session. The consumer reads the request's route, query, header, cookie, or wherever the active step lives, and returns it from a getter:
 
 ```ts
 import { useRoute } from '#imports' // Nuxt
@@ -132,7 +132,7 @@ The getter runs on both server and client. The consumer's route source must be a
 
 ## Letting the framework own slow factories
 
-The library does not special-case slow factories. A request timeout, a `<Suspense>` boundary with a fallback, or a Nuxt-level cache header is the framework's job. When the consumer specifically wants client-only fetching for a slow factory:
+Attaform does not special-case slow factories. A request timeout, a `<Suspense>` boundary with a fallback, or a Nuxt-level cache header is the framework's job. When the consumer specifically wants client-only fetching for a slow factory:
 
 ```ts
 const reportForm = useForm({
@@ -150,7 +150,7 @@ Or wrap the consuming component:
 </ClientOnly>
 ```
 
-Both compose with the rest of the library without special-casing. The transform's coverage analysis sees the same template either way.
+Both compose with the rest of Attaform without special-casing. The transform's coverage analysis sees the same template either way.
 
 ## Transform-uncovered cases
 

--- a/docs/multistep/statuses.md
+++ b/docs/multistep/statuses.md
@@ -32,7 +32,7 @@ type FormStatus = {
 
 Each field tracks the per-step form's `meta`. A step's status flips when its meta does. The four scalars are deliberately small. They're what step indicators, navigation gates, and submit summaries reach for.
 
-## Three call forms
+## How to read it
 
 ```ts
 import { useForm, useWizard } from 'attaform/zod'
@@ -78,13 +78,13 @@ Reading `wizard.statuses['signup-profile'].valid` does NOT activate the `signup-
 </template>
 ```
 
-A step that has not yet been activated reports the pending sentinel (`valid: false`, `dirty: false`, `submitted: false`, `errorCount: 0`) instead of firing its `defaultValues` factory. The rail can render every step's dot without forcing every step's async data to load.
+A step that has not yet been activated reports a pending `FormStatus` (`valid: false`, `dirty: false`, `submitted: false`, `errorCount: 0`) instead of firing its `defaultValues` factory. The rail can render every step's dot without forcing every step's async data to load.
 
 See [lazy activation](/docs/multistep/lazy-activation) for the full activation rule.
 
 ## Seeding statuses up-front (`defaultStatuses`)
 
-For resumable wizards (server-sent step status, draft-restore flows, e-commerce checkouts that reopen mid-flow), `defaultStatuses` seeds `wizard.statuses[key]` BEFORE the per-form meta becomes live. Three shapes mirror `defaultValues`:
+For resumable wizards (server-sent step status, draft-restore flows, e-commerce checkouts that reopen mid-flow), `defaultStatuses` seeds `wizard.statuses[key]` before the per-form meta becomes live. Three shapes mirror `defaultValues`:
 
 ```ts
 import { useWizard } from 'attaform/zod'
@@ -118,13 +118,13 @@ Resolution priority per step:
 
 1. The step's form has `defaultsResolved === true` (its async / sync default settled). Status derives from `form.meta`.
 2. The step has a seed entry from `defaultStatuses`. The seed value renders.
-3. Otherwise, the pending sentinel renders.
+3. Otherwise, a pending `FormStatus` renders.
 
 Unknown keys in the seed object dev-warn and are ignored. Known keys still apply.
 
 ## Reacting to changes (`onStatusChange`)
 
-`onStatusChange` fires whenever a participating form's `valid`, `dirty`, `submitted`, or `errorCount` materially changes. The handler receives the new status and the form whose status changed:
+`onStatusChange` fires whenever a participating form's `valid`, `dirty`, `submitted`, or `errorCount` changes. The handler receives the new status and the form whose status changed:
 
 ```ts
 const wizard = useWizard([account, profile, review] as const, {

--- a/docs/multistep/use-wizard.md
+++ b/docs/multistep/use-wizard.md
@@ -87,10 +87,10 @@ Every reactive read is a plain getter, no `.value`. `wizard.current`, `wizard.pr
 
 ```ts
 wizard.statuses // the whole proxy
-wizard.statuses() // → { account: FormStatus, profile: FormStatus, review: FormStatus }
-wizard.statuses('account') // → FormStatus for account
-wizard.statuses.account // → FormStatus for account (drillable read)
-wizard.statuses.account.valid // → boolean (reactive)
+wizard.statuses() // → { 'signup-account': FormStatus, 'signup-profile': FormStatus, 'signup-review': FormStatus }
+wizard.statuses('signup-account') // → FormStatus for one step
+wizard.statuses['signup-account'] // → FormStatus (drillable read)
+wizard.statuses['signup-account'].valid // → boolean (reactive)
 ```
 
 The drillable read is the template-friendly form; the callable form is convenient in script for one-off reads.

--- a/docs/multistep/use-wizard.md
+++ b/docs/multistep/use-wizard.md
@@ -81,7 +81,7 @@ type UseWizardReturnType<Forms> = {
 | `progress`               | Fraction in `[0, 1]`. Count of valid steps divided by total steps, or the consumer's `progress` override.                  |
 | `next` / `back` / `goTo` | Navigation. `goTo(key)` jumps to an arbitrary step by its form's key.                                                      |
 
-Every reactive read is a plain getter, no `.value`. `wizard.current`, `wizard.progress`, `wizard.allErrors` stay reactive inside templates and `computed` blocks directly, matching the rest of the library (`form.values`, `form.meta`, etc.).
+Every reactive read is a plain getter, no `.value`. `wizard.current`, `wizard.progress`, `wizard.allErrors` stay reactive inside templates and `computed` blocks directly, matching the rest of Attaform (`form.values`, `form.meta`, etc.).
 
 ## `statuses`: how to read it
 
@@ -111,7 +111,7 @@ wizard.goTo('profile') // jump to a specific step by key
 - `back()` on the first step.
 - `goTo(key)` with a key not in the `forms` array.
 
-The wizard never throws on navigation or construction. A third-party library wired into someone's checkout should bend, not crash.
+The wizard never throws on navigation or construction. Wired into someone's checkout, Attaform bends rather than crashing the surrounding app.
 
 ## Active form
 

--- a/docs/multistep/use-wizard.md
+++ b/docs/multistep/use-wizard.md
@@ -73,7 +73,7 @@ type UseWizardReturnType<Forms> = {
 | `current`                | The active step's key (or `undefined` if the wizard is empty). Reactive via a getter, so templates branch on it directly.  |
 | `activeForm`             | The active step's form handle, identity-equal to the matching entry in `forms`. `undefined` when `current` is `undefined`. |
 | `activeIndex`            | Zero-based index of the active step. `-1` when the wizard is empty.                                                        |
-| `forms`                  | The original `forms` array. Iterate it for a rail or table of contents.                                                    |
+| `forms`                  | The `forms` array you passed in. Iterate it for a rail or table of contents.                                               |
 | `count`                  | Number of participating steps. Handy for "Step N of M" labels.                                                             |
 | `statuses`               | Drillable proxy of `FormStatus` per step (`valid`, `dirty`, `submitted`, `errorCount`).                                    |
 | `allValues`              | Drillable record of every step's `values` keyed by form key.                                                               |
@@ -81,9 +81,9 @@ type UseWizardReturnType<Forms> = {
 | `progress`               | Fraction in `[0, 1]`. Count of valid steps divided by total steps, or the consumer's `progress` override.                  |
 | `next` / `back` / `goTo` | Navigation. `goTo(key)` jumps to an arbitrary step by its form's key.                                                      |
 
-Every reactive read is a plain getter, no `.value`. `wizard.current`, `wizard.progress`, `wizard.allErrors` track inside templates and `computed` blocks directly, matching the rest of the library (`form.values`, `form.meta`, etc.).
+Every reactive read is a plain getter, no `.value`. `wizard.current`, `wizard.progress`, `wizard.allErrors` stay reactive inside templates and `computed` blocks directly, matching the rest of the library (`form.values`, `form.meta`, etc.).
 
-## `statuses`: three call forms
+## `statuses`: how to read it
 
 ```ts
 wizard.statuses // the whole proxy
@@ -95,7 +95,7 @@ wizard.statuses.account.valid // → boolean (reactive)
 
 The drillable read is the template-friendly form; the callable form is convenient in script for one-off reads.
 
-`FormStatus` carries `valid`, `dirty`, `submitted`, and `errorCount`. The aggregator gates on each form's `defaultsResolved` so reading a status for a not-yet-activated step returns the pending sentinel without firing that step's factory. The rail can render without thrashing.
+`FormStatus` carries `valid`, `dirty`, `submitted`, and `errorCount`. The aggregator gates on each form's `defaultsResolved` so reading a status for a not-yet-activated step returns a pending `FormStatus` without firing that step's factory. The rail can render without thrashing.
 
 ## Navigation
 
@@ -105,7 +105,7 @@ wizard.back() // step back one
 wizard.goTo('profile') // jump to a specific step by key
 ```
 
-`WizardNavOptions` is currently a placeholder. Pass `{}` or omit it. Out-of-bounds calls dev-warn and no-op:
+`WizardNavOptions` carries `replace?: boolean` for history-replace semantics; see [Browser history](/docs/multistep/history) for the round-trip. Omit it for ordinary navigation. Out-of-bounds calls dev-warn and no-op:
 
 - `next()` on the last step.
 - `back()` on the first step.
@@ -146,7 +146,7 @@ The wizard never throws on navigation or construction. A third-party library wir
 </template>
 ```
 
-Steps that have not been activated contribute nothing to `allErrors`. That keeps the privacy invariant intact: a non-current step with an async `defaultValues` factory will not fire on the server just because the consumer reads the summary list.
+Steps that have not been activated contribute nothing to `allErrors`. That keeps the [privacy invariant](/docs/multistep/ssr#the-stated-invariant) intact: a non-current step with an async `defaultValues` factory will not fire on the server just because the consumer reads the summary list.
 
 ## Degenerate inputs
 


### PR DESCRIPTION
**Stack position**: 13 of 14, base `feat/use-wizard-lazy-activation-ssr` → head `docs/multistep-section-walk`.

**Unique commits in this layer** (10 total):

- docs(multistep): refine useWizard hero phrasing
- docs(multistep): tighten Statuses page phrasing
- docs(multistep): align useWizard hero statuses block with section keys
- docs(multistep): rewrite Browser history default-behavior bullets
- docs(multistep): tighten SSR page emphasis and section header
- docs(multistep): tighten Aggregates page
- docs(multistep): tighten Lazy activation page
- docs(multistep): tighten Patterns page
- docs(multistep): use "Attaform" instead of "the library"
- feat(site): rail steps in use-wizard demo are buttons

---

Part of the 14-PR backlog merge. Stack ordering is derived from branch ancestry; each PR's diff is scoped to its own unique commits as long as the immediately preceding PR (or fork sibling) is merged or rebased first.