### PR TITLE
refactor(aria): unify autoAria across form, app, and per-register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
   `aria-describedby` in sync with each field's gated display state, and
   emits the required / invalid states during SSR too. Any aria attribute
   you author yourself is left untouched. Opt out per binding
-  (`register(path, { aria: false })`), per form
+  (`register(path, { autoAria: false })`), per form
   (`useForm({ autoAria: false })`), or app-wide via
   `createAttaform({ defaults: { autoAria: false } })`.
 

--- a/docs/binding-inputs/v-register.md
+++ b/docs/binding-inputs/v-register.md
@@ -92,13 +92,13 @@ The check happens per attribute and per binding, so reaching for one escape hatc
 
 ### Turning it off
 
-Three opt-outs compose, narrowest first:
+One knob, `autoAria`, at three tiers; the narrower tier wins:
 
-- Per binding: `form.register('email', { aria: false })`.
+- Per binding: `form.register('email', { autoAria: false })`.
 - Per form: `useForm({ schema, autoAria: false })`.
 - App-wide: `createAttaform({ defaults: { autoAria: false } })`.
 
-Any of these hands every aria attribute back to your markup; an authored attribute is always preserved regardless.
+A narrower tier overrides the wider one in either direction, so a single binding can re-enable management with `{ autoAria: true }` even when the form opted out. Any tier set to `false` hands every aria attribute back to your markup; an authored attribute is always preserved regardless.
 
 ## Where to next
 

--- a/src/runtime/core/register-api.ts
+++ b/src/runtime/core/register-api.ts
@@ -29,9 +29,10 @@ export type InstanceRegisterConfig = {
   readonly instanceMeta?: WriteMeta['instance']
   readonly coerce?: boolean | CoercionRegistry
   /**
-   * Form-level `autoAria` resolution. Combined with the per-register
-   * `aria` option to produce each binding's `ariaEnabled`. Omitted
-   * (undefined) is treated as the library default, `true`.
+   * Form-level `autoAria` resolution (form config merged over app
+   * defaults). The per-register `autoAria` option overrides this per
+   * binding to produce each binding's `ariaEnabled`. Omitted (undefined)
+   * is treated as the library default, `true`.
    */
   readonly autoAria?: boolean
   /**
@@ -140,8 +141,8 @@ export function buildRegister<F extends GenericForm>(
   const instanceMeta = instanceConfig?.instanceMeta
   // Form-level aria resolution captured once for this register factory.
   // `autoAria` omitted is the library default (`true`); the per-register
-  // `aria` option is folded in per call below.
-  const formAutoAria = instanceConfig?.autoAria !== false
+  // `autoAria` option overrides this per call below.
+  const formAutoAria = instanceConfig?.autoAria ?? true
   const getDisplayStateAt = instanceConfig?.getDisplayStateAt
   // `meta.instance` is forwarded into every store write below so the
   // store's reads of `validateOn` / `debounceMs` / `rememberVariants`
@@ -304,13 +305,14 @@ export function buildRegister<F extends GenericForm>(
     // Aria wiring baked onto the RegisterValue so the (store-less)
     // directive can drive `aria-*` without a field-state lookup. The
     // ids match `FieldState.aria` exactly (same pure derivation).
-    // `ariaEnabled` folds the form-level `autoAria` with this binding's
-    // per-register `aria` option. `ariaDisplayState` reuses the form's
-    // field-state accessor, so it carries the SAME gated verdict the
-    // visible `form.fields.<path>.displayState` shows.
+    // `ariaEnabled` resolves this binding's per-register `autoAria`
+    // override against the form-level value, so a binding can re-enable
+    // aria even when the form opted out. `ariaDisplayState` reuses the
+    // form's field-state accessor, so it carries the SAME gated verdict
+    // the visible `form.fields.<path>.displayState` shows.
     const { aria } = computeFieldIdentity(formInstanceId, state.formKey, pathKey)
     const isRequired = state.schema.isRequiredAtPath(segments)
-    const ariaEnabled = formAutoAria && options?.aria !== false
+    const ariaEnabled = options?.autoAria ?? formAutoAria
     const ariaDisplayState =
       getDisplayStateAt !== undefined
         ? (computed(() => getDisplayStateAt(segments)) as Readonly<Ref<DisplayState>>)

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -1335,7 +1335,7 @@ export type UseFormConfiguration<
    *
    * **Resolution order (per-register override > per-form > global > library):**
    *
-   *   register(path, { aria })  >  useForm({ autoAria })  >  AttaformDefaults.autoAria  >  library default (`true`)
+   *   register(path, { autoAria })  >  useForm({ autoAria })  >  AttaformDefaults.autoAria  >  library default (`true`)
    *
    * Set `false` to leave all aria wiring to your own markup form-wide.
    * Any aria attribute you author yourself is always left untouched,
@@ -1986,19 +1986,21 @@ export type RegisterOptions = {
    */
   transforms?: ReadonlyArray<RegisterTransform>
   /**
-   * Opt this binding OUT of automatic aria management. By default the
-   * directive keeps `aria-invalid` / `aria-busy` / `aria-required` /
-   * `aria-describedby` in sync with the field's display state. Pass
-   * `aria: false` to leave every aria attribute on this element to you
-   * (the directive still manages value binding and registration).
+   * Per-binding override for automatic aria management, the narrowest
+   * tier of the `autoAria` cascade. By default the directive keeps
+   * `aria-invalid` / `aria-busy` / `aria-required` / `aria-describedby`
+   * in sync with the field's display state. Pass `autoAria: false` to
+   * leave every aria attribute on this element to you (the directive
+   * still manages value binding and registration), or `autoAria: true`
+   * to re-enable management on one binding even when the form set
+   * `useForm({ autoAria: false })`.
    *
-   * This is the per-binding opt-out; `useForm({ autoAria: false })` and
-   * `createAttaform({ defaults: { autoAria: false } })` turn it off
-   * form-wide and app-wide. Writing an aria attribute yourself also
-   * locks the directive out of that one attribute, regardless of this
-   * flag.
+   * Overrides `useForm({ autoAria })` and
+   * `createAttaform({ defaults: { autoAria } })`. Writing an aria
+   * attribute yourself also locks the directive out of that one
+   * attribute, regardless of this flag.
    */
-  aria?: boolean
+  autoAria?: boolean
 }
 
 /**
@@ -2252,9 +2254,9 @@ export type RegisterValue<Value = unknown> = Readonly<{
   isRequired?: boolean
   /**
    * Whether the directive should auto-manage aria attributes for this
-   * binding. Resolves the `autoAria` cascade (form-level) AND the
-   * per-register `aria` option: `formAutoAria && options.aria !== false`.
-   * The directive treats an absent value as off.
+   * binding. Resolves the per-register `autoAria` override against the
+   * form-level value: `options.autoAria ?? formAutoAria`. The directive
+   * treats an absent value as off.
    * @internal
    */
   ariaEnabled?: boolean

