### PR TITLE
Phase 2: Dead-code & dead-type sweep

### DIFF
--- a/src/runtime/adapters/zod-v3/errors.ts
+++ b/src/runtime/adapters/zod-v3/errors.ts
@@ -2,12 +2,16 @@ import { AttaformError } from '../../core/errors'
 
 /**
  * Thrown when a zod-v3 schema includes a kind the form library cannot
- * represent: `z.promise`, `z.function`, `z.map`, `z.symbol`, or a
- * recursive `z.lazy(...)` that loops back into itself.
+ * represent: `z.promise`, `z.function`, `z.map`, or `z.symbol`.
  *
  * The error message includes the dotted path of the offending node
  * so you can locate it without traversing the whole schema. Mirrors
  * the v4 adapter's `UnsupportedSchemaError` so consumers see the same
  * failure shape across adapters.
+ *
+ * Recursive `z.lazy(...)` is supported, not unsupported: the
+ * construction-time walk stops descending on the second encounter
+ * of the same getter, and downstream walks cap their descent via
+ * `maxRecursionDepth`.
  */
 export class UnsupportedSchemaError extends AttaformError {}

--- a/src/runtime/adapters/zod-v3/field-meta.ts
+++ b/src/runtime/adapters/zod-v3/field-meta.ts
@@ -28,7 +28,11 @@
  */
 import type { z } from 'zod-v3'
 import type { FieldMetaPayload } from '../../core/field-meta'
-import { fieldMetaStore, getFieldMetaForSchema } from '../../core/field-meta-store'
+import {
+  fieldMetaStore,
+  getFieldMetaForSchema,
+  getFieldMetaListForSchema,
+} from '../../core/field-meta-store'
 
 /**
  * The shared registry every Attaform-aware Zod 3 schema can register
@@ -49,6 +53,11 @@ type FieldMetaRegistryV3 = {
   get(schema: z.ZodTypeAny): FieldMetaPayload | undefined
   /** True iff a payload has been registered for the schema. */
   has(schema: z.ZodTypeAny): boolean
+  /**
+   * Drop every registered payload for `schema`. Returns the registry
+   * for chaining; idempotent on a never-registered schema.
+   */
+  remove(schema: z.ZodTypeAny): FieldMetaRegistryV3
 }
 
 export const fieldMeta = fieldMetaStore as unknown as FieldMetaRegistryV3
@@ -101,4 +110,18 @@ export function withMeta<S extends z.ZodTypeAny>(schema: S, payload: FieldMetaPa
  */
 export function getFieldMeta(schema: z.ZodTypeAny): FieldMetaPayload | undefined {
   return getFieldMetaForSchema(schema as object)
+}
+
+/**
+ * Read the list of payloads registered against `schema`, in
+ * registration order. Empty list when nothing has been registered.
+ *
+ * Used by the v3 adapter's path-resolver to disambiguate per
+ * occurrence when a schema is shared across multiple form paths.
+ * Most consumers won't need this — use `fieldMeta.get(schema)` for
+ * the single-payload case. Mirrors `getFieldMetaList` on the v4
+ * adapter so per-adapter feature parity stays explicit.
+ */
+export function getFieldMetaList(schema: z.ZodTypeAny): readonly FieldMetaPayload[] {
+  return getFieldMetaListForSchema(schema as object)
 }

--- a/src/runtime/adapters/zod-v3/slim-primitives.ts
+++ b/src/runtime/adapters/zod-v3/slim-primitives.ts
@@ -13,23 +13,22 @@ import { isZodSchemaType } from './helpers'
  * `src/runtime/adapters/zod-v4/slim-primitives.ts`.
  */
 
-export const PERMISSIVE_V3: ReadonlySet<SlimPrimitiveKind> =
-  /* @__PURE__ */ new Set<SlimPrimitiveKind>([
-    'string',
-    'number',
-    'boolean',
-    'bigint',
-    'date',
-    'null',
-    'undefined',
-    'object',
-    'array',
-    'symbol',
-    'function',
-    'map',
-    'set',
-    'file',
-  ])
+const PERMISSIVE_V3: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set<SlimPrimitiveKind>([
+  'string',
+  'number',
+  'boolean',
+  'bigint',
+  'date',
+  'null',
+  'undefined',
+  'object',
+  'array',
+  'symbol',
+  'function',
+  'map',
+  'set',
+  'file',
+])
 
 // Module-level frozen leaf singletons; see the v4 file for rationale.
 const KIND_STRING: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['string'])

--- a/src/runtime/adapters/zod-v3/types-zod.ts
+++ b/src/runtime/adapters/zod-v3/types-zod.ts
@@ -1,38 +1,4 @@
-// import type { NestedType } from '@/utils/types'
 import type { z } from 'zod-v3'
