### PR TITLE
fix(ci): adjust dependabot cooldown to pass both zizmor + Dependabot validation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,17 +20,18 @@ updates:
     # Cap open PRs so a dep graph with many out-of-date packages doesn't
     # carpet-bomb the PR list. Security PRs are NOT counted against this cap.
     open-pull-requests-limit: 5
-    # Cooldown delays a Dependabot PR until a new release has been on the
-    # registry for the floor duration. Belt-and-braces over the install-
-    # time cooldown declared in `.npmrc` (`minimumReleaseAge`): `.npmrc`
-    # gates `pnpm install`, this gates whether Dependabot even opens the
-    # PR. Together they defeat the "worm publishes, downstream CI installs
-    # within the hour" failure mode that hit @tanstack in May 2026.
-    # Major bumps wait longer — they're the highest-risk upgrade class
-    # and rarely time-sensitive.
+    # Cooldown delays a Dependabot PR until a new release has been on
+    # the registry for the floor duration. Belt-and-braces over the
+    # install-time cooldown declared in `.npmrc` (`minimumReleaseAge`):
+    # `.npmrc` gates `pnpm install`, this gates whether Dependabot
+    # even opens the PR. Together they defeat the "worm publishes,
+    # downstream CI installs within the hour" failure mode that hit
+    # TanStack Router in May 2026. Major bumps wait longer (highest-
+    # risk upgrade class, rarely time-sensitive). Security PRs bypass
+    # cooldown entirely, so critical CVEs still surface immediately.
     cooldown:
-      default-days: 2
-      semver-major-days: 7
+      default-days: 7
+      semver-major-days: 14
     # Group non-security updates by kind so the review surface stays small.
     # Security updates are intentionally NOT grouped — each one gets its own
     # PR so the severity, advisory link, and upgrade blast radius are clear.
@@ -62,13 +63,14 @@ updates:
       day: 'monday'
     open-pull-requests-limit: 5
     # No `.npmrc`-equivalent for action SHA pins, so this cooldown is
-    # the ONLY release-age enforcement on the github-actions axis. 2
-    # days catches actively-worming SHAs published in the prior weekly
-    # cycle; 7 days for major bumps adds breathing room for upstream
-    # regressions on the highest-risk upgrade class.
+    # the ONLY release-age enforcement on the github-actions axis. A
+    # 7-day floor catches actively-worming SHAs that surface in the
+    # week after publish. `semver-major-days` is intentionally omitted
+    # — Dependabot rejects it for the github-actions ecosystem because
+    # action versions aren't modeled with strict semver-major
+    # distinction. Security advisories bypass cooldown.
     cooldown:
-      default-days: 2
-      semver-major-days: 7
+      default-days: 7
     # Same pattern as the npm block: scope is in the prefix itself;
     # `include: 'scope'` is intentionally omitted to avoid a double scope.
     commit-message:


### PR DESCRIPTION
## Summary

The cooldown block introduced in #269 failed two checks on main:

1. **Dependabot validation rejected `semver-major-days`** for the `github-actions` ecosystem — that key is npm-only. Action versions aren't modeled with strict semver-major distinction in Dependabot's config schema. [Failure log](https://github.com/attaform/Attaform/runs/77795291903).

2. **zizmor pedantic flagged `default-days: 2`** as below its minimum floor of 7. The original 2-day value was picked as a "minimum viable" cooldown layered on top of `.npmrc minimumReleaseAge=1440` (24h), but pedantic mode's `dependabot-cooldown` rule wants ≥ 7. [Failure log](https://github.com/attaform/Attaform/actions/runs/26427978326/job/77795289409).

## Fix

- `default-days: 7` on both ecosystems
- `semver-major-days: 14` on the npm block (kept for conservative major-bump posture)
- `semver-major-days` dropped from the github-actions block (rejected by Dependabot)

Security advisories bypass cooldown entirely, so critical CVEs still surface immediately. The trade is a 7-day floor for routine maintenance updates — acceptable for a solo-maintained pre-1.0 library where weekly Monday Dependabot batches are the existing cadence.

## Test plan

- [x] Local `zizmor --persona pedantic` → 0 findings
- [ ] CI workflow-lint job green
- [ ] Dependabot config validation green (the `.github/dependabot.yml` check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)