### PR TITLE
ci(publish): switch to npm Trusted Publishing (drop NPM_TOKEN)

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -128,11 +128,22 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-          # `registry-url` alone configures npm auth via NODE_AUTH_TOKEN
-          # for the npm whoami + publish steps below; `always-auth: true`
-          # was redundant and is no longer a valid input in setup-node@v6
-          # (it now emits "Unexpected input(s) 'always-auth'" warnings).
+          # `registry-url` writes the registry endpoint to .npmrc so
+          # `pnpm publish` below knows where to talk. Under Trusted
+          # Publishing (configured on npmjs.com → attaform → Trusted
+          # Publishers), npm exchanges this run's GitHub OIDC token
+          # for an ephemeral publish credential at publish time, so
+          # no NPM_TOKEN secret is required. The `id-token: write`
+          # permission on this job (declared above) is what lets npm
+          # mint that token.
           registry-url: 'https://registry.npmjs.org/'
+
+      - name: Update npm for Trusted Publishing
+        # Node 22 LTS bundles npm 10.x; Trusted Publishing OIDC
+        # support requires npm 11.5.1 or newer. setup-node doesn't
+        # pin the npm version, so we bump explicitly before any
+        # auth-sensitive npm interaction.
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         # --frozen-lockfile aborts if pnpm-lock.yaml is stale, so the
@@ -140,11 +151,6 @@ jobs:
         # the lockfile promises. Prevents a silent lockfile drift from
         # producing a mystery publish diff.
         run: pnpm install --frozen-lockfile
-
-      - name: Validate Auth
-        run: npm whoami
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Stub attaform
         run: pnpm dev:prepare
@@ -220,10 +226,13 @@ jobs:
 
       - name: Publish to npm
         # `--provenance` attaches an OIDC-signed statement linking the
-        # published tarball to this workflow run + commit. The workflow
-        # already declares `id-token: write`; npm's registry records
-        # the statement so consumers can verify a tarball came from
-        # this repo via `npm audit signatures`.
+        # published tarball to this workflow run + commit, recorded by
+        # the npm registry so consumers can verify the tarball with
+        # `npm audit signatures`. Under Trusted Publishing the same
+        # OIDC token also authorises the publish itself — no
+        # NPM_TOKEN secret is involved, and there is nothing to
+        # rotate. The `id-token: write` permission on this job is
+        # what lets npm mint the token at publish time.
         #
         # Prereleases publish under a dist-tag matching the preid (e.g.
         # `attaform@beta`, `attaform@alpha`) — `npm install attaform` still
@@ -237,7 +246,6 @@ jobs:
         # tarball does not shadow the current major on the default
         # `npm install attaform`.
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           PRERELEASE_ID: ${{ github.event.inputs.prerelease_id }}
           DIST_TAG: ${{ github.event.inputs.dist_tag }}
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,11 @@ block in `CHANGELOG.md` to the tagged version.
 
 ### Via GitHub Actions (`publish-npm.yml`)
 
-Recommended — gets OIDC-signed provenance on the npm tarball.
+Recommended. The workflow publishes via npm Trusted Publishing
+(OIDC token exchange against the npmjs.com → `attaform` package →
+Trusted Publishers config; no `NPM_TOKEN` secret involved, nothing
+to rotate) and attaches a signed provenance statement on the
+tarball that consumers can verify with `npm audit signatures`.
 
 Checklist:
 
@@ -131,7 +135,9 @@ pnpm release
 
 Mirrors the CI flow: `pnpm check && pnpm version patch && pnpm
 prepack && pnpm publish && git push --follow-tags`. The local path
-publishes _without_ `--provenance` (OIDC only works in CI), so the
+publishes _without_ `--provenance` (OIDC only works in CI) and
+authenticates with a personal npm access token in your `~/.npmrc`
+rather than the workflow's Trusted Publishing path, so the
 resulting tarball won't carry a signed statement. Prefer the
 workflow when you can.
 


### PR DESCRIPTION
## Summary

The v0.18.0 publish run failed with `E401 Unauthorized` on `npm whoami` — the `NPM_TOKEN` repo secret had expired. Moves the workflow to **npm Trusted Publishing** (OIDC token exchange against the configured Trusted Publisher on npmjs.com) so there is no long-lived token to rotate.

## Changes

`.github/workflows/publish-npm.yml`:
- Drops `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from the publish step.
- Removes the now-defunct `Validate Auth` step (`npm whoami` has no meaning when auth is per-run OIDC).
- Adds `npm install -g npm@latest` after `actions/setup-node@v6` so the runner has npm ≥ 11.5.1, the version that implements the Trusted Publishing handshake. Node 22 LTS bundles npm 10.x by default.
- Updates the comment on `registry-url` to explain the new auth flow.
- Updates the comment on the publish step to name Trusted Publishing.

`CONTRIBUTING.md`:
- Expands the workflow-path note to mention Trusted Publishing as the auth model.
- Flags that the local `pnpm release` path still needs a personal access token in `~/.npmrc` — Trusted Publishing only covers the workflow.

## One-time setup (done)

- [x] **npmjs.com → `attaform` package → Trusted Publishers**: GitHub Actions publisher pinned to `attaform/Attaform` + `publish-npm.yml`.
- [ ] After merge: delete the `NPM_TOKEN` repo secret (Settings → Secrets and variables → Actions). Nothing references it post-merge.

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/publish-npm.yml'))"`).
- [x] No `secrets.NPM` reference remains in any workflow.
- [ ] After merge: trigger a `workflow_dispatch` publish (a patch or prerelease bump) and confirm `pnpm publish --provenance` lands without an `NPM_TOKEN` secret in scope.

## Gotcha to remember

The Trusted Publisher config on npmjs.com is pinned to the workflow filename. If `publish-npm.yml` is ever renamed or moved, the publisher config needs to be updated on npmjs.com before the next publish run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)