### PR TITLE
docs(demos): pare the display-state demo to a single field

### DIFF
--- a/apps/site/docs-demos/display-state.vue
+++ b/apps/site/docs-demos/display-state.vue
@@ -46,12 +46,19 @@
         </span>
       </div>
 
-      <div class="message">
-        <em v-if="form.fields.username.showErrors">{{
+      <p
+        class="message"
+        :class="{
+          'message--error': form.fields.username.showErrors,
+          'message--pending': form.fields.username.showPending,
+        }"
+      >
+        <template v-if="form.fields.username.showErrors">{{
           form.fields.username.firstError?.message
-        }}</em>
-        <small v-else-if="form.fields.username.showPending">Checking availability…</small>
-      </div>
+        }}</template>
+        <template v-else-if="form.fields.username.showPending">Checking availability…</template>
+        <template v-else>&nbsp;</template>
+      </p>
     </div>
 
     <button type="submit">Submit</button>
@@ -145,18 +152,14 @@
   }
   .message {
     margin: 0;
-    min-height: 1.25rem;
+    font-size: 0.8125rem;
     line-height: 1.25rem;
   }
-  em {
+  .message--error {
     color: #dc2626;
-    font-size: 0.8125rem;
-    font-style: normal;
   }
-  small {
+  .message--pending {
     color: #2563eb;
-    font-size: 0.75rem;
-    font-weight: 500;
   }
   button {
     align-self: flex-start;

--- a/apps/site/docs-demos/display-state.vue
+++ b/apps/site/docs-demos/display-state.vue
@@ -15,7 +15,6 @@
       .string()
       .min(3, 'At least 3 characters')
       .refine(async (v) => isAvailable(v), { message: 'That username is taken' }),
-    email: z.email('Enter a valid email'),
   })
 
   const form = useForm({
@@ -24,45 +23,40 @@
     key: 'docs-demo-display-state',
   })
 
-  const fields = [
-    { path: 'username', label: 'Username (taken: ada, champ, athlete)' },
-    { path: 'email', label: 'Email' },
-  ] as const
-
   const onSubmit = form.handleSubmit(() => {})
 </script>
 
 <template>
   <form @submit.prevent="onSubmit">
-    <div v-for="f in fields" :key="f.path" class="field">
+    <div class="field">
       <label>
-        <span>{{ f.label }}</span>
-        <input v-register="form.register(f.path)" />
+        <span>Username (taken: ada, champ, athlete)</span>
+        <input v-register="form.register('username')" />
       </label>
 
       <div class="readout">
-        <span class="badge" :class="form.fields(f.path).displayState">
-          {{ form.fields(f.path).displayState }}
+        <span class="badge" :class="form.fields.username.displayState">
+          {{ form.fields.username.displayState }}
         </span>
         <span class="chips">
-          <span class="chip" :class="{ on: form.fields(f.path).showIdle }">showIdle</span>
-          <span class="chip" :class="{ on: form.fields(f.path).showPending }">showPending</span>
-          <span class="chip" :class="{ on: form.fields(f.path).showErrors }">showErrors</span>
-          <span class="chip" :class="{ on: form.fields(f.path).showSuccess }">showSuccess</span>
+          <span class="chip" :class="{ on: form.fields.username.showIdle }">showIdle</span>
+          <span class="chip" :class="{ on: form.fields.username.showPending }">showPending</span>
+          <span class="chip" :class="{ on: form.fields.username.showErrors }">showErrors</span>
+          <span class="chip" :class="{ on: form.fields.username.showSuccess }">showSuccess</span>
         </span>
       </div>
 
-      <em v-if="form.fields(f.path).showErrors">{{ form.fields(f.path).firstError?.message }}</em>
-      <small v-else-if="form.fields(f.path).showPending">Checking availability…</small>
+      <em v-if="form.fields.username.showErrors">{{ form.fields.username.firstError?.message }}</em>
+      <small v-else-if="form.fields.username.showPending">Checking availability…</small>
     </div>
 
     <button type="submit">Submit</button>
 
     <p class="hint">
-      Every field resolves to one <code>displayState</code>. An untouched field reads
-      <code>idle</code>; blur one to open the gate, watch the async check rest at
-      <code>pending</code>, then settle on <code>error</code> or <code>success</code>. Submit to
-      open the gate on every field at once.
+      One field, one <code>displayState</code>. Untouched reads <code>idle</code>; blur to open the
+      gate, watch the async check rest at <code>pending</code>, then settle on <code>error</code> or
+      <code>success</code>. The chips are the <code>show*</code> booleans, exact projections of the
+      verdict.
     </p>
   </form>
 </template>

--- a/apps/site/docs-demos/display-state.vue
+++ b/apps/site/docs-demos/display-state.vue
@@ -46,8 +46,12 @@
         </span>
       </div>
 
-      <em v-if="form.fields.username.showErrors">{{ form.fields.username.firstError?.message }}</em>
-      <small v-else-if="form.fields.username.showPending">Checking availability…</small>
+      <div class="message">
+        <em v-if="form.fields.username.showErrors">{{
+          form.fields.username.firstError?.message
+        }}</em>
+        <small v-else-if="form.fields.username.showPending">Checking availability…</small>
+      </div>
     </div>
 
     <button type="submit">Submit</button>
@@ -138,6 +142,11 @@
     border-color: #2563eb;
     color: #1d4ed8;
     font-weight: 600;
+  }
+  .message {
+    margin: 0;
+    min-height: 1.25rem;
+    line-height: 1.25rem;
   }
   em {
     color: #dc2626;


### PR DESCRIPTION
## What

The display-state demo looped over a hand-maintained `fields` array of `{ path, label }` pairs. That duplicates what the schema already owns and is pointless indirection for two static fields.

Pared to the core concept: one `username` field (`.min(3)` + async availability `.refine`) that traverses all four `displayState` values, bound with `form.register` and read straight off `form.fields.username`. Dropped the external array, the `v-for`, the second field, and the schema-metadata labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
