### PR TITLE
fix(playground): patch @vue/repl's broken Monaco color-picker edit

### DIFF
--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -23,7 +23,7 @@
     "@resvg/resvg-js": "^2.6.2",
     "@shikijs/twoslash": "^4.0.2",
     "@tailwindcss/typography": "^0.5.19",
-    "@vue/repl": "^4.7.2",
+    "@vue/repl": "4.7.2",
     "attaform": "workspace:*",
     "better-sqlite3": "^12.9.0",
     "lucide-vue-next": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -128,13 +128,17 @@
       "sharp",
       "unrs-resolver",
       "vue-demi"
-    ]
+    ],
+    "patchedDependencies": {
+      "@vue/repl@4.7.2": "patches/@vue__repl@4.7.2.patch"
+    }
   },
   "devDependencies": {
     "@commitlint/cli": "^21.0.1",
     "@commitlint/config-conventional": "^21.0.1",
     "@eslint/js": "^10.0.1",
     "@fast-check/vitest": "^0.4.0",
+    "@nuxt/devtools-kit": "^3.2.0",
     "@nuxt/eslint-config": "^1.15.2",
     "@nuxt/kit": "^4.4.2",
     "@nuxt/module-builder": "^1.0.2",
@@ -147,7 +151,6 @@
     "@types/node": "^25.6.0",
     "@typescript-eslint/eslint-plugin": "^8.59.0",
     "@typescript-eslint/parser": "^8.59.0",
-    "@nuxt/devtools-kit": "^3.2.0",
     "@vitejs/plugin-vue": "^6.0.6",
     "@vitest/coverage-v8": "^4.1.5",
     "@vue/compiler-core": "^3.5.33",

--- a/patches/@vue__repl@4.7.2.patch
+++ b/patches/@vue__repl@4.7.2.patch
@@ -1,0 +1,17 @@
+diff --git a/dist/monaco-editor.js b/dist/monaco-editor.js
+index e9f0a247646eead42081f543d1f59f1e086dc4a8..c3e9d3550f3061712821922a779e2315e9826137 100644
+--- a/dist/monaco-editor.js
++++ b/dist/monaco-editor.js
+@@ -149354,7 +149354,11 @@ async function createLanguageFeaturesProvider(worker, getSyncUris) {
+ 		async provideDocumentColors(model, token) {
+ 			const languageService = await worker.withSyncedResources(getSyncUris());
+ 			const codeResult = await languageService.getDocumentColors(getRequestId(token, languageService), model.uri);
+-			if (codeResult) return codeResult.map(toColorInformation);
++			if (codeResult) return codeResult.map((code) => {
++				const monaco = toColorInformation(code);
++				colorInfos.set(monaco, code);
++				return monaco;
++			});
+ 		},
+ 		async provideColorPresentations(model, monacoResult, token) {
+ 			const languageService = await worker.withSyncedResources(getSyncUris());

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,7 +206,7 @@ importers:
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@4.3.0)
       '@vue/repl':
-        specifier: ^4.7.2
+        specifier: 4.7.2
         version: 4.7.2(patch_hash=a832435783b51fa5c8e55e2332505dc5359537e7238ef8437949989452d026b4)
       attaform:
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,11 @@ overrides:
   '@nuxt/schema': ^4.4.2
   fast-uri: ^3.1.2
 
+patchedDependencies:
+  '@vue/repl@4.7.2':
+    hash: a832435783b51fa5c8e55e2332505dc5359537e7238ef8437949989452d026b4
+    path: patches/@vue__repl@4.7.2.patch
+
 importers:
 
   .:
@@ -202,7 +207,7 @@ importers:
         version: 0.5.19(tailwindcss@4.3.0)
       '@vue/repl':
         specifier: ^4.7.2
-        version: 4.7.2
+        version: 4.7.2(patch_hash=a832435783b51fa5c8e55e2332505dc5359537e7238ef8437949989452d026b4)
       attaform:
         specifier: workspace:*
         version: link:../..
@@ -12663,7 +12668,7 @@ snapshots:
     dependencies:
       '@vue/shared': 3.5.34
 
-  '@vue/repl@4.7.2': {}
+  '@vue/repl@4.7.2(patch_hash=a832435783b51fa5c8e55e2332505dc5359537e7238ef8437949989452d026b4)': {}
 
   '@vue/runtime-core@3.5.34':
     dependencies:


### PR DESCRIPTION
## Summary

The REPL playground's color picker opens on hover but clicking a new colour doesn't update the source — symptom you flagged: "click on a new color, but that doesn't change the color in the styles attribute."

## Root cause

Bug in `@volar/monaco@2.4.23` (bundled into `@vue/repl@4.7.2`'s `dist/monaco-editor.js`). The Monaco color provider's `provideColorPresentations` reads from a `colorInfos` WeakMap, but the paired `provideDocumentColors` never writes to it. So the lookup always returns `undefined` and the function exits before producing any `textEdit`:

```js
// Before
async provideDocumentColors(model, token) {
  const languageService = await worker.withSyncedResources(...)
  const codeResult = await languageService.getDocumentColors(...)
  if (codeResult) return codeResult.map(toColorInformation)
  // ⤴︎ never stores monacoColorInfo → lspColorInfo
},
async provideColorPresentations(model, monacoResult, token) {
  ...
  const codeResult = colorInfos.get(monacoResult)  // always undefined
  if (codeResult) { ... }                          // never enters
},
```

End to end: Volar produces the colour info (swatch appears) → user picks a colour → Monaco asks Volar for presentations → Volar's WeakMap returns undefined → no edit applied.

## Fix

Three lines in the bundled file, applied via `pnpm patch` so it lives in the repo under `patches/@vue__repl@4.7.2.patch` and re-applies on every install:

```js
// After
if (codeResult) return codeResult.map((code) => {
  const monaco = toColorInformation(code)
  colorInfos.set(monaco, code)
  return monaco
})
```

`package.json` picks up a small `pnpm.patchedDependencies` entry; the lockfile records the patch hash.

## Test plan

- [ ] Open any playground (e.g. `/demos/quick-start`), hover a colour value in the editor, click a new colour in the picker, confirm the underlying source updates.
- [ ] CI matrix on this PR.
- [ ] Patch survives a fresh `pnpm install`.

## Worth doing upstream too

The same bug would affect every consumer of `@volar/monaco`. Filing an upstream issue is the obvious follow-up, but landing the patch here unblocks the playground immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)