### PR TITLE
docs(site): tighten the homepage hero + reposition to Zod-first

### DIFF
--- a/apps/site/app.vue
+++ b/apps/site/app.vue
@@ -51,17 +51,14 @@
   })
 
   useSeoMeta({
-    description:
-      'A type-safe, schema-driven form library for Vue 3 and Nuxt with first-class Zod support.',
+    description: 'A type-safe, Zod-first form library for Vue 3 and Nuxt.',
     ogTitle: 'Attaform — Type-safe forms for Vue 3 and Nuxt',
-    ogDescription:
-      'A type-safe, schema-driven form library for Vue 3 and Nuxt with first-class Zod support.',
+    ogDescription: 'A type-safe, Zod-first form library for Vue 3 and Nuxt.',
     ogType: 'website',
     ogSiteName: 'Attaform',
     twitterCard: 'summary_large_image',
     twitterTitle: 'Attaform — Type-safe forms for Vue 3 and Nuxt',
-    twitterDescription:
-      'A type-safe, schema-driven form library for Vue 3 and Nuxt with first-class Zod support.',
+    twitterDescription: 'A type-safe, Zod-first form library for Vue 3 and Nuxt.',
   })
 
   // Default OG card for every route. Pages override per-route by

--- a/apps/site/components/app/AppFooter.vue
+++ b/apps/site/components/app/AppFooter.vue
@@ -65,7 +65,7 @@
             <span>Attaform</span>
           </NuxtLink>
           <p class="text-sm text-fg-muted">
-            A type-safe, schema-driven form library for Vue 3 and Nuxt with first-class Zod support.
+            A type-safe, Zod-first form library for Vue 3 and Nuxt.
           </p>
           <!-- Version chip — warm-soft pair on a small inline pill so
                it ties to the hero release chip without competing with

