### PR TITLE
chore(ci): resolve remaining zizmor warnings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,17 @@ updates:
     # Cap open PRs so a dep graph with many out-of-date packages doesn't
     # carpet-bomb the PR list. Security PRs are NOT counted against this cap.
     open-pull-requests-limit: 5
+    # Cooldown delays a Dependabot PR until a new release has been on the
+    # registry for the floor duration. Belt-and-braces over the install-
+    # time cooldown declared in `.npmrc` (`minimumReleaseAge`): `.npmrc`
+    # gates `pnpm install`, this gates whether Dependabot even opens the
+    # PR. Together they defeat the "worm publishes, downstream CI installs
+    # within the hour" failure mode that hit @tanstack in May 2026.
+    # Major bumps wait longer — they're the highest-risk upgrade class
+    # and rarely time-sensitive.
+    cooldown:
+      default-days: 2
+      semver-major-days: 7
     # Group non-security updates by kind so the review surface stays small.
     # Security updates are intentionally NOT grouped — each one gets its own
     # PR so the severity, advisory link, and upgrade blast radius are clear.
@@ -50,6 +61,14 @@ updates:
       interval: 'weekly'
       day: 'monday'
     open-pull-requests-limit: 5
+    # No `.npmrc`-equivalent for action SHA pins, so this cooldown is
+    # the ONLY release-age enforcement on the github-actions axis. 2
+    # days catches actively-worming SHAs published in the prior weekly
+    # cycle; 7 days for major bumps adds breathing room for upstream
+    # regressions on the highest-risk upgrade class.
+    cooldown:
+      default-days: 2
+      semver-major-days: 7
     # Same pattern as the npm block: scope is in the prefix itself;
     # `include: 'scope'` is intentionally omitted to avoid a double scope.
     commit-message:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -36,19 +36,29 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs on the same PR. A push that adds a new commit
+# supersedes the prior review — the latest commit's dependency diff is
+# what reviewers act on, so finishing the older run wastes compute.
+concurrency:
+  group: dependency-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   dependency-review:
     name: Review dependency changes
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      # Needed for `comment-summary-in-pr: on-failure` below. GitHub
-      # automatically downgrades this to read-only for forked-PR runs,
-      # so the comment post silently no-ops on forks (see note above).
-      pull-requests: write
+      pull-requests: write # Required by `comment-summary-in-pr: on-failure` below. GitHub auto-downgrades this to read-only for forked-PR runs, so the comment post silently no-ops on forks.
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Drop GITHUB_TOKEN from .git/config after checkout. The
+          # dependency-review action reads the dependency graph diff
+          # over the GitHub API using the workflow's job-level token —
+          # it never needs git credentials attached to the working tree.
+          persist-credentials: false
 
       - name: Dependency review
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -27,8 +27,22 @@ on:
         required: false
         default: ''
 
+# Workflow-level default: zero scopes. The `deploy` job below hits a
+# Vercel webhook with a secret — no GitHub API access is needed.
+permissions: {}
+
+# Serialize deploys; never cancel one mid-flight. The Vercel webhook is
+# fire-and-forget — once the POST returns, Vercel has the build queued
+# regardless of whether THIS workflow run continues. Cancelling a deploy
+# step that's already POSTed would just lose the run-summary write,
+# not the deploy itself.
+concurrency:
+  group: deploy-docs
+  cancel-in-progress: false
+
 jobs:
   deploy:
+    name: Deploy to Vercel production
     runs-on: ubuntu-latest
     # Scoping to the `Production (Docs)` GitHub Environment buys three
     # things on top of a plain repo secret:

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -2,7 +2,7 @@ name: Node.js Test Suite
 
 permissions:
   contents: read
-  actions: read
+  actions: read # Read other workflow runs so branch-protection rules can cross-reference status. Read-only; no API write surface.
 
 on:
   push:
