### PR TITLE
chore(security): install cooldown + matrix cache restore/save split

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -36,6 +36,28 @@ concurrency:
 # When adding a new check to `pnpm check`, ALSO add a corresponding
 # job here. `pnpm check` stays the single source-of-truth command
 # for local dev; CI fans the same set out into independent jobs.
+#
+# Cache strategy — every job uses `actions/cache/restore` (read-only)
+# + `actions/cache/save` (write, main-push only). Three things matter:
+#
+#   1. The unified `actions/cache` action saves on every run. PR runs
+#      saving to a key shared with `main` would let a malicious PR
+#      poison the cache that subsequent `main` runs restore — a
+#      variant of the cross-ref cache poisoning vector that hit
+#      TanStack Router (2026-05-11). Splitting restore/save and
+#      gating save on `github.ref == 'refs/heads/main'` closes that.
+#
+#   2. `restore-keys:` (prefix fallback) is deliberately absent.
+#      Prefix-fallback restore is the other half of the poisoning
+#      vector — if a stale `main` cache exists under a partial-match
+#      key, it would be restored into a PR run that didn't pin the
+#      lockfile-hash exact key. Exact-key-only restore means a
+#      lockfile change always cold-installs. PR-CI runs that bump
+#      deps pay +60-90s; the trade is worth it.
+#
+#   3. The save step is additionally gated on
+#      `cache-hit != 'true'` so we don't re-upload an unchanged
+#      blob on every `main` push.
 
 jobs:
   lint:
@@ -58,16 +80,22 @@ jobs:
         run: |
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-      - name: Setup pnpm cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Restore pnpm store cache (read-only)
+        id: pnpm-restore
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      - name: Save pnpm store cache (main-push only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.pnpm-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ steps.pnpm-restore.outputs.cache-primary-key }}
 
       # Generate apps/site/.nuxt/imports.d.ts so the eslint config can
       # parse Nuxt's auto-imports (`computed`, `useState`, etc.) and
@@ -101,16 +129,22 @@ jobs:
         run: |
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-      - name: Setup pnpm cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Restore pnpm store cache (read-only)
+        id: pnpm-restore
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      - name: Save pnpm store cache (main-push only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.pnpm-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ steps.pnpm-restore.outputs.cache-primary-key }}
 
       - name: Stub attaform (Nuxt + site types)
         run: pnpm dev:prepare
@@ -154,16 +188,22 @@ jobs:
         run: |
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-      - name: Setup pnpm cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Restore pnpm store cache (read-only)
+        id: pnpm-restore
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      - name: Save pnpm store cache (main-push only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.pnpm-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ steps.pnpm-restore.outputs.cache-primary-key }}
 
       - name: Stub attaform (Nuxt + site types)
         run: pnpm dev:prepare
@@ -191,16 +231,22 @@ jobs:
         run: |
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-      - name: Setup pnpm cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Restore pnpm store cache (read-only)
+        id: pnpm-restore
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      - name: Save pnpm store cache (main-push only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.pnpm-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ steps.pnpm-restore.outputs.cache-primary-key }}
 
       # `pnpm check:size` runs `pnpm prepack` (unbuild) before
       # invoking size-limit, so we don't need a separate prepack
@@ -236,16 +282,22 @@ jobs:
         run: |
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-      - name: Setup pnpm cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Restore pnpm store cache (read-only)
+        id: pnpm-restore
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      - name: Save pnpm store cache (main-push only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.pnpm-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ steps.pnpm-restore.outputs.cache-primary-key }}
 
       - name: Stub attaform
         run: pnpm dev:prepare
@@ -278,16 +330,22 @@ jobs:
         run: |
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-      - name: Setup pnpm cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Restore pnpm store cache (read-only)
+        id: pnpm-restore
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      - name: Save pnpm store cache (main-push only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.pnpm-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ steps.pnpm-restore.outputs.cache-primary-key }}
 
       - name: Stub attaform (Nuxt + site types)
         run: pnpm dev:prepare
@@ -320,16 +378,22 @@ jobs:
         run: |
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-      - name: Setup pnpm cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Restore pnpm store cache (read-only)
+        id: pnpm-restore
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      - name: Save pnpm store cache (main-push only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.pnpm-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ steps.pnpm-restore.outputs.cache-primary-key }}
 
       - name: Stub attaform
         run: pnpm dev:prepare

--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,34 @@
 shamefully-hoist=false
 strict-peer-dependencies=false
 
