### PR TITLE
Wizard polish: docs, hydration, focus, depart-reveal

### DIFF
--- a/apps/site/components/demo/DemoReplEditor.client.vue
+++ b/apps/site/components/demo/DemoReplEditor.client.vue
@@ -479,8 +479,14 @@ interface ToastOptions {
   /**
    * Secondary text below the title. Same JSON-formatting rules as
    * the message: strings render as-is, objects and arrays pretty-print.
+   * Wider than the message type so form-values aggregates (whose
+   * leaves recurse through a nominally distinct alias like
+   * \`WizardValue\`) pass through without coercion. TypeScript does not
+   * recurse across named-type boundaries when matching unions, so the
+   * explicit Record / Array branches admit structurally-compatible
+   * payloads even when their leaves are not literally \`ToastBody\`.
    */
-  description?: ToastBody
+  description?: ToastBody | Readonly<Record<string, unknown>> | readonly unknown[]
 }
 
 /**

--- a/apps/site/types/playground-globals.d.ts
+++ b/apps/site/types/playground-globals.d.ts
@@ -62,8 +62,14 @@ declare global {
     /**
      * Secondary text below the title. Same JSON-formatting rules as
      * the message: strings render as-is, objects and arrays pretty-print.
+     * Wider than the message type so form-values aggregates (whose
+     * leaves recurse through a nominally distinct alias like
+     * `WizardValue`) pass through without coercion. TypeScript does not
+     * recurse across named-type boundaries when matching unions, so the
+     * explicit Record / Array branches admit structurally-compatible
+     * payloads even when their leaves are not literally `ToastBody`.
      */
