### PR TITLE
chore(deps): pin @nuxt/kit and @nuxt/schema to $nuxt in pnpm.overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,8 @@
   "pnpm": {
     "overrides": {
       "@nuxt/devtools": "3.2.4",
+      "@nuxt/kit": "$nuxt",
+      "@nuxt/schema": "$nuxt",
       "fast-uri": "^3.1.2"
     },
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   '@nuxt/devtools': 3.2.4
+  '@nuxt/kit': ^4.4.2
+  '@nuxt/schema': ^4.4.2
   fast-uri: ^3.1.2
 
 importers:
@@ -1444,7 +1446,7 @@ packages:
     engines: {node: ^16.14.0 || >=18.0.0}
     hasBin: true
     peerDependencies:
-      '@nuxt/schema': ^4.4.5
+      '@nuxt/schema': ^4.4.2
     peerDependenciesMeta:
       '@nuxt/schema':
         optional: true
@@ -1525,10 +1527,6 @@ packages:
   '@nuxt/icon@2.2.2':
     resolution: {integrity: sha512-K9wINW21M9x5GcKF5JEXzPKAT/Kfxl/vdnEyppw54hh5qoLcdi5HmsYoTfDP9gbJ6Z1T6IdH5JxBWk72HMe1Zg==}
 
-  '@nuxt/kit@3.21.5':
-    resolution: {integrity: sha512-eGo9DjJ9NzKMbJpFU/UTd4c5iOSYuivghKD8W/jVGHs7kew+hdSMvUy401IfQB7EObKPvt/WXEutAIaTg9OsyA==}
-    engines: {node: '>=18.12.0'}
-
   '@nuxt/kit@4.4.5':
     resolution: {integrity: sha512-J0BpoOomzd3iVZozYlZJ7AwAVliXRgeChZnAkQLfg8d0h/Q+aMK9kkHuhwFULASaRn5idiD4BIhOUz7/uoLbSw==}
     engines: {node: '>=18.12.0'}
@@ -1563,7 +1561,7 @@ packages:
     engines: {node: '>=18.12.0'}
     hasBin: true
     peerDependencies:
-      '@nuxt/kit': '>=3.0.0'
+      '@nuxt/kit': ^4.4.2
 
   '@nuxt/test-utils@4.0.3':
     resolution: {integrity: sha512-HwF3B+GIwzWeIioskhHIjq+TQttP7+g0GUO39hpivGWFZzYXD3lIspzfmliJkgwwA3m5Xl2Z8XXqX1zAolKX6w==}
@@ -4810,7 +4808,7 @@ packages:
     resolution: {integrity: sha512-EHfBM4ew12HYvGtQ2GDubzRzEVvoZqFu9fKjyzV66RDFyroOBYO8Pjyksa9O78GhkXnoUDH1smwrQ2kYziH1Yg==}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.0.0
-      '@nuxt/kit': ^3.0.0 || ^4.0.0
+      '@nuxt/kit': ^4.4.2
       launch-editor: ^2.0.0
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
@@ -6660,7 +6658,7 @@ packages:
   nuxtseo-shared@0.9.0:
     resolution: {integrity: sha512-3V/vT2F4jON8mRThHPWzwVq6ZTU/J4PsqKwuaoON6b2OraULUhqOl1dOUQcduGHNgfYKhg9UygrT0xk+aUwM/g==}
     peerDependencies:
-      '@nuxt/schema': ^3.16.0 || ^4.0.0
+      '@nuxt/schema': ^4.4.2
       nuxt: ^3.16.0 || ^4.0.0
       nuxt-site-config: ^3.2.0 || ^4.0.0
       vue: ^3.5.0
@@ -6674,7 +6672,7 @@ packages:
   nuxtseo-shared@5.1.3:
     resolution: {integrity: sha512-euCaYANxdjeLzJcxvEczKpLuikxPy/LUT/v69orStKlG2U4pvWaqDv74QO8YMCCmUbAO+8BoRj/SJccu9GcJGQ==}
     peerDependencies:
-      '@nuxt/schema': ^3.16.0 || ^4.0.0
+      '@nuxt/schema': ^4.4.2
       nuxt: ^3.16.0 || ^4.0.0
       nuxt-site-config: ^3.2.0 || ^4.0.0
       vue: ^3.5.0
@@ -8079,7 +8077,7 @@ packages:
     resolution: {integrity: sha512-vWuC8SwqJmxZFYwPojhOhOXDb5xFhNNcEVb9K/RFkyk/3VnfaOjzitWN7v+8DEKpMjSsY2AEGXNgt6I0yQrhRQ==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
-      '@nuxt/kit': ^4.0.0
+      '@nuxt/kit': ^4.4.2
       '@vueuse/core': '*'
     peerDependenciesMeta:
       '@nuxt/kit':
@@ -8125,7 +8123,7 @@ packages:
     resolution: {integrity: sha512-uLdccgS7mf3pv1bCCP20y/hm+u1eOjAmygVkh+Oa70MPkzgl1eQv1L0CwdHNM3gscO8/GDMGIET98Ja47CBbZg==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
-      '@nuxt/kit': ^3.2.2 || ^4.0.0
+      '@nuxt/kit': ^4.4.2
       vue: ^3.0.0
     peerDependenciesMeta:
       '@nuxt/kit':
@@ -8616,8 +8614,8 @@ packages:
   vue-sonner@2.0.9:
     resolution: {integrity: sha512-i6BokNlNDL93fpzNxN/LZSn6D6MzlO+i3qXt6iVZne3x1k7R46d5HlFB4P8tYydhgqOrRbIZEsnRd3kG7qGXyw==}
     peerDependencies:
-      '@nuxt/kit': ^4.0.3
-      '@nuxt/schema': ^4.0.3
+      '@nuxt/kit': ^4.4.2
+      '@nuxt/schema': ^4.4.2
       nuxt: ^4.0.3
     peerDependenciesMeta:
       '@nuxt/kit':
@@ -9988,7 +9986,7 @@ snapshots:
 
   '@nuxt/devtools-kit@2.7.0(magicast@0.5.2)(vite@8.0.12)':
     dependencies:
-      '@nuxt/kit': 3.21.5(magicast@0.5.2)
+      '@nuxt/kit': 4.4.5(magicast@0.5.2)
       execa: 8.0.1
       vite: 8.0.12(@types/node@25.7.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -10165,32 +10163,6 @@ snapshots:
       - vite
       - vue
 
-  '@nuxt/kit@3.21.5(magicast@0.5.2)':
-    dependencies:
-      c12: 3.3.4(magicast@0.5.2)
-      consola: 3.4.2
-      defu: 6.1.7
-      destr: 2.0.5
-      errx: 0.1.0
-      exsolve: 1.0.8
-      ignore: 7.0.5
-      jiti: 2.7.0
-      klona: 2.0.6
-      knitwork: 1.3.0
-      mlly: 1.8.2
-      ohash: 2.0.11
-      pathe: 2.0.3
-      pkg-types: 2.3.1
-      rc9: 3.0.1
-      scule: 1.3.0
-      semver: 7.8.0
-      tinyglobby: 0.2.16
-      ufo: 1.6.4
-      unctx: 2.5.0
-      untyped: 2.0.0
-    transitivePeerDependencies:
-      - magicast
-
   '@nuxt/kit@4.4.5(magicast@0.5.2)':
     dependencies:
       c12: 3.3.4(magicast@0.5.2)
@@ -10330,7 +10302,7 @@ snapshots:
     dependencies:
       '@clack/prompts': 1.2.0
       '@nuxt/devtools-kit': 2.7.0(magicast@0.5.2)(vite@8.0.12)
-      '@nuxt/kit': 3.21.5(magicast@0.5.2)
+      '@nuxt/kit': 4.4.5(magicast@0.5.2)
       c12: 3.3.4(magicast@0.5.2)
       consola: 3.4.2
       defu: 6.1.7
@@ -10544,7 +10516,7 @@ snapshots:
 
   '@nuxtjs/color-mode@3.5.2(magicast@0.5.2)':
     dependencies:
-      '@nuxt/kit': 3.21.5(magicast@0.5.2)
+      '@nuxt/kit': 4.4.5(magicast@0.5.2)
       pathe: 1.1.2
       pkg-types: 1.3.1
       semver: 7.8.0


### PR DESCRIPTION
## Summary

- Forces `@nuxt/kit` and `@nuxt/schema` to resolve to whatever the direct `nuxt` devDep does via pnpm's `$nuxt` override syntax.
- Eliminates the dual-package class of bug that's blocking PR #220 (the nuxt 4.4.5 → 4.4.6 dependabot bump).

## Why

`@nuxt/kit`, `@nuxt/schema`, and `nuxt` are three separate direct devDeps in `package.json`, each with their own `^4.4.2` specifier. When dependabot bumps only the `nuxt` line, pnpm sees `^4.4.2` is still satisfied by the already-locked `@nuxt/kit@4.4.5` + `@nuxt/schema@4.4.5` and leaves them alone, while resolving `nuxt@4.4.6` (which re-pulls its own `@nuxt/kit@4.4.6` + `@nuxt/schema@4.4.6` as transitives). Result on PR #220:

```
test/fixtures/ssr/nuxt.config.ts:4:16 — TS2589: Type instantiation is excessively deep and possibly infinite.
test/fixtures/ssr/nuxt.config.ts:5:13 — TS2322: NuxtModule<…> @nuxt/schema@4.4.6 not assignable to NuxtModule<…> @nuxt/schema@4.4.5
```

The recursive structural compare across two near-identical `NuxtModule<…>` shapes blows past TS's depth budget — and `exactOptionalPropertyTypes: true` makes the cross-version assignability strictly reject. `$nuxt` collapses the family into a single version per install, regardless of which line a future bump touches.

## Verification

| State | Result |
|---|---|
| Override + `nuxt@4.4.5` baseline | Single `@nuxt/schema@4.4.5` resolution; `pnpm typecheck` clean |
| Override + `nuxt@4.4.6` (simulated PR #220) | All nuxt-family packages move to 4.4.6 in lockstep; zero refs to 4.4.5; typecheck clean (confirms PR #220's TS2589/TS2322 disappears with this override) |
| Override + revert to `^4.4.2` (nuxt@4.4.5) | Returns to clean baseline |

## Test plan

- [x] `pnpm install` regenerates the lockfile cleanly (dual-package eliminated)
- [x] `pnpm typecheck` passes on the override-only state
- [ ] CI: matrix passes on this branch
- [ ] After merge: comment `@dependabot rebase` on PR #220 to confirm its typecheck failure resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)