### PR TITLE
fix(ci): drop apps/site prepare step from the publish job

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -286,8 +286,16 @@ jobs:
         # available to the OIDC publish credential.
         run: pnpm install --filter attaform... --frozen-lockfile
 
-      - name: Stub attaform
-        run: pnpm dev:prepare
+      # `pnpm dev:prepare` is NOT run here. It expands to
+      # `unbuild --stub && nuxi prepare apps/site`, and the second
+      # half (`nuxi prepare apps/site`) needs apps/site's deps in
+      # node_modules — but the scoped install above deliberately
+      # omits them to minimise the install-script surface during
+      # the OIDC publish window. The publish path doesn't need
+      # apps/site machinery: the `pnpm prepack` step further down
+      # builds the real `dist/` (full unbuild, not --stub) before
+      # `pnpm pack` + `pnpm publish`. The validate job covers the
+      # full-workspace `dev:prepare` for type-system + lint gates.
 
       # Import a GPG signing key so the version-bump commit + tag created
       # below by `pnpm version` are signed and show as "Verified" on GitHub.


### PR DESCRIPTION
## Summary

The first post-#265 publish attempt failed at the \`Stub attaform\` step (\`pnpm dev:prepare\`). The scoped install above it (\`pnpm install --filter attaform... --frozen-lockfile\`) intentionally omits apps/site's deps to minimize the install-script surface during the OIDC publish window. But \`pnpm dev:prepare\` runs \`nuxi prepare apps/site\` which tries to load \`apps/site/nuxt.config.ts\` and chokes on the missing \`@tailwindcss/vite\` import.

[Failed run](https://github.com/attaform/Attaform/actions/runs/26429096797/job/77799071743).

## Fix

Drop the step from the publish job. The publish path doesn't need apps/site machinery:
- \`pnpm prepack\` further down does the real unbuild that populates \`dist/\`
- \`pnpm pack\` + \`pnpm publish --no-prepack\` operate on that built output
- The validate job (which uses a workspace-wide install) still runs \`pnpm dev:prepare\` for the type-system + lint gates

Pre-existing step that should have been removed in PR #265's publish-job split. Caught by the first real publish attempt.

## Failure was clean

The job failed BEFORE the \`pnpm version\` step, so no version-bump commit was created and no tag was pushed. Nothing to roll back. Just merge this + re-dispatch the publish workflow.

## Test plan

- [ ] CI green on this PR (validate path unaffected)
- [ ] Post-merge: dispatch the publish workflow again, observe the publish job continues past where it previously failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)