@@ -43,9 +43,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Drop GITHUB_TOKEN from .git/config after checkout. CI-only
+          # job; no `git push` or private-ref fetch needs the token
+          # attached to the working tree.
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -86,9 +91,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Drop GITHUB_TOKEN from .git/config after checkout. CI-only
+          # job; no `git push` or private-ref fetch needs the token
+          # attached to the working tree.
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -139,9 +149,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Drop GITHUB_TOKEN from .git/config after checkout. CI-only
+          # job; no `git push` or private-ref fetch needs the token
+          # attached to the working tree.
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -176,9 +191,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Drop GITHUB_TOKEN from .git/config after checkout. CI-only
+          # job; no `git push` or private-ref fetch needs the token
+          # attached to the working tree.
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -221,9 +241,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Drop GITHUB_TOKEN from .git/config after checkout. CI-only
+          # job; no `git push` or private-ref fetch needs the token
+          # attached to the working tree.
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -263,9 +288,14 @@ jobs:
     # the cross-version surface.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Drop GITHUB_TOKEN from .git/config after checkout. CI-only
+          # job; no `git push` or private-ref fetch needs the token
+          # attached to the working tree.
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -305,9 +335,14 @@ jobs:
     # which also fails the job if coverage thresholds drop.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Drop GITHUB_TOKEN from .git/config after checkout. CI-only
+          # job; no `git push` or private-ref fetch needs the token
+          # attached to the working tree.
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node.js (lts)
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/peer-matrix.yml
+++ b/.github/workflows/peer-matrix.yml
@@ -26,12 +26,19 @@ name: Peer-Dep Matrix
 
 permissions:
   contents: read
-  actions: read
+  actions: read # Read other workflow runs so branch-protection rules can cross-reference status. Read-only; no API write surface.
 
 on:
   schedule:
     - cron: '0 6 * * 1'
   workflow_dispatch:
+
+# Serialize the weekly sweep across cron + manual dispatch. A second
+# run starting mid-sweep would re-resolve pnpm.overrides against a
+# scratch package.json that the first run already mutated.
+concurrency:
+  group: peer-matrix
+  cancel-in-progress: false
 
 jobs:
   peer-matrix:
@@ -67,9 +74,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Drop GITHUB_TOKEN from .git/config after checkout. This job
+          # only runs typecheck + test + size against re-resolved deps;
+          # it never pushes or fetches a private ref.
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node.js 22
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -77,20 +89,31 @@ jobs:
           node-version: 22.x
 
       - name: Inject pnpm.overrides for this matrix cell
+        env:
+          # Bind matrix values into env vars so the `node -e` script
+          # below reads them via `process.env` rather than YAML
+          # template-interpolating them into a shell-then-node parse
+          # chain. Matrix values are workflow-defined (not attacker-
+          # controlled), but env-binding eliminates the lower-confidence
+          # template-injection finding without leaving a suppression
+          # comment behind.
+          MATRIX_VUE: ${{ matrix.vue }}
+          MATRIX_VITE: ${{ matrix.vite }}
+          MATRIX_NUXT: ${{ matrix.nuxt }}
         run: |
-          node -e "
-          const fs = require('fs');
-          const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+          node -e '
+          const fs = require("fs");
+          const pkg = JSON.parse(fs.readFileSync("./package.json", "utf8"));
           pkg.pnpm = pkg.pnpm ?? {};
           pkg.pnpm.overrides = {
             ...(pkg.pnpm.overrides ?? {}),
-            vue: '${{ matrix.vue }}',
-            vite: '${{ matrix.vite }}',
-            nuxt: '${{ matrix.nuxt }}',
+            vue: process.env.MATRIX_VUE,
+            vite: process.env.MATRIX_VITE,
+            nuxt: process.env.MATRIX_NUXT,
           };