-    description?: ToastBody
+    description?: ToastBody | Readonly<Record<string, unknown>> | readonly unknown[]
   }
 
   /**

--- a/docs/multistep/aggregates.md
+++ b/docs/multistep/aggregates.md
@@ -77,7 +77,7 @@ type AggregateError = {
 }
 ```
 
-Sort order: BFS order from the wizard's entry, then each form's internal error order. The shape is purpose-built for wizard-wide summary panels:
+Sort order: BFS order from the wizard's entry form, then each form's internal error order. The shape is purpose-built for wizard-wide summary panels:
 
 ```vue
 <template>

--- a/docs/multistep/inject-wizard.md
+++ b/docs/multistep/inject-wizard.md
@@ -8,10 +8,10 @@ metaRows:
     value: 'injectWizard(input?: string | { key? }) => UseWizardReturnType | null'
     kind: code
   - label: Ambient mode
-    value: useWizard(entry) without key
+    value: useWizard(entryForm) without key
     kind: code
   - label: Explicit mode
-    value: useWizard(entry, { key })
+    value: useWizard(entryForm, { key })
     kind: code
 ---
 
@@ -100,7 +100,7 @@ Sticky finish buttons, sidebar status widgets, or any component in a different b
 </template>
 ```
 
-Pass the same `key` the parent passed to `useWizard(entry, { key: 'signup-wizard' })`. The handle returned is identity-equal to the parent's, so `wizard.handleSubmit` wired from a floating button runs the same submission pipeline the parent would.
+Pass the same `key` the parent passed to `useWizard(entryForm, { key: 'signup-wizard' })`. The handle returned is identity-equal to the parent's, so `wizard.handleSubmit` wired from a floating button runs the same submission pipeline the parent would.
 
 `injectWizard` accepts an object form too: `injectWizard({ key: 'signup-wizard' })`. The positional and object forms are equivalent; pick whichever spreads better into the surrounding setup.
 
@@ -108,8 +108,8 @@ Pass the same `key` the parent passed to `useWizard(entry, { key: 'signup-wizard
 
 The two resolution modes are cleanly split:
 
-- **Anonymous (no `key`) → ambient access.** `useWizard(entry)` fills the parent's ambient slot. Any descendant's `injectWizard()` (no key) resolves to it; closest ancestor wins when nested.
-- **Keyed (`key: 'x'`) → ambient AND explicit access.** `useWizard(entry, { key: 'x' })` fills the ambient slot AND registers the wizard under `'x'`. Descendants reach it via `injectWizard()` (closest ancestor) OR `injectWizard('x')` (registry lookup, works from anywhere in the app).
+- **Anonymous (no `key`) → ambient access.** `useWizard(entryForm)` fills the parent's ambient slot. Any descendant's `injectWizard()` (no key) resolves to it; closest ancestor wins when nested.
+- **Keyed (`key: 'x'`) → ambient AND explicit access.** `useWizard(entryForm, { key: 'x' })` fills the ambient slot AND registers the wizard under `'x'`. Descendants reach it via `injectWizard()` (closest ancestor) OR `injectWizard('x')` (registry lookup, works from anywhere in the app).
 
 Skip `key` for single-component wizards (an in-page checkout, a modal flow). Supply one when you want cross-tree lookup, a stable identifier for DevTools, or a sticky finish button rendered far from the step container.
 
@@ -152,7 +152,7 @@ Hot-module reload reuses the existing handle when the parent SFC re-mounts (defe
 
 ## Duplicate keys
 
-Two calls to `useWizard(entry, { key: 'signup-wizard' })` in the same app: the first wins, the second is silently dropped, and a dev-warn names the dropped registration. This mirrors `useForm`'s shared-key behavior and keeps the registry deterministic during HMR transitions or accidental double-setup.
+Two calls to `useWizard(entryForm, { key: 'signup-wizard' })` in the same app: the first wins, the second is silently dropped, and a dev-warn names the dropped registration. This mirrors `useForm`'s shared-key behavior and keeps the registry deterministic during HMR transitions or accidental double-setup.
 
 ## SSR isolation
 

--- a/docs/multistep/ssr.md
+++ b/docs/multistep/ssr.md
@@ -7,7 +7,7 @@ metaRows:
   - label: Wizard skip-list
     value: overrides every other mark for non-current steps
   - label: Active step source
-    value: 'getServerActiveStep | URL ?step | flow.entry'
+    value: 'getServerActiveStep | URL ?step | flow.entryForm'
     kind: code
 ---
 
@@ -130,9 +130,9 @@ The wizard consults `getServerActiveStep()` **before** deciding which form's fac
 
 1. `getServerActiveStep()` returns a known key. The wizard marks that form.
 2. Returns `undefined` and the request URL carries `?step=<key>` (matched against `history.param`). The wizard marks that form.
-3. Otherwise the wizard marks `flow.entry` (the entry form passed to `useWizard`).
+3. Otherwise the wizard marks `flow.entryForm` (the entry form passed to `useWizard`).
 
-The getter runs on both server and client. The consumer's route source must be available on both. Returning a key that doesn't appear in the reachable graph dev-warns and falls back to `flow.entry`.
+The getter runs on both server and client. The consumer's route source must be available on both. Returning a key that doesn't appear in the reachable graph dev-warns and falls back to `flow.entryForm`.
 
 ## Letting the framework own slow factories
 

--- a/docs/multistep/use-wizard.md
+++ b/docs/multistep/use-wizard.md
@@ -241,7 +241,7 @@ type WizardSubmitContext = {
 4. For a branching `next` with the current form **valid**, `pick(parsed)` chooses one branch and the walk recurses on it.
 5. For a branching `next` with the current form **invalid**, every declared `forms` subgraph is walked in parallel (`Promise.all`), so prerequisites for every reachable path surface at once without serial latency.
 6. Builds `ctx = { values, get, path }` from the runtime path and either calls `onSubmit(ctx)` (all forms valid) or `onError(errors)` (any invalid). On success, `wizard.complete = true`.
-7. On failure with `navigateToFirstError: true` (the default), the wizard calls `goTo(firstFailedKey)` then `firstFailedForm.applyInvalidSubmitPolicy()`. The DOM swap lands before the focus call.
+7. On failure with `navigateToFirstError: true` (the default), the wizard calls `goTo(firstFailedKey)`, awaits one `nextTick` so the failed step's form mounts (the common `v-if="wizard.current === ..."` template pattern means its inputs only exist after the render flush), then calls `firstFailedForm.applyInvalidSubmitPolicy()`. The focus or scroll lands on the first error field.
 8. Always: `wizard.submissionAttempts` increments and `wizard.submitting` returns to `false`.
 
 `wizard.complete` flips back to `false` the first time any walked-path form's `meta.dirty` flips `true`. Editing after a successful submit reads as "ready to submit again."

--- a/docs/multistep/use-wizard.md
+++ b/docs/multistep/use-wizard.md
@@ -5,7 +5,7 @@ metaRows:
   - label: Category
     value: Composable
   - label: Signature
-    value: 'useWizard(entry, options?)'
+    value: 'useWizard(entryForm, options?)'
     kind: code
   - label: Graph source
     value: 'useForm({ next })' per step
@@ -17,12 +17,12 @@ metaRows:
 
 # useWizard
 
-> Compose a graph of `useForm` calls into a reactive wizard. Each form declares its successor via `useForm({ next })`, and `useWizard(entry)` walks the graph from there to discover every reachable step, drive navigation, aggregate status, and validate the runtime path on submit.
+> Compose a graph of `useForm` calls into a reactive wizard. Each form declares its successor via `useForm({ next })`, and `useWizard(entryForm)` walks the graph from there to discover every reachable step, drive navigation, aggregate status, and validate the runtime path on submit.
 
 ::docs-meta-table
 ::
 
-Three small `useForm` calls (account, profile, review) feed into one `useWizard`. Each form names its successor with `next:`, so the wizard rebuilds the chain from a single entry. The progress bar reflects `wizard.progress`, the rail highlights `wizard.current`, and each step's form keeps its own schema and reactive surface. Tap **Next** / **Back** to walk the chain; the **Finish** button fires on the last step.
+Three small forms chain via `next:` declarations: `account` → `profile` → `review`. `useWizard(account)` walks the chain from the entry form and discovers every reachable step. The progress bar reflects `wizard.progress`, the rail highlights `wizard.current`, and each step keeps its own schema and reactive surface. Tap **Next** / **Back** to walk the chain; the **Finish** button fires on the last step.
 
 ::docs-demo{slug="use-wizard" label="Wizard Demo"}
 ::
@@ -92,7 +92,7 @@ type UseWizardReturnType = {
   readonly current: string | undefined
   readonly activeForm: AnyForm | undefined
   readonly activeIndex: number
-  readonly entry: AnyForm
+  readonly entryForm: AnyForm
   readonly allForms: readonly AnyForm[]
   readonly count: number
 
@@ -124,28 +124,28 @@ type UseWizardReturnType = {
 }
 ```
 
-| Member                   | What it is                                                                                                                             |
-| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `key`                    | The wizard's identifier for [`injectWizard`](/docs/multistep/inject-wizard). `undefined` when no `key` is passed in options.           |
-| `current`                | The active step's key (or `undefined` for a degenerate wizard). Reactive via a getter, so templates branch on it directly.             |
-| `activeForm`             | The active step's form handle, identity-equal to the matching entry in `allForms`. `undefined` when `current` is `undefined`.          |
-| `activeIndex`            | Zero-based index of the active step within `allForms` (BFS order). `-1` when `current` is `undefined`.                                 |
-| `entry`                  | The form passed to `useWizard(entry)`. Identity-equal to the argument; immutable for the wizard's lifetime.                            |
-| `allForms`               | BFS-ordered, deduped list of every form reachable from `entry`. Iterate it for a rail, sitemap, or "Step N of M" label.                |
-| `count`                  | `allForms.length`.                                                                                                                     |
-| `canAdvance`             | `true` when the active form has a non-empty `next` declaration. Graph-structural; reflects the static graph, not the validation state. |
-| `canGoBack`              | `true` when a prior step exists in BFS order (`activeIndex > 0`).                                                                      |
-| `complete`               | `true` once `wizard.handleSubmit`'s callback resolves without throwing. Flips back to `false` when any walked-path form becomes dirty. |
-| `submitting`             | `true` while a `wizard.handleSubmit` call is in flight (path walk + callback).                                                         |
-| `submissionAttempts`     | Count of `wizard.handleSubmit` invocations (success or failure).                                                                       |
-| `statuses`               | Drillable proxy of `FormStatus` per step (`valid`, `dirty`, `submitted`, `errorCount`).                                                |
-| `allValues`              | Drillable record of every step's `values` keyed by form key.                                                                           |
-| `allErrors`              | Cross-step `AggregateError[]` for a wizard-wide summary. Dormant (unactivated) steps contribute nothing.                               |
-| `progress`               | Fraction in `[0, 1]`. Count of valid forms divided by total, or the consumer's `progress` override.                                    |
-| `next` / `back` / `goTo` | Navigation. `next()` is async because it validates the current step before advancing.                                                  |
-| `handleSubmit`           | Returns a submit handler that walks the runtime path, validates every form along the way, then calls the consumer's `onSubmit`.        |
-| `reset`                  | Zeros wizard lifecycle and calls `form.reset()` on every reachable form.                                                               |
-| `flow`                   | Introspection namespace: `entry`, `tree`, `allForms`, `visited`, `diagnose()`. The structured hand-off for sitemaps and diagnostics.   |
+| Member                   | What it is                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `key`                    | The wizard's identifier for [`injectWizard`](/docs/multistep/inject-wizard). `undefined` when no `key` is passed in options.             |
+| `current`                | The active step's key (or `undefined` for a degenerate wizard). Reactive via a getter, so templates branch on it directly.               |
+| `activeForm`             | The active step's form handle, identity-equal to the matching entry in `allForms`. `undefined` when `current` is `undefined`.            |
+| `activeIndex`            | Zero-based index of the active step within `allForms` (BFS order). `-1` when `current` is `undefined`.                                   |
+| `entryForm`              | The form passed to `useWizard(entryForm)`. Identity-equal to the argument; immutable for the wizard's lifetime.                          |
+| `allForms`               | BFS-ordered, deduped list of every form reachable from the entry form. Iterate it for a rail, sitemap, or "Step N of M" label.           |
+| `count`                  | `allForms.length`.                                                                                                                       |
+| `canAdvance`             | `true` when the active form has a non-empty `next` declaration. Graph-structural; reflects the static graph, not the validation state.   |
+| `canGoBack`              | `true` when a prior step exists in BFS order (`activeIndex > 0`).                                                                        |
+| `complete`               | `true` once `wizard.handleSubmit`'s callback resolves without throwing. Flips back to `false` when any walked-path form becomes dirty.   |
+| `submitting`             | `true` while a `wizard.handleSubmit` call is in flight (path walk + callback).                                                           |
+| `submissionAttempts`     | Count of `wizard.handleSubmit` invocations (success or failure).                                                                         |
+| `statuses`               | Drillable proxy of `FormStatus` per step (`valid`, `dirty`, `submitted`, `errorCount`).                                                  |
+| `allValues`              | Drillable record of every step's `values` keyed by form key.                                                                             |
+| `allErrors`              | Cross-step `AggregateError[]` for a wizard-wide summary. Dormant (unactivated) steps contribute nothing.                                 |
+| `progress`               | Fraction in `[0, 1]`. Count of valid forms divided by total, or the consumer's `progress` override.                                      |
+| `next` / `back` / `goTo` | Navigation. `next()` is async because it validates the current step before advancing.                                                    |
+| `handleSubmit`           | Returns a submit handler that walks the runtime path, validates every form along the way, then calls the consumer's `onSubmit`.          |
+| `reset`                  | Zeros wizard lifecycle and calls `form.reset()` on every reachable form.                                                                 |
+| `flow`                   | Introspection namespace: `entryForm`, `tree`, `allForms`, `visited`, `diagnose()`. The structured hand-off for sitemaps and diagnostics. |
 
 Every reactive read is a plain getter, no `.value`. `wizard.current`, `wizard.progress`, `wizard.allErrors` stay reactive inside templates and `computed` blocks directly, matching the rest of Attaform (`form.values`, `form.meta`, etc.).
 
@@ -185,7 +185,7 @@ The wizard never throws on navigation. Wired into someone's checkout, Attaform b
 
 ## Submission with `handleSubmit`
 
-`wizard.handleSubmit(onSubmit, onError?)` returns a submit handler. On invocation it walks the runtime path from `entry`, validates each form along the way, then calls `onSubmit` with the aggregated context:
+`wizard.handleSubmit(onSubmit, onError?)` returns a submit handler. On invocation it walks the runtime path from the entry form, validates each form along the way, then calls `onSubmit` with the aggregated context:
 
 ```vue
 <script setup lang="ts">
@@ -231,12 +231,12 @@ type WizardSubmitContext = {
 
 - `ctx.values` is the loose-keyed aggregate of every walked form's parsed output. Use it for "POST everything to the backend" wiring.
 - `ctx.get(formRef)` returns the form's parsed output, typed by its schema. Works across the wizard's reachable set and also with forms reached through [`injectForm`](/docs/cross-cutting-state/inject-form), since the form ref carries its own schema info.
-- `ctx.path` is the ordered runtime path from `entry` to terminal, with branching `pick(parsed)` callbacks resolved against the current parsed values. Iterate it for per-form audit logs or sequential POSTs.
+- `ctx.path` is the ordered runtime path from the entry form to terminal, with branching `pick(parsed)` callbacks resolved against the current parsed values. Iterate it for per-form audit logs or sequential POSTs.
 
 ### What `handleSubmit` actually does
 
 1. Sets `wizard.submitting = true`. Per-form `meta.submitting` does NOT flip during the walk; subscribe to `wizard.submitting` for wizard-scoped submitting state.
-2. Walks the path starting from `entry`. For each form: activates (await async `defaultValues`), then validates. Activation failure surfaces as a synthetic `ValidationError` with `code: 'atta:activation-failed'` and the walk continues so every problem reaches the consumer.
+2. Walks the path starting from the entry form. For each form: activates (await async `defaultValues`), then validates. Activation failure surfaces as a synthetic `ValidationError` with `code: 'atta:activation-failed'` and the walk continues so every problem reaches the consumer.
 3. For a single-target `next`, the walk is sequential: errors aggregate and the walk continues to terminal even when an upstream form is invalid.
 4. For a branching `next` with the current form **valid**, `pick(parsed)` chooses one branch and the walk recurses on it.
 5. For a branching `next` with the current form **invalid**, every declared `forms` subgraph is walked in parallel (`Promise.all`), so prerequisites for every reachable path surface at once without serial latency.
@@ -283,9 +283,9 @@ Steps that have not been activated contribute nothing to `allErrors`. That keeps
 
 ## Static analysis at construction
 
-`useWizard(entry)` walks the reachable graph BFS-first and surfaces structural anomalies up front:
+`useWizard(entryForm)` walks the reachable graph BFS-first and surfaces structural anomalies up front:
 
-- **Cycle.** A form whose chain leads back to itself throws at `useWizard(entry)` construction. Consumers who want intentional re-entry use `wizard.goTo()` rather than declaring a cycle.
+- **Cycle.** A form whose chain leads back to itself throws at `useWizard(entryForm)` construction. Consumers who want intentional re-entry use `wizard.goTo()` rather than declaring a cycle.
 - **Missing terminal.** Every path from entry should reach a terminal (no `next`, or branching with an empty `forms` array). Hard error if no terminal is reachable.
 - **Unreachable form.** A form constructed in scope that no chain from entry reaches. Dev-warn.
 - **Empty `forms` in branching `next`.** Dev-warn; treated as a terminal.
@@ -320,7 +320,7 @@ Conditions that would otherwise crash the surrounding app dev-warn and degrade:
 - **A form with `key: ''`.** Filtered out of the participating set; dev-warn names the dropped count.
 - **Duplicate keys in the reachable graph.** First occurrence wins; dev-warn lists the dropped keys.
 - **`defaultStatuses` with an unknown key.** The unknown entry is ignored; the known entries still apply.
-- **`getServerActiveStep` returning a key not in the reachable set.** Dev-warn; the wizard falls back to `entry.key`.
+- **`getServerActiveStep` returning a key not in the reachable set.** Dev-warn; the wizard falls back to the entry form's `key`.
 
 A wizard wired into someone's signup or checkout never crashes the surrounding app for shapes that are clearly a mistake.
 

--- a/src/runtime/composables/inject-wizard.ts
+++ b/src/runtime/composables/inject-wizard.ts
@@ -40,7 +40,7 @@ export type InjectWizardInput = {
  *
  * Resolution rules (keyed form): registry lookup by string key,
  * independent of component-tree position. The wizard must have been
- * constructed with `useWizard(entry, { key })` to be reachable.
+ * constructed with `useWizard(entryForm, { key })` to be reachable.
  *
  * Returns `null` when no matching wizard exists (no ambient ancestor,
  * or the named key isn't registered). A dev-mode warning points at the

--- a/src/runtime/composables/use-wizard.ts
+++ b/src/runtime/composables/use-wizard.ts
@@ -566,6 +566,15 @@ export function useWizard(entryForm: AnyForm, options: WizardOptions = {}): UseW
       )
       return
     }
+    // Bump departAttempts before validation runs so the depart arm of
+    // `defaultShouldShowErrors` is already true by the time the
+    // invalid-submit policy focuses the first error field. Bumping
+    // here also covers the successful-next path: a clean departure
+    // still records an attempt so revisits show prior errors if any.
+    const activeStore = registry.forms.get(activeKey)
+    if (activeStore !== undefined) {
+      activeStore.departAttempts.value += 1
+    }
     const result = await activeForm.process()
     if (result.success !== true) {
       // Invalid form blocks navigation. Fire the form's own
@@ -596,6 +605,13 @@ export function useWizard(entryForm: AnyForm, options: WizardOptions = {}): UseW
       )
       return
     }
+    // Record the departure before navigating. A user who deep-links to
+    // a mid-flow step then presses Back has engaged with the current
+    // form via the wizard, so its errors should reveal on revisit.
+    const activeStore = registry.forms.get(current.value)
+    if (activeStore !== undefined) {
+      activeStore.departAttempts.value += 1
+    }
     setCurrent(formKeys[idx - 1] as string, navOptions?.replace === true ? 'replace' : 'push')
   }
 
@@ -609,6 +625,14 @@ export function useWizard(entryForm: AnyForm, options: WizardOptions = {}): UseW
         `[attaform] useWizard.goTo("${key}"): unknown step key. Known keys: ${formKeys.map((k) => `"${k}"`).join(', ')}. Ignoring.`
       )
       return
+    }
+    // Record the departure only when the target differs from current;
+    // a same-key goTo is a no-op and should not move the counter.
+    if (key !== current.value) {
+      const activeStore = registry.forms.get(current.value)
+      if (activeStore !== undefined) {
+        activeStore.departAttempts.value += 1
+      }
     }
     setCurrent(key, navOptions?.replace === true ? 'replace' : 'push')
   }

--- a/src/runtime/composables/use-wizard.ts
+++ b/src/runtime/composables/use-wizard.ts
@@ -2,6 +2,7 @@ import {
   computed,
   getCurrentInstance,
   getCurrentScope,
+  nextTick,
   onScopeDispose,
   provide,
   ref,
@@ -698,6 +699,16 @@ export function useWizard(entryForm: AnyForm, options: WizardOptions = {}): UseW
               // gated on `submitting` — that gate is for user-initiated
               // navigation, not the wizard's own failure routing.
               setCurrent(firstFailedKey, 'push')
+              // Wait for Vue to flush the render cycle so the failed
+              // step's form mounts before we focus. Consumers commonly
+              // template the wizard with `v-if="wizard.current === ..."`
+              // per step, so the failed form's inputs aren't in the DOM
+              // until after this tick; without the wait, the policy
+              // call would walk an empty registration set and silently
+              // no-op. One `nextTick` covers Vue's render-then-mount
+              // flush including the `v-register` directive's mounted
+              // hook, which is where field elements register.
+              await nextTick()
               const failedForm = byKey.get(firstFailedKey) as unknown as
                 | SubmissionSourceForm
                 | undefined

--- a/src/runtime/composables/use-wizard.ts
+++ b/src/runtime/composables/use-wizard.ts
@@ -2,7 +2,9 @@ import {
   computed,
   getCurrentInstance,
   getCurrentScope,
+  inject,
   nextTick,
+  onMounted,
   onScopeDispose,
   provide,
   ref,
@@ -11,7 +13,11 @@ import {
 } from 'vue'
 import { buildWizardGraph, WizardCycleError } from '../core/wizard-graph'
 import { __DEV__ } from '../core/dev'
-import { kAttaformAncestorWizard, useRegistry } from '../core/registry'
+import {
+  kAttaformAncestorWizard,
+  kAttaformWizardActiveStepResolver,
+  useRegistry,
+} from '../core/registry'
 import { resolveTrichotomy } from '../core/resolve-default-values'
 import { createWizardHistory, NOOP_WIZARD_HISTORY } from '../core/wizard-history'
 import { buildWizardStatusesProxy } from '../core/wizard-statuses-proxy'
@@ -125,22 +131,71 @@ export function useWizard(entryForm: AnyForm, options: WizardOptions = {}): UseW
   const wizardHistory = historyConfig.enabled
     ? createWizardHistory(historyConfig.param)
     : NOOP_WIZARD_HISTORY
-  // Resolve initial step. Priority: `getServerActiveStep()` (SSR
-  // source of truth, returned identically on client) → URL
-  // `?step=<key>` (reload preservation when no getter is wired) →
-  // the entry form's `key` fallback. Unknown keys at any level fall
-  // through so a stale link can't crash construction.
-  const fromGetter = options.getServerActiveStep?.()
-  const fromUrl = wizardHistory.read()
+  // Resolve initial step. Priority for the first-render key:
+  //   1. `options.getServerActiveStep()` — the explicit consumer hook,
+  //      called on both server and client so both sides compute the
+  //      same key.
+  //   2. The injected `kAttaformWizardActiveStepResolver` — installed
+  //      by the `attaform/nuxt` runtime plugin from `useRoute()`, so
+  //      Nuxt apps get the framework-agnostic equivalent for free.
+  //   3. The entry form's `key` fallback.
+  //
+  // The URL is deliberately NOT consulted here. `wizardHistory.read()`
+  // returns a value on the client and `undefined` on the server (the
+  // no-op SSR handle), and bridging that gap is the load-bearing source
+  // of the deep-link hydration mismatch cascade — server renders entry
+  // while client renders the URL's step, and Vue's hydration walks a
+  // wall of warnings. Instead, the URL is read once on mount (below)
+  // and reconciled via a direct ref update when it names a step the
+  // initial resolution didn't pick. Consumers who DO supply an
+  // explicit getter (or use `attaform/nuxt`'s auto-bridge) get
+  // zero-flicker server rendering for deep links; framework-agnostic
+  // consumers see a brief entry frame before the post-mount restore.
+  const explicitGetter = options.getServerActiveStep
+  const injectedResolver = inject(kAttaformWizardActiveStepResolver, null)
+  const fromGetter =
+    explicitGetter !== undefined
+      ? explicitGetter()
+      : injectedResolver !== null
+        ? injectedResolver(historyConfig.param)
+        : undefined
   let initialKey: string
   if (fromGetter !== undefined && seenKeys.has(fromGetter)) {
     initialKey = fromGetter
-  } else if (fromUrl !== undefined && seenKeys.has(fromUrl)) {
-    initialKey = fromUrl
   } else {
     initialKey = entryForm.key
   }
   const current = ref<string>(initialKey)
+
+  // Post-hydration URL restore. Only runs on the client (`onMounted`
+  // is a no-op during SSR). When the deep-link URL names a known step
+  // that the initial resolution didn't already pick, the wizard reaches
+  // that step via a direct ref update — no `setCurrent` call, because
+  // the entry frame was a hydration-time wash rather than a user
+  // navigation: `visited` gets clamped to the restored step,
+  // `onStatusChange` doesn't fire a phantom entry→restore transition,
+  // and the URL itself stays as the deep-link wrote it (no history
+  // push or replace). The form for the restored step is activated to
+  // match what `setCurrent`'s navigation path would do.
+  const urlValueAtSetup = wizardHistory.read()
+  const willRestoreFromUrl =
+    fromGetter === undefined &&
+    urlValueAtSetup !== undefined &&
+    seenKeys.has(urlValueAtSetup) &&
+    urlValueAtSetup !== initialKey
+  if (willRestoreFromUrl) {
+    const restoredKey = urlValueAtSetup
+    onMounted(() => {
+      current.value = restoredKey
+      visited.value = [restoredKey]
+      const restoredForm = byKey.get(restoredKey) as unknown as
+        | { activate?: () => Promise<void> }
+        | undefined
+      if (restoredForm !== undefined && typeof restoredForm.activate === 'function') {
+        void restoredForm.activate()
+      }
+    })
+  }
 
   // Runtime navigation audit log. Seeded with the initial step so the
   // trail always starts somewhere, then appended in `setCurrent` on every
@@ -152,8 +207,15 @@ export function useWizard(entryForm: AnyForm, options: WizardOptions = {}): UseW
   const visited = ref<string[]>([initialKey])
 
   // Replace the URL so it always reflects the active step on mount —
-  // idempotent when the URL already named the correct key.
-  wizardHistory.replace(initialKey)
+  // idempotent when the URL already named the correct key. Skipped
+  // when the post-hydration URL restore is scheduled: overwriting the
+  // deep-link with `initialKey` now would defeat the restore (the
+  // mount-time read would see the entry key we just wrote instead of
+  // the user's deep link), so we leave the URL as the deep link wrote
+  // it and let the restore reconcile internal state in place.
+  if (!willRestoreFromUrl) {
+    wizardHistory.replace(initialKey)
+  }
 
   const registry = useRegistry()
 

--- a/src/runtime/composables/use-wizard.ts
+++ b/src/runtime/composables/use-wizard.ts
@@ -77,7 +77,7 @@ type SubmissionSourceForm = StatusSourceForm & {
 
 /**
  * Multistep-form orchestrator. Walks the static graph declared by
- * `useForm({ next })` declarations starting from `entry`, composing
+ * `useForm({ next })` declarations starting from `entryForm`, composing
  * the reachable forms into a wizard with navigation, status aggregation,
  * browser history, and lazy activation (so a step's async
  * `defaultValues` factory only fires once the step becomes current).
@@ -90,16 +90,16 @@ type SubmissionSourceForm = StatusSourceForm & {
  *    upstream paths shows up once in `allForms`.
  *  - Cycles throw `WizardCycleError` at construction; consumers who want
  *    intentional revisits use `wizard.goTo(key)`.
- *  - Single-step wizards (entry has no `next`) are valid; a one-time
- *    dev-warn notes the navigation surface is degenerate.
+ *  - Single-step wizards (the entry form has no `next`) are valid; a
+ *    one-time dev-warn notes the navigation surface is degenerate.
  *
  * Each reachable form gets a ref-count via `registry.trackConsumer(key)`.
  * This pins the FormStore for the wizard's lifetime — so a step's state
  * survives even when its component is unmounted between visits
  * (v-if pattern). The ref is released on `onScopeDispose`.
  */
