### PR TITLE
Phase 3: Pure perf wins on the keystroke hot path (CORE-P1b + CORE-P2a)

### DIFF
--- a/src/runtime/adapters/zod-v3/index.ts
+++ b/src/runtime/adapters/zod-v3/index.ts
@@ -116,6 +116,60 @@ export function zodAdapter<
     // Per-adapter cache for the preprocess predicate. The slim-primitive
     // write gate consults it at every level of value-tree descent.
     const preprocessOrCoerceCache = new Map<PathKey, boolean>()
+    // Per-adapter cache for `getUnionDiscriminatorAtPath`. The walker
+    // path is consulted on every `setValue` and every `form.meta` read
+    // (every ancestor segment, every time), and the result is a pure
+    // function of (schema, path) — once computed it never changes for
+    // the lifetime of the adapter. Caches both positive and negative
+    // (no-DU) results so the common no-DU schema pays the walk cost
+    // once per path instead of per keystroke.
+    const discriminatorCache = new Map<PathKey, UnionDiscriminatorContext | undefined>()
+
+    function computeDiscriminator(path: Path): UnionDiscriminatorContext | undefined {
+      const candidates =
+        path.length === 0
+          ? [_zodSchema as z.ZodTypeAny]
+          : (getNestedZodSchemasAtPath(_zodSchema, path) as z.ZodTypeAny[])
+      let matchedUnion: z.ZodTypeAny | undefined
+      for (const candidate of candidates) {
+        const peeled = peelV3Wrappers(candidate)
+        if (!isZodSchemaType(peeled, 'ZodDiscriminatedUnion')) continue
+        if (matchedUnion !== undefined && matchedUnion !== peeled) return undefined
+        matchedUnion = peeled
+      }
+      if (matchedUnion === undefined) return undefined
+      const discKey = (
+        matchedUnion as z.ZodDiscriminatedUnion<string, z.ZodDiscriminatedUnionOption<string>[]>
+      )._def.discriminator
+      const options = (
+        matchedUnion as z.ZodDiscriminatedUnion<string, z.ZodDiscriminatedUnionOption<string>[]>
+      )._def.options
+      const literalSet = new Set<unknown>()
+      for (const opt of options) {
+        const litSchema = opt.shape[discKey] as z.ZodTypeAny | undefined
+        if (!litSchema) continue
+        if (!isZodSchemaType(litSchema, 'ZodLiteral')) continue
+        literalSet.add(litSchema._def.value)
+      }
+      return {
+        discriminatorKey: discKey,
+        getVariantDefault(value: unknown): unknown {
+          for (const opt of options) {
+            const litSchema = opt.shape[discKey] as z.ZodTypeAny | undefined
+            if (!litSchema) continue
+            if (!isZodSchemaType(litSchema, 'ZodLiteral')) continue
+            if (litSchema._def.value === value) {
+              return getDefaultValuesFromZodSchema(opt as unknown as z.ZodSchema, true, _formKey)
+            }
+          }
+          return undefined
+        },
+        isVariantSelected(value: unknown): boolean {
+          return literalSet.has(value)
+        },
+      }
+    }
+
     const abstractSchema: AbstractSchema<Form, GetValueFormType> = {
       fingerprint: () => fingerprintZodSchema(_zodSchema),
       getDefaultValues(config) {
@@ -450,48 +504,13 @@ export function zodAdapter<
         // is (or wraps) a discriminated union. `peelV3Wrappers` peels
         // optional / nullable / default / effects / pipeline / readonly
         // / branded.
-        const candidates =
-          path.length === 0
-            ? [_zodSchema as z.ZodTypeAny]
-            : (getNestedZodSchemasAtPath(_zodSchema, path) as z.ZodTypeAny[])
-        let matchedUnion: z.ZodTypeAny | undefined
-        for (const candidate of candidates) {
-          const peeled = peelV3Wrappers(candidate)
-          if (!isZodSchemaType(peeled, 'ZodDiscriminatedUnion')) continue
-          if (matchedUnion !== undefined && matchedUnion !== peeled) return undefined
-          matchedUnion = peeled
+        const cacheKey = canonicalizePath(path).key
+        if (discriminatorCache.has(cacheKey)) {
+          return discriminatorCache.get(cacheKey)
         }
-        if (matchedUnion === undefined) return undefined
-        const discKey = (
-          matchedUnion as z.ZodDiscriminatedUnion<string, z.ZodDiscriminatedUnionOption<string>[]>
-        )._def.discriminator
-        const options = (
-          matchedUnion as z.ZodDiscriminatedUnion<string, z.ZodDiscriminatedUnionOption<string>[]>
-        )._def.options
-        const literalSet = new Set<unknown>()
-        for (const opt of options) {
-          const litSchema = opt.shape[discKey] as z.ZodTypeAny | undefined
-          if (!litSchema) continue
-          if (!isZodSchemaType(litSchema, 'ZodLiteral')) continue
-          literalSet.add(litSchema._def.value)
-        }
-        return {
-          discriminatorKey: discKey,
-          getVariantDefault(value: unknown): unknown {
-            for (const opt of options) {
-              const litSchema = opt.shape[discKey] as z.ZodTypeAny | undefined
-              if (!litSchema) continue
-              if (!isZodSchemaType(litSchema, 'ZodLiteral')) continue
-              if (litSchema._def.value === value) {
-                return getDefaultValuesFromZodSchema(opt as unknown as z.ZodSchema, true, _formKey)
-              }
-            }
-            return undefined
-          },
-          isVariantSelected(value: unknown): boolean {
-            return literalSet.has(value)
-          },
-        }
+        const result = computeDiscriminator(path)
+        discriminatorCache.set(cacheKey, result)
+        return result
       },
       getSlimPrimitiveTypesAtPath(path) {
         if (path.length === 0) return new Set(['object'])

--- a/src/runtime/adapters/zod-v4/adapter.ts
+++ b/src/runtime/adapters/zod-v4/adapter.ts
@@ -276,10 +276,61 @@ export function zodV4Adapter<
     // primitive write gate consults it at every level of value-tree
     // descent; the prefix walk is cheap but adds up across deep writes.
     const preprocessOrCoerceCache = new Map<PathKey, boolean>()
+    // Per-adapter cache for `getUnionDiscriminatorAtPath`. The walker
+    // path is consulted on every `setValue` and every `form.meta` read
+    // (every ancestor segment, every time), and the result is a pure
+    // function of (schema, path) — once computed it never changes for
+    // the lifetime of the adapter. Caches both positive and negative
+    // (no-DU) results so the common no-DU schema pays the walk cost
+    // once per path instead of per keystroke.
+    const discriminatorCache = new Map<PathKey, UnionDiscriminatorContext | undefined>()
     // Memoised one-shot walk; `needsAsyncValidation` is queried at
     // construction and possibly again from devtools, so a single tree
     // traversal earns its keep across the adapter's lifetime.
     let asyncValidationFlag: boolean | null = null
+
+    function computeDiscriminator(path: Path): UnionDiscriminatorContext | undefined {
+      const candidates =
+        path.length === 0
+          ? [rootSchema as z.ZodType]
+          : getNestedZodSchemasAtPath(rootSchema, path, maxRecursionDepth)
+      let matchedUnion: z.ZodType | undefined
+      for (const candidate of candidates) {
+        const du = unwrapToDiscriminatedUnion(candidate)
+        if (du === undefined) continue
+        if (matchedUnion !== undefined && matchedUnion !== du) return undefined
+        matchedUnion = du
+      }
+      if (matchedUnion === undefined) return undefined
+      const discKey = getDiscriminator(matchedUnion)
+      if (discKey === undefined) return undefined
+      const options = getDiscriminatedOptions(matchedUnion)
+      const literalSet = new Set<unknown>()
+      for (const opt of options) {
+        const shape = getObjectShape(opt)
+        const litSchema = shape[discKey]
+        if (litSchema === undefined) continue
+        if (kindOf(litSchema) !== 'literal') continue
+        for (const v of getLiteralValues(litSchema)) literalSet.add(v)
+      }
+      return {
+        discriminatorKey: discKey,
+        getVariantDefault(value: unknown): unknown {
+          for (const opt of options) {
+            const shape = getObjectShape(opt)
+            const litSchema = shape[discKey]
+            if (litSchema === undefined) continue
+            if (kindOf(litSchema) !== 'literal') continue
+            const literalValues = getLiteralValues(litSchema)
+            if (literalValues.includes(value)) return deriveDefault(opt, true, maxRecursionDepth)
+          }
+          return undefined
+        },
+        isVariantSelected(value: unknown): boolean {
+          return literalSet.has(value)
+        },
+      }
+    }
 
     return {
       fingerprint: () => fingerprintZodSchema(rootSchema),
@@ -548,46 +599,13 @@ export function zodV4Adapter<
         // `unwrapToDiscriminatedUnion`. Ambiguous resolutions (two
         // distinct DUs both reachable) bail — the runtime then falls
         // back to a plain write.
-        const candidates =
-          path.length === 0
-            ? [rootSchema as z.ZodType]
-            : getNestedZodSchemasAtPath(rootSchema, path, maxRecursionDepth)
-        let matchedUnion: z.ZodType | undefined
-        for (const candidate of candidates) {
-          const du = unwrapToDiscriminatedUnion(candidate)
-          if (du === undefined) continue
-          if (matchedUnion !== undefined && matchedUnion !== du) return undefined
-          matchedUnion = du
+        const cacheKey = canonicalizePath(path).key
+        if (discriminatorCache.has(cacheKey)) {
+          return discriminatorCache.get(cacheKey)
         }
-        if (matchedUnion === undefined) return undefined
-        const discKey = getDiscriminator(matchedUnion)
-        if (discKey === undefined) return undefined
-        const options = getDiscriminatedOptions(matchedUnion)
-        const literalSet = new Set<unknown>()
-        for (const opt of options) {
-          const shape = getObjectShape(opt)
-          const litSchema = shape[discKey]
-          if (litSchema === undefined) continue
-          if (kindOf(litSchema) !== 'literal') continue
-          for (const v of getLiteralValues(litSchema)) literalSet.add(v)
-        }
-        return {
-          discriminatorKey: discKey,
-          getVariantDefault(value: unknown): unknown {
-            for (const opt of options) {
-              const shape = getObjectShape(opt)
-              const litSchema = shape[discKey]
-              if (litSchema === undefined) continue
-              if (kindOf(litSchema) !== 'literal') continue
-              const literalValues = getLiteralValues(litSchema)
-              if (literalValues.includes(value)) return deriveDefault(opt, true, maxRecursionDepth)
-            }
-            return undefined
-          },
-          isVariantSelected(value: unknown): boolean {
-            return literalSet.has(value)
-          },
-        }
+        const result = computeDiscriminator(path)
+        discriminatorCache.set(cacheKey, result)
+        return result
       },
 
       validateAtPath(

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -485,6 +485,14 @@ export type FormStore<F extends GenericForm, G extends GenericForm = F> = {
    */
   pathHasAsyncValidation(path: Path): boolean
   /**
+   * Precomputed-key shortcut for `pathHasAsyncValidation`. The
+   * canonical key is required and must correspond to `segments`; the
+   * helper skips the `canonicalizePath` round-trip so descendant-walk
+   * loops (whose Map iteration already yields the canonical key) can
+   * read the async-gate verdict without a per-leaf canonicalize.
+   */
+  pathHasAsyncValidationByKey(key: PathKey, segments: Path): boolean
+  /**
    * Per-path counter of in-flight field-level validation runs.
    * `field.validating` on `FieldState` mirrors
    * `(fieldValidationCounts.get(key) ?? 0) > 0`.
@@ -648,6 +656,14 @@ export type FormStore<F extends GenericForm, G extends GenericForm = F> = {
    * isn't exposed to consumers.
    */
   isPristineAtPath(path: Path): boolean
+  /**
+   * Precomputed-key shortcut for `isPristineAtPath`. The canonical
+   * key is required and must correspond to `segments`; the helper
+   * skips the `canonicalizePath` round-trip so descendant-walk loops
+   * (whose Map iteration already yields the canonical key) can read
+   * the pristine verdict without a per-leaf canonicalize.
+   */
+  isPristineAtPathByKey(key: PathKey, segments: Path): boolean
   /**
    * Whether any tracked array under `path` has changed shape — a reorder,
    * insert, or removal — relative to its construction/reset baseline. The
@@ -1723,6 +1739,9 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
   const pathAsyncCache = new Map<PathKey, boolean>()
   function pathHasAsyncValidation(path: Path): boolean {
     const { key } = canonicalizePath(path)
+    return pathHasAsyncValidationByKey(key, path)
+  }
+  function pathHasAsyncValidationByKey(key: PathKey, segments: Path): boolean {
     const cached = pathAsyncCache.get(key)
     if (cached !== undefined) return cached
     // `getSchemasAtPath` returns every candidate sub-schema (DU
@@ -1731,7 +1750,7 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     // conservative and gate. Adapters that don't expose
     // `needsAsyncValidation` are treated as `false`, matching the
     // optional-method contract on AbstractSchema.
-    const candidates = schema.getSchemasAtPath(path)
+    const candidates = schema.getSchemasAtPath(segments)
     const hasAsync = candidates.some((sub) => sub.needsAsyncValidation?.() === true)
     pathAsyncCache.set(key, hasAsync)
     return hasAsync
@@ -3486,6 +3505,9 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
 
   function isPristineAtPath(path: Path): boolean {
     const { key, segments } = canonicalizePath(path)
+    return isPristineAtPathByKey(key, segments)
+  }
+  function isPristineAtPathByKey(key: PathKey, segments: Path): boolean {
     // Storage match is necessary but not sufficient: a primitive leaf
     // toggled between "displayed empty" (blank + slim default)
     // and "explicitly the slim default" carries the same storage value
@@ -3590,6 +3612,7 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     activeValidations,
     firstValidationDone,
     pathHasAsyncValidation,
+    pathHasAsyncValidationByKey,
     fieldValidationCounts,
 
     applyFormReplacement,
@@ -3619,6 +3642,7 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     markConnectedOptimistically,
 
     isPristineAtPath,
+    isPristineAtPathByKey,
     hasStructuralChangeUnder,
     getFieldRecord,
     getOriginalAtPath,

--- a/src/runtime/core/field-state-api.ts
+++ b/src/runtime/core/field-state-api.ts
@@ -259,13 +259,19 @@ export function buildContainerFieldStateBase<F extends GenericForm>(
   // shows up here and re-runs the computed.
   const formValue = state.form.value
   const value = state.getValueAtPath(segments)
-  const original = state.originals.get(canonicalizePath(segments).key)?.value
+  // `key` is the canonical key of `segments` (every caller derives it
+  // via `canonicalizePath` already); use it directly instead of
+  // re-canonicalizing on every read.
+  const original = state.originals.get(key)?.value
   // Enumerate active descendant leaves under the container path.
   // The `originals` Map tracks every leaf the form has ever seen;
   // filter via `isPathPrefix` for descendant-membership and via
   // `hasAtPath(formValue, leafSeg)` to keep only the active-variant
   // leaves (DU switches reshape `formValue` wholesale, so this is
-  // the live ground truth).
+  // the live ground truth). The Map's key IS the canonical key for
+  // its entry's segments (every `originals.set` writes via
+  // `canonicalizePath(...).key`), so destructure it off the
+  // iteration tuple rather than re-canonicalizing per leaf.
   let pristine = true
   let blank = true
   let dirty = false
@@ -278,13 +284,16 @@ export function buildContainerFieldStateBase<F extends GenericForm>(
   let validating = false
   let updatedAt: string | null = null
   let asyncPending = false
-  for (const [, entry] of state.originals) {
+  for (const [leafKey, entry] of state.originals) {
     if (!isPathPrefix(segments, entry.segments)) continue
     if (segments.length === entry.segments.length) continue // self isn't a descendant
     if (!hasAtPath(formValue, entry.segments)) continue
-    const leafKey = canonicalizePath(entry.segments).key
     const leafRecord = state.fields.get(leafKey)
-    if (!state.isPristineAtPath(entry.segments)) {
+    // The by-key variants of `isPristineAtPath` and
+    // `pathHasAsyncValidation` skip the canonicalize round-trip
+    // (`leafKey` IS the canonical key for `entry.segments`), keeping
+    // the per-leaf walk allocation-free on the meta hot path.
+    if (!state.isPristineAtPathByKey(leafKey, entry.segments)) {
       pristine = false
       dirty = true
     }
@@ -296,7 +305,7 @@ export function buildContainerFieldStateBase<F extends GenericForm>(
     if (leafRecord?.blurredAfterInteraction === true) blurredAfterInteraction = true
     if (leafRecord?.connected === true) connected = true
     if ((state.fieldValidationCounts.get(leafKey) ?? 0) > 0) validating = true
-    if (state.pathHasAsyncValidation(entry.segments)) asyncPending = true
+    if (state.pathHasAsyncValidationByKey(leafKey, entry.segments)) asyncPending = true
     const ts = leafRecord?.updatedAt
     if (ts !== undefined && ts !== null) {
       // ISO 8601 timestamps sort lexicographically; max-string is

--- a/test/adapters/discriminator-cache.test.ts
+++ b/test/adapters/discriminator-cache.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Perf gate for `AbstractSchema#getUnionDiscriminatorAtPath`.
+ *
+ * The hot writer path walks every ancestor segment on a `setValue`
+ * call and consults the discriminator lookup at each step. Without a
+ * cache, every keystroke re-walks the schema (an O(depth) tree
+ * descent) even on schemas that have no discriminated union anywhere.
+ *
+ * This file pins the cache:
+ *   - v4 perf gate: the second lookup for the same path does NOT
+ *     re-invoke `getNestedZodSchemasAtPath` (the heavy inner walker).
+ *   - v3 / v4 parity: the cache returns the same DU context object
+ *     across repeated lookups and surfaces the same result for both
+ *     adapters on the same schema shape.
+ */
+import { z as zV3 } from 'zod-v3'
+import { z as zV4 } from 'zod'
+import { describe, expect, it, vi } from 'vitest'
+import { zodAdapter as zodAdapterV3 } from '../../src/runtime/adapters/zod-v3'
+import { zodV4Adapter } from '../../src/runtime/adapters/zod-v4/adapter'
+import * as v4Walker from '../../src/runtime/adapters/zod-v4/path-walker'
+
+describe('getUnionDiscriminatorAtPath cache', () => {
+  it('v4: second lookup for the same path does not re-walk the schema', () => {
+    // A schema with no discriminated union anywhere — the hot real
+    // case the audit calls out (every ancestor walk on every
+    // keystroke pays the full walker cost).
+    const schema = zV4.object({
+      profile: zV4.object({
+        name: zV4.string(),
+        nested: zV4.object({
+          deep: zV4.string(),
+        }),
+      }),
+    })
+    const adapter = zodV4Adapter(schema)('test-form', { maxRecursionDepth: 8 })
+
+    // Prime: cold call. Records whatever incidental walks happen.
+    adapter.getUnionDiscriminatorAtPath(['profile', 'nested'])
+
+    const spy = vi.spyOn(v4Walker, 'getNestedZodSchemasAtPath')
+    // Warm: repeated calls for the same path must short-circuit to the cache.
+    for (let i = 0; i < 25; i++) {
+      adapter.getUnionDiscriminatorAtPath(['profile', 'nested'])
+    }
+    const calls = spy.mock.calls.length
+    spy.mockRestore()
+    expect(calls).toBe(0)
+  })
+
+  it('v4: cache returns undefined consistently on no-DU schemas at varied depths', () => {
+    const schema = zV4.object({
+      profile: zV4.object({
+        name: zV4.string(),
+        nested: zV4.object({ deep: zV4.string() }),
+      }),
+    })
+    const adapter = zodV4Adapter(schema)('test-form', { maxRecursionDepth: 8 })
+    expect(adapter.getUnionDiscriminatorAtPath([])).toBeUndefined()
+    expect(adapter.getUnionDiscriminatorAtPath(['profile'])).toBeUndefined()
+    expect(adapter.getUnionDiscriminatorAtPath(['profile', 'nested'])).toBeUndefined()
+    expect(adapter.getUnionDiscriminatorAtPath(['profile', 'nested', 'deep'])).toBeUndefined()
+    // Repeats land on the cache; same `undefined` returned.
+    expect(adapter.getUnionDiscriminatorAtPath(['profile', 'nested'])).toBeUndefined()
+  })
+
+  it('v4: cache surfaces the real DU context once a discriminated union is at the path', () => {
+    const schema = zV4.object({
+      notify: zV4.discriminatedUnion('channel', [
+        zV4.object({ channel: zV4.literal('email'), address: zV4.string() }),
+        zV4.object({ channel: zV4.literal('sms'), number: zV4.string() }),
+      ]),
+    })
+    const adapter = zodV4Adapter(schema)('test-form', { maxRecursionDepth: 8 })
+    const first = adapter.getUnionDiscriminatorAtPath(['notify'])
+    expect(first?.discriminatorKey).toBe('channel')
+    expect(first?.isVariantSelected('email')).toBe(true)
+    expect(first?.isVariantSelected('telegram')).toBe(false)
+    // Subsequent reads hit the cache; same identity-preserving result.
+    const second = adapter.getUnionDiscriminatorAtPath(['notify'])
+    expect(second).toBe(first)
+  })
+
+  it('v3: cache returns undefined consistently on no-DU schemas and the DU context otherwise', () => {
+    const noDU = zV3.object({
+      profile: zV3.object({ name: zV3.string() }),
+    })
+    const v3NoDU = zodAdapterV3(noDU)('test-form', { maxRecursionDepth: 8 })
+    expect(v3NoDU.getUnionDiscriminatorAtPath(['profile'])).toBeUndefined()
+    expect(v3NoDU.getUnionDiscriminatorAtPath(['profile'])).toBeUndefined()
+
+    const withDU = zV3.object({
+      notify: zV3.discriminatedUnion('channel', [
+        zV3.object({ channel: zV3.literal('email'), address: zV3.string() }),
+        zV3.object({ channel: zV3.literal('sms'), number: zV3.string() }),
+      ]),
+    })
+    const v3WithDU = zodAdapterV3(withDU)('test-form', { maxRecursionDepth: 8 })
+    const first = v3WithDU.getUnionDiscriminatorAtPath(['notify'])
+    expect(first?.discriminatorKey).toBe('channel')
+    expect(first?.isVariantSelected('sms')).toBe(true)
+    expect(first?.isVariantSelected('mail-pigeon')).toBe(false)
+    const second = v3WithDU.getUnionDiscriminatorAtPath(['notify'])
+    expect(second).toBe(first)
+  })
+})

--- a/test/core/field-state-meta-leaf-walk.test.ts
+++ b/test/core/field-state-meta-leaf-walk.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Perf gate for `buildContainerFieldStateBase`'s descendant walk.
+ *
+ * The hot path runs once per `form.meta` read (and every container
+ * field-state read). It iterates `state.originals` to aggregate leaf
+ * dirty/blank/focused/blurred flags. Each iteration must NOT
+ * re-canonicalize the leaf path: the `originals` Map is keyed by the
+ * canonical key already, so the loop can destructure the key off the
+ * iteration tuple.
+ *
+ * Pre-fix this test fails because the loop calls `canonicalizePath`
+ * per leaf; post-fix it passes (constant calls regardless of N). Phase
+ * 3 of the audit-remediation plan owns this regression boundary.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { createFormStore } from '../../src/runtime/core/create-form-store'
+import { buildFieldStateAccessor } from '../../src/runtime/core/field-state-api'
+import * as paths from '../../src/runtime/core/paths'
+import { fakeSchema } from '../utils/fake-schema'
+
+function makeWideForm(leafCount: number) {
+  const defaults: Record<string, string> = {}
+  for (let i = 0; i < leafCount; i++) defaults[`f${i}`] = ''
+  const state = createFormStore<Record<string, string>>({
+    formKey: 'wide',
+    schema: fakeSchema<Record<string, string>>(defaults),
+  })
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  const getFormMetaBase = () => ({ submissionAttempts: 0 }) as never
+  return {
+    state,
+    getFieldState: buildFieldStateAccessor(state, 'wide-instance', getFormMetaBase),
+  }
+}
+
+describe('buildContainerFieldStateBase — leaf-walk canonicalize budget', () => {
+  it('does not re-canonicalize per leaf when reading the root container state on a 500-leaf form', () => {
+    const LEAVES = 500
+    const { state, getFieldState } = makeWideForm(LEAVES)
+    // Prime the accessor so the first canonicalizePath call (on the
+    // input `[]`) is not counted against the leaf-walk budget.
+    const rootState = getFieldState([])
+    // Touch root once to materialize the computed before spying.
+    void rootState.value.dirty
+
+    // Trigger a single-leaf mutation so the loop has something to aggregate.
+    state.setValueAtPath(['f0'], 'x')
+
+    const spy = vi.spyOn(paths, 'canonicalizePath')
+    void rootState.value.dirty
+    const calls = spy.mock.calls.length
+    spy.mockRestore()
+
+    // The leaf walk visits LEAVES entries; before CORE-P1b each leaf
+    // re-canonicalizes its segments. The fixed loop reads the Map's
+    // own key. A handful of incidental canonicalizes elsewhere on the
+    // path is fine — the gate is that the count is decoupled from N.
+    // Set well below `LEAVES` so a regression that re-introduces a
+    // per-leaf canonicalize fails loudly. Picked at LEAVES/50 = 10 so
+    // the bound is decoupled from the leaf count by an order of
+    // magnitude; the post-fix observed count is 0 — every avoidable
+    // call removed.
+    expect(calls).toBeLessThan(LEAVES / 50)
+  })
+})


### PR DESCRIPTION
**Phase 3 of the audit-remediation plan** (`/Users/ozzy/.claude/plans/rustling-whistling-planet.md`).
Two pure-internal perf wins on the keystroke + meta read hot paths. Behavior-neutral; no
public API delta.

## Findings closed

| Audit ID | Commit | Win |
|---|---|---|
| CORE-P1b | `83c6af4` | Container leaf walk no longer canonicalizes per leaf — 0 avoidable calls (was N+) on a 500-leaf `form.meta` read |
| CORE-P2a | `f566c1a` | `getUnionDiscriminatorAtPath` cached per canonical path; cross-branch DU writes +11% throughput in `pnpm bench` |

### CORE-P1b — `83c6af4`

`buildContainerFieldStateBase` iterated `state.originals` and re-canonicalized
`entry.segments` per leaf even though the Map's own key IS the canonical key. Destructure
`leafKey` off the iteration tuple. The container-path original lookup at the head of the
function had the same redundancy (re-canonicalizing `segments` even though the caller
already supplied `key`) — reuse the parameter.

The descendant walk also routed through `state.isPristineAtPath` and
`state.pathHasAsyncValidation`, each of which canonicalizes internally. Added two
internal-only `*ByKey` shortcuts on the `FormStore` interface that accept the precomputed
key + segments and skip the round-trip. `FormStore` isn't exported from any public barrel,
so this is an internal-API addition only.

### CORE-P2a — `f566c1a`

Both adapters' `getUnionDiscriminatorAtPath` were uncached O(depth) schema walks. The hot
writer path calls them per ancestor segment of every `setValue`
(`create-form-store.ts:1981`/`2028`/`2062`) and the meta read does the same per leaf — so
a 100-keystroke session against a non-DU schema did ~500 redundant schema walks for
nothing.

Added a per-adapter `Map<PathKey, UnionDiscriminatorContext | undefined>` keyed by
canonical path. Caches both positive (DU found) and negative (no-DU) results; lifetime
equals the adapter, and the entry never goes stale because `(schema, path) → result` is
pure. Hoists the per-call schema-walking logic into a closure-local `computeDiscriminator`
on each adapter; v3 and v4 stay structurally parallel.

## Verification

**Red-green gates** (both run red against pre-fix code, green after):

- `test/core/field-state-meta-leaf-walk.test.ts` — spies `canonicalizePath`, reads
  `form.meta.dirty` on a 500-leaf form, asserts `calls < LEAVES/50 = 10`. Pre-fix: 1,502
  calls. Post-fix: 0 avoidable calls. Hits the plan's verification target verbatim.
- `test/adapters/discriminator-cache.test.ts` —
  - v4 spy gate: 25 repeated `getUnionDiscriminatorAtPath` lookups → 0 inner
    `getNestedZodSchemasAtPath` invocations (was 1 per call).
  - v3 / v4 identity preservation: returned context object is `===` across repeated
    lookups (proves the cache is engaged).
  - Both adapters: cache produces the same observable result the pre-cache code did.

**Full gate** (all green):

| | Result |
|---|---|
| `pnpm lint` | ✓ |
| `pnpm typecheck` | ✓ — types 497,894 (+1,091 from internal helper types), instantiations 2,125,502, memory 1.32 GB |
| `pnpm check:site` | ✓ |
| `pnpm test` | ✓ 3,148 passed + 17 skipped (+5 net new tests this phase) |
| `pnpm check:size` | ✓ `index.mjs` 46.05/48 kB; all entries under budget |
| `pnpm check:bench` | ✓ All ratios well above the 3× floor; keystroke 5.45× / 10.55× headroom |
| `pnpm check:coverage` | ✓ 91.4% line / 87.2% statement (unchanged) |

### Bench delta (pre → post)

| Scenario | hz before | hz after | Δ |
|---|---|---|---|
| DU cross-branch flip ×1000 | 51,321 | 56,989 | **+11.0%** |
| DU single-field assignment (active branch) | 64,164 | 65,809 | +2.6% |
| keystroke 500-leaf (new writer) | 36,494 | 36,636 | +0.4% |
| field-validation per keystroke | 63,705 | 62,412 | −2.0% (within noise) |

The headline win is the DU cross-branch flip path because that case exercises
`getUnionDiscriminatorAtPath` at every ancestor of the write target. The 500-leaf
keystroke bench is flat because it sets one leaf on a non-DU schema; the CORE-P1b
optimization mostly helps `form.meta` reads (per-keystroke aggregation), and 500-leaf
keystroke timing is dominated by the diff/apply pipeline, not the meta read.

## API & behavior-change ledger

**None.** Public-surface diff:

```
git diff main..HEAD -- src/index.ts src/zod.ts src/zod-v3.ts src/zod-v4.ts
(empty)
```

Internal-only additions: `FormStore.isPristineAtPathByKey`,
`FormStore.pathHasAsyncValidationByKey` (both consumed only by `field-state-api.ts`);
per-adapter `discriminatorCache` Map + closure-local `computeDiscriminator` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)