### PR TITLE
chore(security): scope publish-job GPG secrets to a GitHub Environment

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -112,6 +112,23 @@ jobs:
 
   publish:
     name: Publish
+    # Scoping to the `Production (NPM)` GitHub Environment buys three
+    # things on top of plain repo secrets:
+    #   1. Activity log: each publish shows up under repo →
+    #      Deployments, with timestamp + triggering user, so the npm-
+    #      release ledger lives in one obvious place.
+    #   2. Branch restriction: the environment's "Deployment branches
+    #      and tags" rules gate which refs can read GPG_PRIVATE_KEY +
+    #      GPG_PASSPHRASE. Restricted to `main` so a fork or feature-
+    #      branch copy of this workflow can't reach the signing
+    #      credentials.
+    #   3. Optional reviewer gate: the environment's "Required
+    #      reviewers" rule (configured in the repo's settings, NOT
+    #      here) can add a manual-approval click before each publish.
+    #      Currently disabled (solo maintainer; reviewer-required
+    #      would block self-deploys).
+    environment:
+      name: 'Production (NPM)'
     needs: [validate]
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

Wraps the publish job in \`publish-npm.yml\` in a \`Production (NPM)\` GitHub Environment, mirroring the pattern \`deploy-docs.yml\` already uses for \`VERCEL_DEPLOY_HOOK_URL\`. Closes the two HIGH-confidence \`secrets-outside-env\` findings the zizmor \`auditor\` persona surfaced (but \`pedantic\` mode silently suppressed).

## What the environment buys

1. **Activity log** — each publish appears in repo → Deployments with timestamp + triggering user. One obvious ledger for the npm-release history.
2. **Branch restriction** — \`GPG_PRIVATE_KEY\` + \`GPG_PASSPHRASE\` are readable only from refs matching the environment's "Deployment branches and tags" rule (configured to \`main\`-only). A fork or feature-branch copy of this workflow can no longer reach the signing credentials.
3. **Optional reviewer gate** — the environment's "Required reviewers" rule can add a manual-approval click before each publish. Currently **disabled** (solo maintainer; would block self-deploys), but available without a code change when a co-maintainer joins.

## Repo settings changes required AFTER merge

1. Repo → Settings → Environments → New environment → name: \`Production (NPM)\`
2. Configure "Deployment branches and tags" → Selected branches → add \`main\`
3. Leave **Required reviewers** unchecked, **Wait timer** unset
4. Copy \`GPG_PRIVATE_KEY\` + \`GPG_PASSPHRASE\` from repo-level secrets to environment-level secrets
5. Once a dry-run publish confirms the env-scoped reads work, **delete** the repo-level copies (removes the ambient access surface)

GitHub resolves secret names with environment-scope taking precedence over repo-scope, so the workflow reads from env secrets transparently once they exist.

## What's NOT addressed

- \`artipacked\` LOW-confidence finding on the publish-job checkout (line 138, \`persist-credentials: true\`). Intentional — the post-publish \`git push --follow-tags\` needs the token attached. Documented in code; pedantic mode already drops it to low confidence.

## Verification (local)

\`zizmor --persona auditor .github/workflows/publish-npm.yml\` → **1 finding** (down from 3 — just the intentional \`artipacked\`)
\`zizmor --persona pedantic .github/workflows/*.yml\` → **suppressed count drops from 3 → 1**

## Test plan

- [ ] CI workflow-lint stays green (pedantic mode unchanged)
- [ ] Confirm \`Production (NPM)\` environment created in repo settings before merging
- [ ] Confirm \`GPG_PRIVATE_KEY\` + \`GPG_PASSPHRASE\` copied to env-level secrets before merging
- [ ] Post-merge dry-run: dispatch \`Publish to NPM and Version Bump\` with \`exact_version\` set to current version. Workflow will fail at \`pnpm version\` (refuses same-version bump), but only AFTER GPG step succeeds — proving env-scoped secret resolution works.
- [ ] Delete repo-level \`GPG_PRIVATE_KEY\` + \`GPG_PASSPHRASE\` after the dry-run confirms env-scoping

🤖 Generated with [Claude Code](https://claude.com/claude-code)