### PR TITLE
docs: add llms.txt + restore CHANGELOG Unreleased convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,6 @@
 # Changelog
 
 ## Unreleased
-
-_No unreleased changes yet._
-
-## v0.18.0
 Multistep flows (`useWizard` + `injectWizard`), a Nuxt DevTools
 panel, schema-faithful preprocess (`z.preprocess` / `z.coerce`
 no longer mutate `form.values`), `v-register` on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,11 @@ rip-and-replace; no compat shims.
   `docs/server-and-ssr/performance.md` (keystroke /
   validation / submit / persistence figures against the
   16.7 ms 60 fps budget).
+- **`llms.txt`** at
+  [`attaform.com/llms.txt`](https://www.attaform.com/llms.txt)
+  gives AI crawlers and other LLMs a focused, terse view of
+  Attaform's mental model plus categorised links into the
+  docs.
 
 ## v0.17.2
 _No unreleased changes yet._

--- a/apps/site/components/app/AppFooter.vue
+++ b/apps/site/components/app/AppFooter.vue
@@ -122,14 +122,6 @@
             >Oswald Chisala</a
           >
           <span class="text-fg-subtle/50" aria-hidden="true">·</span>
-          <a
-            href="https://github.com/ozzyfromspace"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="font-medium text-fg-muted transition-colors hover:text-fg"
-            >@ozzyfromspace</a
-          >
-          <span class="text-fg-subtle/50" aria-hidden="true">·</span>
           <span>MIT License</span>
         </p>
         <p class="flex items-center gap-1.5 text-sm text-fg-subtle">

--- a/apps/site/components/app/AppFooter.vue
+++ b/apps/site/components/app/AppFooter.vue
@@ -112,8 +112,25 @@
       <div
         class="flex flex-col items-center justify-between gap-3 border-t border-border py-6 sm:flex-row"
       >
-        <p class="flex items-center gap-1.5 text-sm text-fg-subtle">
-          <span>© {{ year }} Oswald Chisala · MIT License</span>
+        <p class="flex flex-wrap items-center gap-1.5 text-sm text-fg-subtle">
+          <span>© {{ year }}</span>
+          <a
+            href="https://www.linkedin.com/in/chisalao/"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="font-medium text-fg-muted transition-colors hover:text-fg"
+            >Oswald Chisala</a
+          >
+          <span class="text-fg-subtle/50" aria-hidden="true">·</span>
+          <a
+            href="https://github.com/ozzyfromspace"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="font-medium text-fg-muted transition-colors hover:text-fg"
+            >@ozzyfromspace</a
+          >
+          <span class="text-fg-subtle/50" aria-hidden="true">·</span>
+          <span>MIT License</span>
         </p>
         <p class="flex items-center gap-1.5 text-sm text-fg-subtle">
           <span class="heart-host inline-flex items-center gap-1.5">

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -73,6 +73,47 @@ const onComplete = wizard.handleSubmit(async (ctx) => {
 
 Steps can be `useForm` references, bare strings (affordance-only positions), eager function slots, or `lazy(ctx => ...)` markers. `wizard.handleSubmit` validates the active form and advances on intermediate steps, then validates every form in parallel on the final step.
 
+## Quick reference
+
+The form handle returned by `useForm({ schema })`:
+
+- `form.values` reactive view of form state. Drill: `form.values.email`. Call: `form.values('user.email')`.
+- `form.errors` reactive error map by path. Same drill and call shapes.
+- `form.fields.<path>` per-field state. Most-touched keys: `value`, `touched`, `dirty`, `blank`, `showErrors`, `firstError`, `validating`, `valid`, `errors`, `focused`, `blurred`, `connected`.
+- `form.meta` top-level flags: `valid`, `dirty`, `submitting`, `submitted`, `submissionAttempts`, `submitError`, `errorCount`, `errors`, `key`, `instanceId`.
+- `form.register(path, opts?)` returns the binding for `v-register`. Options: `persist`, `transforms`, `multiTab`, `acknowledgeSensitive`.
+- `form.handleSubmit(onSubmit, onError?)` submit wrapper. Validates, routes errors, calls `onSubmit` with the parsed values.
+- `form.setValue(path, value)`, `form.reset(defaults?)`, `form.resetField(path)`, `form.clear(path?)`, `form.unset(path)` programmatic writes.
+- `form.validate(path?)`, `form.validateAsync(path?)`, `form.process(path?)` manual validation.
+- `form.setFieldErrors(errors)`, `form.addFieldErrors(errors)`, `form.clearFieldErrors(path?)` server-error routing.
+- `form.setFormErrors(errors)`, `form.clearFormErrors()` form-level errors.
+- `form.history.{undo, redo, clear, canUndo, canRedo, size}` undo/redo namespace.
+- `form.applyInvalidSubmitPolicy(policy?)`, `form.focusFirstError()`, `form.scrollToFirstError()` UX primitives.
+- `form.touch(path?)`, `form.toRef(path)`, `form.rehydrate()`, `form.clearPersistedDraft(path?)` introspection and lifecycle helpers.
+
+The wizard handle returned by `useWizard({ steps })`:
+
+- `wizard.currentStep`, `wizard.activeForm`, `wizard.activeIndex`, `wizard.count`, `wizard.isFinalStep` position.
+- `wizard.next()`, `wizard.back()`, `wizard.goTo(key)`, `wizard.reset()` navigation.
+- `wizard.handleSubmit(onSubmit, onError?)` universal submit. Intermediate steps validate the active form and advance; the final step validates every form in parallel.
+- `wizard.forms.<key>` typed map of step forms.
+- `wizard.allValues`, `wizard.allErrors`, `wizard.statuses` namespaced aggregates.
+- `wizard.progress`, `wizard.canAdvance`, `wizard.canGoBack`, `wizard.complete`, `wizard.done` derived signals.
+- `wizard.submitting`, `wizard.submissionAttempts`, `wizard.visited` submission state.
+
+## Idioms
+
+Patterns that keep Attaform code clean.
+
+- **Hoist schemas.** Declare `const schema = z.object({...})`, then pass `useForm({ schema })`. Inlining the Zod schema inflates the visible API surface in templates.
+- **Use the form handle. Don't destructure.** `const form = useForm(...)`, then reach for `form.register('email')`, `form.setValue(...)`, etc. Destructuring loses the central noun and the reactive bindings.
+- **Reach with `?.` on nullable returns.** `injectForm()` and `injectWizard()` return `T | null`. Chain optional access at every consumption site (`form?.register('email')`, `form?.fields.email.showErrors`). Skip the `!` non-null assertion; a single mount-order regression turns a quiet no-op into a runtime crash.
+- **Read errors through `field.showErrors` and `field.firstError`.** The visibility heuristic lives in `showErrors`; reaching into `field.errors[0]` directly bypasses it.
+- **Use `key` for stable forms.** Anonymous `useForm({ schema })` works for one-off forms. Pass `key: 'signup'` when you want cross-component lookup via `injectForm('signup')`, multi-tab sync, or stable persistence.
+- **Compose, don't nest.** For multistep flows, compose multiple `useForm` instances under `useWizard` rather than nesting concerns into one schema.
+- **Native inputs first.** Bind to `<input>`, `<select>`, `<textarea>` with `v-register`. Reach for `useRegister` only when wrapping a custom component.
+- **`form.values` is the verbatim input.** Values coerced by `z.coerce.*` or transformed by `z.preprocess` only materialise in the parsed `data` callback inside `form.handleSubmit((data) => ...)`.
+
 ## Getting started
 
 - [Quick start](https://www.attaform.com/docs/getting-started/quick-start): paste-and-run minimal example.
@@ -185,3 +226,7 @@ Steps can be `useForm` references, bare strings (affordance-only positions), eag
 - [GitHub](https://github.com/attaform/attaform): source, issues, discussions.
 - [npm](https://www.npmjs.com/package/attaform): published versions and install command.
 - [CHANGELOG](https://github.com/attaform/attaform/blob/main/CHANGELOG.md): release history.
+
+## Author
+
+Attaform is created and maintained by Oswald Chisala ([@ozzyfromspace](https://github.com/ozzyfromspace)).

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -2,6 +2,8 @@
 
 > A type-safe, schema-driven form library for Vue 3 and Nuxt with first-class Zod support. Hand a Zod schema to `useForm` and Attaform turns it into a reactive form, typed end-to-end, with live errors and SSR out of the box.
 
+*This index is hand-maintained and may lag the live source. These things happen. If a link 404s, an export looks missing, or a signature seems off, treat the docs at [attaform.com](https://www.attaform.com), the published `attaform` types, and the source at [github.com/attaform/attaform](https://github.com/attaform/attaform) as canonical. When in doubt, crawl from the homepage rather than giving up on the project.*
+
 Attaform's core idea is that the schema IS the form. One Zod schema declares the shape, the defaults, the validation, the per-field errors, and the input/output types. Attaform builds the reactive surface around it.
 
 The single entry point `attaform/zod` dispatches between Zod v3 and v4 per call, so projects on either version (or a mix) share one import. The Nuxt module auto-wires the plugin, the `v-register` directive, the SSR plumbing, and the DevTools panel. Bare Vue + Vite works through the Vite plugin without Nuxt.

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -1,0 +1,185 @@
+# Attaform
+
+> A type-safe, schema-driven form library for Vue 3 and Nuxt with first-class Zod support. Hand a Zod schema to `useForm` and Attaform turns it into a reactive form, typed end-to-end, with live errors and SSR out of the box.
+
+Attaform's core idea is that the schema IS the form. One Zod schema declares the shape, the defaults, the validation, the per-field errors, and the input/output types. Attaform builds the reactive surface around it.
+
+The single entry point `attaform/zod` dispatches between Zod v3 and v4 per call, so projects on either version (or a mix) share one import. The Nuxt module auto-wires the plugin, the `v-register` directive, the SSR plumbing, and the DevTools panel. Bare Vue + Vite works through the Vite plugin without Nuxt.
+
+Forms are bound to native inputs through the `v-register` directive. Submission goes through `form.handleSubmit(onSubmit)`. Multistep flows compose multiple `useForm` instances under `useWizard`. Persistence, undo/redo, multi-tab sync, server-error routing, and a Nuxt DevTools panel are all opt-in.
+
+## API at a glance
+
+```ts
+// script setup
+import { z } from 'zod'
+import { useForm } from 'attaform/zod'
+
+const schema = z.object({
+  email: z.email(),
+  password: z.string().min(8),
+})
+
+const form = useForm({ schema, key: 'signup' })
+
+const onSubmit = form.handleSubmit(async (values) => {
+  await fetch('/signup', { method: 'POST', body: JSON.stringify(values) })
+})
+```
+
+```vue
+<!-- template -->
+<form @submit.prevent="onSubmit">
+  <label>
+    Email
+    <input v-register="form.register('email')" />
+    <em v-if="form.fields.email.showErrors">
+      {{ form.fields.email.firstError?.message }}
+    </em>
+  </label>
+
+  <label>
+    Password
+    <input type="password" v-register="form.register('password', { persist: true })" />
+    <em v-if="form.fields.password.showErrors">
+      {{ form.fields.password.firstError?.message }}
+    </em>
+  </label>
+
+  <button :disabled="!form.meta.valid || form.meta.submitting">Sign up</button>
+</form>
+```
+
+The form handle exposes reactive reads (`form.values`, `form.errors`, `form.fields`, `form.meta`), mutation helpers (`form.setValue`, `form.reset`, `form.history.undo`), and submission (`form.handleSubmit`). The `v-register` directive accepts `{ persist, transforms, multiTab, acknowledgeSensitive }` options for per-field opt-ins.
+
+Multistep flows compose forms under `useWizard`:
+
+```ts
+import { useForm, useWizard } from 'attaform/zod'
+
+const account = useForm({ schema: accountSchema, key: 'account' })
+const profile = useForm({ schema: profileSchema, key: 'profile' })
+
+const wizard = useWizard({
+  steps: [account, 'review', profile],
+})
+
+const onComplete = wizard.handleSubmit(async (ctx) => {
+  await fetch('/onboarding', { method: 'POST', body: JSON.stringify(ctx.values) })
+})
+```
+
+Steps can be `useForm` references, bare strings (affordance-only positions), eager function slots, or `lazy(ctx => ...)` markers. `wizard.handleSubmit` validates the active form and advances on intermediate steps, then validates every form in parallel on the final step.
+
+## Getting started
+
+- [Quick start](https://www.attaform.com/docs/getting-started/quick-start): paste-and-run minimal example.
+- [Why Attaform](https://www.attaform.com/docs/getting-started/why-attaform): the design pitch and five convictions.
+- [Installation](https://www.attaform.com/docs/getting-started/installation): Vue, Nuxt, and Vite setups.
+- [Your first schema](https://www.attaform.com/docs/getting-started/your-first-schema): walks the schema-to-form arc.
+- [From schema to inputs](https://www.attaform.com/docs/getting-started/from-schema-to-inputs): binding side of the arc.
+- [From inputs to submit](https://www.attaform.com/docs/getting-started/from-inputs-to-submit): submission side of the arc.
+
+## Core API
+
+- [The form](https://www.attaform.com/docs/reading-the-form/the-form): what `useForm` returns.
+- [`v-register`](https://www.attaform.com/docs/binding-inputs/v-register): the binding directive.
+- [Values](https://www.attaform.com/docs/reading-the-form/values), [errors](https://www.attaform.com/docs/reading-the-form/errors), [fields](https://www.attaform.com/docs/reading-the-form/fields), [meta](https://www.attaform.com/docs/reading-the-form/meta): the reactive reads.
+- [Type safety](https://www.attaform.com/docs/reading-the-form/type-safety): inference and `toRef`.
+- [`injectForm`](https://www.attaform.com/docs/cross-cutting-state/inject-form): reach a form from any descendant.
+- [`useRegister`](https://www.attaform.com/docs/binding-inputs/use-register): re-bind `v-register` inside wrapper components.
+
+## Schemas
+
+- [Abstract schema](https://www.attaform.com/docs/schemas/abstract-schema): the schema contract Attaform consumes.
+- [Defaults](https://www.attaform.com/docs/schemas/defaults): function and value forms, async hydration, SSR.
+- [Optional vs nullable](https://www.attaform.com/docs/schemas/optional-nullable): the storage-shape distinction.
+- [Nested objects](https://www.attaform.com/docs/schemas/nested-objects), [arrays and tuples](https://www.attaform.com/docs/schemas/arrays-and-tuples), [records](https://www.attaform.com/docs/schemas/records): container kinds.
+- [Discriminated unions](https://www.attaform.com/docs/schemas/discriminated-unions): variants, variant memory, merged metadata.
+- [Storage shape](https://www.attaform.com/docs/schemas/storage-shape): what actually lives in `form.values`.
+
+## Binding inputs
+
+- [`v-register`](https://www.attaform.com/docs/binding-inputs/v-register): canonical pattern.
+- [Text, number, textarea](https://www.attaform.com/docs/binding-inputs/text-number-textarea), [checkbox](https://www.attaform.com/docs/binding-inputs/checkbox), [radio](https://www.attaform.com/docs/binding-inputs/radio), [select](https://www.attaform.com/docs/binding-inputs/select), [file](https://www.attaform.com/docs/binding-inputs/file): native input kinds.
+- [Modifiers](https://www.attaform.com/docs/binding-inputs/modifiers): `.lazy`, `.trim`, `.number`.
+- [Coercion](https://www.attaform.com/docs/binding-inputs/coercion): user input string-to-target coercion.
+- [Transforms](https://www.attaform.com/docs/binding-inputs/transforms): per-field sync transform pipeline.
+- [Custom assigners](https://www.attaform.com/docs/binding-inputs/custom-assigners): bind to non-native components.
+
+## Validation
+
+- [When validation runs](https://www.attaform.com/docs/validation/when-validation-runs): `validateOn` + `debounceMs`.
+- [Showing errors](https://www.attaform.com/docs/validation/showing-errors): the default `shouldShowErrors` heuristic and custom predicates.
+- [Async refinements](https://www.attaform.com/docs/validation/async-refinements): debounced async checks.
+- [Per-field validation](https://www.attaform.com/docs/validation/per-field-validation): `form.validate(path)` and `form.validateAsync(path)`.
+- [Lifecycle](https://www.attaform.com/docs/validation/lifecycle): sync versus async, when errors land.
+- [Blank fields](https://www.attaform.com/docs/validation/blank): how Attaform handles "no value supplied".
+
+## Submitting
+
+- [`handleSubmit`](https://www.attaform.com/docs/submitting/handle-submit): the full lifecycle.
+- [Focus and scroll](https://www.attaform.com/docs/submitting/focus-scroll): invalid-submit policy.
+- [Server-side errors](https://www.attaform.com/docs/submitting/server-side-errors): `parseApiErrors` + `form.setFieldErrors`.
+
+## Writing and mutating
+
+- [`setValue`](https://www.attaform.com/docs/writing-and-mutating/set-value), [`reset`](https://www.attaform.com/docs/writing-and-mutating/reset), [`clear`](https://www.attaform.com/docs/writing-and-mutating/clear), [`unset`](https://www.attaform.com/docs/writing-and-mutating/unset): programmatic writes.
+- [Field arrays](https://www.attaform.com/docs/writing-and-mutating/field-arrays): append, insert, remove, swap, move.
+- [Variant memory](https://www.attaform.com/docs/writing-and-mutating/variant-memory): switching discriminated-union variants without losing data.
+
+## Multistep
+
+- [`useWizard`](https://www.attaform.com/docs/multistep/use-wizard): the list-based step orchestrator.
+- [Step slots](https://www.attaform.com/docs/multistep/step-slots): forms, strings, function slots, `lazy()`.
+- [`injectWizard`](https://www.attaform.com/docs/multistep/inject-wizard): cross-component access.
+- [Wizard `handleSubmit`](https://www.attaform.com/docs/multistep/handle-submit): the universal submit lifecycle.
+- [URL sync](https://www.attaform.com/docs/multistep/url-sync): `?step=` round-trip, Nuxt deep-link hydration.
+- [Statuses](https://www.attaform.com/docs/multistep/statuses) and [aggregates](https://www.attaform.com/docs/multistep/aggregates): per-step state, namespaced `allValues` / `allErrors`.
+- [Patterns](https://www.attaform.com/docs/multistep/patterns): common multistep recipes.
+
+## Persistence
+
+- [Overview](https://www.attaform.com/docs/persistence/overview): when persistence runs.
+- [Storage backends](https://www.attaform.com/docs/persistence/storage-backends): localStorage, sessionStorage, IndexedDB, custom adapters.
+- [Per-field opt-in](https://www.attaform.com/docs/persistence/per-field-opt-in): `register(path, { persist: true })`.
+- [Sensitive names](https://www.attaform.com/docs/persistence/sensitive-names): the redact guard.
+- [Imperative API](https://www.attaform.com/docs/persistence/imperative): `form.persist` and `form.clearPersistedDraft`.
+- [Edge cases](https://www.attaform.com/docs/persistence/edge-cases): hydration races, file inputs, the "upload-on-select" pattern.
+
+## Cross-cutting state
+
+- [`injectForm`](https://www.attaform.com/docs/cross-cutting-state/inject-form): ambient or keyed form lookup.
+- [App defaults](https://www.attaform.com/docs/cross-cutting-state/app-defaults): global config defaults.
+- [Multi-tab sync](https://www.attaform.com/docs/cross-cutting-state/multi-tab-sync): `BroadcastChannel`-backed cross-tab state.
+- [Undo and redo](https://www.attaform.com/docs/cross-cutting-state/undo-redo): `form.history`.
+
+## Server and SSR
+
+- [SSR in Nuxt](https://www.attaform.com/docs/server-and-ssr/ssr-nuxt): the canonical SSR setup.
+- [SSR in bare Vue](https://www.attaform.com/docs/server-and-ssr/ssr-bare-vue): without Nuxt.
+- [`parseApiErrors`](https://www.attaform.com/docs/server-and-ssr/parse-api-errors): route server responses into `form.errors`.
+- [Performance](https://www.attaform.com/docs/server-and-ssr/performance): measured numbers anchored against the 60 fps budget.
+
+## DevTools and debugging
+
+- [DevTools panel](https://www.attaform.com/docs/devtools-and-debugging/devtools-panel): the Nuxt DevTools tab.
+- [Vue DevTools](https://www.attaform.com/docs/devtools-and-debugging/vue-devtools): the Chrome extension surface.
+- [Troubleshooting](https://www.attaform.com/docs/devtools-and-debugging/troubleshooting): common pitfalls.
+
+## Reference
+
+- [Entry points](https://www.attaform.com/docs/reference/entry-points): every package subpath (`attaform`, `attaform/zod`, `attaform/zod-v3`, `attaform/zod-v4`, `attaform/vite`, `attaform/nuxt`, `attaform/devtools-panel`).
+- [Errors](https://www.attaform.com/docs/reference/errors): `AttaformErrorCode` table and the error class hierarchy.
+- [Types](https://www.attaform.com/docs/reference/types): every exported type.
+- [Custom adapters](https://www.attaform.com/docs/reference/custom-adapters): building a non-Zod schema adapter.
+
+## Interactive
+
+- [Demos](https://www.attaform.com/demos): every docs demo as a standalone editable playground.
+
+## Optional
+
+- [GitHub](https://github.com/attaform/attaform): source, issues, discussions.
+- [npm](https://www.npmjs.com/package/attaform): published versions and install command.
+- [CHANGELOG](https://github.com/attaform/attaform/blob/main/CHANGELOG.md): release history.

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -229,4 +229,4 @@ Patterns that keep Attaform code clean.
 
 ## Author
 
-Attaform is created and maintained by Oswald Chisala ([@ozzyfromspace](https://github.com/ozzyfromspace)).
+Attaform is created and maintained by [Oswald Chisala](https://www.linkedin.com/in/chisalao/) ([@ozzyfromspace](https://github.com/ozzyfromspace) on GitHub).


### PR DESCRIPTION
## Summary

Two related housekeeping changes off latest main.

### 1. Restore the `## Unreleased` convention in `CHANGELOG.md`

The v0.18.0 entry that landed in PR #250 was written under `## v0.18.0`. Per `CONTRIBUTING.md` (the *Releasing* section) and `scripts/promote-changelog.mjs` (the `version` npm hook), entries live under `## Unreleased`; the publish flow finds that header, promotes it to `## v<version>`, and seeds a fresh placeholder. Hand-writing the version header would break the script's idempotency assumption: on the next publish the regex finds no `## Unreleased` body, skips its work, and the next release ships under stale placeholder content.

Structural-only fix; the entries themselves are unchanged.

### 2. Add `apps/site/public/llms.txt`

Drops a hand-maintained, focused index of Attaform at `attaform.com/llms.txt` following the [llmstxt.org](https://llmstxt.org) convention. Layout:

- Blockquote summary mirroring the README pitch.
- Freshness caveat right after the blockquote so an LLM hitting a stale URL or signature is told to fall back to `attaform.com`, the published types, or the GitHub source rather than give up.
- Three mental-model paragraphs and a short *API at a glance* code block (canonical `useForm` snippet + a `useWizard` mini-example) so an LLM with a tight tool budget can write working Attaform code from this file alone.
- Categorised link sections mirroring the docs sidebar: Getting started, Core API, Schemas, Binding inputs, Validation, Submitting, Writing & mutating, Multistep, Persistence, Cross-cutting state, Server & SSR, DevTools & debugging, Reference, Interactive (demos).
- `## Optional` section per the spec: GitHub, npm, CHANGELOG.

Adoption of `llms.txt` is on a rising curve (Cursor, Codex, various agentic clients), and the cost is small: ~190 lines, hand-maintained, drift mitigated by the caveat. Forward optionality plus a small craft signal.

Also adds a one-line bullet to the CHANGELOG `Docs` subsection so the Unreleased block records this addition.

## Test plan

- [x] `curl http://localhost:3000/llms.txt` returns 200 with `Content-Type: text/plain; charset=utf-8`.
- [x] 9 docs URLs spot-checked locally (Quick start, Why Attaform, The form, v-register, useWizard, Persistence overview, parseApiErrors, Reference entry points, /demos) all 200.
- [x] `grep '^## v0.18' CHANGELOG.md` returns zero hits.
- [x] `grep -A 1 '^## Unreleased' CHANGELOG.md` shows the v0.18.0 lede directly under the header.
- [x] No em-dashes, no "the library", no UK spellings in `llms.txt`.
- [x] After merge: confirm `https://www.attaform.com/llms.txt` serves 200 in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)