### PR TITLE
chore: align package.json description with the homepage + README

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "version": "node scripts/promote-changelog.mjs && (node scripts/generate-release-notes.mjs || echo '[version] release-notes step failed; continuing') && git add CHANGELOG.md RELEASES.md",
     "prepare": "husky"
   },
-  "description": "A fully type-safe, schema-driven form library for Vue 3 that gives you superpowers.",
+  "description": "A type-safe, schema-driven form library for Vue 3 and Nuxt with first-class Zod support.",
   "author": "Oswald Chisala",
   "bugs": {
     "url": "https://github.com/attaform/attaform/issues"


### PR DESCRIPTION
## Summary

The \`package.json\` description has drifted from the rest of the project's positioning surfaces. Three concrete drifts:

1. **Missing Nuxt** — every other surface (homepage H2, Schema.org description, README tagline) mentions Vue 3 *and* Nuxt; \`attaform/nuxt\` is a first-class module.
2. **No Zod positioning** — homepage leads with "Zod-first" / "first-class Zod support"; old description said only "schema-driven."
3. **"gives you superpowers"** — vague marketing voice that predates the current Zod-first repositioning.

## Change

\`\`\`diff
- "description": "A fully type-safe, schema-driven form library for Vue 3 that gives you superpowers.",
+ "description": "A type-safe, schema-driven form library for Vue 3 and Nuxt with first-class Zod support.",
\`\`\`

New description matches the **README tagline verbatim**, so npm search results, deps.dev cards, and IDE hover all read the same line.

## Surface check (all now aligned)

- \`README.md\` line 9 (tagline)
- \`apps/site/pages/index.vue\` line 121 (Schema.org \`description\`)
- \`apps/site/pages/index.vue\` H2 (\`The type-safe, Zod-first form library for Vue 3 and Nuxt.\`)
- \`package.json\` \`description\` (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)