-export function useWizard(entry: AnyForm, options: WizardOptions = {}): UseWizardReturnType {
-  const graph = buildWizardGraph(entry)
+export function useWizard(entryForm: AnyForm, options: WizardOptions = {}): UseWizardReturnType {
+  const graph = buildWizardGraph(entryForm)
   const forms = graph.allForms
   const byKey = graph.byKey
   const formKeys = forms.map((form) => form.key)
@@ -127,8 +127,8 @@ export function useWizard(entry: AnyForm, options: WizardOptions = {}): UseWizar
   // Resolve initial step. Priority: `getServerActiveStep()` (SSR
   // source of truth, returned identically on client) → URL
   // `?step=<key>` (reload preservation when no getter is wired) →
-  // `entry.key` fallback. Unknown keys at any level fall through so a
-  // stale link can't crash construction.
+  // the entry form's `key` fallback. Unknown keys at any level fall
+  // through so a stale link can't crash construction.
   const fromGetter = options.getServerActiveStep?.()
   const fromUrl = wizardHistory.read()
   let initialKey: string
@@ -137,7 +137,7 @@ export function useWizard(entry: AnyForm, options: WizardOptions = {}): UseWizar
   } else if (fromUrl !== undefined && seenKeys.has(fromUrl)) {
     initialKey = fromUrl
   } else {
-    initialKey = entry.key
+    initialKey = entryForm.key
   }
   const current = ref<string>(initialKey)
 
@@ -642,7 +642,7 @@ export function useWizard(entry: AnyForm, options: WizardOptions = {}): UseWizar
       submitting.value = true
       try {
         const cache = new Map<string, Processed>()
-        const walk = await walkSubgraph(entry, cache)
+        const walk = await walkSubgraph(entryForm, cache)
         // Aggregate errors and parsed values from the cache in BFS order
         // (matching `forms`) so the error list and value record are
         // stable regardless of branch interleaving.
@@ -734,7 +734,7 @@ export function useWizard(entry: AnyForm, options: WizardOptions = {}): UseWizar
   const diagnose = (): readonly WizardWarning[] => graph.warnings
 
   const flow: WizardFlow = Object.freeze({
-    entry,
+    entryForm,
     tree: graph.tree,
     allForms: forms,
     get visited(): readonly string[] {
@@ -746,7 +746,7 @@ export function useWizard(entry: AnyForm, options: WizardOptions = {}): UseWizar
   const wizardKey = options.key
   const handle: UseWizardReturnType = {
     key: wizardKey,
-    entry,
+    entryForm,
     allForms: forms,
     count: forms.length,
     statuses,

--- a/src/runtime/core/build-form-api.ts
+++ b/src/runtime/core/build-form-api.ts
@@ -458,6 +458,13 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
   const submitted = computed<boolean>(() => state.submitted.value)
   const submitError = computed<unknown>(() => state.submitError.value)
 
+  // --- Wizard departure lifecycle ---
+  // `useWizard` bumps `state.departAttempts` whenever navigation
+  // (`next` / `back` / `goTo`) actually departs this form. The
+  // computed mirror surfaces on `form.meta.departAttempts` for
+  // templates and the depart arm of `defaultShouldShowErrors`.
+  const departAttempts = computed<number>(() => state.departAttempts.value)
+
   // --- Validation lifecycle ---
   const validating = computed<boolean>(() => state.activeValidations.value > 0)
   // `valid` is "we've validated at least once AND no errors AND not
@@ -555,6 +562,7 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
       ...rootBase,
       submitting: state.submitting.value,
       submissionAttempts: state.submissionAttempts.value,
+      departAttempts: state.departAttempts.value,
       submitError: state.submitError.value,
       errorCount: rootBase.errors.length,
       submitted: state.submitted.value,
@@ -622,6 +630,7 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
       // Lifecycle (form-level only — not on FieldState).
       submitting,
       submissionAttempts,
+      departAttempts,
       submitError,
       // Scalar mirror over the array — meta is a single sticky surface
       // for both templates and `useWizard`'s `FormStatus`, so the

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -344,6 +344,18 @@ export type FormStore<F extends GenericForm, G extends GenericForm = F> = {
   readonly submitted: Ref<boolean>
   readonly submitError: Ref<unknown>
 
+  // --- wizard navigation lifecycle ---
+  // Bumped by `useWizard` each time wizard navigation (`next`, `back`,
+  // `goTo`) actually departs this form. Cleared by `reset()` alongside
+  // the submission lifecycle. Drives the depart arm of
+  // `defaultShouldShowErrors`: once wizard navigation has left this
+  // form, any errors on the form reveal regardless of touched / blurred
+  // state. Distinct from `submissionAttempts` (which counts
+  // `handleSubmit` passes only) so submission accounting stays
+  // unambiguous; distinct from `form.validate()`, which is a read-only
+  // primitive that never bumps any counter.
+  readonly departAttempts: Ref<number>
+
   /**
    * `true` while a function-form `defaultValues` factory is in flight.
    * Stays `false` for plain-value `defaultValues`. Shared across every
@@ -1519,6 +1531,10 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
   const submissionAttempts = ref(0)
   const submitted = ref(false)
   const submitError = ref<unknown>(null)
+  // Counts wizard departures from this form. Bumped by `useWizard`
+  // when `next` / `back` / `goTo` actually leaves this form; zeroed by
+  // `reset()` below. Drives the depart arm of `defaultShouldShowErrors`.
+  const departAttempts = ref(0)
   const submissionGeneration = ref(0)
   const activeValidations = ref(0)
   // Async-defaults lifecycle. `useAbstractForm` writes these on the
@@ -3109,6 +3125,7 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     submissionAttempts.value = 0
     submitted.value = false
     submitError.value = null
+    departAttempts.value = 0
     // Drop any pending field-validation timers / in-flight runs. Writes
     // that reached the controller-aborted branch resolve to a no-op, so
     // the error store stays clean after the reset clears it above.
@@ -3360,6 +3377,7 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     submissionAttempts,
     submitted,
     submitError,
+    departAttempts,
     hydrating,
     hydrateError,
     defaultValuesFactory,

--- a/src/runtime/core/devtools.ts
+++ b/src/runtime/core/devtools.ts
@@ -248,6 +248,7 @@ function wire(api: UnsafeDevtoolsApi, app: App, registry: AttaformRegistry): voi
     payload.state['Aggregates'] = [
       { key: 'submitting', value: state.submitting.value },
       { key: 'submissionAttempts', value: state.submissionAttempts.value },
+      { key: 'departAttempts', value: state.departAttempts.value },
       { key: 'submitError', value: state.submitError.value },
       { key: 'activeValidations', value: state.activeValidations.value },
     ]

--- a/src/runtime/core/registry.ts
+++ b/src/runtime/core/registry.ts
@@ -73,7 +73,7 @@ export type AttaformRegistry = {
   readonly forms: Map<FormKey, FormStore<GenericForm>>
   /**
    * Live wizards keyed by the consumer-supplied `key` option. Populated
-   * by `useWizard(entry, { key })`; consulted by `injectWizard(key)` to
+   * by `useWizard(entryForm, { key })`; consulted by `injectWizard(key)` to
    * resolve cross-component wizard handles. Anonymous wizards (no
    * `key`) do NOT register here — they're reachable only via ambient
    * provide/inject.

--- a/src/runtime/core/registry.ts
+++ b/src/runtime/core/registry.ts
@@ -173,6 +173,25 @@ export const kAttaformAncestorWizard: InjectionKey<UseWizardReturnType> = Symbol
 )
 
 /**
+ * Optional framework-aware resolver for the wizard's active step. The
+ * `attaform/nuxt` runtime plugin provides this so `useWizard` can read
+ * the current step from `useRoute().query[<historyParam>]` without the
+ * wizard core importing any framework router. Bare-Vue consumers wire
+ * `options.getServerActiveStep` explicitly instead, or let the
+ * post-hydration URL restore in `useWizard` handle the deep-link case.
+ *
+ * Shape: a single function that receives the wizard's configured
+ * `history.param` (default `'step'`) and returns the matching query
+ * value or `undefined`. Called once during `useWizard()` construction,
+ * after any explicit `options.getServerActiveStep` is consulted.
+ */
+export type WizardActiveStepResolver = (param: string) => string | undefined
+
+export const kAttaformWizardActiveStepResolver: InjectionKey<WizardActiveStepResolver> = Symbol.for(
+  'attaform:wizard-active-step-resolver'
+)
+
+/**
  * Provides the current form's FormStore to descendants. Installed by
  * `useAbstractForm` after it resolves the state, so any nested component
  * can call `injectForm()` without prop-threading the form API.

--- a/src/runtime/core/should-show-errors.ts
+++ b/src/runtime/core/should-show-errors.ts
@@ -31,14 +31,18 @@ import type { ShouldShowErrors, ShouldShowErrorsConfig } from '../types/types-ap
  *    container's `showErrors` too. The error returns the moment the
  *    new verdict lands and `validating` flips back to false.
  *
- * 3. **Post-submit override.** Once `formMeta.submissionAttempts > 0` the
- *    heuristic surfaces every own-path error unconditionally (subject
- *    only to the two gates above). The consumer asked the form to
- *    commit; transient mid-edit hiding is no longer appropriate
- *    because the user has signalled they're done editing. This
- *    deliberately covers focused fields, pristine fields, and
- *    untouched fields, so a submit attempt against a half-completed
- *    form lights up every problem the validator found.
+ * 3. **Post-submit override.** Once `formMeta.submissionAttempts > 0` OR
+ *    `formMeta.departAttempts > 0` the heuristic surfaces every own-path
+ *    error unconditionally (subject only to the two gates above). The
+ *    `submissionAttempts` arm fires when the consumer ran `handleSubmit`:
+ *    they asked the form to commit, transient mid-edit hiding is no
+ *    longer appropriate. The `departAttempts` arm fires when wizard
+ *    navigation (`wizard.next`, `wizard.back`, `wizard.goTo`) actually
+ *    left this form: the user pressed onward (or moved off the step
+ *    entirely), so the form should reveal whatever was blocking them
+ *    when they come back. Both arms deliberately cover focused,
+ *    pristine, and untouched fields, so the next paint after the user
+ *    tried to progress lights up every problem the validator found.
  *
  * 4. **Pre-submit timing gate.** Before the first submit attempt,
  *    show once the user has touched the field (sticky-true after the
@@ -76,6 +80,7 @@ export const defaultShouldShowErrors: ShouldShowErrors = (field, formMeta) => {
   if (!hasOwnError) return false
   if (field.validating === true) return false
   if (formMeta.submissionAttempts > 0) return true
+  if (formMeta.departAttempts > 0) return true
   return field.touched === true && field.focused !== true
 }
 

--- a/src/runtime/core/wizard-graph.ts
+++ b/src/runtime/core/wizard-graph.ts
@@ -39,7 +39,7 @@ export class WizardCycleError extends AttaformError {
 
 /**
  * Static description of the wizard's reachable graph. Produced once
- * at `useWizard(entry)` construction; immutable for the wizard's
+ * at `useWizard(entryForm)` construction; immutable for the wizard's
  * lifetime (the graph topology is declared in code, not data).
  *
  *  - `entry` — the input form. Identity-equal to the argument.

--- a/src/runtime/plugins/attaform.ts
+++ b/src/runtime/plugins/attaform.ts
@@ -8,10 +8,10 @@
  * for directive lifecycle hooks, so the same plugin works on both sides
  * without a stub.
  */
-import { defineNuxtPlugin, useRuntimeConfig } from 'nuxt/app'
+import { defineNuxtPlugin, useRoute, useRuntimeConfig } from 'nuxt/app'
 import { DEVTOOLS_WINDOW_KEY } from '../core/devtools-shared'
 import { createAttaform } from '../core/plugin'
-import { getRegistryFromApp } from '../core/registry'
+import { getRegistryFromApp, kAttaformWizardActiveStepResolver } from '../core/registry'
 import { hydrateAttaformState, renderAttaformState } from '../core/serialize'
 import type { SerializedAttaformState } from '../core/serialize'
 import type { AttaformDefaults } from '../types/types-api'
@@ -35,6 +35,23 @@ export default defineNuxtPlugin({
     const { defaults, version } = config.attaform
 
     nuxtApp.vueApp.use(createAttaform({ ssr: isServer, defaults }))
+
+    // Bridge `useWizard`'s active-step resolution to the Nuxt route so
+    // deep-links hydrate without flicker. On the server, `useRoute()`
+    // reads the incoming request URL; on the client, it reads the live
+    // route — so server and client compute the same initial step and
+    // Vue's hydration walks a matching tree. Without this bridge, the
+    // wizard would fall back to its `entryForm.key` on the server while
+    // the client reads the URL, producing the deep-link mismatch
+    // cascade. Consumers can still pass `options.getServerActiveStep`
+    // explicitly to override; this just removes the boilerplate for the
+    // common case.
+    nuxtApp.vueApp.provide(kAttaformWizardActiveStepResolver, (param) => {
+      const value = useRoute().query[param]
+      if (typeof value === 'string') return value
+      if (Array.isArray(value) && typeof value[0] === 'string') return value[0]
+      return undefined
+    })
 
     if (isServer) {
       // After the app renders, capture every FormStore into the Nuxt payload

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -3178,6 +3178,28 @@ export type FormMeta<F = unknown> = FieldState<F> & {
   readonly submissionAttempts: number
 
   /**
+   * How many times wizard navigation (`wizard.next`, `wizard.back`,
+   * `wizard.goTo`) has actually departed this form. Bumped on real
+   * departures only: no-ops like `back()` from the first step, a
+   * same-key `goTo`, or a `next()` blocked by failed activation leave
+   * the counter at its prior value.
+   *
+   * Drives the depart arm of `defaultShouldShowErrors`: once wizard
+   * navigation has left this form, any errors on the form reveal
+   * regardless of touched / blurred state. Useful for the "the user
+   * tried to advance past this step, so show what blocked them" UX.
+   *
+   * Distinct from `submissionAttempts`, which counts `handleSubmit`
+   * passes only — wizard departures and form submissions are tracked
+   * separately so consumers can introspect each cleanly. Distinct
+   * from `form.validate()`, which is a read-only inspection primitive
+   * that never bumps any counter.
+   *
+   * Cleared by `form.reset()`.
+   */
+  readonly departAttempts: number
+
+  /**
    * The error thrown or rejected by the most recent submit callback
    * (or its `onError` handler). Cleared to `null` at the start of
    * each new submission attempt; stays `null` on success.

--- a/src/runtime/types/types-wizard.ts
+++ b/src/runtime/types/types-wizard.ts
@@ -2,8 +2,8 @@
  * Public types for `useWizard` — the multistep-form orchestrator.
  *
  * Forms self-describe their downstream neighbor(s) via `useForm({ next })`,
- * and `useWizard(entry)` walks the declared graph from the entry form to
- * discover every reachable step. Navigation, status aggregation, and
+ * and `useWizard(entryForm)` walks the declared graph from the entry form
+ * to discover every reachable step. Navigation, status aggregation, and
  * activation lifecycle layer on top of that graph view.
  *
  * The wizard surface is loosely keyed (`Record<string, FormStatus>` /
@@ -24,9 +24,9 @@ import type { FormKey } from './types-api'
  * at runtime and exposes the original form objects untouched.
  *
  * `next` is the graph-position declaration (see `useForm({ next })`).
- * Forms self-describe their successor(s), and `useWizard(entry)` walks
- * the graph from there. The field is optional: a form without `next`
- * is a terminal.
+ * Forms self-describe their successor(s), and `useWizard(entryForm)`
+ * walks the graph from there. The field is optional: a form without
+ * `next` is a terminal.
  *
  * `UseFormReturnType<...>` satisfies this shape because its `key`
  * field is `readonly key: K extends FormKey` and its `next` field is
@@ -234,10 +234,10 @@ export type WizardHistoryConfig = {
 }
 
 /**
- * Options for `useWizard(entry, options)`. Loosely keyed because the
- * wizard's reachable graph is discovered at construction from the
- * entry's `next` declarations; the option types are framework-facing
- * and cannot pre-commit to the literal-union of reachable keys.
+ * Options for `useWizard(entryForm, options)`. Loosely keyed because
+ * the wizard's reachable graph is discovered at construction from the
+ * entry form's `next` declarations; the option types are framework-
+ * facing and cannot pre-commit to the literal-union of reachable keys.
  */
 export type WizardOptions = {
   /**
@@ -310,7 +310,8 @@ export type WizardOptions = {
    * server-side and non-active steps stay deferred.
    *
    * The getter runs on both server and client; returning `undefined`
-   * falls through to URL `?step=<key>` and finally to `entry.key`.
+   * falls through to URL `?step=<key>` and finally to the entry form's
+   * `key`.
    */
   readonly getServerActiveStep?: () => string | undefined
   /**
@@ -348,7 +349,7 @@ export type WizardTreeNode = {
  * `diagnose()` channel.
  *
  *  - `cycle` — a form's chain leads back to itself. Hard error at
- *    `useWizard(entry)` construction (thrown, not warned).
+ *    `useWizard(entryForm)` construction (thrown, not warned).
  *  - `missing-terminal` — every path from entry should reach a terminal
  *    (`next` omitted, or empty branching). In a finite acyclic graph
  *    this is equivalent to `cycle`; surfaced for completeness.
@@ -381,12 +382,12 @@ export type WizardWarning = {
  * runtime tracker, so consumers can render sitemaps, breadcrumb trails,
  * diagnostic panels, and step-counter UIs from one cohesive namespace.
  *
- *  - `entry`     — the form passed to `useWizard(entry)`. Identity-equal
- *                  to that argument; immutable for the wizard's
+ *  - `entryForm` — the form passed to `useWizard(entryForm)`. Identity-
+ *                  equal to that argument; immutable for the wizard's
  *                  lifetime.
- *  - `tree`      — recursive `WizardTreeNode` view rooted at `entry`.
- *                  Suitable for sitemap rendering via a recursive Vue
- *                  component; convergent paths duplicate by design.
+ *  - `tree`      — recursive `WizardTreeNode` view rooted at the entry
+ *                  form. Suitable for sitemap rendering via a recursive
+ *                  Vue component; convergent paths duplicate by design.
  *  - `allForms`  — BFS-ordered, deduped list of reachable forms. The
  *                  same list exposed at `wizard.allForms`; mirrored
  *                  here so `wizard.flow` is the single hand-off when a
@@ -403,7 +404,7 @@ export type WizardWarning = {
  *                  the result into a dev-only warning panel.
  */
 export type WizardFlow = {
-  readonly entry: AnyForm
+  readonly entryForm: AnyForm
   readonly tree: WizardTreeNode
   readonly allForms: readonly AnyForm[]
   readonly visited: readonly FormKey[]
@@ -411,12 +412,11 @@ export type WizardFlow = {
 }
 
 /**
- * Return shape of `useWizard(entry, options)`. Every reactive read is
- * a plain getter (no `.value`) — `wizard.current`, `wizard.progress`,
+ * Return shape of `useWizard(entryForm, options)`. Every reactive read
+ * is a plain getter (no `.value`) — `wizard.current`, `wizard.progress`,
  * `wizard.allErrors` track inside `computed` / template effects
- * directly. This matches the rest of the library (form.values,
- * form.meta, etc.) and keeps the consumer surface free of `.value`
- * plumbing.
+ * directly. This matches the rest of Attaform (form.values, form.meta,
+ * etc.) and keeps the consumer surface free of `.value` plumbing.
  *
  *   - `current`     — the active step's key (or `undefined` for a
  *                     degenerate wizard).
@@ -425,8 +425,8 @@ export type WizardFlow = {
  *                     `undefined` when `current` is `undefined`.
  *   - `activeIndex` — 0-based BFS-ordered index of the active step;
  *                     `-1` when `current` is `undefined`.
- *   - `entry`       — the entry form, identity-equal to the argument
- *                     passed to `useWizard(entry)`.
+ *   - `entryForm`   — the entry form, identity-equal to the argument
+ *                     passed to `useWizard(entryForm)`.
  *   - `allForms`    — BFS-ordered, deduped list of forms reachable
  *                     from the entry. Use this for sitemaps, step
  *                     counters, and "step N of M" displays.
@@ -478,12 +478,12 @@ export type WizardFlow = {
  *                     `form.reset()` on every reachable form. Returns
  *                     the wizard to its construction state.
  *   - `flow`        — introspection namespace bundling the static graph
- *                     (`entry`, `tree`, `allForms`), runtime navigation
- *                     history (`visited`), and the diagnostic warnings
- *                     channel (`diagnose()`). The same data backs the
- *                     top-level `entry` / `allForms` aliases — the
- *                     namespace is the structured hand-off for sitemap
- *                     and diagnostic UIs.
+ *                     (`entryForm`, `tree`, `allForms`), runtime
+ *                     navigation history (`visited`), and the diagnostic
+ *                     warnings channel (`diagnose()`). The same data
+ *                     backs the top-level `entryForm` / `allForms`
+ *                     aliases — the namespace is the structured hand-off
+ *                     for sitemap and diagnostic UIs.
  */
 export type UseWizardReturnType = {
   /**
@@ -495,7 +495,7 @@ export type UseWizardReturnType = {
   readonly current: string | undefined
   readonly activeForm: AnyForm | undefined
   readonly activeIndex: number
-  readonly entry: AnyForm
+  readonly entryForm: AnyForm
   readonly allForms: readonly AnyForm[]
   readonly count: number
   readonly statuses: WizardStatusesProxy<Record<string, FormStatus>>

--- a/test/composables/wizard-depart-reveal-errors.test.ts
+++ b/test/composables/wizard-depart-reveal-errors.test.ts
@@ -1,0 +1,296 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, nextTick, type App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { useWizard } from '../../src/runtime/composables/use-wizard'
+import { createAttaform } from '../../src/runtime/core/plugin'
+
+/**
+ * `form.meta.departAttempts` + wizard navigation reveal contract.
+ *
+ * Locks in the API and behavior added with `departAttempts`:
+ *
+ *  - The counter lives on `form.meta` alongside `submissionAttempts`,
+ *    type-visible to consumers; both surface on the readonly meta proxy.
+ *  - Wizard navigation (`next`, `back`, `goTo`) bumps the departing
+ *    form's counter on real departures only — early-return guards
+ *    (back from first, same-key goTo, next at terminal,
+ *    activation failed) leave it alone.
+ *  - `submissionAttempts` and `departAttempts` are accounting-distinct:
+ *    `wizard.handleSubmit` moves submissionAttempts, wizard navigation
+ *    moves departAttempts, `form.validate()` moves neither.
+ *  - The depart arm of `defaultShouldShowErrors` reveals every error on
+ *    a form once it has been departed — the user-facing payoff that
+ *    motivated the change.
+ *  - `form.reset()` zeros departAttempts alongside the rest of the
+ *    submission lifecycle.
+ */
+
+const strictSchema = z.object({
+  email: z.email('Enter a valid email'),
+  password: z.string().min(8, 'At least 8 characters'),
+})
+
+const permissiveSchema = z.object({
+  name: z.string().optional(),
+})
+
+function mountHarness<R>(setup: () => R): { app: App; result: R } {
+  const handle: { result?: R } = {}
+  const App = defineComponent({
+    setup() {
+      handle.result = setup()
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  app.config.warnHandler = () => {}
+  app.config.errorHandler = () => {}
+  app.mount(document.createElement('div'))
+  return { app, result: handle.result as R }
+}
+
+describe('wizard navigation bumps form.meta.departAttempts', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('failed wizard.next() bumps departAttempts and leaves submissionAttempts at 0', async () => {
+    const { app, result } = mountHarness(() => {
+      const b = useForm({ schema: permissiveSchema, key: 'dep-1-b' })
+      const a = useForm({ schema: strictSchema, key: 'dep-1-a', next: b })
+      const wizard = useWizard(a)
+      return { a, b, wizard }
+    })
+    apps.push(app)
+    expect(result.a.meta.departAttempts).toBe(0)
+    expect(result.a.meta.submissionAttempts).toBe(0)
+    await result.wizard.next()
+    expect(result.wizard.current).toBe('dep-1-a') // blocked
+    expect(result.a.meta.departAttempts).toBe(1)
+    expect(result.a.meta.submissionAttempts).toBe(0)
+  })
+
+  it('successful wizard.next() also bumps departAttempts on the departed form', async () => {
+    const { app, result } = mountHarness(() => {
+      const b = useForm({ schema: permissiveSchema, key: 'dep-2-b' })
+      const a = useForm({
+        schema: strictSchema,
+        key: 'dep-2-a',
+        defaultValues: { email: 'a@a.com', password: 'longenough' },
+        next: b,
+      })
+      const wizard = useWizard(a)
+      return { a, b, wizard }
+    })
+    apps.push(app)
+    await result.wizard.next()
+    expect(result.wizard.current).toBe('dep-2-b')
+    expect(result.a.meta.departAttempts).toBe(1)
+    expect(result.b.meta.departAttempts).toBe(0)
+    expect(result.a.meta.submissionAttempts).toBe(0)
+  })
+
+  it('wizard.next() with no `next` declaration does NOT bump (terminal step)', async () => {
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema: permissiveSchema, key: 'dep-3-a' })
+      const wizard = useWizard(a)
+      return { a, wizard }
+    })
+    apps.push(app)
+    await result.wizard.next()
+    expect(result.a.meta.departAttempts).toBe(0)
+  })
+
+  it('wizard.back() bumps the departing form on real backward navigation', async () => {
+    const { app, result } = mountHarness(() => {
+      const b = useForm({ schema: permissiveSchema, key: 'dep-4-b' })
+      const a = useForm({
+        schema: strictSchema,
+        key: 'dep-4-a',
+        defaultValues: { email: 'a@a.com', password: 'longenough' },
+        next: b,
+      })
+      const wizard = useWizard(a)
+      return { a, b, wizard }
+    })
+    apps.push(app)
+    await result.wizard.next()
+    expect(result.wizard.current).toBe('dep-4-b')
+    const beforeA = result.a.meta.departAttempts
+    const beforeB = result.b.meta.departAttempts
+    result.wizard.back()
+    expect(result.wizard.current).toBe('dep-4-a')
+    expect(result.b.meta.departAttempts).toBe(beforeB + 1)
+    expect(result.a.meta.departAttempts).toBe(beforeA) // a unaffected
+  })
+
+  it('wizard.back() from the first step is a no-op and does NOT bump', () => {
+    const { app, result } = mountHarness(() => {
+      const b = useForm({ schema: permissiveSchema, key: 'dep-5-b' })
+      const a = useForm({ schema: permissiveSchema, key: 'dep-5-a', next: b })
+      const wizard = useWizard(a)
+      return { a, wizard }
+    })
+    apps.push(app)
+    expect(result.wizard.current).toBe('dep-5-a')
+    result.wizard.back()
+    expect(result.wizard.current).toBe('dep-5-a')
+    expect(result.a.meta.departAttempts).toBe(0)
+  })
+
+  it('wizard.goTo(otherKey) bumps the departing form', () => {
+    const { app, result } = mountHarness(() => {
+      const c = useForm({ schema: permissiveSchema, key: 'dep-6-c' })
+      const b = useForm({ schema: permissiveSchema, key: 'dep-6-b', next: c })
+      const a = useForm({ schema: permissiveSchema, key: 'dep-6-a', next: b })
+      const wizard = useWizard(a)
+      return { a, b, c, wizard }
+    })
+    apps.push(app)
+    result.wizard.goTo('dep-6-c')
+    expect(result.wizard.current).toBe('dep-6-c')
+    expect(result.a.meta.departAttempts).toBe(1)
+    expect(result.b.meta.departAttempts).toBe(0)
+    expect(result.c.meta.departAttempts).toBe(0)
+  })
+
+  it('wizard.goTo(currentKey) is a no-op and does NOT bump', () => {
+    const { app, result } = mountHarness(() => {
+      const b = useForm({ schema: permissiveSchema, key: 'dep-7-b' })
+      const a = useForm({ schema: permissiveSchema, key: 'dep-7-a', next: b })
+      const wizard = useWizard(a)
+      return { a, wizard }
+    })
+    apps.push(app)
+    result.wizard.goTo('dep-7-a')
+    expect(result.a.meta.departAttempts).toBe(0)
+  })
+
+  it('wizard.goTo(unknownKey) dev-warns and does NOT bump', () => {
+    const { app, result } = mountHarness(() => {
+      const b = useForm({ schema: permissiveSchema, key: 'dep-8-b' })
+      const a = useForm({ schema: permissiveSchema, key: 'dep-8-a', next: b })
+      const wizard = useWizard(a)
+      return { a, wizard }
+    })
+    apps.push(app)
+    result.wizard.goTo('dep-8-unknown')
+    expect(result.a.meta.departAttempts).toBe(0)
+  })
+})
+
+describe('departAttempts and submissionAttempts stay accounting-distinct', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('wizard.handleSubmit failure bumps submissionAttempts but NOT departAttempts', async () => {
+    const { app, result } = mountHarness(() => {
+      const b = useForm({ schema: strictSchema, key: 'acc-1-b' })
+      const a = useForm({
+        schema: strictSchema,
+        key: 'acc-1-a',
+        defaultValues: { email: 'a@a.com', password: 'longenough' },
+        next: b,
+      })
+      const wizard = useWizard(a)
+      return { a, b, wizard }
+    })
+    apps.push(app)
+    const onSubmit = result.wizard.handleSubmit(async () => {})
+    await onSubmit()
+    expect(result.a.meta.submissionAttempts).toBeGreaterThan(0)
+    expect(result.b.meta.submissionAttempts).toBeGreaterThan(0)
+    expect(result.a.meta.departAttempts).toBe(0)
+    expect(result.b.meta.departAttempts).toBe(0)
+  })
+
+  it('form.validate() leaves both counters at 0', async () => {
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema: strictSchema, key: 'acc-2-a' })
+      // validate() must be called inside an effect scope; reading the
+      // ref inside setup keeps the watcher tied to this mount.
+      const status = a.validate()
+      void status.value
+      return { a }
+    })
+    apps.push(app)
+    await nextTick()
+    expect(result.a.meta.submissionAttempts).toBe(0)
+    expect(result.a.meta.departAttempts).toBe(0)
+  })
+})
+
+describe('defaultShouldShowErrors reveals on the depart arm', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('after failed wizard.next(), every error field reports showErrors=true even when never touched', async () => {
+    const { app, result } = mountHarness(() => {
+      const b = useForm({ schema: permissiveSchema, key: 'show-1-b' })
+      const a = useForm({ schema: strictSchema, key: 'show-1-a', next: b })
+      const wizard = useWizard(a)
+      return { a, wizard }
+    })
+    apps.push(app)
+    expect(result.a.fields.email.touched).toBe(false)
+    expect(result.a.fields.password.touched).toBe(false)
+    expect(result.a.fields.email.showErrors).toBe(false)
+    expect(result.a.fields.password.showErrors).toBe(false)
+    await result.wizard.next()
+    expect(result.a.meta.departAttempts).toBe(1)
+    expect(result.a.fields.email.showErrors).toBe(true)
+    expect(result.a.fields.password.showErrors).toBe(true)
+  })
+
+  it('after wizard.back() leaves an invalid step, its errors reveal on the way back', async () => {
+    // Mirrors the user's deep-link scenario: a flow starts on step b,
+    // user presses Back to a (departing b before ever editing it), then
+    // returns. b's errors should be visible from departure onward.
+    const { app, result } = mountHarness(() => {
+      const b = useForm({ schema: strictSchema, key: 'show-2-b' })
+      const a = useForm({
+        schema: strictSchema,
+        key: 'show-2-a',
+        defaultValues: { email: 'a@a.com', password: 'longenough' },
+        next: b,
+      })
+      const wizard = useWizard(a, { getServerActiveStep: () => 'show-2-b' })
+      return { a, b, wizard }
+    })
+    apps.push(app)
+    expect(result.wizard.current).toBe('show-2-b')
+    expect(result.b.fields.email.showErrors).toBe(false)
+    result.wizard.back()
+    expect(result.b.meta.departAttempts).toBe(1)
+    expect(result.b.fields.email.showErrors).toBe(true)
+    expect(result.b.fields.password.showErrors).toBe(true)
+  })
+})
+
+describe('form.reset() clears departAttempts', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('zeros departAttempts alongside the rest of the submission lifecycle', async () => {
+    const { app, result } = mountHarness(() => {
+      const b = useForm({ schema: permissiveSchema, key: 'rst-1-b' })
+      const a = useForm({ schema: strictSchema, key: 'rst-1-a', next: b })
+      const wizard = useWizard(a)
+      return { a, wizard }
+    })
+    apps.push(app)
+    await result.wizard.next()
+    expect(result.a.meta.departAttempts).toBe(1)
+    result.a.reset()
+    expect(result.a.meta.departAttempts).toBe(0)
+  })
+})

--- a/test/composables/wizard-flow-introspection.test.ts
+++ b/test/composables/wizard-flow-introspection.test.ts
@@ -8,8 +8,8 @@ import { createAttaform } from '../../src/runtime/core/plugin'
 
 /**
  * `wizard.flow` — Phase 5 introspection surface. Composes the static
- * graph (`entry`, `tree`, `allForms`) with the runtime navigation log
- * (`visited`) and the diagnostic warnings channel (`diagnose()`).
+ * graph (`entryForm`, `tree`, `allForms`) with the runtime navigation
+ * log (`visited`) and the diagnostic warnings channel (`diagnose()`).
  *
  * Static-graph coverage (tree shape for linear / branching / convergent
  * graphs, BFS ordering, dedupe) lives in `wizard-graph.test.ts` against
@@ -51,7 +51,7 @@ describe('wizard.flow — static graph view', () => {
       return { wizard, a }
     })
     apps.push(app)
-    expect(result.wizard.flow.entry).toBe(result.a)
+    expect(result.wizard.flow.entryForm).toBe(result.a)
   })
 
   it('exposes allForms BFS-ordered, deduped across convergent paths', () => {

--- a/test/composables/wizard-handle-submit.test.ts
+++ b/test/composables/wizard-handle-submit.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, nextTick, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
@@ -505,5 +505,128 @@ describe('useWizard — handleSubmit + lifecycle signals', () => {
     expect(failedKeys.has('hs-13-b')).toBe(true)
     // Parallel: total elapsed under 150ms (well below the 50ms * 2 = 100ms sequential floor + slack).
     expect(elapsed).toBeLessThan(150)
+  })
+})
+
+/**
+ * Standing regression for the v-if step-swap focus race: `goTo()`
+ * updates `wizard.current` synchronously, but the failed step's form
+ * doesn't mount until Vue's next render flush. The wizard awaits one
+ * `nextTick` before firing `applyInvalidSubmitPolicy()` so the focus
+ * call lands on a registered, connected input rather than walking an
+ * empty registration set. Without the wait, `getFirstErrorElement`
+ * returns `null` and the focus policy silently no-ops.
+ */
+describe('useWizard — navigateToFirstError lands focus through v-if step swap', () => {
+  const apps: App[] = []
+  let focusSpy: ReturnType<typeof vi.spyOn>
+  let offsetParentDescriptor: PropertyDescriptor | undefined
+
+  beforeEach(() => {
+    focusSpy = vi.spyOn(HTMLElement.prototype, 'focus')
+    offsetParentDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetParent')
+    // jsdom returns `null` for `offsetParent`; `getFirstErrorElement`
+    // uses that to filter `display:none` ancestors. Force a truthy
+    // value for connected elements so the visibility check passes.
+    Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+      configurable: true,
+      get(this: HTMLElement) {
+        return this.isConnected ? document.body : null
+      },
+    })
+  })
+
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+    focusSpy.mockRestore()
+    if (offsetParentDescriptor !== undefined) {
+      Object.defineProperty(HTMLElement.prototype, 'offsetParent', offsetParentDescriptor)
+    } else {
+      delete (HTMLElement.prototype as unknown as Record<string, unknown>)['offsetParent']
+    }
+  })
+
+  it("focuses the failed step's first error field after the step mounts", async () => {
+    const handle: {
+      wizard?: ReturnType<typeof useWizard>
+    } = {}
+
+    const App = defineComponent({
+      setup() {
+        const review = useForm({
+          schema: reviewSchema,
+          key: 'vif-review',
+          defaultValues: { tos: true as const },
+        })
+        const profile = useForm({
+          schema: profileSchema,
+          // `name` is required; blank default trips validation when the
+          // wizard walks profile during handleSubmit.
+          key: 'vif-profile',
+          defaultValues: { city: 'Cambridge' },
+          next: review,
+        })
+        const account = useForm({
+          schema: accountSchema,
+          key: 'vif-account',
+          defaultValues: { email: 'a@b.c', password: 'passw0rd' },
+          next: profile,
+        })
+        const wizard = useWizard(account)
+        handle.wizard = wizard
+
+        return () => {
+          if (wizard.current === 'vif-account') {
+            const reg = account.register('email')
+            return h('form', [
+              h('input', {
+                ref: (el: unknown) => {
+                  if (el instanceof HTMLInputElement) reg.registerElement(el)
+                },
+                'data-field': 'account-email',
+              }),
+            ])
+          }
+          if (wizard.current === 'vif-profile') {
+            const reg = profile.register('name')
+            return h('form', [
+              h('input', {
+                ref: (el: unknown) => {
+                  if (el instanceof HTMLInputElement) reg.registerElement(el)
+                },
+                'data-field': 'profile-name',
+              }),
+            ])
+          }
+          return h('div')
+        }
+      },
+    })
+
+    const app = createApp(App).use(createAttaform())
+    app.config.warnHandler = () => {}
+    app.config.errorHandler = () => {}
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    apps.push(app)
+
+    // Pre-condition: only the account input is in the DOM — the
+    // profile step's form isn't rendered until current flips.
+    expect(document.querySelector('[data-field="account-email"]')).not.toBeNull()
+    expect(document.querySelector('[data-field="profile-name"]')).toBeNull()
+
+    await handle.wizard!.handleSubmit(vi.fn(), vi.fn())()
+
+    // The wizard navigated past account (valid) to profile (invalid).
+    expect(handle.wizard!.current).toBe('vif-profile')
+    const target = document.querySelector('[data-field="profile-name"]') as HTMLInputElement | null
+    expect(target).not.toBeNull()
+    // `.focus()` was called on the now-mounted profile input — proves
+    // the nextTick wait gave the v-if'd form time to mount and register
+    // its inputs before the policy ran.
+    expect(focusSpy).toHaveBeenCalled()
+    const focused = focusSpy.mock.instances as HTMLElement[]
+    expect(focused[focused.length - 1]).toBe(target)
   })
 })

--- a/test/composables/wizard-hydration-restore.test.ts
+++ b/test/composables/wizard-hydration-restore.test.ts
@@ -1,0 +1,285 @@
+// @vitest-environment jsdom
+import { renderToString } from '@vue/server-renderer'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createApp, createSSRApp, defineComponent, h, nextTick, type App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { useWizard } from '../../src/runtime/composables/use-wizard'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import {
+  kAttaformWizardActiveStepResolver,
+  type WizardActiveStepResolver,
+} from '../../src/runtime/core/registry'
+
+/**
+ * Deep-link hydration safety. Without these guards, a wizard that
+ * deep-links to a non-entry step would render `entryForm.key` on the
+ * server (no `window.location`) while reading the URL on the client,
+ * cascading every node inside the wizard into a hydration mismatch.
+ *
+ * Two paths close the gap:
+ *
+ *  - The `attaform/nuxt` runtime plugin provides a
+ *    `kAttaformWizardActiveStepResolver` that reads `useRoute()`.
+ *    Server and client compute the same initial step, hydration walks
+ *    a matching tree, and the deep-link renders correctly with zero
+ *    flicker (Path A — auto-bridge).
+ *
+ *  - For framework-agnostic SSR setups with no resolver, the wizard
+ *    initial-renders the entry form on both sides and reconciles to
+ *    the URL key in a post-mount `onMounted` hook. Hydration matches,
+ *    but the user sees a one-frame entry flash before the restore
+ *    takes effect (Path D — post-hydration restore).
+ *
+ * The standing tests below probe both paths plus the pre-restore
+ * preservation of the deep-link URL and the SSR-to-client hydration
+ * walk against a real Vue server-renderer pass.
+ */
+
+const schemaA = z.object({ a: z.string() })
+const schemaB = z.object({ b: z.string() })
+const schemaC = z.object({ c: z.string() })
+
+const ORIGINAL_URL = 'http://localhost:3000/wizard'
+
+function mountWithResolver<R>(
+  setup: () => R,
+  resolver: WizardActiveStepResolver | null
+): { app: App; result: R } {
+  const handle: { result?: R } = {}
+  const App = defineComponent({
+    setup() {
+      handle.result = setup()
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  if (resolver !== null) {
+    app.provide(kAttaformWizardActiveStepResolver, resolver)
+  }
+  app.config.warnHandler = () => {}
+  app.config.errorHandler = () => {}
+  app.mount(document.createElement('div'))
+  return { app, result: handle.result as R }
+}
+
+describe('useWizard — injected active-step resolver (Path A)', () => {
+  const apps: App[] = []
+  beforeEach(() => {
+    window.history.replaceState(null, '', ORIGINAL_URL)
+  })
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('seeds initial current from the resolver when no explicit getter is wired', () => {
+    const { app, result } = mountWithResolver(
+      () => {
+        const c = useForm({ schema: schemaC, key: 'inj-1-c' })
+        const b = useForm({ schema: schemaB, key: 'inj-1-b', next: c })
+        const a = useForm({ schema: schemaA, key: 'inj-1-a', next: b })
+        return useWizard(a)
+      },
+      (param) => (param === 'step' ? 'inj-1-b' : undefined)
+    )
+    apps.push(app)
+    expect(result.current).toBe('inj-1-b')
+  })
+
+  it('passes the configured history.param to the resolver', () => {
+    const resolverCalls: string[] = []
+    const { app, result } = mountWithResolver(
+      () => {
+        const b = useForm({ schema: schemaB, key: 'inj-2-b' })
+        const a = useForm({ schema: schemaA, key: 'inj-2-a', next: b })
+        return useWizard(a, { history: { param: 'wiz' } })
+      },
+      (param) => {
+        resolverCalls.push(param)
+        return param === 'wiz' ? 'inj-2-b' : undefined
+      }
+    )
+    apps.push(app)
+    expect(resolverCalls).toEqual(['wiz'])
+    expect(result.current).toBe('inj-2-b')
+  })
+
+  it('explicit getServerActiveStep wins over the injected resolver', () => {
+    const { app, result } = mountWithResolver(
+      () => {
+        const c = useForm({ schema: schemaC, key: 'inj-3-c' })
+        const b = useForm({ schema: schemaB, key: 'inj-3-b', next: c })
+        const a = useForm({ schema: schemaA, key: 'inj-3-a', next: b })
+        return useWizard(a, { getServerActiveStep: () => 'inj-3-c' })
+      },
+      () => 'inj-3-b'
+    )
+    apps.push(app)
+    expect(result.current).toBe('inj-3-c')
+  })
+
+  it('falls back to entry when both explicit getter and resolver return undefined', () => {
+    const { app, result } = mountWithResolver(
+      () => {
+        const b = useForm({ schema: schemaB, key: 'inj-4-b' })
+        const a = useForm({ schema: schemaA, key: 'inj-4-a', next: b })
+        return useWizard(a, { getServerActiveStep: () => undefined })
+      },
+      () => undefined
+    )
+    apps.push(app)
+    expect(result.current).toBe('inj-4-a')
+  })
+
+  it('an unknown key from the resolver falls through to entry', () => {
+    const { app, result } = mountWithResolver(
+      () => {
+        const b = useForm({ schema: schemaB, key: 'inj-5-b' })
+        const a = useForm({ schema: schemaA, key: 'inj-5-a', next: b })
+        return useWizard(a)
+      },
+      () => 'inj-5-unknown'
+    )
+    apps.push(app)
+    expect(result.current).toBe('inj-5-a')
+  })
+})
+
+describe('useWizard — post-hydration URL restore (Path D)', () => {
+  const apps: App[] = []
+  beforeEach(() => {
+    window.history.replaceState(null, '', ORIGINAL_URL)
+  })
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+    window.history.replaceState(null, '', ORIGINAL_URL)
+  })
+
+  it('reconciles current to the URL key in onMounted when no resolver is wired', () => {
+    window.history.replaceState(null, '', `${ORIGINAL_URL}?step=pmr-1-b`)
+    const { app, result } = mountWithResolver(() => {
+      const c = useForm({ schema: schemaC, key: 'pmr-1-c' })
+      const b = useForm({ schema: schemaB, key: 'pmr-1-b', next: c })
+      const a = useForm({ schema: schemaA, key: 'pmr-1-a', next: b })
+      return useWizard(a)
+    }, null)
+    apps.push(app)
+    // Synchronous mount in jsdom fires onMounted before mount returns;
+    // by the time we read `current`, the restore has settled.
+    expect(result.current).toBe('pmr-1-b')
+  })
+
+  it('clamps visited to the restored step (no phantom entry visit)', () => {
+    window.history.replaceState(null, '', `${ORIGINAL_URL}?step=pmr-2-b`)
+    const { app, result } = mountWithResolver(() => {
+      const c = useForm({ schema: schemaC, key: 'pmr-2-c' })
+      const b = useForm({ schema: schemaB, key: 'pmr-2-b', next: c })
+      const a = useForm({ schema: schemaA, key: 'pmr-2-a', next: b })
+      return useWizard(a)
+    }, null)
+    apps.push(app)
+    expect(result.flow.visited).toEqual(['pmr-2-b'])
+  })
+
+  it('preserves the deep-link URL during setup (does NOT overwrite with entry)', () => {
+    window.history.replaceState(null, '', `${ORIGINAL_URL}?step=pmr-3-b`)
+    const { app } = mountWithResolver(() => {
+      const c = useForm({ schema: schemaC, key: 'pmr-3-c' })
+      const b = useForm({ schema: schemaB, key: 'pmr-3-b', next: c })
+      const a = useForm({ schema: schemaA, key: 'pmr-3-a', next: b })
+      return useWizard(a)
+    }, null)
+    apps.push(app)
+    // The deep-link URL is preserved through setup; the entry-key
+    // write-back that fires for non-deep-link mounts is skipped here.
+    expect(new URL(window.location.href).searchParams.get('step')).toBe('pmr-3-b')
+  })
+
+  it('does not redirect when URL key matches the explicit getter', () => {
+    window.history.replaceState(null, '', `${ORIGINAL_URL}?step=pmr-4-c`)
+    const { app, result } = mountWithResolver(() => {
+      const c = useForm({ schema: schemaC, key: 'pmr-4-c' })
+      const b = useForm({ schema: schemaB, key: 'pmr-4-b', next: c })
+      const a = useForm({ schema: schemaA, key: 'pmr-4-a', next: b })
+      return useWizard(a, { getServerActiveStep: () => 'pmr-4-c' })
+    }, null)
+    apps.push(app)
+    expect(result.current).toBe('pmr-4-c')
+    expect(result.flow.visited).toEqual(['pmr-4-c'])
+  })
+
+  it('falls through to entry when URL key is unknown', () => {
+    window.history.replaceState(null, '', `${ORIGINAL_URL}?step=pmr-5-nope`)
+    const { app, result } = mountWithResolver(() => {
+      const b = useForm({ schema: schemaB, key: 'pmr-5-b' })
+      const a = useForm({ schema: schemaA, key: 'pmr-5-a', next: b })
+      return useWizard(a)
+    }, null)
+    apps.push(app)
+    expect(result.current).toBe('pmr-5-a')
+    expect(result.flow.visited).toEqual(['pmr-5-a'])
+  })
+})
+
+describe('useWizard — SSR-to-client hydration safety', () => {
+  const apps: App[] = []
+  beforeEach(() => {
+    window.history.replaceState(null, '', ORIGINAL_URL)
+  })
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+    window.history.replaceState(null, '', ORIGINAL_URL)
+  })
+
+  it('hydrates an SSR-rendered entry against a deep-link URL with no mismatch warnings', async () => {
+    const WizardSfc = defineComponent({
+      setup() {
+        const b = useForm({ schema: schemaB, key: 'hyd-b' })
+        const a = useForm({ schema: schemaA, key: 'hyd-a', next: b })
+        const wizard = useWizard(a)
+        return () =>
+          h(
+            'div',
+            { class: wizard.current === 'hyd-a' ? 'on-a' : 'on-b' },
+            `step:${wizard.current}`
+          )
+      },
+    })
+
+    // Server-side render. No `window`; the wizard falls back to entry.
+    const ssrApp = createSSRApp(WizardSfc).use(createAttaform({ ssr: true }))
+    const ssrHtml = await renderToString(ssrApp)
+    expect(ssrHtml).toContain('on-a')
+    expect(ssrHtml).toContain('step:hyd-a')
+
+    // Stage the SSR HTML in a host element, then point the URL at a
+    // non-entry step so the client wizard's restore path fires.
+    const host = document.createElement('div')
+    host.innerHTML = ssrHtml
+    document.body.appendChild(host)
+    window.history.replaceState(null, '', `${ORIGINAL_URL}?step=hyd-b`)
+
+    // Capture every Vue warning surfaced during hydration. Hydration
+    // mismatches are emitted via `app.config.warnHandler` (or fall back
+    // to `console.warn` when no handler is set) — installing a handler
+    // lets us assert against the captured stream rather than scraping
+    // jsdom's console.
+    const warnings: string[] = []
+    const clientApp = createSSRApp(WizardSfc).use(createAttaform({ ssr: false }))
+    clientApp.config.warnHandler = (msg) => {
+      warnings.push(msg)
+    }
+    clientApp.mount(host)
+    apps.push(clientApp)
+
+    const hydrationWarnings = warnings.filter((msg) => /hydration|mismatch/i.test(msg))
+    expect(hydrationWarnings).toEqual([])
+
+    // The restore's reactive write fires in `onMounted` but Vue
+    // batches the re-render into a microtask, so flush before
+    // inspecting the DOM.
+    await nextTick()
+    expect(host.querySelector('.on-b')).not.toBeNull()
+    expect(host.textContent).toContain('step:hyd-b')
+  })
+})

