### PR TITLE
fix(home): stop the multistep code block forcing mobile horizontal scroll

### DIFF
--- a/apps/site/pages/index.vue
+++ b/apps/site/pages/index.vue
@@ -566,7 +566,7 @@
               </UiButton>
             </div>
           </div>
-          <AppHighlighted class="homepage-shiki" :tree="wizardSnippetTree" />
+          <AppHighlighted class="homepage-shiki min-w-0" :tree="wizardSnippetTree" />
         </div>
       </UiContainer>
     </section>


### PR DESCRIPTION
## What

The `useWizard` snippet in the home page's multistep callout is a direct grid item. Grid items default to `min-width: auto`, so the code block refused to shrink below its longest line and stretched the single mobile column past the viewport, scrolling the whole page sideways.

`min-w-0` lets the item shrink so the code block's existing `overflow-x: auto` scrolls it internally instead, matching how the canonical and v-register snippets already behave.

## Scope

One line in `apps/site/pages/index.vue`. Independent of the validation-signals stack, based directly on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