+# Supply-chain cooldown: refuse to install any package version
+# published less than 24h ago (1440 minutes). Defeats the
+# "worm publishes, downstream CI installs within the hour" failure
+# mode that hit TanStack Router on 2026-05-11 (Mini Shai-Hulud).
+#
+# Scope of the gate:
+#   - Applies to fresh `pnpm install` / `pnpm add` resolution.
+#   - Does NOT apply to lockfile-pinned installs
+#     (`pnpm install --frozen-lockfile`), so CI runs against the
+#     committed lockfile are unaffected even when the lockfile lists
+#     a <24h-old version.
+#   - Does NOT apply to local-file or workspace-protocol deps.
+#
+# Dependabot interaction:
+#   PRs that bump to a fresh upstream patch will fail CI with a
+#   release-age error until 24h post-publish. This is the intended
+#   behavior — the friction IS the security control. Leave the red
+#   PR; Dependabot rebases on the next sweep.
+#
+# Self-exclude:
+#   `minimumReleaseAgeExclude=attaform` keeps downstream consumers
+#   testing against the just-published `attaform@<v>` from being
+#   blocked by their own cooldown for 24h after our publishes. The
+#   exclude trusts our own publish chain (Trusted Publishing + OIDC
+#   + provenance + the split validate/publish workflow).
+minimumReleaseAge=1440
+minimumReleaseAgeExclude=attaform
+
 # Hoist the unified/remark/rehype ecosystem to the workspace root so
 # Vite's optimizeDeps resolver (used by @nuxt/content's `@nuxtjs/mdc`)
 # can satisfy `optimizeDeps.include` entries like `@nuxtjs/mdc >


### PR DESCRIPTION
PR 4 of 4 in the supply-chain hardening series (#262 → #263 → #264 → #265 → **this**). Closes the last two gaps left after the publish-job split.

## What changes

### `.npmrc` — install-time cooldown
- `minimumReleaseAge=1440` refuses to install any package version published less than 24h ago. Defeats the *worm publishes, downstream CI installs within the hour* failure mode that hit TanStack Router on 2026-05-11 (Mini Shai-Hulud).
- `minimumReleaseAgeExclude=attaform` so downstream consumers testing against the just-published `attaform@<v>` are not blocked for 24h by their own cooldown.
- Lockfile-pinned installs (`--frozen-lockfile`) bypass the gate, so existing CI is unaffected.

### `matrix.yml` — cache restore/save split
Every one of the 7 cache blocks (lint, typecheck, test, size, bench, build-site, coverage-artifact) becomes:

| Step | Before | After |
|------|--------|-------|
| Restore | `actions/cache@v5` (read+write, all events) | `actions/cache/restore@v5` (read-only) |
| Save | (implicit, runs on all events) | `actions/cache/save@v5`, gated on \`github.event_name == 'push' && github.ref == 'refs/heads/main' && cache-hit != 'true'\` |
| Fallback | \`restore-keys: \${{ runner.os }}-pnpm-store-\` | dropped — exact-key match only |
| Install | \`pnpm install\` | \`pnpm install --frozen-lockfile\` |

Two attack surfaces close:
1. **Cross-ref poisoning** — PR runs no longer save into a key namespace that main restores from.
2. **Prefix-fallback restore** — a stale main cache under a partial-match key cannot leak into a PR run with a lockfile-hash mismatch.

`--frozen-lockfile` is load-bearing for the new release-age gate: it is what makes lockfile-pinned installs immune to `minimumReleaseAge`, and as a side benefit catches lockfile drift at PR time.

## Trade-offs (intentional)

- Dependabot bumps to <24h-old upstream versions will fail CI until the cooldown elapses. **This friction is the security control.** Leave the red PR; Dependabot rebases on the next sweep.
- PR-CI runs that bump deps now cold-install (no fallback to a stale main cache): +60-90s per matrix job per dep-changing PR. Prefix-fallback IS the poisoning vector, so the cost is worth it.

## Test plan

- [ ] Open a no-dep-change PR → matrix runs green, save step shows *skipped* on every job (PR event, not main push).
- [ ] After merge to main → save step runs once on each job, cache uploaded under the exact lockfile-hash key.
- [ ] Subsequent main push restores via the exact key; save step is skipped due to \`cache-hit != 'true'\` being false.
- [ ] \`grep -rn 'restore-keys' .github/workflows/\` returns only comment-text references.
- [ ] On a throwaway branch, \`pnpm install vue@<just-published-version>\` locally → fails with release-age error.

## Stack

#262 (pnpm 11) ← #263 (SHA-pin + CODEOWNERS + SECURITY) ← #264 (zizmor + Scorecard) ← #265 (publish-split + tarball budget) ← **this PR**