-import type { NestedType } from '../../types/types-core'
-
-// Given potentially wrapped schema type, get deeply wrapped schema matching Zod type
-export type UnwrapZodSchemaToAccessTargetSchemaType<
-  Subject extends z.ZodTypeAny,
-  Target extends z.ZodTypeAny,
-> = Subject extends Target
-  ? Subject
-  : Subject extends z.ZodNullable<infer Child>
-    ? UnwrapZodSchemaToAccessTargetSchemaType<Child, Target>
-    : Subject extends z.ZodOptional<infer Child>
-      ? UnwrapZodSchemaToAccessTargetSchemaType<Child, Target>
-      : Subject extends z.ZodDefault<infer Child>
-        ? UnwrapZodSchemaToAccessTargetSchemaType<Child, Target>
-        : Subject extends z.ZodEffects<infer Child>
-          ? UnwrapZodSchemaToAccessTargetSchemaType<Child, Target>
-          : never
-
-// This explicitly defines the Zod classes that can wrap the subject schema
-export type PossiblyWrappedZodSchema<
-  Subject extends z.ZodTypeAny,
-  Target extends z.ZodTypeAny,
-> = Subject extends Target
-  ? Subject
-  : Subject extends z.ZodNullable<infer NextChild>
-    ? z.ZodNullable<PossiblyWrappedZodSchema<NextChild, Target>>
-    : Subject extends z.ZodOptional<infer NextChild>
-      ? z.ZodOptional<PossiblyWrappedZodSchema<NextChild, Target>>
-      : Subject extends z.ZodDefault<infer NextChild>
-        ? z.ZodDefault<PossiblyWrappedZodSchema<NextChild, Target>>
-        : Subject extends z.ZodEffects<infer NextChild>
-          ? z.ZodEffects<PossiblyWrappedZodSchema<NextChild, Target>>
-          : never
 
 /**
  * Narrow accessor type for Zod v3's internal `_def`. Only useful
@@ -83,8 +49,3 @@ export type TypeWithNullableDynamicKeys<
             }[keyof Options & number]
           : // Fallback to z.infer for all other schemas
               z.infer<Schema> | (CrossedBoundary extends true ? undefined : never)
-
-export type GetValueReturnTypeFromZodSchema<
-  Schema extends z.ZodSchema,
-  FlattenedPath extends string,
-> = NestedType<TypeWithNullableDynamicKeys<Schema>, FlattenedPath>

--- a/src/runtime/adapters/zod-v4/errors.ts
+++ b/src/runtime/adapters/zod-v4/errors.ts
@@ -50,10 +50,14 @@ export function zodIssuesToValidationErrors(
 
 /**
  * Thrown when a Zod schema includes a kind the form library cannot
- * represent: `z.promise`, `z.custom`, `z.templateLiteral`, or a
- * recursive `z.lazy(...)` that loops back into itself.
+ * represent: `z.promise`, `z.custom`, or `z.templateLiteral`.
  *
  * The error message includes the dotted path of the offending node
  * so you can locate it without traversing the whole schema.
+ *
+ * Recursive `z.lazy(...)` is supported, not unsupported: the
+ * construction-time walk stops descending on the second encounter
+ * of the same getter, and downstream walks cap their descent via
+ * `maxRecursionDepth`.
  */
 export class UnsupportedSchemaError extends AttaformError {}

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -613,7 +613,6 @@ export type FormStore<F extends GenericForm, G extends GenericForm = F> = {
     focused: boolean,
     meta?: { readonly instance?: WriteMeta['instance'] }
   ): void
-  markTouched(path: Path): void
   /**
    * Flip `interacted: true` on a leaf — the sticky value-mutation flag.
    * Driven by the directive's input listeners (via the RegisterValue's
@@ -2954,11 +2953,6 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     }
   }
 
-  function markTouched(path: Path): void {
-    const { key } = canonicalizePath(path)
-    touchFieldRecord(key, path, { touched: true })
-  }
-
   function markInteracted(path: Path): void {
     const { key } = canonicalizePath(path)
     // Fired per keystroke from the directive's input listeners; skip the
@@ -3634,7 +3628,6 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     registerElement,
     deregisterElement,
     markFocused,
-    markTouched,
     markInteracted,
     touchAtPath,
     markConnectedOptimistically,

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -28,6 +28,7 @@ import {
   FORM_ERRORS_PATH,
   FORM_ERRORS_PATH_KEY,
   isDangerousSegment,
+  isPathPrefix,
   segmentsForPathKey,
   type Path,
   type PathKey,
@@ -3479,21 +3480,6 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
       interacted: false,
       blurredAfterInteraction: false,
     })
-  }
-
-  /**
-   * True iff `prefix` is a path-prefix of `candidate`. Equal arrays count as
-   * a prefix (every array is a prefix of itself). Segment equality is strict
-   * `===` — `'0'` and `0` are distinct here even though canonicalizePath
-   * normalises them upstream; both paths always come from the same
-   * canonicalisation so the check holds.
-   */
-  function isPathPrefix(prefix: readonly Segment[], candidate: readonly Segment[]): boolean {
-    if (prefix.length > candidate.length) return false
-    for (let i = 0; i < prefix.length; i++) {
-      if (prefix[i] !== candidate[i]) return false
-    }
-    return true
   }
 
   // --- Derived ---

