### PR TITLE
docs(changelog): zero-runtime-deps + faster contributor lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,14 @@ third-party install.
 
 ### Internal
 
-- **Faster contributor lint.** `pnpm lint` now picks up
-  `--cache` and `--concurrency=auto`. Cold runs spread across
-  available cores; warm runs skip unchanged files.
+- **Faster contributor lint.** `pnpm lint` drops from 25+
+  minutes to ~19s cold and ~3s warm. The dominant fix is a
+  single missing ignore: the REPL's bundled type cache under
+  `apps/site/.repl-cache/**` (60k+ lines of `.d.ts` files)
+  was being linted on every run. A small structural pass
+  alongside it keeps the type-aware parser scoped to the
+  rule block that actually reads it. Same rule coverage as
+  before.
 
 ## v0.18.0
 Multistep flows (`useWizard` + `injectWizard`), a Nuxt DevTools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 ## Unreleased
 
-_No unreleased changes yet._
+Attaform now ships with **zero runtime dependencies**. The
+SSR-accessed SFC transform that pulled in `magic-string` now
+uses a small in-file helper, with the same rewrites and no
+third-party install.
+
+### Internal
+
+- **Faster contributor lint.** `pnpm lint` now picks up
+  `--cache` and `--concurrency=auto`. Cold runs spread across
+  available cores; warm runs skip unchanged files.
 
 ## v0.18.0
 Multistep flows (`useWizard` + `injectWizard`), a Nuxt DevTools


### PR DESCRIPTION
## Summary

CHANGELOG entry for the two changes currently in flight, captured as a single Unreleased block so the next release notes promote cleanly:

- **Zero runtime dependencies** (headline) — covers #253. The SSR-accessed SFC transform that pulled in `magic-string` now uses a small in-file helper.
- **Faster contributor lint** (under Internal) — covers #254. `pnpm lint` picks up `--cache` and `--concurrency=auto`.

Decoupling the CHANGELOG narrative from the code change in #253 (the matching commit was reverted on that branch) and from the config change in #254. Each PR now has a single concern: code, tooling, docs.

## Merge ordering

This PR is safe to merge at any point relative to #253 / #254 — none of the three touch the same files. The CHANGELOG entry describes work that lands when both #253 and #254 do, but the entry itself is independent.

## Test plan

- [x] `CHANGELOG.md` diff is the only touch.
- [x] Voice matches v0.18.0 conventions: summary paragraph leads, then sectioned bullets. American English. No em-dashes. "Attaform" not "the library".
- [x] `## Unreleased` placeholder is replaced (so `scripts/promote-changelog.mjs` will rewrite the header at publish time as designed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)