-          fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
-          console.log('applied overrides:', pkg.pnpm.overrides);
-          "
+          fs.writeFileSync("./package.json", JSON.stringify(pkg, null, 2) + "\n");
+          console.log("applied overrides:", pkg.pnpm.overrides);
+          '
 
       - name: Install with overrides
         # --no-frozen-lockfile: the override mutation invalidates the

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -20,6 +20,22 @@ on:
         required: false
         default: ''
 
+# Workflow-level default: read-only. The `publish` job below upgrades
+# to `contents: write` + `id-token: write` for the version-bump commit
+# push + Trusted Publishing OIDC handshake. The `validate` job inherits
+# the workflow-level `contents: read`.
+permissions:
+  contents: read
+
+# Serialize publishes strictly. Two concurrent publishes would race on
+# the version-bump commit + tag and could leave the repo in a state
+# where main has the bump but the tag is missing (or vice versa). The
+# cost of `cancel-in-progress: false` is at most one queued workflow
+# run; the cost of overlapping publishes is a corrupted release.
+concurrency:
+  group: publish-npm
+  cancel-in-progress: false
+
 # Job topology — split into `validate` and `publish` to minimise the
 # attack surface of the privileged publish step:
 #
@@ -61,9 +77,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Drop GITHUB_TOKEN from .git/config after checkout. This job
+          # only runs `pnpm check` against the working tree; it never
+          # pushes or fetches a private ref. Keeping the token attached
+          # would be unnecessary ambient authority during the `pnpm
+          # install` install-script window.
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -92,8 +115,8 @@ jobs:
     needs: [validate]
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      id-token: write
+      contents: write # Push the version-bump commit + tag to protected `main` via `git push --follow-tags`. Read alone would 403 at the GitHub API layer.
+      id-token: write # Mint an ephemeral npm publish credential from this run's GitHub OIDC token under Trusted Publishing. No NPM_TOKEN secret is involved.
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -103,6 +126,13 @@ jobs:
           # `gh api .../generate-notes` and needs to resolve the prior
           # tag from `git tag --sort=-version:refname`.
           fetch-depth: 0
+          # Keep the GITHUB_TOKEN attached to .git/config so the
+          # `git push --follow-tags` step below can authenticate
+          # against the protected `main` branch. The publish job is
+          # `workflow_dispatch`-only (maintainer-restricted) and the
+          # token's scope here is the explicit `contents: write` job
+          # permission above, so the ambient authority is bounded.
+          persist-credentials: true
 
       - name: Calculate next version
         id: calculate-next-version
@@ -192,10 +222,17 @@ jobs:
           fi
 
       - name: Update version
-        run: echo "::notice title=Version::Publishing version ${{ steps.calculate-next-version.outputs.next_version }}"
+        env:
+          # Bind the step output into an env var so the `run:` block
+          # references it as an ordinary shell variable. Step outputs
+          # are not user-controllable, but env-binding eliminates the
+          # lower-confidence template-injection finding without leaving
+          # a suppression comment behind.
+          NEXT_VERSION: ${{ steps.calculate-next-version.outputs.next_version }}
+        run: echo "::notice title=Version::Publishing version $NEXT_VERSION"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -403,9 +440,18 @@ jobs:
           # classic GitHub Actions template-injection pattern.
           INPUT_DIST_TAG: ${{ github.event.inputs.dist_tag }}
           INPUT_PRERELEASE_ID: ${{ github.event.inputs.prerelease_id }}
+          # Bind workflow-context values + step output the same way.
+          # github.server_url / .repository / .run_id are GitHub-set and
+          # not attacker-controllable, but env-binding eliminates the
+          # template-injection finding without leaving a suppression
+          # comment behind.
+          NEXT_VERSION: ${{ steps.calculate-next-version.outputs.next_version }}
+          GH_SERVER_URL: ${{ github.server_url }}
+          GH_REPOSITORY: ${{ github.repository }}
+          GH_RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
-          VERSION="${{ steps.calculate-next-version.outputs.next_version }}"
+          VERSION="$NEXT_VERSION"
           TAG="v$VERSION"
 
           # Metadata harvested from the version-bump commit at HEAD.