--- a/test/types/type-pressure-4-form.test.ts
+++ b/test/types/type-pressure-4-form.test.ts
@@ -125,7 +125,7 @@ describe('Type-pressure — 4 useForm calls + useWizard composition', () => {
 
       expectTypeOf(wizard.current).toEqualTypeOf<string | undefined>()
       expectTypeOf(wizard.count).toEqualTypeOf<number>()
-      expectTypeOf(wizard.entry).toMatchTypeOf<{ readonly key: string }>()
+      expectTypeOf(wizard.entryForm).toMatchTypeOf<{ readonly key: string }>()
     }
     void _neverInvoked
   })


### PR DESCRIPTION
## Summary

Five-commit polish sweep over the wizard surface that landed during a docs page-walk on `docs/multistep/`. Mix of docs cleanup, two library-level bug fixes, a small playground type widening, and one new public feature (`form.meta.departAttempts`).

**Commits**:
- `662ce71` docs(wizard): polish sweep + rename `useWizard` parameter `entry` → `entryForm`
- `1bf1a65` fix(wizard): `await nextTick` before focusing after `navigateToFirstError`
- `c82c035` fix(wizard): close the deep-link hydration mismatch cascade
- `2a833e6` fix(playground): widen toast `description` to admit form-values aggregates
- `94a4a87` feat(wizard): reveal errors on wizard departure via `form.meta.departAttempts`

