### PR TITLE
chore(security): pin action SHAs, add CODEOWNERS and SECURITY.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,24 @@
+# Default owner for everything. Branch protection on `main` already
+# restricts push to the maintainer; this file is defense-in-depth +
+# auto-reviewer assignment + a single place to flip ownership if a
+# co-maintainer joins.
+
+*                      @ozzyfromspace
+
+# High-impact paths — explicit re-listing so the GitHub UI sidebar
+# highlights the privileged surface on PRs that touch it.
+/.github/              @ozzyfromspace
+/package.json          @ozzyfromspace
+/pnpm-workspace.yaml   @ozzyfromspace
+/pnpm-lock.yaml        @ozzyfromspace
+/.npmrc                @ozzyfromspace
+/.npmignore            @ozzyfromspace
+/build.config.ts       @ozzyfromspace
+/tsconfig.json         @ozzyfromspace
+/vitest.config.ts      @ozzyfromspace
+/eslint.config.js      @ozzyfromspace
+/scripts/              @ozzyfromspace
+/.husky/               @ozzyfromspace
+/Dockerfile            @ozzyfromspace
+/Makefile              @ozzyfromspace
+/SECURITY.md           @ozzyfromspace

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -43,10 +43,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Dependency review
-        uses: actions/dependency-review-action@v5
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           # Fail the PR when any newly introduced dependency has a known
           # vulnerability at `moderate` or higher. Tighten to `high` if the

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -42,13 +42,13 @@ jobs:
     name: Lint and format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 'lts/*'
 
@@ -59,7 +59,7 @@ jobs:
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: Setup pnpm cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -85,13 +85,13 @@ jobs:
     name: Typecheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 'lts/*'
 
@@ -102,7 +102,7 @@ jobs:
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: Setup pnpm cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -138,13 +138,13 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -155,7 +155,7 @@ jobs:
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: Setup pnpm cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -175,13 +175,13 @@ jobs:
     name: Bundle size
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 'lts/*'
 
@@ -192,7 +192,7 @@ jobs:
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: Setup pnpm cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -220,13 +220,13 @@ jobs:
     name: Performance benchmarks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 'lts/*'
 
@@ -237,7 +237,7 @@ jobs:
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: Setup pnpm cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -262,13 +262,13 @@ jobs:
     # agnostic: a single LTS run is enough; the test matrix covers
     # the cross-version surface.
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 'lts/*'
 
@@ -279,7 +279,7 @@ jobs:
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: Setup pnpm cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -304,13 +304,13 @@ jobs:
     # `pnpm check:coverage` (vitest with coverage instrumentation),
     # which also fails the job if coverage thresholds drop.
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
 
       - name: Setup Node.js (lts)
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 'lts/*'
 
@@ -321,7 +321,7 @@ jobs:
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: Setup pnpm cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -338,7 +338,7 @@ jobs:
         run: pnpm check:coverage
 
       - name: Upload coverage HTML
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-html
           path: coverage/

--- a/.github/workflows/peer-matrix.yml
+++ b/.github/workflows/peer-matrix.yml
@@ -66,13 +66,13 @@ jobs:
             nuxt: ^4.0.0
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
 
       - name: Setup Node.js 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22.x
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -27,7 +27,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -122,10 +122,10 @@ jobs:
         run: echo "::notice title=Version::Publishing version ${{ steps.calculate-next-version.outputs.next_version }}"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           # `registry-url` writes the registry endpoint to .npmrc so
@@ -172,7 +172,7 @@ jobs:
       # whose email is in the key's UID, otherwise GitHub still marks the
       # commit "Unverified".
       - name: Import GPG signing key