--- a/src/runtime/core/defaults.ts
+++ b/src/runtime/core/defaults.ts
@@ -62,10 +62,10 @@ export const DEFAULT_HISTORY_MAX_SNAPSHOTS = 128
 
 /**
  * Storage-key namespace for persistence. Resolved once at
- * `resolveStorageKey` to `${PERSISTENCE_KEY_PREFIX}${formKey}` unless
- * the consumer passes an explicit `persist.key`. Kept as a separate
- * constant so multi-tenant deployments can audit or reserve their
- * own prefix without grepping for the literal.
+ * `resolveStorageKeyBase` to `${PERSISTENCE_KEY_PREFIX}${formKey}`
+ * unless the consumer passes an explicit `persist.key`. Kept as a
+ * separate constant so multi-tenant deployments can audit or reserve
+ * their own prefix without grepping for the literal.
  */
 export const PERSISTENCE_KEY_PREFIX = 'attaform:'
 

--- a/src/runtime/core/directive.ts
+++ b/src/runtime/core/directive.ts
@@ -288,10 +288,6 @@ function logTransformFailure(
 }
 
 /**
- * Log a Promise-returning transform. Same dev/prod posture as
- * `logTransformFailure` — informative in dev, opaque in prod.
- */
-/**
  * Apply the field's coerce closure (built at register-time by
  * `buildCoerceFn`) to a post-transform value. Identity when the
  * RegisterValue is a hand-rolled mock that omits the field, or when
@@ -316,6 +312,10 @@ function applyElementCoerce(value: unknown, registerValue: RegisterValue): unkno
   return registerValue.coerceElement !== undefined ? registerValue.coerceElement(value) : value
 }
 
+/**
+ * Log a Promise-returning transform. Same dev/prod posture as
+ * `logTransformFailure` — informative in dev, opaque in prod.
+ */
 function logTransformAsync(path: PathKey): void {
   if (__DEV__) {
     console.error(

--- a/src/runtime/core/persistence/index.ts
+++ b/src/runtime/core/persistence/index.ts
@@ -312,29 +312,14 @@ export function createDebouncedWriter(
  * `attaform:${formKey}` — consumers who want a different
  * namespace (multi-tenant app, per-user prefix) pass `persist.key`.
  *
- * The full storage key is `${base}:${fingerprint}` (see
- * `resolveStorageKey`). The base is exposed separately so the
- * orphan-cleanup pass can `listKeys(base)` and prune any entry under
- * an old fingerprint.
+ * The full storage key is composed at the wirePersistence call site
+ * as `${base}:${fingerprint}` so the writer holds the schema's
+ * structural fingerprint directly. The base is exposed separately so
+ * the orphan-cleanup pass can `listKeys(base)` and prune any entry
+ * under an old fingerprint.
  */
 export function resolveStorageKeyBase(config: PersistConfigOptions, formKey: string): string {
   return config.key ?? `${PERSISTENCE_KEY_PREFIX}${formKey}`
-}
-
-/**
- * Resolve the full per-form storage key, composed of the base and the
- * schema's structural fingerprint. The fingerprint suffix gives free
- * automatic invalidation: any structural schema change produces a new
- * fingerprint, so the new mount looks up a fresh key and the old
- * draft becomes an orphan (cleaned up on the same mount via
- * `cleanupOrphanKeys`).
- */
-export function resolveStorageKey(
-  config: PersistConfigOptions,
-  formKey: string,
-  fingerprint: string
-): string {
-  return `${resolveStorageKeyBase(config, formKey)}:${fingerprint}`
 }
 
 /**

--- a/src/runtime/core/persistence/index.ts
+++ b/src/runtime/core/persistence/index.ts
@@ -323,8 +323,8 @@ export function resolveStorageKeyBase(config: PersistConfigOptions, formKey: str
 }
 
 /**
- * Delete every attaform-managed key under `base` that's not the current
- * fingerprint key. Sweeps two shapes:
+ * Delete every attaform-managed key under `base` from `adapter`,
+ * skipping any key equal to `keepKey`. Sweeps two shapes:
  *   - Unfingerprinted keys (no `:` suffix at all) — defensive cover
  *     for hand-written or migration-written entries that skipped the
  *     fingerprint suffix.
@@ -333,15 +333,17 @@ export function resolveStorageKeyBase(config: PersistConfigOptions, formKey: str
  *
  * Exact-or-`:`-prefix match prevents collision with sibling forms
  * whose `config.key` shares a string prefix (e.g. `'my-form'` vs
- * `'my-form-2'`).
+ * `'my-form-2'`). Fire-and-forget; per-key `removeItem` errors are
+ * swallowed and a failing `listKeys` returns silently.
  *
- * Fire-and-forget; never throws. SSR-guarded by the caller (cleanup
- * runs inside `wirePersistence`, which is itself client-only).
+ * Pass `keepKey` to retain the current fingerprint entry; leave it
+ * undefined for an unconditional sweep (used by the cross-store
+ * passes that wipe every attaform-managed key under `base`).
  */
-export async function cleanupOrphanKeys(
+async function removeMatchingKeys(
   adapter: FormStorage,
   base: string,
-  currentKey: string
+  keepKey?: string
 ): Promise<void> {
   let keys: string[]
   try {
@@ -350,13 +352,24 @@ export async function cleanupOrphanKeys(
     return
   }
   for (const key of keys) {
-    if (key === currentKey) continue
-    // Match either the exact base (unfingerprinted key) or an
-    // explicit `:` continuation (stale-fingerprint key).
+    if (key === keepKey) continue
     if (key === base || key.startsWith(`${base}:`)) {
       void adapter.removeItem(key).catch(() => undefined)
     }
   }
+}
+
+/**
+ * Delete every attaform-managed key under `base` that's not the
+ * current fingerprint key. SSR-guarded by the caller (cleanup runs
+ * inside `wirePersistence`, which is itself client-only).
+ */
+export async function cleanupOrphanKeys(
+  adapter: FormStorage,
+  base: string,
+  currentKey: string
+): Promise<void> {
+  await removeMatchingKeys(adapter, base, currentKey)
 }
 
 /**
@@ -392,25 +405,18 @@ export function normalizePersistConfig(input: PersistConfig): PersistConfigOptio
 }
 
 /**
- * Wipe every attaform-managed key under `base` from every standard backend.
- * Fire-and-forget. Used when no `persist:` is configured on the form:
- * a previous deployment may have written entries under this base
- * (any fingerprint), and the dev removing persistence should mean the
- * on-disk artifact is gone too — for every fingerprint that ever ran.
- *
- * Sweeps unfingerprinted keys (no `:` suffix) and fingerprint-
- * suffixed keys equally. Errors per backend are swallowed.
+ * Wipe every attaform-managed key under `base` from every standard
+ * backend. Fire-and-forget. Used when no `persist:` is configured on
+ * the form: a previous deployment may have written entries under this
+ * base (any fingerprint), and the dev removing persistence should
+ * mean the on-disk artifact is gone too — for every fingerprint that
+ * ever ran.
  */
 export async function sweepAllOrphansAcrossStandardStores(base: string): Promise<void> {
   for (const kind of STANDARD_STORAGE_KINDS) {
     try {
       const adapter = await getStorageAdapter(kind)
-      const keys = await adapter.listKeys(base)
-      for (const key of keys) {
-        if (key === base || key.startsWith(`${base}:`)) {
-          void adapter.removeItem(key).catch(() => undefined)
-        }
-      }
+      await removeMatchingKeys(adapter, base)
     } catch {
       // Backend unavailable (Node, Safari private mode, IDB blocked).
     }
@@ -418,9 +424,10 @@ export async function sweepAllOrphansAcrossStandardStores(base: string): Promise
 }
 
 /**
- * Cross-store cleanup. Calls `removeItem(key)` on every standard
- * backend that's NOT the configured one — fire-and-forget. Runs once
- * at form mount.
+ * Cross-store orphan cleanup: wipe every attaform-managed key under
+ * `base` from each standard backend that's NOT the configured one.
+ * Symmetric with `cleanupOrphanKeys` on the configured store — ensures
+ * stale drafts don't survive in stores the dev migrated AWAY from.
  *
  * Why this matters: if a form was persisting to `'local'` and the dev
  * later switches to `'session'` (or a custom encrypted adapter), the
@@ -430,32 +437,10 @@ export async function sweepAllOrphansAcrossStandardStores(base: string): Promise
  * truth for "where the draft lives now"; everything else is hysteresis
  * from past app states and should be wiped.
  *
- * Implementation note: deletion is inlined per-backend rather than going
- * through `getStorageAdapter`. Inlining avoids dynamic-importing the
- * adapter chunks the consumer specifically chose NOT to use — a form
- * configured for `'local'` shouldn't pull the IndexedDB chunk just to
- * sweep it.
- *
- * If `configured` is a custom `FormStorage` adapter, all three standard
- * backends are swept (we don't know which built-in the dev migrated
- * away from, and we can't reach custom adapters by enumeration).
- *
- * Errors are swallowed — cleanup is best-effort. Backend unavailable
- * (Node, Safari private mode, IDB blocked) is also a silent skip.
- */
-/**
- * Cross-store orphan cleanup: wipe every attaform-managed key under `base`
- * from each standard backend that's NOT the configured one. Symmetric
- * with `cleanupOrphanKeys` on the configured store: ensures stale
- * drafts don't survive in stores the dev migrated AWAY from. Sweeps
- * unfingerprinted and stale-fingerprint keys equally.
- *
  * If `configured` is a custom `FormStorage` adapter, all three
  * standard backends are swept (we don't know which built-in the dev
  * migrated away from, and we can't reach custom adapters by
- * enumeration).
- *
- * Fire-and-forget. Per-backend errors swallowed.
+ * enumeration). Fire-and-forget; per-backend errors swallowed.
  */
 export async function sweepNonConfiguredStandardStoresForOrphans(
   configured: FormStorageKind | FormStorage,
@@ -466,12 +451,7 @@ export async function sweepNonConfiguredStandardStoresForOrphans(
     if (kind === configuredKind) continue
     try {
       const adapter = await getStorageAdapter(kind)
-      const keys = await adapter.listKeys(base)
-      for (const key of keys) {
-        if (key === base || key.startsWith(`${base}:`)) {
-          void adapter.removeItem(key).catch(() => undefined)
-        }
-      }
+      await removeMatchingKeys(adapter, base)
     } catch {
       // Backend unavailable.
     }

--- a/src/runtime/core/wizard-history.ts
+++ b/src/runtime/core/wizard-history.ts
@@ -5,11 +5,9 @@
  * coupling.
  *
  * The handle exposes four operations:
- *   - `push(key)` — pushState that records `key` in `?<param>=<key>`
- *     while preserving any other search params already on the URL.
- *   - `replace(key)` — same write, but via replaceState so the
- *     history stack doesn't grow (used for the initial entry and for
- *     `goTo({ replace: true })`).
+ *   - `replace(key)` — write `key` into `?<param>=<key>` via
+ *     replaceState so the history stack doesn't grow. Preserves any
+ *     other search params already on the URL.
  *   - `read()` — read the current step key from the URL, or
  *     `undefined` if the param is absent.
  *   - `subscribe(cb)` — register a popstate listener; the callback
@@ -22,7 +20,6 @@
  */
 
 export type WizardHistoryHandle = {
-  push(key: string): void
   replace(key: string): void
   read(): string | undefined
   subscribe(callback: (key: string | undefined) => void): void
@@ -35,7 +32,6 @@ export type WizardHistoryHandle = {
  * `history: false`. Every method is a safe call-site shim.
  */
 export const NOOP_WIZARD_HISTORY: WizardHistoryHandle = {
-  push() {},
   replace() {},
   read() {
     return undefined
@@ -70,16 +66,15 @@ export function createWizardHistory(param: string): WizardHistoryHandle {
   // sandboxed iframes, and data: URLs. In those, `buildUrl(key)`
   // resolves to a URL whose origin doesn't match the document's
   // (the document inherits the parent's origin, but the synthesized
-  // URL keeps the scheme), and `history.pushState` / `replaceState`
-  // throw `SecurityError`. The user-visible step state still works
-  // — `current` / `goTo()` drive the form via the in-memory wizard
-  // — they just won't appear in the URL bar. Silently swallowing
-  // keeps the preview functional without coupling the library to
+  // URL keeps the scheme), and `history.replaceState` throws
+  // `SecurityError`. The user-visible step state still works —
+  // `current` / `goTo()` drive the form via the in-memory wizard —
+  // they just won't appear in the URL bar. Silently swallowing keeps
+  // the preview functional without coupling the library to
   // embed-detection logic.
-  function safeWriteState(key: string, op: 'push' | 'replace'): void {
+  function safeReplaceState(key: string): void {
     try {
-      const fn = op === 'push' ? window.history.pushState : window.history.replaceState
-      fn.call(window.history, {}, '', buildUrl(key))
+      window.history.replaceState({}, '', buildUrl(key))
     } catch {
       // SecurityError or similar — origin mismatch, sandboxed history,
       // or a host that's locked down the History API. No remediation
@@ -89,13 +84,9 @@ export function createWizardHistory(param: string): WizardHistoryHandle {
   }
 
   return {
-    push(key) {
-      if (disposed) return
-      safeWriteState(key, 'push')
-    },
     replace(key) {
       if (disposed) return
-      safeWriteState(key, 'replace')
+      safeReplaceState(key)
     },
     read() {
       const url = new URL(window.location.href)

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -1579,16 +1579,6 @@ export type AttaformDefaults = {
 
 export type FormStore<TData extends GenericForm> = Map<FormKey, TData>
 
-export type FormSummaryValue = {
-  originalValue: unknown
-  previousValue: unknown
-  currentValue: unknown
-  pristine: boolean
-  dirty: boolean
-}
-export type FormSummaryValueRecord = Record<string, FormSummaryValue>
-export type FormSummaryStore = Map<FormKey, FormSummaryValueRecord>
-
 /**
  * Callback invoked by `handleSubmit` after the form parses successfully.
  * Receives the strictly-typed parsed value — refinements have run, so
@@ -1758,8 +1748,6 @@ export type MetaTrackerValue = {
    */
   blank: boolean
 }
-export type MetaTracker = Record<string, MetaTrackerValue>
-export type MetaTrackerStore = Map<FormKey, MetaTracker>
 
 // Generates every registrable path inside `Form`. Arrays of primitive
 // items (string / number / boolean / bigint) expose BOTH the array root
@@ -2648,41 +2636,6 @@ export type PathSetValuePayload<Leaf> =
       : SetValuePayload<DefaultValuesShape<Leaf>, NonNullable<WriteShape<Leaf>>>
 
 /**
- * Focus / blur / touched / interacted flags for a registered field.
- *
- * - `focused` — `true` while the user is interacting with the field,
- *   `false` after blur. `null` while no DOM element is connected for
- *   this path (the DOM-state concept doesn't apply with no element).
- * - `blurred` — strictly the inverse of `focused` when an element is
- *   connected: `true` while not focused, `false` while focused. `null`
- *   while no element is connected.
- * - `touched` — focus/blur history. Plain `boolean`: `false` at
- *   registration, flips to `true` on the first blur, stays `true`
- *   thereafter, and is preserved across disconnects. Cleared only by
- *   `form.reset()` / `form.resetField(path)`.
- * - `interacted` — value-mutation history. Plain `boolean`: `false` at
- *   registration, flips to `true` on the user's first value edit, stays
- *   `true` thereafter. Set only by user input (never hydration or
- *   programmatic writes); cleared with `touched`. Together they support
- *   "show feedback only after the user has actually engaged" UX.
- * - `blurredAfterInteraction` — the first blur that follows a value edit
- *   (edited, then left). Plain `boolean`, sticky. A tab-through with no
- *   edit never sets it. Composes `interacted` with the departure and
- *   drives the default display gate.
- */
-export type DOMFieldState = {
-  /** `true` while focused; `false` while connected but not focused; `null` while no element is connected. */
-  focused: boolean | null
-  /** Inverse of `focused` when connected; `null` while no element is connected. */
-  blurred: boolean | null
-  /** `true` after the first blur; persists across disconnects until `reset()`. */
-  touched: boolean
-  /** `true` after the user's first value edit; persists until `reset()`. */
-  interacted: boolean
-  /** `true` after the first blur that follows an edit; persists until `reset()`. */
-  blurredAfterInteraction: boolean
-}
-/**
  * Per-field reactive shape returned by `form.fields.<leaf-path>` and
  * `form.fields(path)`. Slim, readonly across the board. The unified
  * shape replaces the older split between `FieldState` /
@@ -3161,8 +3114,6 @@ export type FieldStateMap<Form extends GenericForm> = ([IsUnion<Form>] extends [
   (): FieldState<Form>
 }
 
-export type DOMFieldStateStore = Map<string, DOMFieldState | undefined>
-
 /**
  * Untyped error map keyed by dotted-string path. The same data
  * exposed by `form.errors`, but as a plain record — useful when
@@ -3170,7 +3121,6 @@ export type DOMFieldStateStore = Map<string, DOMFieldState | undefined>
  * type doesn't know about.
  */
 export type FormErrorRecord = Record<string, ValidationError[]>
-export type FormErrorStore = Map<FormKey, FormErrorRecord>
 
 /**
  * Type of `form.errors`. Leaf-aware drillable callable Proxy. At a

--- a/src/runtime/types/types-core.ts
+++ b/src/runtime/types/types-core.ts
@@ -47,29 +47,6 @@ export type PartialFlatPath<Form, Key extends keyof Form = keyof Form> =
         : never
     : never
 
-export type CompleteFlatPath<Form, Key extends keyof Form = keyof Form> =
-  IsObjectOrArray<Form> extends true
-    ? Key extends string
-      ? Form[Key] extends infer Value
-        ? Value extends Array<infer ArrayItem>
-          ? `${Key}.${number}.${CompleteFlatPath<ArrayItem>}`
-          : Value extends GenericForm
-            ? `${Key}.${CompleteFlatPath<Value>}`
-            : `${Key}`
-        : never
-      : Key extends number
-        ?
-            | `${Key}`
-            | (Form[Key] extends GenericForm
-                ? `${Key}.${CompleteFlatPath<Form[Key]>}`
-                : Form[Key] extends Array<infer ArrayItem>
-                  ? IsObjectOrArray<ArrayItem> extends true
-                    ? `${Key}.${number}.${CompleteFlatPath<ArrayItem>}`
-                    : `${Key}.${number}`
-                  : never)
-        : never
-    : never
-
 // FlatPath Generic Gotchas:
 //
 // 1. Typescript collapses paths like `something.${string}` | `something.${string}.deeper`
@@ -92,15 +69,8 @@ export type CompleteFlatPath<Form, Key extends keyof Form = keyof Form> =
  * Used by every path-addressed API (`setValue(path, value)`,
  * `register(path)`, `toRef(path)`, etc.) so paths autocomplete in
  * the IDE and typos compile-error.
- *
- * Set `ForceFullPath` to `true` to restrict to leaf paths only
- * (no intermediate container paths).
  */
-export type FlatPath<
-  Form,
-  Key extends keyof Form = keyof Form,
-  ForceFullPath extends boolean = false,
-> = ForceFullPath extends true ? CompleteFlatPath<Form, Key> : PartialFlatPath<Form, Key>
+export type FlatPath<Form, Key extends keyof Form = keyof Form> = PartialFlatPath<Form, Key>
 
 /**
  * Convert a tuple of path segments to its dotted-string equivalent.

--- a/test/core/wizard-history.test.ts
+++ b/test/core/wizard-history.test.ts
@@ -5,8 +5,8 @@ import { createWizardHistory } from '../../src/runtime/core/wizard-history'
 /**
  * `createWizardHistory(param)` encapsulates `window.history` for the
  * wizard. The primitive is the only DOM-touching module in the
- * wizard surface — it abstracts pushState / replaceState / popstate
- * behind a small handle, lets the wizard composable stay focused on
+ * wizard surface — it abstracts replaceState / popstate behind a
+ * small handle, lets the wizard composable stay focused on
  * navigation semantics, and stays SSR-safe by returning a no-op
  * handle when `window` is undefined.
  */
@@ -22,17 +22,7 @@ describe('createWizardHistory — primitive', () => {
     window.history.replaceState(null, '', ORIGINAL_URL)
   })
 
-  it('push(key) calls pushState and writes `?step=<key>`', () => {
-    const handle = createWizardHistory('step')
-    const pushSpy = vi.spyOn(window.history, 'pushState')
-    handle.push('cargo')
-    expect(pushSpy).toHaveBeenCalledTimes(1)
-    expect(new URL(window.location.href).searchParams.get('step')).toBe('cargo')
-    pushSpy.mockRestore()
-    handle.dispose()
-  })
-
-  it('replace(key) calls replaceState — no pushState', () => {
+  it('replace(key) calls replaceState and writes `?step=<key>`', () => {
     const handle = createWizardHistory('step')
     const pushSpy = vi.spyOn(window.history, 'pushState')
     const replaceSpy = vi.spyOn(window.history, 'replaceState')
@@ -48,7 +38,7 @@ describe('createWizardHistory — primitive', () => {
   it('read() returns the current step param value (or undefined)', () => {
     const handle = createWizardHistory('step')
     expect(handle.read()).toBeUndefined()
-    handle.push('reference')
+    handle.replace('reference')
     expect(handle.read()).toBe('reference')
     handle.dispose()
   })
@@ -57,8 +47,11 @@ describe('createWizardHistory — primitive', () => {
     const handle = createWizardHistory('step')
     const seen: Array<string | undefined> = []
     handle.subscribe((key) => seen.push(key))
-    handle.push('a')
-    handle.push('b')
+    // Two real pushState writes so `history.back()` has somewhere to go;
+    // the handle itself only ever replaces, but popstate behaviour is
+    // browser-driven and exercised through real navigation entries.
+    window.history.pushState({}, '', `${ORIGINAL_URL}?step=a`)
+    window.history.pushState({}, '', `${ORIGINAL_URL}?step=b`)
     window.history.back()
     await new Promise((resolve) => setTimeout(resolve, 20))
     expect(seen[seen.length - 1]).toBe('a')
@@ -69,7 +62,7 @@ describe('createWizardHistory — primitive', () => {
     const handle = createWizardHistory('step')
     const cb = vi.fn()
     handle.subscribe(cb)
-    handle.push('a')
+    handle.replace('a')
     handle.dispose()
     handle.dispose() // idempotent
     window.history.replaceState(null, '', ORIGINAL_URL + '?step=zzz')
@@ -81,7 +74,7 @@ describe('createWizardHistory — primitive', () => {
   it('preserves existing search params when writing the step param', () => {
     window.history.replaceState(null, '', `${ORIGINAL_URL}?ref=email&utm=launch`)
     const handle = createWizardHistory('step')
-    handle.push('cargo')
+    handle.replace('cargo')
     const url = new URL(window.location.href)
     expect(url.searchParams.get('step')).toBe('cargo')
     expect(url.searchParams.get('ref')).toBe('email')


### PR DESCRIPTION
Phase 2 of the audit-remediation plan ([plans/rustling-whistling-planet.md](../../../.claude/plans/rustling-whistling-planet.md)). Zero observable behavior change, zero public-entry-barrel diff. Concentrated cleanup that drops the tsc instantiation count and unblocks later phases.

## Findings cleared (12 commits, one per finding)

| # | Finding | Shape | Δ |
|---|---|---|---|
| 1 | **TYPES-dead** | Delete 8 dead types (FormSummary family, DOMFieldState family, MetaTracker family, FormErrorStore) | −50 LOC types-api.ts |
| 2 | **TYPES-D1** | Collapse `FlatPath` generic; delete `CompleteFlatPath` + `ForceFullPath` param (zero callers ever instantiated `FlatPath<_, _, true>`) | −30 LOC types-core.ts |
| 3 | **CORE-P2b** | Delete unused `markTouched` (the public `form.touch()` API uses `touchAtPath`) | −7 LOC create-form-store.ts |
| 4 | **CORE-P2c** | Import `isPathPrefix` from `paths.ts` (3 sibling files already do) | −15 LOC create-form-store.ts |
| 5 | **WH-DEAD-1** | Delete `WizardHistoryHandle.push` + `op` param + push-only tests (the wizard only ever calls `replace`) | −38 LOC wizard-history.ts + test |
| 6 | **PERSIST-DEAD-1** | Delete `resolveStorageKey` (the storage key is built inline at the `wirePersistence` call site) | −24 LOC persistence/index.ts |
| 7 | **PERSIST-DUP-1** | Extract `removeMatchingKeys(adapter, base, keepKey?)` from the 3 orphan-sweep functions; drop the duplicate docblock | −56 LOC ↔ +36 LOC persistence/index.ts |
| 8 | **ADAPT-X1** | Delete 3 unused v3-only types (`UnwrapZodSchemaToAccessTargetSchemaType`, `PossiblyWrappedZodSchema`, `GetValueReturnTypeFromZodSchema`) | −39 LOC v3/types-zod.ts |
| 9 | **ADAPT-X2** | Drop `export` on `PERMISSIVE_V3` (module-internal) | 0 LOC (visibility tweak) |
| 10 | **DIR-F3** | Relocate orphan docblock onto `logTransformAsync` (was floating above `applyCoerce`) | 0 LOC (text move) |
| 11 | **SF9** | Export `getFieldMetaList` from v3 + add `remove` to `FieldMetaRegistryV3` (the runtime already supports it; docblock already promised it) | +24 LOC v3/field-meta.ts |
| 12 | **SF10** | Correct false "thrown for recursive `z.lazy`" claim in `UnsupportedSchemaError` docblock on both adapters (neither throws — both return on second-encounter of the same getter) | +8 LOC errors.ts ×2 |

## API & behavior-change ledger

**None.** Per the plan: this phase ships **no observable behavior change** and **no public-API delta**.

`git diff main..HEAD -- src/index.ts src/zod.ts src/zod-v3.ts src/zod-v4.ts` is empty — the 4 public entry barrels are byte-identical. SF9's `getFieldMetaList` export is at the v3-adapter MODULE level only (not re-exported from `src/zod-v3.ts`), matching how v4's `field-meta.ts:96` already does. The internal types removed were not re-exported anywhere.

## tsc instantiation diff (before → after)

| Metric | Before | After | Δ |
|---|---:|---:|---:|
| Types | 498,332 | 496,803 | −1,529 |
| Instantiations | 2,125,343 | 2,120,916 | −4,427 |
| Memory | 1,338 MB | 1,322 MB | −16 MB |
| tsc time | 5.23s | 5.32s | noise |

Larger drops are landed in Phase 16 (TYPES-D2/D3/D4/D7 — public, inference-load-bearing); this phase is the warm-up.

## Verification

- `pnpm lint` ✓
- `pnpm typecheck` ✓
- `pnpm check:site` ✓
- `pnpm test` ✓ **3,160 tests** in 245 files (down 1 from Phase 1: the push-only wizard-history test was deleted; the remaining 5 specs cover all retained surface)
- `pnpm check:size` ✓ `index.mjs` 46.01 / 48 kB (~1.99 kB headroom)
- `pnpm check:bench` ✓ all scenarios within 3× floor
- `pnpm check:coverage` ✓ 91.4% line / 87.2% statement

## Notes for review

- **TYPES-dead**: DOMFieldState carried a docblock describing focus/blur/touched/interacted/blurredAfterInteraction. Its content for `interacted` and `blurredAfterInteraction` is already on the live `FieldState` (types-api.ts:2707-2731); the `touched`/`focused`/`blurred` inline docs were terser-but-equivalent. Net: minor information loss, judged worth it for killing the unmaintained duplicate (the recent display-state branch had to sync `FieldRecord` + `FieldState`; this third copy would have drifted next).
- **WH-DEAD-1**: The `subscribe(cb) fires the callback on popstate` test no longer goes through `handle.push` — it uses two real `window.history.pushState` calls so `history.back()` has somewhere to land. The handle itself never pushes; popstate dispatch is browser-driven and is the actual contract under test.
- **PERSIST-DUP-1**: `removeMatchingKeys` is kept module-private (no export); behavior preserved (per-key `removeItem` stays fire-and-forget with swallowed errors; failing `listKeys` returns silently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)