**Headline changes:**

- **`form.meta.departAttempts`** — new per-form counter that bumps whenever wizard navigation (`next` / `back` / `goTo`) actually departs the form. `defaultShouldShowErrors` gains a depart arm: once a form has been left, every own-path error reveals regardless of touched / focused state. Accounting stays distinct from `submissionAttempts` (which remains `handleSubmit`-only) and `form.validate()` (which still bumps neither).
- **Deep-link hydration safety** — `useWizard` no longer reads URL state during SSR setup. A Nuxt-only auto-bridge (`kAttaformWizardActiveStepResolver` injected by the runtime plugin) lets the same step resolve on server and client. Framework-agnostic SSR setups get a post-mount restore that reconciles without producing hydration warnings.
- **Focus race on invalid submit** — `wizard.handleSubmit`'s failure path now `await nextTick()` before invoking `applyInvalidSubmitPolicy`, so v-if-mounted error fields exist by the time focus tries to land.
- **`useWizard(entry)` → `useWizard(entryForm)`** — public-surface rename for self-documentation. Applied across source, JSDoc, tests, and docs.
- **Playground toast typing** — `ToastOptions.description` now admits arbitrary record / array shapes so `toast.success('…', { description: values })` works in demos without coercion.

**Test additions:**

- `test/composables/wizard-depart-reveal-errors.test.ts` — 13 new tests locking in the bump-on-real-departure contract, accounting-distinct invariants, reveal effects, deep-link Back scenario, and reset clearing.
- `test/composables/wizard-hydration-restore.test.ts` — 11 new tests covering injected-resolver path, post-mount restore, and a real SSR-to-client hydration walk against pre-rendered HTML.
- `test/composables/wizard-handle-submit.test.ts` — added a v-if mount-after-focus regression test.

**Suite**: 3005 passing / 17 skipped. Typecheck + lint clean.

## Open follow-up

The departAttempts work surfaced a deeper architectural question: `useWizard` today is a state-machine primitive (forms declare `next:` and routing via `pick(parsed)`, `wizard.next()` gates on validation because branching needs parsed data). This works for prescriptive flows but adds friction for exploratory ones where consumers want to bounce between pages freely. A deeper refactor is queued to move flow structure off `useForm` and into `useWizard` config — landing this PR first for academic completeness.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 3005 / 17 skipped (was 2992 + 13 new + 11 new + ~5 added)
- [x] Manual probe: type invalid email on wizard demo, press Next, error reveals immediately
- [x] Manual probe: deep-link to `?step=docs-demo-wizard-review`, no hydration warnings in console
- [x] Manual probe: after deep-link to step 3, press Back, return to step 3, errors visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)