-        uses: crazy-max/ghaction-import-gpg@v7
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,70 @@
+# Security Policy
+
+Thanks for taking the time to report a security issue in Attaform. Coordinated disclosure helps every consumer of the library, and is genuinely appreciated.
+
+## Supported versions
+
+Attaform is pre-1.0. The most recent `0.x` minor on the `latest` dist-tag receives security fixes; older minors do not. Once 1.0 ships, the support window expands; the policy will be updated then.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.18.x  | :white_check_mark: |
+| < 0.18  | :x:                |
+
+## Reporting a vulnerability
+
+**Preferred channel — GitHub Private Vulnerability Reporting:**
+
+[https://github.com/attaform/Attaform/security/advisories/new](https://github.com/attaform/Attaform/security/advisories/new)
+
+This routes the report directly to the maintainer through GitHub's encrypted advisory workflow. The thread stays private until a fix ships and an advisory is published.
+
+**Backup channel — email:**
+
+`oswald.kay.chisala@gmail.com` with the subject prefix `[security][attaform]`. Use this only if GitHub Private Vulnerability Reporting is unavailable.
+
+Please include, as best you can:
+
+- Affected version(s) of Attaform.
+- A minimal reproducer, or a clear description of the attack surface.
+- The impact you've assessed (RCE, data exposure, supply-chain, etc.).
+- Whether the issue is publicly known or already mitigated downstream.
+
+## Scope
+
+**In scope:**
+
+- The published `attaform` npm tarball and everything it ships at runtime.
+- The build and publish pipeline under `.github/workflows/`.
+- The docs site at `apps/site/` (the Vercel deployment of `docs.attaform.dev` and `attaform.dev`).
+- Repository-level configuration: branch protection, secrets handling, trusted publishing setup.
+
+**Out of scope:**
+
+- Transitive dependency CVEs that do not reach Attaform's consumer surface (those are tracked through Dependabot + Dependency Review).
+- Vulnerabilities in third-party Nuxt, Vue, or Vite plugins that the docs site loads but the library itself does not depend on.
+- Social-engineering of maintainers, account-recovery flows, or non-technical impersonation.
+- Issues that require a compromised maintainer credential as a precondition (the project already invests in WebAuthn 2FA, trusted publishing, and branch protection to harden that surface).
+
+## Response targets
+
+The maintainer is solo. The targets below are best-effort, not contractual.
+
+- **Initial acknowledgement:** within 5 business days of receipt.
+- **Triage outcome (confirmed / not-a-vuln / needs-more-info):** within 10 business days.
+- **Fix timeline:**
+  - Critical (RCE, supply-chain compromise, prototype pollution affecting consumer code): targeted within 14 days.
+  - High / moderate: next patch release on the supported minor.
+  - Low / informational: next minor.
+
+If a fix requires a coordinated release window with downstream consumers, the embargo will be discussed in the advisory thread before publication.
+
+## Disclosure
+
+After a fix ships:
+
+1. A GitHub Security Advisory is published with the CVE (if assigned) and credit to the reporter (or anonymous, as preferred).
+2. The advisory is mirrored to the npm registry through `npm audit` metadata.
+3. A note is added to `CHANGELOG.md` under the affected version.
+
+Thank you again.


### PR DESCRIPTION
## Summary

Defense-in-depth against the **Mini Shai-Hulud / TanStack Router** supply-chain incident class (May 2026). Three independent controls land together; all are pure config / additions with **zero runtime impact**.

- **SHA-pin every `uses:` line** across the 5 workflows. Replaces moving major tags (`@v6`, `@v7`, etc.) with the specific commit SHA the latest patch tag resolves to, with the readable version in a trailing comment so Dependabot's `github-actions` updater keeps both fields in lockstep. Closes the "tag re-pointed under us" vector for every action in the surface, including the highest-risk third-party action (`crazy-max/ghaction-import-gpg`).
- **`.github/CODEOWNERS`** — branch protection already restricts push to the maintainer; CODEOWNERS adds auto-reviewer assignment + a single place to flip ownership if a co-maintainer ever joins. High-impact paths re-listed explicitly so they show in the GitHub UI sidebar on PRs that touch them.
- **`SECURITY.md`** — supported-versions window (current minor only, pre-1.0), disclosure channels (GitHub Private Vulnerability Reporting primary, email backup), in-scope vs out-of-scope surface, best-effort response targets. Surfaces a "Security policy" checkmark on the Security tab.

## Pinned versions

| Action | Version | SHA |
| --- | --- | --- |
| `actions/checkout` | v6.0.2 | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| `actions/setup-node` | v6.4.0 | `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` |
| `actions/cache` | v5.0.5 | `27d5ce7f107fe9357f9df03efb73ab90386fccae` |
| `actions/upload-artifact` | v7.0.1 | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` |
| `actions/dependency-review-action` | v5.0.0 | `a1d282b36b6f3519aa1f3fc636f609c47dddb294` |
| `pnpm/action-setup` | v6.0.8 | `d15e628ca66d93ee5f352c71671a7bc6a97af5c9` |
| `crazy-max/ghaction-import-gpg` | v7.0.0 | `2dc316deee8e90f13e1a351ab510b4d5bc0c82cd` |

## Test plan

- [x] `grep -rn 'uses: .*@v[0-9]' .github/workflows/` returns zero hits.
- [x] YAML still parses (`python3 -c yaml.safe_load` on every workflow file).
- [x] Pre-commit hook (lint-staged → prettier) passes; pre-push hook (unbuild) passes.
- [ ] CI green on this PR — actions resolve to the pinned SHAs and run as before.
- [ ] `gh api repos/attaform/Attaform/codeowners/errors` returns an empty array.
- [ ] Security tab → "Security policy" shows a green check after merge.
- [ ] Next Dependabot run lands a PR that bumps **both** the SHA and the `# vN.N.N` comment.

## Stacked on top of #262

Base set to `chore/pnpm-11-node-22-bump` (PR #262) so the diff stays scoped to PR 1's three changes. Will rebase onto `main` automatically when #262 merges; targets `main` after that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)