### PR TITLE
chore(security): push version bump without persisting GITHUB_TOKEN

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -126,13 +126,12 @@ jobs:
           # `gh api .../generate-notes` and needs to resolve the prior
           # tag from `git tag --sort=-version:refname`.
           fetch-depth: 0
-          # Keep the GITHUB_TOKEN attached to .git/config so the
-          # `git push --follow-tags` step below can authenticate
-          # against the protected `main` branch. The publish job is
-          # `workflow_dispatch`-only (maintainer-restricted) and the
-          # token's scope here is the explicit `contents: write` job
-          # permission above, so the ambient authority is bounded.
-          persist-credentials: true
+          # Drop GITHUB_TOKEN from .git/config after checkout. The
+          # `Push version bump` step below wires `gh` as a credential
+          # helper via `gh auth setup-git` instead, so the token lives
+          # in env (retrieved on-demand by `gh auth git-credential`)
+          # rather than persisted in the working tree's git config.
+          persist-credentials: false
 
       - name: Calculate next version
         id: calculate-next-version
@@ -413,7 +412,17 @@ jobs:
 
       - name: Push version bump
         if: success()
-        run: git push --follow-tags
+        env:
+          # `gh auth setup-git` configures git to use the `gh` CLI as
+          # the credential helper for github.com. The helper calls
+          # `gh auth git-credential` on demand, which reads GH_TOKEN
+          # from env — the token never lands in the working tree's
+          # .git/config. Pairs with `persist-credentials: false` on
+          # the publish-job checkout above.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh auth setup-git
+          git push --follow-tags
 
       # Create the GitHub Release for the just-pushed tag. Runs AFTER
       # npm publish + git push so a release on


### PR DESCRIPTION
## Summary

Flips the publish-job checkout to \`persist-credentials: false\` and wires \`gh auth setup-git\` as the credential helper for the \`git push --follow-tags\` step that follows. The token lives in env (retrieved on-demand by \`gh auth git-credential\`) rather than persisted in the working tree's \`.git/config\`.

## Why this matters

zizmor's \`artipacked\` rule (suppressed in pedantic mode but surfaced by the \`auditor\` persona at LOW confidence) flagged the previous \`persist-credentials: true\` setting because a GitHub Actions artifact upload during the publish window could theoretically contain the \`.git/config\` bearer token. The publish job doesn't currently upload artifacts, but structurally the finding is correct — a defense-in-depth move to remove ambient credential exposure during the OIDC publish window.

The publish job already uses \`gh\` extensively (release-notes API, \`gh release create\`), so \`gh auth setup-git\` is a one-liner addition on a tool that's already on the runner.

## State of zizmor findings

| State | Pedantic | Auditor |
|---|---|---|
| Before this branch | 0 findings, **1 suppressed** | 1 finding (artipacked LOW) |
| After this PR alone | 0 findings, 2 suppressed (the 2× \`secrets-outside-env\` that #271 closes) | 2 findings (the same secrets-outside-env) |
| With both this + #271 merged | **0 findings, 0 suppressed** | 0 findings |

Order of merge between this PR and #271 doesn't matter; both land independently and the end state is identical.

## Test plan

- [x] Local \`zizmor --persona auditor .github/workflows/publish-npm.yml\` → \`artipacked\` finding is gone
- [ ] CI workflow-lint green
- [ ] All other CI checks green
- [ ] Post-merge dry-run of the publish workflow confirms \`git push --follow-tags\` still works with the gh-CLI credential helper (the most testable assertion before a real release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)