--- a/test/composables/aria.test.ts
+++ b/test/composables/aria.test.ts
@@ -21,7 +21,7 @@ function uniqueKey(): string {
 
 async function mountField(opts?: {
   autoAria?: boolean
-  registerAria?: boolean
+  registerAutoAria?: boolean
   getDisplayState?: GetDisplayState
   authored?: Record<string, unknown>
   path?: 'email' | 'note'
@@ -38,7 +38,7 @@ async function mountField(opts?: {
       handle.api = api
       const rv = api.register(
         opts?.path ?? 'email',
-        opts?.registerAria === false ? { aria: false } : undefined
+        opts?.registerAutoAria === false ? { autoAria: false } : undefined
       )
       return () =>
         withDirectives(h('input', { type: 'text', ...(opts?.authored ?? {}) }), [[vRegister, rv]])
@@ -166,8 +166,8 @@ describe('auto-aria opt-out tiers', () => {
     expect(mounted.input.hasAttribute('aria-required')).toBe(false)
   })
 
-  it('manages nothing when the binding passes aria: false', async () => {
-    mounted = await mountField({ registerAria: false, getDisplayState: forceState('error') })
+  it('manages nothing when the binding passes autoAria: false', async () => {
+    mounted = await mountField({ registerAutoAria: false, getDisplayState: forceState('error') })
     expect(mounted.input.hasAttribute('aria-invalid')).toBe(false)
     expect(mounted.input.hasAttribute('aria-required')).toBe(false)
   })

--- a/test/core/register-api.test.ts
+++ b/test/core/register-api.test.ts
@@ -339,11 +339,19 @@ describe('buildRegister', () => {
       expect(register(['email']).ariaEnabled).toBe(false)
     })
 
-    it('disables aria per-binding via the register aria option', () => {
+    it('disables aria per-binding via the register autoAria option', () => {
       const { register } = makeAriaRegister({ getDisplayStateAt: () => 'idle' })
-      expect(register(['email'], { aria: false }).ariaEnabled).toBe(false)
+      expect(register(['email'], { autoAria: false }).ariaEnabled).toBe(false)
       // Sibling bindings on the same form keep aria on.
       expect(register(['note']).ariaEnabled).toBe(true)
+    })
+
+    it('re-enables aria per-binding even when the form opted out', () => {
+      const { register } = makeAriaRegister({ autoAria: false, getDisplayStateAt: () => 'idle' })
+      // Per-binding autoAria overrides the form-level opt-out in both directions.
+      expect(register(['email'], { autoAria: true }).ariaEnabled).toBe(true)
+      // Bindings that don't override still inherit the form's opt-out.
+      expect(register(['note']).ariaEnabled).toBe(false)
     })
 
     it('omits ariaDisplayState when no accessor is wired (hand-rolled factory)', () => {


### PR DESCRIPTION
## Summary

Makes the auto-aria opt-out surface consistent. The per-register knob was named `aria` (a boolean) while the form and app tiers used `autoAria`, and it was AND-combined into `ariaEnabled` so a binding could only ever opt OUT — which contradicted the documented `register > useForm > defaults` precedence and collided with the `aria` id objects on `FieldState` and the register value.

- Renames `RegisterOptions.aria` → `autoAria`, so one knob spans all three tiers (app / form / per-register).
- Switches the resolution from `formAutoAria && options?.aria !== false` to `options?.autoAria ?? formAutoAria`, a true override cascade: a binding can now re-enable aria even when the form set `autoAria: false`.
- Updates the v-register docs, the CHANGELOG entry, and the opt-out tests; adds a case proving a binding re-enables aria when the form opted out.

Pre-1.0, no back-compat shims.

## Testing

- `pnpm typecheck` clean
- Relevant suites green: `register-api`, `aria`, `aria-ssr`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