--- a/apps/site/nuxt.config.ts
+++ b/apps/site/nuxt.config.ts
@@ -315,8 +315,7 @@ export default defineNuxtConfig({
   site: {
     url: 'https://www.attaform.com',
     name: 'Attaform',
-    description:
-      'A type-safe, schema-driven form library for Vue 3 and Nuxt with first-class Zod support.',
+    description: 'A type-safe, Zod-first form library for Vue 3 and Nuxt.',
     defaultLocale: 'en',
     indexable: process.env.VERCEL_ENV === 'production',
   },

--- a/apps/site/pages/docs/index.vue
+++ b/apps/site/pages/docs/index.vue
@@ -51,7 +51,7 @@
         Everything you need to use Attaform.
       </h1>
       <p class="mt-4 max-w-2xl text-lg text-fg-muted">
-        A type-safe, schema-driven form library for Vue 3 and Nuxt with first-class Zod support.
+        A type-safe, Zod-first form library for Vue 3 and Nuxt.
       </p>
 
       <!-- Install card — first action a reader can take. Self-

--- a/apps/site/pages/index.vue
+++ b/apps/site/pages/index.vue
@@ -45,7 +45,7 @@
     `${LT}template>`,
     `  ${LT}form @submit.prevent="onSubmit">`,
     `    ${LT}input v-register="form.register('email')" />`,
-    `    ${LT}p v-if="form.errors.email">{{ form.errors.email[0].message }}${LT}/p>`,
+    `    ${LT}p v-if="form.fields.email.showErrors">{{ form.fields.email.firstError?.message }}${LT}/p>`,
     '',
     `    ${LT}button :disabled="form.meta.submitting">Sign up${LT}/button>`,
     `  ${LT}/form>`,
@@ -114,8 +114,7 @@
       name: 'Attaform',
       applicationCategory: 'DeveloperApplication',
       operatingSystem: 'Cross-platform',
-      description:
-        'A type-safe, schema-driven form library for Vue 3 and Nuxt with first-class Zod support.',
+      description: 'A type-safe, Zod-first form library for Vue 3 and Nuxt.',
       url: 'https://www.attaform.com',
       author: { '@type': 'Person', name: 'Oswald Chisala' },
       // MIT-licensed and free — surface the price-zero offer so the
@@ -250,7 +249,7 @@
             style="--reveal-step-delay: 100ms"
           >
             The
-            <span class="font-semibold text-fg">type-safe, schema-driven</span> form library for
+            <span class="font-semibold text-fg">type-safe, Zod-first</span> form library for
             Vue&nbsp;3 and Nuxt.
           </h2>
 
@@ -258,10 +257,9 @@
             class="reveal-step max-w-2xl text-lg text-balance text-fg-muted"
             style="--reveal-step-delay: 140ms"
           >
-            Hand a Zod schema to <UiInlineCode>useForm</UiInlineCode> and Attaform turns it into a
-            reactive form, typed end-to-end, with live errors and SSR out of the box. It scales from
-            the simplest forms to the most comprehensive multistep wizards while keeping the core
-            experience clear and focused. Because Vue and Nuxt devs deserve nice things, too.
+            <strong class="font-semibold text-fg">Your schema is enough.</strong> Hand it to
+            Attaform and get back types, state, validation, errors, persistence, SSR, and more, all
+            from one definition. Because Vue and Nuxt devs deserve nice things.
           </p>
 
           <div class="reveal-step flex flex-wrap gap-3" style="--reveal-step-delay: 180ms">

--- a/apps/site/pages/index.vue
+++ b/apps/site/pages/index.vue
@@ -259,7 +259,7 @@
           >
             <strong class="font-semibold text-fg">Your schema is enough.</strong> Hand it to
             Attaform and get back types, state, validation, errors, persistence, SSR, and more, all
-            from one definition. Because Vue and Nuxt devs deserve nice things.
+            from one definition. Because Vue devs deserve nice things.
           </p>
 
           <div class="reveal-step flex flex-wrap gap-3" style="--reveal-step-delay: 180ms">


### PR DESCRIPTION
## Summary

Three small homepage threads, landing together because they reinforce each other.

### 1. Hero pitch (lede paragraph)

Rewrote the lede from a `useForm` mechanics summary to a thesis-led claim. Old framing put `useForm` and the wizard sentence in the spotlight, which read as "look how the API works" rather than "look at what we believe." New framing:

> **Your schema is enough.** Hand it to Attaform and get back types, state, validation, errors, persistence, SSR, and more, all from one definition. Because Vue and Nuxt devs deserve nice things.

- "Your schema is enough." takes the same `font-semibold text-fg` bold treatment the H2 already uses for its emphasised phrase, so the eye lands on the thesis on first scan.
- The multistep-wizard sentence is gone — its own homepage section handles wizards. The lede shouldn't race the later sections for attention.

### 2. Demo snippet (signup form code block)

Swapped `form.errors.email[0].message` for `form.fields.email.firstError?.message`, gated by `form.fields.email.showErrors`. Same line, but it shows the field-handle pattern + the `showErrors` heuristic + the safe-access idiom all on one visible line. The hero demo now signals "this library thought about *when* to surface errors, not just *how* to read them" — which is what most form libraries get wrong.

### 3. Zod-first repositioning (site-wide)

H2 below the H1 now reads "the type-safe, **Zod-first** form library for Vue 3 and Nuxt" instead of "type-safe, schema-driven … with first-class Zod support."

The reasoning: Zod is the only adapter shipping today. The `AbstractSchema` escape hatch is theoretically open but realistically untravelled. Selling "schema-driven" reads as a hedge against a future that hasn't arrived. "Zod-first" is the confident, accurate framing.

Same flip applied across every brand-positioning surface that carried the old line:

| Surface | File |
|---|---|
| Homepage H2 | `apps/site/pages/index.vue` |
| Homepage `useSchemaOrg` SoftwareApplication entry | `apps/site/pages/index.vue` |
| Site-wide `og:` / `twitter:` / `description` meta | `apps/site/app.vue` |
| Nuxt config site description | `apps/site/nuxt.config.ts` |
| Footer tagline | `apps/site/components/app/AppFooter.vue` |
| Docs landing lede | `apps/site/pages/docs/index.vue` |

"Schema-driven" remains in exactly one place: `index.vue:366`'s "schema-driven coercion at the directive layer." That's describing a *feature*, not the brand. Accurate regardless of which schema library is wired in.

When a second adapter ships, one find-and-replace flips the positioning back to "schema-driven."

## Test plan

- [x] H2 + meta + footer render with "Zod-first" in SSR output (curl'd).
- [x] Hero pitch renders with the bold "Your schema is enough." in SSR.
- [x] Demo snippet renders `form.fields.email.showErrors` + `firstError?.message`.
- [x] Pre-commit hook ran clean (lint + format + site typecheck via Docker).
- [ ] Visual review in browser at `localhost:3000`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)