@@ -415,13 +461,13 @@ jobs:
           COMMIT_AUTHOR_EMAIL=$(git log -1 --pretty=%ae HEAD)
           COMMIT_DATE_ISO=$(git log -1 --pretty=%aI HEAD)
           SHORT_SHA="${COMMIT_SHA:0:12}"
-          REPO_URL="${{ github.server_url }}/${{ github.repository }}"
+          REPO_URL="${GH_SERVER_URL}/${GH_REPOSITORY}"
 
           # Auto-generated PR-grouped notes — follows `.github/release.yml`
           # if present, otherwise GitHub's default categorisation.
           AUTO_NOTES=$(gh api \
             --method POST \
-            "/repos/${{ github.repository }}/releases/generate-notes" \
+            "/repos/${GH_REPOSITORY}/releases/generate-notes" \
             -f tag_name="$TAG" \
             --jq .body)
 
@@ -430,7 +476,7 @@ jobs:
             echo ""
             echo "- Commit: [\`$SHORT_SHA\`]($REPO_URL/commit/$COMMIT_SHA) — $COMMIT_TITLE"
             echo "- Author: **$COMMIT_AUTHOR_NAME** <$COMMIT_AUTHOR_EMAIL>"
-            echo "- Published via: [workflow run]($REPO_URL/actions/runs/${{ github.run_id }})"
+            echo "- Published via: [workflow run]($REPO_URL/actions/runs/${GH_RUN_ID})"
             echo "- npm: [\`attaform@$VERSION\`](https://www.npmjs.com/package/attaform/v/$VERSION)"
             echo ""
             echo "---"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -39,24 +39,30 @@ on:
     branches: ['main']
   workflow_dispatch:
 
-# Default to read-only at the workflow level; the analysis job
-# upgrades only the scopes it actually needs.
-permissions: read-all
+# Workflow-level default: zero scopes. The `analysis` job declares the
+# exact scopes it needs (security-events: write, id-token: write,
+# contents: read, actions: read). Pedantic least-privilege — narrower
+# than the previous `read-all`, which granted read on every scope
+# regardless of whether the job consumed them.
+permissions: {}
+
+# Serialize scorecard runs across schedule + push + dispatch triggers.
+# A second run kicking off mid-analysis would just compete for the same
+# OIDC token audience (`securityscorecards.dev`) and write back
+# overlapping SARIF.
+concurrency:
+  group: scorecard
+  cancel-in-progress: false
 
 jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:
-      # Required to upload SARIF to Code Scanning.
-      security-events: write
-      # Required to mint an OIDC token for the Scorecard publishing
-      # service (`api.securityscorecards.dev`). Audience is
-      # `securityscorecards.dev`, distinct from the npm Trusted
-      # Publishing audience used by `publish-npm.yml`.
-      id-token: write
+      security-events: write # Upload SARIF to Code Scanning.
+      id-token: write # Mint an OIDC token for the Scorecard publishing service (`api.securityscorecards.dev`). Audience is distinct from the npm Trusted Publishing audience used by `publish-npm.yml`.
       contents: read
-      actions: read
+      actions: read # Read other workflow runs so the analyzer can score branch-protection + workflow-token-permission posture.
 
     steps:
       - name: Checkout
@@ -68,7 +74,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
@@ -86,6 +92,6 @@ jobs:
           retention-days: 14
 
       - name: Upload to Code Scanning
-        uses: github/codeql-action/upload-sarif@f52b05f4acaaa234e44466e66d29050e135ea9ef # v4.36.0
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: results.sarif

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -35,18 +35,21 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs on the same ref. New commits supersede the
+# prior lint result — only the latest commit's findings matter for the
+# PR check.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   zizmor:
     name: zizmor (pedantic)
     runs-on: ubuntu-latest
     permissions:
-      # Required to upload SARIF results to Code Scanning.
-      security-events: write
-      # Required so zizmor can resolve workflow context against the
-      # checked-out commit on private repos (no-op on this public repo
-      # but the upstream README recommends keeping it set for parity).
+      security-events: write # Upload SARIF results to Code Scanning.
       contents: read
-      actions: read
+      actions: read # Read workflow context against the checked-out commit on private repos (no-op on this public repo; upstream README recommends keeping it set for parity).
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Sweeps the ~60 lower-severity findings the pedantic zizmor scan surfaced once #268 cleared the 6 errors. Local `zizmor --persona pedantic` now reports zero findings.

**Stacked on #268** (still open). When #268 merges first, this PR will auto-rebase onto main; otherwise the two can land in either order.

## What's resolved

| Rule | Hits | Fix |
|---|---|---|
| `ref-version-mismatch` + `stale-action-refs` | 24 | Re-pin pnpm/action-setup, ossf/scorecard-action, codeql-action/upload-sarif to actual commit SHAs (previous pins were the tags' annotated-tag-object SHAs, which resolve to the same commits at runtime but didn't match the version comments) |
| `artipacked` | 11 | Drop GITHUB_TOKEN from `.git/config` after checkout on every read-only job. The publish job (which pushes the version-bump commit) keeps it attached explicitly with a comment |
| `template-injection` (help + info) | 9 | Bind `github.server_url` / `.repository` / `.run_id`, matrix vars, and step outputs into env vars so shell + node scripts read them as ordinary variables |
| `excessive-permissions` | 3 | Workflow-level `permissions: {}` on `deploy-docs.yml` + `scorecard.yml` (replacing `read-all`); workflow-level `contents: read` on `publish-npm.yml` |
| `undocumented-permissions` | 6 | Convert block comments to inline trailing comments — pedantic mode picks those up but not preceding-block comments |
| `concurrency-limits` | 6 | Per-workflow concurrency blocks; publish + deploy never cancel mid-flight, PR-time workflows cancel stale runs |
| `dependabot-cooldown` | 2 | Add `cooldown:` (default-days: 2, semver-major-days: 7) to both npm + github-actions Dependabot ecosystems |
| `anonymous-definition` | 1 | Name the deploy job in `deploy-docs.yml` |

## Investigation note

The three "impostor SHA" findings on `pnpm/action-setup@d15e628...`, `ossf/scorecard-action@99c09fe...`, and `github/codeql-action/upload-sarif@f52b05f...` were tag-object SHAs, not impostor pins. Each tag is annotated; `gh api repos/<o>/<r>/git/tags/<tag-sha>` dereferences to the actual commit SHA. Functionally equivalent (GitHub resolves both at action-run time), but the convention is to pin to the commit SHA so the SHA matches what `git log` shows upstream. No security incident.

## Test plan

- [x] Local `zizmor --persona pedantic .github/workflows/*.yml` → 0 findings (online + offline)
- [ ] CI `workflow-lint.yml` reports zero findings in Code Scanning
- [ ] Other CI jobs (matrix, peer-matrix, dependency-review) stay green — the persist-credentials changes are the only ones with theoretical runtime impact
- [ ] Confirm Dependabot's syntax-validates the new `cooldown:` blocks
- [ ] Sanity-check re-pinned SHAs via `gh api repos/<owner>/<repo>/commits/<new-sha>` — all 3 verified during planning (commit messages match v6.0.8 / v2.4.3 / v4.36.0)

## Out of scope

- `actions/cache` restore-keys prefix fallback in `matrix.yml` — PR #266 (`chore/install-cooldown-cache-split`) is still open and addresses this structurally
- Removing `npm install -g npm@latest` from `publish-npm.yml` — already removed in PR #265; verified the publish step is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)