### PR TITLE
fix: blank-mark & array-state correctness (Phase 5 — PASS2-1/6/7/8/9/S1)

### DIFF
--- a/src/runtime/composables/use-abstract-form.ts
+++ b/src/runtime/composables/use-abstract-form.ts
@@ -45,7 +45,7 @@ import { createIsSensitivePath } from '../core/persistence/sensitive-names'
 import { hashStableString } from '../core/hash'
 import { createMultiTabSyncModule, MULTI_TAB_SYNC_MODULE_KEY } from '../core/multi-tab-sync'
 import { isSecureContext, warnOnceInsecureContext } from '../core/insecure-context-warn'
-import { canonicalizePath, coerceToPathKey, type Path, type PathKey } from '../core/paths'
+import { canonicalizePath, type Path, type PathKey } from '../core/paths'
 import { deleteAtPath, getAtPath, setAtPath, isPlainRecord } from '../core/path-walker'
 import { ensureAttaformInstalled } from '../core/plugin'
 import { kFormContext, kFormInstanceId, useRegistry, type AttaformRegistry } from '../core/registry'
@@ -1168,14 +1168,12 @@ function wirePersistence<F extends GenericForm>(
         state.originalBlankPaths.delete(k)
       }
       for (const k of payload.data.blankPaths ?? []) {
-        // Persisted blankPaths land on disk in dotted-string form (see
-        // `buildPersistedPayload`'s `pathKeyToDotted` conversion).
-        // `coerceToPathKey` normalises back to the internal PathKey so
-        // every lookup (`.has(canonical)`, dirty diff, persistence
-        // filter) keys on a single representation.
-        const key = coerceToPathKey(k)
-        state.blankPaths.add(key)
-        state.originalBlankPaths.add(key)
+        // v=6 stores blankPaths in the canonical `PathKey` JSON shape,
+        // matching the in-memory representation. No conversion needed
+        // at the I/O boundary — see the v=6 docblock on
+        // `PERSISTED_ENVELOPE_VERSION`.
+        state.blankPaths.add(k)
+        state.originalBlankPaths.add(k)
       }
       if (include === 'form+errors') {
         // Each store rebuilds independently from its persisted entries.

--- a/src/runtime/core/array-identity.ts
+++ b/src/runtime/core/array-identity.ts
@@ -1,6 +1,7 @@
 import type { WriteMeta } from '../types/types-api'
+import type { IndexRemap } from './array-state-migrate'
 import { canonicalizePath, isPathPrefix, segmentsForPathKey } from './paths'
-import type { Path, PathKey } from './paths'
+import type { Path, PathKey, Segment } from './paths'
 
 type ArrayOp = NonNullable<WriteMeta['arrayOp']>
 
@@ -31,6 +32,17 @@ export type ArrayIdentity = {
   tokenAt(arraySegs: Path, index: number): string
   /** Replay a structural mutation's exact permutation onto the token list. */
   applyOp(arraySegs: Path, op: ArrayOp): void
+  /**
+   * Relocate every tracked array entry sitting under `arrayPath`'s nested
+   * elements along `remap`. Mirrors the path-keyed Map / Set migrations in
+   * `array-state-migrate.ts` so a nested-array's own identity tokens follow
+   * its parent row across an outer-array structural mutation. Without this,
+   * the inner `tokens` / `baselines` entries at `items.<old>.…` would either
+   * leak (the source slot is gone but its entry survives) or collide (the
+   * new occupant at the source slot reads stale tokens belonging to the
+   * departed row).
+   */
+  applyRemap(arrayPath: Path, remap: IndexRemap): void
   /** Realign a tracked array's tokens to its current length by position. */
   realign(arraySegs: Path): void
   /**
@@ -128,6 +140,40 @@ export function createArrayIdentity(getArrayLength: (arraySegs: Path) => number)
           ids[op.index] = allocate()
           return
       }
+    },
+
+    applyRemap(arrayPath, remap) {
+      if (remap.moved.size === 0 && remap.vacated.size === 0 && remap.fresh.size === 0) return
+      // Snapshot then mutate, mirroring `migrateMapSubtree`: a destination
+      // write can't clobber a not-yet-snapshotted source. Walk both maps the
+      // same way; the index segment to rewrite sits at depth `arrayPath.length`.
+      const relocate = (store: Map<PathKey, string[]>): void => {
+        const idxPos = arrayPath.length
+        const snapshots: Array<{ segments: Segment[]; index: number; value: string[] }> = []
+        for (const [key, value] of store) {
+          const segments = segmentsForPathKey(key)
+          if (segments === null) continue
+          if (!isPathPrefix(arrayPath, segments)) continue
+          if (segments.length <= idxPos) continue
+          const idxSeg = segments[idxPos]
+          if (typeof idxSeg !== 'number') continue
+          if (!remap.moved.has(idxSeg) && !remap.vacated.has(idxSeg) && !remap.fresh.has(idxSeg)) {
+            continue
+          }
+          snapshots.push({ segments: [...segments], index: idxSeg, value })
+        }
+        if (snapshots.length === 0) return
+        for (const snap of snapshots) store.delete(canonicalizePath(snap.segments).key)
+        for (const snap of snapshots) {
+          const target = remap.moved.get(snap.index)
+          if (target === undefined) continue // vacated / replaced — already source-deleted; drop
+          const relocated = snap.segments.slice()
+          relocated[idxPos] = target
+          store.set(canonicalizePath(relocated).key, snap.value)
+        }
+      }
+      relocate(tokens)
+      relocate(baselines)
     },
 
     realign(arraySegs) {

--- a/src/runtime/core/build-form-api.ts
+++ b/src/runtime/core/build-form-api.ts
@@ -46,7 +46,7 @@ import { PERSISTENCE_MODULE_KEY, type PersistenceModule } from './persistence'
 import { allowSensitivePersist } from './persistence/sensitive-names'
 import { applyInvalidSubmitPolicy, buildProcessForm } from './process-form'
 import { buildRegister } from './register-api'
-import { isUnset } from './unset'
+import { isUnset, unset } from './unset'
 import {
   blankForKind,
   expandUnsetAt,
@@ -225,23 +225,28 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
       // Whole-form `unset` sentinels (consumer wrote `setValue(unset)`
       // or returned `unset` for some leaf in a function form) flow
       // through the walker — every leaf gets translated, the cleaned
-      // value lands in storage, and the discovered paths are added to
-      // `blankPaths` via direct setValueAtPath calls (the
-      // gate hook handles the bookkeeping).
+      // value lands in storage, and the discovered paths land blank-
+      // marks via same-value `{ blank: true }` writes that hit the
+      // identity short-circuit (bookkeeping-only, no extra history
+      // delta). Order matters: the root write FIRST so the
+      // descendant-sweep in the gate hook doesn't reap the marks we're
+      // about to set. Matching pattern in `writeUnsetAt` below.
       const walked = walkUnsetSentinels(
         next,
         state.schema as unknown as Parameters<typeof walkUnsetSentinels>[1]
       )
-      // Pre-add descendant blank marks to `state.blankPaths` so the
-      // upcoming root write's `applyFormReplacement` captures them in
-      // a single history delta alongside the storage change. The
-      // root-level write itself never marks `[]` (no leaf at root),
-      // so `{blank: true}` is not passed. See `writeUnsetAt` for the
-      // matching mark-routing rationale.
+      const ok = state.setValueAtPath([], walked.cleanedValues, withInstanceMeta())
+      if (!ok) return false
       for (const pathKey of walked.paths) {
-        state.blankPaths.add(pathKey)
+        const blankSegments = segmentsForPathKey(pathKey)
+        if (blankSegments === null) continue
+        state.setValueAtPath(
+          blankSegments,
+          state.getValueAtPath(blankSegments),
+          withInstanceMeta({ blank: true })
+        )
       }
-      return state.setValueAtPath([], walked.cleanedValues, withInstanceMeta())
+      return true
     }
     const segments = canonicalizePath(pathOrValue as string | Path).segments
     // `unset` at a specific path — direct or returned by the path-form
@@ -730,15 +735,23 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
   }
 
   // --- Clear ---
-  // `clear()` wipes the whole form to per-leaf falsy concrete; `clear(path)`
-  // wipes a sub-tree. The `pathInput === undefined` check is what
-  // distinguishes "no arg" (whole-form) from explicit `clear('')`
-  // (the empty-string path slot); canonicalizePath preserves the
-  // distinction (`''` → `['']` segments, undefined never reaches it).
-  // Mirrors `touch`'s arg handling.
+  // `clear()` and `clear(path)` are sugar over `setValue(unset)` /
+  // `setValue(path, unset)` — same storage (the schema's slim default
+  // at every reached primitive leaf, with `.default()` / `.catch()`
+  // wrappers skipped) AND the matching blank-marks so the verbs settle
+  // on identical observable state. The PASS2-S1 alignment closed a
+  // gap where `clear()` silently silenced required-validation by
+  // writing the slim default without the blank-mark (a required
+  // `z.string()` cleared via `clear` quietly passed submit with `''`).
+  // The `pathInput === undefined` check distinguishes "no arg" (whole-
+  // form) from explicit `clear('')` (the empty-string path slot);
+  // canonicalizePath preserves the distinction. Mirrors `touch`'s arg
+  // handling.
   function clear(pathInput?: string | readonly (string | number)[]): boolean {
-    const segments = pathInput === undefined ? ROOT_PATH : canonicalizePath(pathInput).segments
-    return state.clear(segments)
+    if (pathInput === undefined) {
+      return setValueImpl(unset)
+    }
+    return setValueImpl(pathInput as string | Path, unset)
   }
 
   // --- Persistence (imperative APIs) ---

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -2104,16 +2104,31 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
 
     // Blank bookkeeping. `blank: true` adds the path
     // to the set (the call site declares "this write represents an
-    // empty intent"); any other write removes it (the user typed a
-    // real value or programmatically reassigned). The mark/unmark sit
-    // BEFORE the identity short-circuit so transitions that don't
-    // change storage value (e.g. typing 0 over slim-default 0) still
-    // update the visual / blank state correctly.
+    // empty intent"); any other write removes the exact key. A
+    // container write also drops every descendant blank-mark under
+    // `path` (mirrors the DU-reshape path's `isPathKeyUnder` sweep) —
+    // a write to `addr` replaces every leaf beneath, so any prior
+    // "I'm blank" mark at `addr.zip` is now stale. The arrayOp branch
+    // skips the descendant sweep because `migrateArrayElementState`
+    // relocates per-element blank-marks across the operation's exact
+    // permutation downstream; sweeping ahead of it would delete the
+    // marks the migration needs to carry forward. The mark/unmark
+    // sit BEFORE the identity short-circuit so transitions that
+    // don't change storage value (e.g. typing 0 over slim-default 0)
+    // still update the visual / blank state correctly.
     const pathKey = canonicalizePath(path).key
     if (meta?.blank === true) {
       blankPaths.add(pathKey)
-    } else if (blankPaths.has(pathKey)) {
-      blankPaths.delete(pathKey)
+    } else {
+      if (blankPaths.has(pathKey)) blankPaths.delete(pathKey)
+      if (meta?.arrayOp === undefined) {
+        // Container write at `path` (or root `[]`) — sweep descendants.
+        // `isPathKeyUnder` returns true at root for every non-empty key,
+        // so a root write correctly drops all marks.
+        for (const existingKey of [...blankPaths]) {
+          if (isPathKeyUnder(existingKey, path)) blankPaths.delete(existingKey)
+        }
+      }
     }
 
     // Authored bookkeeping: a setValue is the consumer authoring `path`

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -1540,6 +1540,12 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     }))
     migrateSetSubtree(blankPaths, arrayPath, remap)
     migrateSetSubtree(originalBlankPaths, arrayPath, remap)
+    // In-flight field-validation counter (`field.validating` mirror).
+    // Same identity reasoning as the other path-keyed maps: the spinner
+    // belongs to the validating element, not the slot. Self-heals on the
+    // next validation pass; this migration just spares the wrong-row
+    // visible flicker in between.
+    migrateMapSubtree(fieldValidationCounts, arrayPath, remap, (count) => count)
     // Nested-array identity: relocate every tracked array sitting under
     // `arrayPath`'s element slots so a nested `v-for :key` stays stable
     // across an outer-array mutation (no token leak, no collision on the

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -1540,6 +1540,11 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     }))
     migrateSetSubtree(blankPaths, arrayPath, remap)
     migrateSetSubtree(originalBlankPaths, arrayPath, remap)
+    // Nested-array identity: relocate every tracked array sitting under
+    // `arrayPath`'s element slots so a nested `v-for :key` stays stable
+    // across an outer-array mutation (no token leak, no collision on the
+    // new occupant of a vacated slot).
+    arrayIdentity.applyRemap(arrayPath, remap)
   }
 
   // Register a freshly created element (an insert slot, a replace-at target)

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -548,17 +548,9 @@ export type FormStore<F extends GenericForm, G extends GenericForm = F> = {
    */
   arrayElementKey(path: Path): string
 
-  // --- reset / clear ---
+  // --- reset ---
   reset(nextDefaultValues?: DeepPartial<WriteShape<F>>): void
   resetField(path: Path): void
-  /**
-   * Wipe `path` (or the whole form when `path === ''`) to the
-   * schema's "appropriate nullish value" — the underlying type's
-   * empty/falsy concrete, with `.default()` / `.catch()` wrappers
-   * INTENTIONALLY skipped. Sugar for
-   * `setValueAtPath(path, schema.getEmptyValueAtPath(path))`.
-   */
-  clear(path: Path): boolean
 
   // --- errors ---
   // Schema-driven writers. Used by the validation pipeline + handleSubmit.
@@ -3033,30 +3025,6 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     }
   }
 
-  // --- Clear ---
-
-  function clear(path: Path): boolean {
-    // `clear` is sugar over `setValueAtPath`: ask the adapter for the
-    // "appropriate nullish value" at this path (the underlying type's
-    // empty/falsy concrete, with `.default()` / `.catch()` wrappers
-    // intentionally skipped) and write it. No bookkeeping that
-    // `setValueAtPath` doesn't already do — variant memory, history,
-    // persistence, and listeners all see this as a regular write.
-    //
-    // `path` is segments (canonical form). An empty segment list
-    // (`[]`) targets the whole form; `['']` targets the empty-string
-    // slot (`form.errors('')` bucket / `form.touch('')` semantics
-    // from #184). The two are NOT interchangeable — special-casing
-    // either would create a maintenance footgun.
-    //
-    // The adapter may legitimately return `undefined` as the empty
-    // value (e.g. `z.string().optional()` — the wrapper's "absent"
-    // marker IS `undefined`). The slim-primitive write gate inside
-    // `setValueAtPath` decides whether that's an acceptable write at
-    // the path — we forward unconditionally and let it adjudicate.
-    return setValueAtPath(path, schema.getEmptyValueAtPath(path))
-  }
-
   // --- Rehydrate ---
   // Imperative re-fire of the captured function-form `defaultValues`
   // factory. Lives on the store so every consumer of the shared key
@@ -3637,7 +3605,6 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
 
     reset,
     resetField,
-    clear,
 
     setSchemaErrorsForPath,
     setAllSchemaErrors,

--- a/src/runtime/core/field-arrays.ts
+++ b/src/runtime/core/field-arrays.ts
@@ -80,12 +80,19 @@ export function buildFieldArrayApi<F extends GenericForm>(
     },
     insert(path, index, value) {
       const next = readArray(path)
-      // splice clamps `index` to `[0, length]`; negative values count from
-      // the end. We pass through untouched — Array semantics are the
-      // consumer's expected behaviour here.
-      next.splice(index, 0, value)
-      const clampedIndex = Math.max(0, Math.min(index, next.length))
-      return writeArray(path, next, { kind: 'insert', index: clampedIndex })
+      // Compute the actual insertion index using JS `splice` semantics
+      // BEFORE the splice runs — negative values count from the end against
+      // the PRE-splice length, positive values clamp to `[0, preLen]`. Then
+      // pass that same index to both `splice` and the recorded `arrayOp`,
+      // so downstream consumers (variant-memory eviction, identity-token
+      // applyOp, per-element migration) act on the slot the element
+      // actually landed in. Pre-fix the recorded `op.index` was clamped
+      // against POST-splice length, which for negative inputs yielded 0
+      // even when splice had placed the element later in the array.
+      const preLen = next.length
+      const insertIndex = index < 0 ? Math.max(0, preLen + index) : Math.min(index, preLen)
+      next.splice(insertIndex, 0, value)
+      return writeArray(path, next, { kind: 'insert', index: insertIndex })
     },
     remove(path, index) {
       const next = readArray(path)

--- a/src/runtime/core/persistence/index.ts
+++ b/src/runtime/core/persistence/index.ts
@@ -12,7 +12,6 @@ import { isPlainRecord, setAtPath, getAtPath } from '../path-walker'
 import {
   isDangerousSegment,
   isPathPrefix,
-  pathKeyToDotted,
   segmentsForPathKey,
   type Path,
   type PathKey,
@@ -123,15 +122,21 @@ export type PersistedPayload<Form> = {
     readonly schemaErrors?: ReadonlyArray<readonly [string, ValidationError[]]>
     readonly userErrors?: ReadonlyArray<readonly [string, ValidationError[]]>
     /**
-     * Dotted public paths that were in the form's `blankPaths` set at
-     * serialisation time. Optional — forms with no blank paths skip
-     * the field. Replayed into the reactive Set on the next mount so
-     * an accidental refresh preserves the user's "displayed empty"
-     * state across sessions. Introduced in envelope v=3; the on-disk
-     * shape switched from canonical `PathKey` JSON to dotted strings
-     * in v=5.
+     * Canonical `PathKey` JSON entries (`'["profile","bio"]'`) for the
+     * paths that were in the form's `blankPaths` set at serialisation
+     * time. Optional — forms with no blank paths skip the field.
+     * Replayed into the reactive Set on the next mount so an accidental
+     * refresh preserves the user's "displayed empty" state across
+     * sessions. Introduced in envelope v=3.
+     *
+     * The encoding restored the JSON-array shape at v=6 (after a v=5
+     * dotted-string detour) so literal-dot record keys
+     * (`record["foo.bar"]` vs `record.foo.bar`) and integer-looking
+     * record keys (`record["1"]` vs `record[1]`) survive the round-trip
+     * unambiguously — the PathKey carries segment kind, dotted
+     * notation does not.
      */
-    readonly blankPaths?: ReadonlyArray<string>
+    readonly blankPaths?: ReadonlyArray<PathKey>
   }
 }
 
@@ -154,8 +159,17 @@ export type PersistedPayload<Form> = {
  * strings (`'["profile","bio"]'`) to dotted public-path strings
  * (`'profile.bio'`), matching the path notation everywhere else in
  * the public API. v=4 payloads are dropped with a one-time dev-warn.
+ *
+ * v=6: `data.blankPaths` switched BACK to the canonical `PathKey` JSON
+ * shape (`'["profile","bio"]'`). The dotted notation collapses literal-
+ * dot record keys (`record["foo.bar"]` vs. `record.foo.bar`) and
+ * integer-looking record keys (`record["1"]` vs. `record[1]`) onto
+ * the same wire shape, silently flipping the blank-mark onto a sibling
+ * slot on hydrate. The JSON-array carries segment kind, so the
+ * distinction round-trips losslessly. v=5 payloads are dropped with a
+ * one-time dev-warn.
  */
-export const PERSISTED_ENVELOPE_VERSION = 5
+export const PERSISTED_ENVELOPE_VERSION = 6
 
 /**
  * `value` is expected to be a raw `PersistedPayload` (parsed JSON or
@@ -210,21 +224,17 @@ export function buildPersistedPayload<Form>(
   userErrors: ReadonlyMap<string, ValidationError[]>,
   blankPaths?: ReadonlySet<string>
 ): PersistedPayload<Form> {
-  // The blank list is part of the form's restorable UI
-  // state — its visibility doesn't depend on the `include` mode
-  // (which only governs whether errors come along for the ride).
-  // Skip the field when the set is empty so v=5 round-trips with
-  // unchanged minimal payload size for forms that never go empty.
-  // Convert PathKey → dotted at the I/O boundary so the on-disk
-  // shape matches the rest of the public path notation.
-  let transientList: ReadonlyArray<string> | undefined
+  // The blank list is part of the form's restorable UI state — its
+  // visibility doesn't depend on the `include` mode (which only governs
+  // whether errors come along for the ride). Skip the field when the
+  // set is empty so v=6 round-trips with unchanged minimal payload
+  // size for forms that never go empty. The PathKey JSON shape (a
+  // JSON-array string) goes through to disk verbatim so segment kind
+  // survives the round-trip — see [[PASS2-8]] and the v=6 docblock
+  // on `PERSISTED_ENVELOPE_VERSION`.
+  let transientList: ReadonlyArray<PathKey> | undefined
   if (blankPaths !== undefined && blankPaths.size > 0) {
-    const dotted: string[] = []
-    for (const key of blankPaths) {
-      const d = pathKeyToDotted(key as PathKey)
-      if (d !== null) dotted.push(d)
-    }
-    transientList = dotted.length > 0 ? dotted : undefined
+    transientList = [...blankPaths] as PathKey[]
   }
 
   if (include === 'form') {

--- a/test/composables/api-surface-contract.test.ts
+++ b/test/composables/api-surface-contract.test.ts
@@ -761,7 +761,7 @@ describe('multi-tab sync — BroadcastChannel', () => {
     expect(api.values.name).toBe('local-typed')
 
     // Wipe storage to a sentinel, then push a sibling-driven write.
-    const sentinel = JSON.stringify({ v: 5, data: { form: { name: 'sentinel' } } })
+    const sentinel = JSON.stringify({ v: 6, data: { form: { name: 'sentinel' } } })
     localStorage.setItem(persistKey, sentinel)
 
     const external = new BroadcastChannel(channelName)

--- a/test/composables/blank-persistence.test.ts
+++ b/test/composables/blank-persistence.test.ts
@@ -121,17 +121,17 @@ describe('persistence — blank round-trips across mount', () => {
     document.body.innerHTML = ''
   })
 
-  it('a v=5 payload with blankPaths restores the empty UI state on next mount', async () => {
-    // Pre-seed a v=5 payload that mirrors what the lib would have
+  it('a v=6 payload with blankPaths restores the empty UI state on next mount', async () => {
+    // Pre-seed a v=6 payload that mirrors what the lib would have
     // written on a previous session: storage holds the slim default
-    // (0) but the path is in `blankPaths` so the UI re-renders
-    // blank. On-disk blankPaths shape switched to dotted public
-    // paths at v=5.
+    // (0) but the path is in `blankPaths` so the UI re-renders blank.
+    // On-disk blankPaths shape returned to the canonical PathKey JSON
+    // form at v=6 (PASS2-8).
     localStorage.setItem(
       fpKey('te-rt'),
       JSON.stringify({
-        v: 5,
-        data: { form: { income: 0 }, blankPaths: ['income'] },
+        v: 6,
+        data: { form: { income: 0 }, blankPaths: ['["income"]'] },
       })
     )
 
@@ -225,27 +225,29 @@ describe('persistence — blank round-trips across mount', () => {
 
     // Poll until the post-clear write lands the blankPaths entry —
     // the 10ms debounce + adapter.setItem can outlast a fixed pump.
+    // v=6 writes the canonical PathKey JSON form (`'["income"]'`),
+    // matching the in-memory representation.
     const raw = await waitUntil(() => {
       const r = localStorage.getItem(fpKey('te-write'))
       if (r === null) return null
       const p = JSON.parse(r) as { data?: { blankPaths?: string[] } }
-      return p.data?.blankPaths?.includes('income') === true ? r : null
+      return p.data?.blankPaths?.includes('["income"]') === true ? r : null
     })
     expect(raw).not.toBeNull()
     const payload = JSON.parse(raw as string)
-    expect(payload.v).toBe(5)
-    expect(payload.data.blankPaths).toContain('income')
+    expect(payload.v).toBe(6)
+    expect(payload.data.blankPaths).toContain('["income"]')
   })
 
   it('hydration overrides construction-time auto-mark — persisted empty list wins', async () => {
     // The form has no defaultValues, so construction-time auto-mark
-    // would mark `income`. But a v=3 payload pre-seeded with an EMPTY
+    // would mark `income`. But a v=6 payload pre-seeded with an EMPTY
     // `blankPaths` list (representing "user previously filled
     // this in") must override — the hydrated set is the truth.
     localStorage.setItem(
       fpKey('te-hyd'),
       JSON.stringify({
-        v: 5,
+        v: 6,
         data: { form: { income: 100 }, blankPaths: [] },
       })
     )

--- a/test/composables/clear-blank-alignment.test.ts
+++ b/test/composables/clear-blank-alignment.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+/**
+ * PASS2-S1 — `form.clear(path)` aligns with `form.setValue(path, unset)`.
+ * Pre-fix `clear` wrote the slim primitive (`''` / `0` / `false`) but
+ * did NOT mark the path blank, so:
+ *
+ *   - `displayValue` rendered the slim default (`'0'` for numbers) even
+ *     though the consumer had asked for the field to be cleared.
+ *   - The synthesised "No value supplied" error never fired on submit;
+ *     a required `z.string()` cleared via `form.clear` silently passed
+ *     validation with `''`.
+ *
+ * The fix delegates `clear` to the same path as `setValue(unset)` so
+ * the two verbs settle on identical observable state: same storage,
+ * same blank-mark, same required-validation verdict.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { z as zV4 } from 'zod'
+import { z as zV3 } from 'zod-v3'
+import { useForm as useFormV4, unset as unsetV4 } from '../../src/zod-v4'
+import { useForm as useFormV3, unset as unsetV3 } from '../../src/zod-v3'
+import { AttaformErrorCode } from '../../src/runtime/core/error-codes'
+import { makeMounter } from '../utils/form-harness'
+
+const schemaV4 = zV4.object({
+  age: zV4.number(),
+  name: zV4.string(),
+  agreed: zV4.boolean(),
+})
+
+const schemaV3 = zV3.object({
+  age: zV3.number(),
+  name: zV3.string(),
+  agreed: zV3.boolean(),
+})
+
+const adapters = [
+  { name: 'v4', mount: makeMounter(useFormV4, schemaV4), unset: unsetV4 },
+  { name: 'v3', mount: makeMounter(useFormV3, schemaV3), unset: unsetV3 },
+] as const
+
+describe.each(adapters)('clear aligns with setValue(unset) — $name', ({ mount, unset }) => {
+  const apps: ReturnType<typeof mount>['app'][] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  function mountOne() {
+    const { api, app } = mount()
+    apps.push(app)
+    return api
+  }
+
+  it('clear("age") marks the path blank (z.number required)', () => {
+    const form = mountOne()
+    form.setValue('age', 42)
+    expect(form.blankPaths.value.has('age')).toBe(false)
+
+    form.clear('age')
+
+    expect(form.blankPaths.value.has('age')).toBe(true)
+    expect(form.values.age).toBe(0)
+  })
+
+  it('clear("name") marks the path blank (z.string required)', () => {
+    const form = mountOne()
+    form.setValue('name', 'ozzy')
+
+    form.clear('name')
+
+    expect(form.blankPaths.value.has('name')).toBe(true)
+    expect(form.values.name).toBe('')
+  })
+
+  it('clear("agreed") marks the path blank (z.boolean required)', () => {
+    const form = mountOne()
+    form.setValue('agreed', true)
+
+    form.clear('agreed')
+
+    expect(form.blankPaths.value.has('agreed')).toBe(true)
+    expect(form.values.agreed).toBe(false)
+  })
+
+  it('handleSubmit rejects with required-blank after clear() on a required leaf', async () => {
+    const form = mountOne()
+    form.setValue('age', 42)
+    form.setValue('name', 'ozzy')
+    form.setValue('agreed', true)
+
+    form.clear('age')
+
+    const onSubmit = vi.fn()
+    const onError = vi.fn()
+    await form.handleSubmit(onSubmit, onError)()
+
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(onError).toHaveBeenCalledTimes(1)
+    const errors = onError.mock.calls[0]?.[0] as Array<{ code: string; path: unknown[] }>
+    expect(
+      errors.some((e) => e.code === AttaformErrorCode.NoValueSupplied && e.path[0] === 'age')
+    ).toBe(true)
+  })
+
+  it('clear() converges to the same state as setValue(unset) for primitives', () => {
+    const formA = mountOne()
+    const formB = mountOne()
+
+    formA.setValue('age', 42)
+    formA.clear('age')
+
+    formB.setValue('age', 42)
+    formB.setValue('age', unset)
+
+    // Storage parity.
+    expect(formA.values.age).toBe(formB.values.age)
+    // Blank-mark parity.
+    expect(formA.blankPaths.value.has('age')).toBe(formB.blankPaths.value.has('age'))
+  })
+
+  it('whole-form clear() marks every required primitive blank', () => {
+    const form = mountOne()
+    form.setValue('age', 42)
+    form.setValue('name', 'ozzy')
+    form.setValue('agreed', true)
+
+    form.clear()
+
+    expect(form.blankPaths.value.has('age')).toBe(true)
+    expect(form.blankPaths.value.has('name')).toBe(true)
+    expect(form.blankPaths.value.has('agreed')).toBe(true)
+  })
+})

--- a/test/composables/du-variant-persistence.test.ts
+++ b/test/composables/du-variant-persistence.test.ts
@@ -282,7 +282,7 @@ describe('rememberVariants × persistence — refresh-survives contract', () => 
     localStorage.setItem(
       fpKey('seed'),
       JSON.stringify({
-        v: 5,
+        v: 6,
         data: { form: { notify: { channel: 'sms', number: 'pre-seeded' } } },
       })
     )

--- a/test/composables/library-hardening-probes.test.ts
+++ b/test/composables/library-hardening-probes.test.ts
@@ -4328,7 +4328,7 @@ describe('chaos — persistence: hydrate with invalid discriminator in stored pa
     localStorage.setItem(
       storageKey,
       JSON.stringify({
-        v: 5,
+        v: 6,
         data: {
           form: {
             name: 'Ada',
@@ -4371,7 +4371,7 @@ describe('chaos — persistence: hydrate with invalid discriminator in stored pa
     localStorage.setItem(
       storageKey,
       JSON.stringify({
-        v: 5,
+        v: 6,
         data: {
           form: {
             name: 'Ada',
@@ -4541,7 +4541,7 @@ describe('chaos — persistence: hydrate with invalid discriminator in stored pa
     localStorage.setItem(
       storageKey,
       JSON.stringify({
-        v: 5,
+        v: 6,
         data: {
           form: {
             name: 'Ada',
@@ -4909,7 +4909,7 @@ describe('chaos — persistence + history together', () => {
     localStorage.setItem(
       storageKey,
       JSON.stringify({
-        v: 5,
+        v: 6,
         data: {
           form: { name: 'persisted', notify: { channel: 'email', address: 'p@x.io' } },
         },
@@ -5553,7 +5553,7 @@ describe('chaos — server/client default-value divergence on a DU', () => {
     localStorage.setItem(
       storageKey,
       JSON.stringify({
-        v: 5,
+        v: 6,
         data: {
           form: { name: 'Persisted', notify: { channel: 'sms', number: '5551234' } },
         },
@@ -5621,7 +5621,7 @@ describe('chaos — multi-tab persistence via the storage event', () => {
 
     // Simulate: another tab wrote to the same key.
     const newPayload = JSON.stringify({
-      v: 5,
+      v: 6,
       data: { form: { name: 'tab-B', notify: { channel: 'email', address: 'b@c.io' } } },
     })
     localStorage.setItem(storageKey, newPayload)
@@ -5933,7 +5933,7 @@ describe('chaos — mount then immediately unmount during async hydration', () =
     localStorage.setItem(
       storageKey,
       JSON.stringify({
-        v: 5,
+        v: 6,
         data: { form: { name: 'p', notify: { channel: 'email', address: 'p@x.io' } } },
       })
     )

--- a/test/composables/persist-hydration-validate.test.ts
+++ b/test/composables/persist-hydration-validate.test.ts
@@ -152,7 +152,7 @@ describe('persistence hydration — validation runs against the rehydrated value
     // Pre-fix the refine never fired on hydration; the form looked valid.
     localStorage.setItem(
       `test-async-hydrate-strict:${ASYNC_FP}`,
-      JSON.stringify({ v: 5, data: { form: { email: 'taken@example.com' } } })
+      JSON.stringify({ v: 6, data: { form: { email: 'taken@example.com' } } })
     )
     const { app, api } = mountAsyncForm('test-async-hydrate-strict', true)
     apps.push(app)
@@ -170,7 +170,7 @@ describe('persistence hydration — validation runs against the rehydrated value
     // post-hydration revalidation is independent of `strict`.
     localStorage.setItem(
       `test-async-hydrate-lax:${ASYNC_FP}`,
-      JSON.stringify({ v: 5, data: { form: { email: 'taken@example.com' } } })
+      JSON.stringify({ v: 6, data: { form: { email: 'taken@example.com' } } })
     )
     const { app, api } = mountAsyncForm('test-async-hydrate-lax', false)
     apps.push(app)
@@ -187,7 +187,7 @@ describe('persistence hydration — validation runs against the rehydrated value
     // construction-time seed disagreed with the rehydrated value.
     localStorage.setItem(
       `test-sync-hydrate:${SYNC_FP}`,
-      JSON.stringify({ v: 5, data: { form: { email: 'not-an-email' } } })
+      JSON.stringify({ v: 6, data: { form: { email: 'not-an-email' } } })
     )
     const { app, api } = mountSyncForm('test-sync-hydrate')
     apps.push(app)
@@ -204,7 +204,7 @@ describe('persistence hydration — validation runs against the rehydrated value
     // carrying a stale "Invalid email" about the empty default.
     localStorage.setItem(
       `test-async-hydrate-valid:${ASYNC_FP}`,
-      JSON.stringify({ v: 5, data: { form: { email: 'fresh@example.com' } } })
+      JSON.stringify({ v: 6, data: { form: { email: 'fresh@example.com' } } })
     )
     const { app, api } = mountAsyncForm('test-async-hydrate-valid', true)
     apps.push(app)
@@ -221,7 +221,7 @@ describe('persistence hydration — validation runs against the rehydrated value
     // `validating` never flipped true.
     localStorage.setItem(
       `test-async-hydrate-flag:${ASYNC_FP}`,
-      JSON.stringify({ v: 5, data: { form: { email: 'taken@example.com' } } })
+      JSON.stringify({ v: 6, data: { form: { email: 'taken@example.com' } } })
     )
     const { app, api } = mountAsyncForm('test-async-hydrate-flag', true)
     apps.push(app)

--- a/test/composables/persistence.test.ts
+++ b/test/composables/persistence.test.ts
@@ -184,14 +184,14 @@ describe('persistence — localStorage backend', () => {
     const raw = await waitUntil(() => localStorage.getItem(fpKey('test-local')))
     expect(raw).not.toBeNull()
     const payload = JSON.parse(raw as string) as { v: number; data: { form: { email: string } } }
-    expect(payload.v).toBe(5)
+    expect(payload.v).toBe(6)
     expect(payload.data.form.email).toBe('alice@example.com')
   })
 
   it('hydrates from a persisted payload on mount', async () => {
     localStorage.setItem(
       fpKey('test-hydrate'),
-      JSON.stringify({ v: 5, data: { form: { email: 'seed@example.com', password: 'pw' } } })
+      JSON.stringify({ v: 6, data: { form: { email: 'seed@example.com', password: 'pw' } } })
     )
     const { app, api } = mountForm({ storage: 'local', key: 'test-hydrate', debounceMs: 20 })
     apps.push(app)
@@ -244,7 +244,7 @@ describe('persistence — localStorage backend', () => {
   it('clears the persisted entry on submit success', async () => {
     localStorage.setItem(
       fpKey('test-clear'),
-      JSON.stringify({ v: 5, data: { form: { email: 'pre@x.com', password: 'pw' } } })
+      JSON.stringify({ v: 6, data: { form: { email: 'pre@x.com', password: 'pw' } } })
     )
     const { app, api } = mountForm({ storage: 'local', key: 'test-clear', debounceMs: 20 })
     apps.push(app)
@@ -326,7 +326,7 @@ describe('persistence — non-opted-in blank paths survive hydration', () => {
     sessionStorage.setItem(
       customKey,
       JSON.stringify({
-        v: 5,
+        v: 6,
         data: { form: { email: 'seed@example.com' }, blankPaths: [] },
       })
     )
@@ -972,7 +972,7 @@ describe('persistence — form.persist / form.clearPersistedDraft', () => {
     // path's update — the other field's persisted value must survive.
     localStorage.setItem(
       fpKey('test-imp-merge'),
-      JSON.stringify({ v: 5, data: { form: { email: 'prev@x.com', password: 'prev-pw' } } })
+      JSON.stringify({ v: 6, data: { form: { email: 'prev@x.com', password: 'prev-pw' } } })
     )
     const handle: { api?: ApiReturn } = {}
     const App = defineComponent({
@@ -1007,7 +1007,7 @@ describe('persistence — form.persist / form.clearPersistedDraft', () => {
   it('form.clearPersistedDraft() wipes the entry; form.clearPersistedDraft(path) wipes only that subpath', async () => {
     localStorage.setItem(
       fpKey('test-clear-api'),
-      JSON.stringify({ v: 5, data: { form: { email: 'a@x.com', password: 'pw' } } })
+      JSON.stringify({ v: 6, data: { form: { email: 'a@x.com', password: 'pw' } } })
     )
     const handle: { api?: ApiReturn } = {}
     const App = defineComponent({
@@ -1156,7 +1156,7 @@ describe('persistence — reset wipes the persisted draft', () => {
     // hydrates from the seed, password falls back to schema default.
     localStorage.setItem(
       fpKey('test-sparse-hydrate'),
-      JSON.stringify({ v: 5, data: { form: { email: 'sparse-seed@x.com' } } })
+      JSON.stringify({ v: 6, data: { form: { email: 'sparse-seed@x.com' } } })
     )
     const { app, api } = mountForm({
       storage: 'local',
@@ -1301,7 +1301,7 @@ describe('persistence — reset wipes the persisted draft', () => {
     // 'email'. Storage should drop email but keep password.
     localStorage.setItem(
       fpKey('test-reset-field'),
-      JSON.stringify({ v: 5, data: { form: { email: 'seed@x.com', password: 'seed-pw' } } })
+      JSON.stringify({ v: 6, data: { form: { email: 'seed@x.com', password: 'seed-pw' } } })
     )
     const { app, api } = mountForm({
       storage: 'local',
@@ -1385,7 +1385,7 @@ describe('persistence — shorthand config', () => {
     const raw = await waitUntil(() => localStorage.getItem(expectedKey), 1000)
     expect(raw).not.toBeNull()
     const payload = JSON.parse(raw as string) as { v: number; data: { form: { email: string } } }
-    expect(payload.v).toBe(5)
+    expect(payload.v).toBe(6)
     expect(payload.data.form.email).toBe('shorthand@example.com')
   })
 
@@ -1488,7 +1488,7 @@ describe('persistence — cross-store cleanup at mount', () => {
     sessionStorage.setItem(key, JSON.stringify({ stale: 'data' }))
     // Current-fingerprint key in configured store stays (cleanup only
     // touches non-current-fingerprint orphans).
-    localStorage.setItem(fpKey(key), JSON.stringify({ v: 5, data: { form: { email: 'keep' } } }))
+    localStorage.setItem(fpKey(key), JSON.stringify({ v: 6, data: { form: { email: 'keep' } } }))
     expect(sessionStorage.getItem(key)).not.toBeNull()
     mountMinimal({ storage: 'local', key })
     // Cleanup is fire-and-forget; poll for the session entry to vanish.
@@ -1501,7 +1501,7 @@ describe('persistence — cross-store cleanup at mount', () => {
   it("configured 'session' wipes orphan entries from localStorage", async () => {
     const key = 'cleanup-shared-key-2'
     localStorage.setItem(key, JSON.stringify({ stale: 'data' }))
-    sessionStorage.setItem(fpKey(key), JSON.stringify({ v: 5, data: { form: { email: 'keep' } } }))
+    sessionStorage.setItem(fpKey(key), JSON.stringify({ v: 6, data: { form: { email: 'keep' } } }))
     mountMinimal({ storage: 'session', key })
     await waitUntil(() => (localStorage.getItem(key) === null ? true : null), 500)
     expect(localStorage.getItem(key)).toBeNull()
@@ -1585,11 +1585,11 @@ describe('persistence — cross-store cleanup at mount', () => {
     const expectedStorageKey = `attaform:${formKey}`
     localStorage.setItem(
       expectedStorageKey,
-      JSON.stringify({ v: 5, data: { form: { email: 'old@x.com' } } })
+      JSON.stringify({ v: 6, data: { form: { email: 'old@x.com' } } })
     )
     sessionStorage.setItem(
       expectedStorageKey,
-      JSON.stringify({ v: 5, data: { form: { email: 'older@x.com' } } })
+      JSON.stringify({ v: 6, data: { form: { email: 'older@x.com' } } })
     )
     expect(localStorage.getItem(expectedStorageKey)).not.toBeNull()
     expect(sessionStorage.getItem(expectedStorageKey)).not.toBeNull()
@@ -1652,7 +1652,7 @@ describe('persistence — fingerprint-keyed storage + orphan cleanup', () => {
 
   it('schema-A → schema-B: fingerprint differs → no rehydration', async () => {
     const stalePayload = JSON.stringify({
-      v: 5,
+      v: 6,
       data: { form: { email: 'stale@x.com', password: 'stale' } },
     })
     localStorage.setItem('fp-mismatch:OLD-FINGERPRINT', stalePayload)
@@ -1664,14 +1664,14 @@ describe('persistence — fingerprint-keyed storage + orphan cleanup', () => {
 
   it('orphan cleanup: stale-fingerprint entries wiped on mount of the same form', async () => {
     const stalePayload = JSON.stringify({
-      v: 5,
+      v: 6,
       data: { form: { email: 'stale@x.com', password: 'stale' } },
     })
     localStorage.setItem('fp-orphan:OLD-FP-1', stalePayload)
     localStorage.setItem('fp-orphan:OLD-FP-2', stalePayload)
     localStorage.setItem(
       fpKey('fp-orphan'),
-      JSON.stringify({ v: 5, data: { form: { email: 'live@x.com', password: 'live' } } })
+      JSON.stringify({ v: 6, data: { form: { email: 'live@x.com', password: 'live' } } })
     )
     const { app, api } = mountForm({ storage: 'local', key: 'fp-orphan', debounceMs: 20 })
     apps.push(app)
@@ -1690,7 +1690,7 @@ describe('persistence — fingerprint-keyed storage + orphan cleanup', () => {
   it('orphan cleanup: unfingerprinted keys (no `:` suffix) are wiped', async () => {
     localStorage.setItem(
       'fp-orphan-bare',
-      JSON.stringify({ v: 5, data: { form: { email: 'bare@x.com', password: 'pw' } } })
+      JSON.stringify({ v: 6, data: { form: { email: 'bare@x.com', password: 'pw' } } })
     )
     const { app } = mountForm({ storage: 'local', key: 'fp-orphan-bare', debounceMs: 20 })
     apps.push(app)
@@ -1701,7 +1701,7 @@ describe('persistence — fingerprint-keyed storage + orphan cleanup', () => {
   it('orphan cleanup uses exact-or-`:`-prefix match (no sibling-form collision)', async () => {
     localStorage.setItem(
       fpKey('my-form-2'),
-      JSON.stringify({ v: 5, data: { form: { email: 'sibling@x.com', password: 'pw' } } })
+      JSON.stringify({ v: 6, data: { form: { email: 'sibling@x.com', password: 'pw' } } })
     )
     const { app, api } = mountForm({ storage: 'local', key: 'my-form', debounceMs: 20 })
     apps.push(app)
@@ -1746,9 +1746,9 @@ describe('FormStorage.listKeys — per-backend', () => {
     __resetIndexedDbForTests()
     const { createIndexedDbAdapter } = await import('../../src/runtime/core/persistence/indexeddb')
     const adapter = createIndexedDbAdapter()
-    await adapter.setItem('idb-test:a', { v: 5, data: { form: { x: 1 } } })
-    await adapter.setItem('idb-test:b:fp', { v: 5, data: { form: { x: 2 } } })
-    await adapter.setItem('other:x', { v: 5, data: { form: {} } })
+    await adapter.setItem('idb-test:a', { v: 6, data: { form: { x: 1 } } })
+    await adapter.setItem('idb-test:b:fp', { v: 6, data: { form: { x: 2 } } })
+    await adapter.setItem('other:x', { v: 6, data: { form: {} } })
     const keys = await adapter.listKeys('idb-test:')
     expect(keys.sort()).toEqual(['idb-test:a', 'idb-test:b:fp'])
     __resetIndexedDbForTests()

--- a/test/composables/use-form-v3-forwarding.test.ts
+++ b/test/composables/use-form-v3-forwarding.test.ts
@@ -127,7 +127,7 @@ describe('v3 useForm forwards opt-in options to useAbstractForm', () => {
     const fp = hashStableString(fingerprintZodSchema(schema))
     expect(key).toBe(`attaform:v3-persist:${fp}`)
     expect(payload).toMatchObject({
-      v: 5,
+      v: 6,
       data: { form: { email: 'alice@example.com' } },
     })
   })

--- a/test/core/blank-mark-descendants.test.ts
+++ b/test/core/blank-mark-descendants.test.ts
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+/**
+ * PASS2-1 — `setValueAtPath` clears descendant blank-marks on a non-blank
+ * write. The pre-fix gate hook only consulted `blankPaths.has(pathKey)`
+ * for the EXACT key being written; a write to a container path (`addr`)
+ * left every descendant blank-mark (`addr.zip`) intact, even though the
+ * consumer just wrote a real value at that leaf. Effects rippled into:
+ *
+ *   1. `handleSubmit` false-rejects with a synthesised "No value supplied"
+ *      error at the descendant — the form is populated but submit fails.
+ *   2. `displayValue` at the descendant reads as empty — the input
+ *      visually clears even though storage holds the consumer's value.
+ *   3. `form.meta.errors` carries the stale required-blank entry.
+ *
+ * The fix mirrors the already-correct DU-reshape path at
+ * `create-form-store.ts:2346` (`isPathKeyUnder` sweep). Pinned across
+ * v3 + v4 and across the two consumer-facing entry shapes (path-form
+ * `setValue('addr', …)` and root-form `setValue({ addr: … })`).
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, type App } from 'vue'
+import { z as zV4 } from 'zod'
+import { z as zV3 } from 'zod-v3'
+import { useForm as useFormV4, unset as unsetV4 } from '../../src/zod-v4'
+import { useForm as useFormV3, unset as unsetV3 } from '../../src/zod-v3'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import { AttaformErrorCode } from '../../src/runtime/core/error-codes'
+
+const schemaV4 = zV4.object({
+  addr: zV4.object({
+    zip: zV4.number(),
+    city: zV4.string(),
+  }),
+})
+
+const schemaV3 = zV3.object({
+  addr: zV3.object({
+    zip: zV3.number(),
+    city: zV3.string(),
+  }),
+})
+
+const adapters = [
+  { name: 'v4', useForm: useFormV4, unset: unsetV4, schema: schemaV4 },
+  { name: 'v3', useForm: useFormV3, unset: unsetV3, schema: schemaV3 },
+] as const
+
+describe.each(adapters)(
+  'setValue clears descendant blank-marks — $name',
+  ({ useForm, unset, schema }) => {
+    const apps: App[] = []
+    afterEach(() => {
+      while (apps.length > 0) apps.pop()?.unmount()
+    })
+
+    type Api = ReturnType<typeof useForm<typeof schema>>
+
+    function mount(): Api {
+      let captured!: Api
+      const Probe = defineComponent({
+        setup() {
+          captured = useForm({
+            schema,
+            key: `blank-desc-${Math.random().toString(36).slice(2)}`,
+            strict: false,
+          }) as Api
+          return () => h('div')
+        },
+      })
+      const app = createApp(Probe).use(createAttaform())
+      const root = document.createElement('div')
+      document.body.appendChild(root)
+      app.mount(root)
+      apps.push(app)
+      return captured
+    }
+
+    it('path-form: setValue("addr", {zip:N}) clears the addr.zip blank-mark', () => {
+      const form = mount()
+      form.setValue('addr.zip', unset)
+      expect(form.blankPaths.value.has('addr.zip')).toBe(true)
+
+      form.setValue('addr', { zip: 12345, city: 'Boise' })
+      expect(form.blankPaths.value.has('addr.zip')).toBe(false)
+      expect(form.values.addr.zip).toBe(12345)
+    })
+
+    it('root-form: setValue({addr:{...}}) clears descendant blank-marks', () => {
+      const form = mount()
+      form.setValue('addr.zip', unset)
+      expect(form.blankPaths.value.has('addr.zip')).toBe(true)
+
+      form.setValue({ addr: { zip: 12345, city: 'Boise' } })
+      expect(form.blankPaths.value.has('addr.zip')).toBe(false)
+      expect(form.values.addr.zip).toBe(12345)
+    })
+
+    it('handleSubmit accepts after the container write — no false required-blank rejection', async () => {
+      const form = mount()
+      form.setValue('addr.zip', unset)
+      form.setValue('addr.city', 'placeholder')
+
+      // Sanity: with the blank-mark live, submit rejects on the descendant.
+      {
+        const onSubmit = vi.fn()
+        const onError = vi.fn()
+        await form.handleSubmit(onSubmit, onError)()
+        expect(onSubmit).not.toHaveBeenCalled()
+        expect(onError).toHaveBeenCalledTimes(1)
+        const errors = onError.mock.calls[0]?.[0] as Array<{ code: string; path: unknown[] }>
+        expect(
+          errors.some((e) => e.code === AttaformErrorCode.NoValueSupplied && e.path[1] === 'zip')
+        ).toBe(true)
+      }
+
+      // Container write supplies the real value; submit must now resolve.
+      form.setValue('addr', { zip: 12345, city: 'Boise' })
+
+      const onSubmit2 = vi.fn()
+      const onError2 = vi.fn()
+      await form.handleSubmit(onSubmit2, onError2)()
+      expect(onError2).not.toHaveBeenCalled()
+      expect(onSubmit2).toHaveBeenCalledTimes(1)
+    })
+
+    it('a descendant write with a non-blank meta also clears the mark (exact-key parity)', () => {
+      const form = mount()
+      form.setValue('addr.zip', unset)
+      expect(form.blankPaths.value.has('addr.zip')).toBe(true)
+
+      form.setValue('addr.zip', 12345)
+      expect(form.blankPaths.value.has('addr.zip')).toBe(false)
+    })
+
+    it('a sibling-descendant blank-mark is untouched by a write to a different sub-container', () => {
+      const form = mount()
+      form.setValue('addr.zip', unset)
+      expect(form.blankPaths.value.has('addr.zip')).toBe(true)
+
+      // Writing only to a sibling leaf must NOT bleed into addr.zip's mark.
+      form.setValue('addr.city', 'Boise')
+      expect(form.blankPaths.value.has('addr.zip')).toBe(true)
+    })
+  }
+)

--- a/test/core/blank-mark-descendants.test.ts
+++ b/test/core/blank-mark-descendants.test.ts
@@ -18,13 +18,12 @@
  * `setValue('addr', …)` and root-form `setValue({ addr: … })`).
  */
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { createApp, defineComponent, h, type App } from 'vue'
 import { z as zV4 } from 'zod'
 import { z as zV3 } from 'zod-v3'
 import { useForm as useFormV4, unset as unsetV4 } from '../../src/zod-v4'
 import { useForm as useFormV3, unset as unsetV3 } from '../../src/zod-v3'
-import { createAttaform } from '../../src/runtime/core/plugin'
 import { AttaformErrorCode } from '../../src/runtime/core/error-codes'
+import { makeMounter } from '../utils/form-harness'
 
 const schemaV4 = zV4.object({
   addr: zV4.object({
@@ -41,105 +40,86 @@ const schemaV3 = zV3.object({
 })
 
 const adapters = [
-  { name: 'v4', useForm: useFormV4, unset: unsetV4, schema: schemaV4 },
-  { name: 'v3', useForm: useFormV3, unset: unsetV3, schema: schemaV3 },
+  { name: 'v4', mount: makeMounter(useFormV4, schemaV4), unset: unsetV4 },
+  { name: 'v3', mount: makeMounter(useFormV3, schemaV3), unset: unsetV3 },
 ] as const
 
-describe.each(adapters)(
-  'setValue clears descendant blank-marks — $name',
-  ({ useForm, unset, schema }) => {
-    const apps: App[] = []
-    afterEach(() => {
-      while (apps.length > 0) apps.pop()?.unmount()
-    })
+describe.each(adapters)('setValue clears descendant blank-marks — $name', ({ mount, unset }) => {
+  const apps: ReturnType<typeof mount>['app'][] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
 
-    type Api = ReturnType<typeof useForm<typeof schema>>
+  function mountOne() {
+    const { api, app } = mount()
+    apps.push(app)
+    return api
+  }
 
-    function mount(): Api {
-      let captured!: Api
-      const Probe = defineComponent({
-        setup() {
-          captured = useForm({
-            schema,
-            key: `blank-desc-${Math.random().toString(36).slice(2)}`,
-            strict: false,
-          }) as Api
-          return () => h('div')
-        },
-      })
-      const app = createApp(Probe).use(createAttaform())
-      const root = document.createElement('div')
-      document.body.appendChild(root)
-      app.mount(root)
-      apps.push(app)
-      return captured
+  it('path-form: setValue("addr", {zip:N}) clears the addr.zip blank-mark', () => {
+    const form = mountOne()
+    form.setValue('addr.zip', unset)
+    expect(form.blankPaths.value.has('addr.zip')).toBe(true)
+
+    form.setValue('addr', { zip: 12345, city: 'Boise' })
+    expect(form.blankPaths.value.has('addr.zip')).toBe(false)
+    expect(form.values.addr.zip).toBe(12345)
+  })
+
+  it('root-form: setValue({addr:{...}}) clears descendant blank-marks', () => {
+    const form = mountOne()
+    form.setValue('addr.zip', unset)
+    expect(form.blankPaths.value.has('addr.zip')).toBe(true)
+
+    form.setValue({ addr: { zip: 12345, city: 'Boise' } })
+    expect(form.blankPaths.value.has('addr.zip')).toBe(false)
+    expect(form.values.addr.zip).toBe(12345)
+  })
+
+  it('handleSubmit accepts after the container write — no false required-blank rejection', async () => {
+    const form = mountOne()
+    form.setValue('addr.zip', unset)
+    form.setValue('addr.city', 'placeholder')
+
+    // Sanity: with the blank-mark live, submit rejects on the descendant.
+    {
+      const onSubmit = vi.fn()
+      const onError = vi.fn()
+      await form.handleSubmit(onSubmit, onError)()
+      expect(onSubmit).not.toHaveBeenCalled()
+      expect(onError).toHaveBeenCalledTimes(1)
+      const errors = onError.mock.calls[0]?.[0] as Array<{ code: string; path: unknown[] }>
+      expect(
+        errors.some((e) => e.code === AttaformErrorCode.NoValueSupplied && e.path[1] === 'zip')
+      ).toBe(true)
     }
 
-    it('path-form: setValue("addr", {zip:N}) clears the addr.zip blank-mark', () => {
-      const form = mount()
-      form.setValue('addr.zip', unset)
-      expect(form.blankPaths.value.has('addr.zip')).toBe(true)
+    // Container write supplies the real value; submit must now resolve.
+    form.setValue('addr', { zip: 12345, city: 'Boise' })
 
-      form.setValue('addr', { zip: 12345, city: 'Boise' })
-      expect(form.blankPaths.value.has('addr.zip')).toBe(false)
-      expect(form.values.addr.zip).toBe(12345)
-    })
+    const onSubmit2 = vi.fn()
+    const onError2 = vi.fn()
+    await form.handleSubmit(onSubmit2, onError2)()
+    expect(onError2).not.toHaveBeenCalled()
+    expect(onSubmit2).toHaveBeenCalledTimes(1)
+  })
 
-    it('root-form: setValue({addr:{...}}) clears descendant blank-marks', () => {
-      const form = mount()
-      form.setValue('addr.zip', unset)
-      expect(form.blankPaths.value.has('addr.zip')).toBe(true)
+  it('a descendant write with a non-blank meta also clears the mark (exact-key parity)', () => {
+    const form = mountOne()
+    form.setValue('addr.zip', unset)
+    expect(form.blankPaths.value.has('addr.zip')).toBe(true)
 
-      form.setValue({ addr: { zip: 12345, city: 'Boise' } })
-      expect(form.blankPaths.value.has('addr.zip')).toBe(false)
-      expect(form.values.addr.zip).toBe(12345)
-    })
+    form.setValue('addr.zip', 12345)
+    expect(form.blankPaths.value.has('addr.zip')).toBe(false)
+  })
 
-    it('handleSubmit accepts after the container write — no false required-blank rejection', async () => {
-      const form = mount()
-      form.setValue('addr.zip', unset)
-      form.setValue('addr.city', 'placeholder')
+  it('a sibling-descendant blank-mark is untouched by a write to a different sub-container', () => {
+    const form = mountOne()
+    form.setValue('addr.zip', unset)
+    expect(form.blankPaths.value.has('addr.zip')).toBe(true)
 
-      // Sanity: with the blank-mark live, submit rejects on the descendant.
-      {
-        const onSubmit = vi.fn()
-        const onError = vi.fn()
-        await form.handleSubmit(onSubmit, onError)()
-        expect(onSubmit).not.toHaveBeenCalled()
-        expect(onError).toHaveBeenCalledTimes(1)
-        const errors = onError.mock.calls[0]?.[0] as Array<{ code: string; path: unknown[] }>
-        expect(
-          errors.some((e) => e.code === AttaformErrorCode.NoValueSupplied && e.path[1] === 'zip')
-        ).toBe(true)
-      }
-
-      // Container write supplies the real value; submit must now resolve.
-      form.setValue('addr', { zip: 12345, city: 'Boise' })
-
-      const onSubmit2 = vi.fn()
-      const onError2 = vi.fn()
-      await form.handleSubmit(onSubmit2, onError2)()
-      expect(onError2).not.toHaveBeenCalled()
-      expect(onSubmit2).toHaveBeenCalledTimes(1)
-    })
-
-    it('a descendant write with a non-blank meta also clears the mark (exact-key parity)', () => {
-      const form = mount()
-      form.setValue('addr.zip', unset)
-      expect(form.blankPaths.value.has('addr.zip')).toBe(true)
-
-      form.setValue('addr.zip', 12345)
-      expect(form.blankPaths.value.has('addr.zip')).toBe(false)
-    })
-
-    it('a sibling-descendant blank-mark is untouched by a write to a different sub-container', () => {
-      const form = mount()
-      form.setValue('addr.zip', unset)
-      expect(form.blankPaths.value.has('addr.zip')).toBe(true)
-
-      // Writing only to a sibling leaf must NOT bleed into addr.zip's mark.
-      form.setValue('addr.city', 'Boise')
-      expect(form.blankPaths.value.has('addr.zip')).toBe(true)
-    })
-  }
-)
+    // Writing only to a sibling leaf must NOT bleed into addr.zip's mark.
+    form.setValue('addr.city', 'Boise')
+    expect(form.blankPaths.value.has('addr.zip')).toBe(true)
+  })
+})

--- a/test/core/blank-path-encoding.test.ts
+++ b/test/core/blank-path-encoding.test.ts
@@ -1,0 +1,98 @@
+/**
+ * PASS2-8 — `data.blankPaths` round-trips through persistence without
+ * losing the structural distinction between literal-dot record keys
+ * (`record["foo.bar"]`, segments `['record', 'foo.bar']`) and dotted
+ * public-path segments (`record.foo.bar`, segments
+ * `['record', 'foo', 'bar']`).
+ *
+ * v=5 wrote the blank set as an array of dotted public-path strings
+ * (`'foo.bar'`), collapsing both shapes above onto the same wire. On
+ * hydrate, the dotted decoder then split the literal-dot segment into
+ * two — the blank-mark landed on the wrong slot, silently flipping
+ * the displayed-blank UX and the synthesised required-blank error.
+ *
+ * v=6 keeps the canonical `PathKey` JSON shape on disk verbatim.
+ * The JSON-array carries segment kind (string vs. number) and
+ * tolerates literal dots inside a quoted segment — so the on-disk
+ * shape and the in-memory `PathKey` are identical.
+ *
+ * The test pins the round-trip directly through the I/O helpers
+ * (`buildPersistedPayload` / `readPersistedPayload`) so the
+ * payload-shape contract is independently verified, decoupled from
+ * adapter timing.
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  buildPersistedPayload,
+  PERSISTED_ENVELOPE_VERSION,
+  readPersistedPayload,
+} from '../../src/runtime/core/persistence'
+import { canonicalizePath } from '../../src/runtime/core/paths'
+import type { PathKey } from '../../src/runtime/core/paths'
+
+describe('persistence — blankPaths lossless encoding', () => {
+  it('envelope version is v=6', () => {
+    expect(PERSISTED_ENVELOPE_VERSION).toBe(6)
+  })
+
+  it('round-trips a blank-mark at a literal-dot record key', () => {
+    // Internal: `record["foo.bar"]` produces the 2-segment path
+    // `['record', 'foo.bar']` and the PathKey `'["record","foo.bar"]'`.
+    // The dotted form `record.foo.bar` is the 3-segment path
+    // `['record', 'foo', 'bar']` and PathKey `'["record","foo","bar"]'`.
+    // These are distinct in-memory; the v=5 wire shape collapsed them.
+    const literalDotKey = canonicalizePath(['record', 'foo.bar']).key
+    const dottedSegmentsKey = canonicalizePath(['record', 'foo', 'bar']).key
+    expect(literalDotKey).not.toBe(dottedSegmentsKey)
+
+    const payload = buildPersistedPayload(
+      { record: { 'foo.bar': '' } },
+      'form',
+      new Map(),
+      new Map(),
+      new Set<PathKey>([literalDotKey])
+    )
+
+    const read = readPersistedPayload<{ record: Record<string, string> }>(
+      JSON.parse(JSON.stringify(payload))
+    )
+    expect(read).not.toBeNull()
+    const persistedList = read?.data.blankPaths
+    expect(persistedList).toBeDefined()
+    expect(persistedList).toHaveLength(1)
+    // v=6 stores the PathKey JSON verbatim — the on-disk shape IS the
+    // in-memory PathKey, so the equality is direct.
+    expect(persistedList?.[0]).toBe(literalDotKey)
+    expect(persistedList?.[0]).not.toBe(dottedSegmentsKey)
+  })
+
+  it('plain segments still round-trip cleanly (the common case)', () => {
+    const incomeKey = canonicalizePath(['income']).key
+    const userNameKey = canonicalizePath(['user', 'name']).key
+
+    const payload = buildPersistedPayload(
+      { income: 0, user: { name: '' } },
+      'form',
+      new Map(),
+      new Map(),
+      new Set<PathKey>([incomeKey, userNameKey])
+    )
+
+    const read = readPersistedPayload<{ income: number; user: { name: string } }>(
+      JSON.parse(JSON.stringify(payload))
+    )
+    expect(read?.data.blankPaths).toHaveLength(2)
+    expect(read?.data.blankPaths).toEqual(expect.arrayContaining([incomeKey, userNameKey]))
+  })
+
+  it('a v=5 payload (the dotted-shape predecessor) is dropped', () => {
+    const stale = { v: 5, data: { form: { income: 0 }, blankPaths: ['income'] } }
+    const read = readPersistedPayload<{ income: number }>(stale)
+    expect(read).toBeNull()
+  })
+
+  it('a v=6 payload with no blank set omits the field', () => {
+    const payload = buildPersistedPayload({ income: 5 }, 'form', new Map(), new Map(), new Set())
+    expect(payload.data.blankPaths).toBeUndefined()
+  })
+})

--- a/test/core/field-validation-counts-migration.test.ts
+++ b/test/core/field-validation-counts-migration.test.ts
@@ -56,7 +56,11 @@ describe.each(adapters)('fieldValidationCounts migration — $name', ({ useForm,
       setup() {
         // Anonymous useForm (no `key`) so the FormStore is provided as
         // `kFormContext` to descendants — see use-abstract-form.ts:493.
-        form = useForm({
+        // `useForm` is parameterised across adapters via `describe.each`;
+        // TS sees the v3-or-v4 union and can't reconcile the signatures,
+        // so a loose call cast is the right tool here.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        form = (useForm as any)({
           schema,
           strict: false,
           defaultValues: defaults,

--- a/test/core/field-validation-counts-migration.test.ts
+++ b/test/core/field-validation-counts-migration.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+/**
+ * PASS2-9 — `fieldValidationCounts` (the per-path in-flight async-
+ * validation counter that backs `field.validating`) was not relocated
+ * across array structural mutations alongside the other path-keyed
+ * maps. An async validation that landed mid-`move` left the spinner
+ * on the OLD outer index (now occupied by a different element) until
+ * the next validation pass overwrote the entry — visible flicker on a
+ * row that wasn't actually validating.
+ *
+ * The fix plugs `fieldValidationCounts` into the existing
+ * `migrateMapSubtree` sweep in `migrateArrayElementState`, mirroring
+ * the treatment of `fields` / `originals` / `userErrors`. We pin it
+ * by reading the FormStore directly via `inject(kFormContext)`,
+ * seeding the counter at a pre-mutation index, replaying the array
+ * move, and asserting the entry follows the element. Going through
+ * the real async-validation pipeline would couple the test to
+ * scheduler timing the migration semantics don't depend on.
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, inject, type App } from 'vue'
+import { z as zV4 } from 'zod'
+import { z as zV3 } from 'zod-v3'
+import { useForm as useFormV4 } from '../../src/zod-v4'
+import { useForm as useFormV3 } from '../../src/zod-v3'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import { kFormContext } from '../../src/runtime/core/registry'
+import { canonicalizePath } from '../../src/runtime/core/paths'
+import type { FormStore } from '../../src/runtime/core/create-form-store'
+import type { GenericForm } from '../../src/runtime/types/types-core'
+
+const schemaV4 = zV4.object({ tags: zV4.array(zV4.string()) })
+const schemaV3 = zV3.object({ tags: zV3.array(zV3.string()) })
+const defaults = { tags: ['a', 'b', 'c'] }
+
+const adapters = [
+  { name: 'v4', useForm: useFormV4, schema: schemaV4 },
+  { name: 'v3', useForm: useFormV3, schema: schemaV3 },
+] as const
+
+describe.each(adapters)('fieldValidationCounts migration — $name', ({ useForm, schema }) => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  function mountOne(): {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    form: any
+    store: FormStore<GenericForm>
+  } {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let form: any
+    let store: FormStore<GenericForm> | undefined
+    const Root = defineComponent({
+      setup() {
+        // Anonymous useForm (no `key`) so the FormStore is provided as
+        // `kFormContext` to descendants — see use-abstract-form.ts:493.
+        form = useForm({
+          schema,
+          strict: false,
+          defaultValues: defaults,
+        })
+        return () => h(Child)
+      },
+    })
+    const Child = defineComponent({
+      setup() {
+        store = inject(kFormContext)
+        return () => h('div')
+      },
+    })
+    const app = createApp(Root).use(createAttaform())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    apps.push(app)
+    if (store === undefined) throw new Error('kFormContext was not injected')
+    return { form, store }
+  }
+
+  const key = (path: readonly (string | number)[]) => canonicalizePath(path).key
+
+  it('move relocates the counter from old index to new index', () => {
+    const { form, store } = mountOne()
+    store.fieldValidationCounts.set(key(['tags', 1]), 1)
+
+    form.move('tags', 1, 0)
+
+    expect(store.fieldValidationCounts.get(key(['tags', 0]))).toBe(1)
+    expect(store.fieldValidationCounts.has(key(['tags', 1]))).toBe(false)
+  })
+
+  it('swap relocates counters in both directions', () => {
+    const { form, store } = mountOne()
+    store.fieldValidationCounts.set(key(['tags', 0]), 1)
+    store.fieldValidationCounts.set(key(['tags', 2]), 2)
+
+    form.swap('tags', 0, 2)
+
+    expect(store.fieldValidationCounts.get(key(['tags', 0]))).toBe(2)
+    expect(store.fieldValidationCounts.get(key(['tags', 2]))).toBe(1)
+  })
+
+  it('remove drops the counter at the removed index and shifts the rest down', () => {
+    const { form, store } = mountOne()
+    store.fieldValidationCounts.set(key(['tags', 0]), 1)
+    store.fieldValidationCounts.set(key(['tags', 2]), 2)
+
+    form.remove('tags', 0)
+
+    // Pre-op `tags.0` ('a', counter=1) is vacated and dropped. Pre-op
+    // `tags.1` ('b', no counter) shifts to index 0 — no counter to migrate.
+    // Pre-op `tags.2` ('c', counter=2) shifts to index 1.
+    expect(store.fieldValidationCounts.has(key(['tags', 0]))).toBe(false)
+    expect(store.fieldValidationCounts.get(key(['tags', 1]))).toBe(2)
+    expect(store.fieldValidationCounts.has(key(['tags', 2]))).toBe(false)
+  })
+
+  it('insert shifts counters at and past the insert position up by one', () => {
+    const { form, store } = mountOne()
+    store.fieldValidationCounts.set(key(['tags', 1]), 1)
+
+    form.insert('tags', 1, 'X')
+
+    // tags.1 → tags.2.
+    expect(store.fieldValidationCounts.get(key(['tags', 2]))).toBe(1)
+    expect(store.fieldValidationCounts.has(key(['tags', 1]))).toBe(false)
+  })
+})

--- a/test/core/insert-negative-index.test.ts
+++ b/test/core/insert-negative-index.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+/**
+ * PASS2-6 — `field-arrays.ts:insert` recorded `op.index` against the
+ * POST-splice length, not the pre-splice length. For a negative
+ * `index` argument, JS `splice` normalises against PRE-splice length
+ * (e.g. `-1` on length-2 → position 1), but the recorded
+ * `arrayOp.index` was the SAME `index` clamped to `[0, postLen]`,
+ * yielding `0` for the negative case. Downstream consumers
+ * (`applyArrayOpToMemory`, `arrayIdentity.applyOp`, `remapForOp`)
+ * then operated on the wrong slot — variant memory was cleared at
+ * index 0 (where nothing happened), and the identity-token list got
+ * its splice at index 0 (clobbering the unchanged head element's
+ * token instead of the actual new arrival's slot).
+ *
+ * The fix computes the insertion index BEFORE splice using JS's
+ * negative-index normalisation, then passes the same index to both
+ * `splice` and the recorded `arrayOp`. Per-element state and tokens
+ * now follow the actual permutation.
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { z as zV4 } from 'zod'
+import { z as zV3 } from 'zod-v3'
+import { useForm as useFormV4 } from '../../src/zod-v4'
+import { useForm as useFormV3 } from '../../src/zod-v3'
+import { makeMounter } from '../utils/form-harness'
+
+const schemaV4 = zV4.object({ tags: zV4.array(zV4.string()) })
+const schemaV3 = zV3.object({ tags: zV3.array(zV3.string()) })
+const defaults = { tags: ['a', 'b'] }
+
+const adapters = [
+  { name: 'v4', mount: makeMounter(useFormV4, schemaV4, { defaultValues: defaults }) },
+  { name: 'v3', mount: makeMounter(useFormV3, schemaV3, { defaultValues: defaults }) },
+] as const
+
+describe.each(adapters)('insert negative index — $name', ({ mount }) => {
+  const apps: ReturnType<typeof mount>['app'][] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  function mountOne() {
+    const { api, app } = mount()
+    apps.push(app)
+    return api
+  }
+
+  it("storage matches splice's negative-index normalisation (sanity)", () => {
+    const form = mountOne()
+    form.insert('tags', -1, 'X')
+    expect(form.values.tags).toEqual(['a', 'X', 'b'])
+  })
+
+  it('identity tokens record the splice at the actual insertion slot', () => {
+    const form = mountOne()
+    const aToken = form.fields('tags.0').key
+    const bToken = form.fields('tags.1').key
+
+    form.insert('tags', -1, 'X')
+
+    // 'a' is unchanged at index 0; 'X' is fresh at index 1; 'b' shifted to index 2.
+    expect(form.fields('tags.0').key).toBe(aToken)
+    expect(form.fields('tags.1').key).not.toBe(aToken)
+    expect(form.fields('tags.1').key).not.toBe(bToken)
+    expect(form.fields('tags.2').key).toBe(bToken)
+  })
+
+  it("touched state on 'a' survives an insert(-1) — its index didn't change", () => {
+    const form = mountOne()
+    form.touch('tags.0')
+    expect(form.fields('tags.0').touched).toBe(true)
+
+    form.insert('tags', -1, 'X')
+
+    expect(form.fields('tags.0').touched).toBe(true)
+    // 'X' arrived at index 1 with no carry-over.
+    expect(form.fields('tags.1').touched).toBe(false)
+  })
+
+  it("touched state on 'b' relocates from index 1 to index 2", () => {
+    const form = mountOne()
+    form.touch('tags.1')
+
+    form.insert('tags', -1, 'X')
+
+    expect(form.fields('tags.2').touched).toBe(true)
+    expect(form.fields('tags.1').touched).toBe(false)
+  })
+
+  it('a very-negative index clamps to 0 (preLen + idx < 0)', () => {
+    const form = mountOne()
+    form.touch('tags.0')
+
+    form.insert('tags', -10, 'X')
+
+    expect(form.values.tags).toEqual(['X', 'a', 'b'])
+    // 'a' relocates from index 0 to index 1.
+    expect(form.fields('tags.1').touched).toBe(true)
+    expect(form.fields('tags.0').touched).toBe(false)
+  })
+
+  it('negative index on an empty array clamps to 0', () => {
+    const form = mountOne()
+    // Empty the array first.
+    form.remove('tags', 0)
+    form.remove('tags', 0)
+    expect(form.values.tags).toEqual([])
+
+    form.insert('tags', -1, 'X')
+    expect(form.values.tags).toEqual(['X'])
+  })
+})

--- a/test/core/nested-array-identity.test.ts
+++ b/test/core/nested-array-identity.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+/**
+ * PASS2-7 — nested-array identity follows its element across outer-array
+ * mutations. Pre-fix the `tokens` / `baselines` maps inside `arrayIdentity`
+ * were keyed by absolute path (e.g. `items.1` for the inner array under
+ * outer index 1) but `migrateArrayElementState` only migrated the path-
+ * keyed maps it knew about (`fields`, `userErrors`, `originals`, blank
+ * marks) — the identity tracker's internal maps were left untouched.
+ *
+ * Consequences:
+ *
+ *   - After `form.remove('items', 0)`, the inner array's tokens at
+ *     `items.1` stayed at `items.1`. Reading `form.fields('items.0.0').key`
+ *     allocated a NEW token (no entry at the relocated key), and the inner
+ *     `v-for :key` reset for every nested row — Vue tore down + recreated
+ *     every nested input.
+ *   - The orphaned entry at `items.1.*` leaked indefinitely (an unbounded
+ *     token Map leak proportional to outer-array churn).
+ *
+ * The fix exposes `applyRemap(arrayPath, remap)` on the `ArrayIdentity`
+ * interface; `migrateArrayElementState` invokes it alongside the existing
+ * Map / Set migrations so the identity tracker's internal state stays in
+ * lockstep with the rest of the per-element bookkeeping.
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { z as zV4 } from 'zod'
+import { z as zV3 } from 'zod-v3'
+import { useForm as useFormV4 } from '../../src/zod-v4'
+import { useForm as useFormV3 } from '../../src/zod-v3'
+import { makeMounter } from '../utils/form-harness'
+
+const schemaV4 = zV4.object({
+  rows: zV4.array(zV4.array(zV4.string())),
+})
+
+const schemaV3 = zV3.object({
+  rows: zV3.array(zV3.array(zV3.string())),
+})
+
+const defaults = { rows: [['a', 'b'], ['c', 'd'], ['e']] }
+
+const adapters = [
+  { name: 'v4', mount: makeMounter(useFormV4, schemaV4, { defaultValues: defaults }) },
+  { name: 'v3', mount: makeMounter(useFormV3, schemaV3, { defaultValues: defaults }) },
+] as const
+
+describe.each(adapters)('nested-array identity migration — $name', ({ mount }) => {
+  const apps: ReturnType<typeof mount>['app'][] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  function mountOne() {
+    const { api, app } = mount()
+    apps.push(app)
+    return api
+  }
+
+  it('outer remove: inner tokens follow the surviving rows to their new outer index', () => {
+    const form = mountOne()
+    // Materialise inner tokens at outer indices 1 and 2 before the mutation.
+    const cTokenBefore = form.fields('rows.1.0').key
+    const dTokenBefore = form.fields('rows.1.1').key
+    const eTokenBefore = form.fields('rows.2.0').key
+    expect(cTokenBefore).toBeTruthy()
+    expect(dTokenBefore).toBeTruthy()
+    expect(eTokenBefore).toBeTruthy()
+
+    // Remove outer index 0 (the `['a', 'b']` row); `['c','d']` shifts to 0,
+    // `['e']` shifts to 1.
+    form.remove('rows', 0)
+
+    // Inner tokens must carry to the new outer positions.
+    expect(form.fields('rows.0.0').key).toBe(cTokenBefore)
+    expect(form.fields('rows.0.1').key).toBe(dTokenBefore)
+    expect(form.fields('rows.1.0').key).toBe(eTokenBefore)
+  })
+
+  it('outer move: inner tokens follow the moved row to its destination outer index', () => {
+    const form = mountOne()
+    const cToken = form.fields('rows.1.0').key
+    const dToken = form.fields('rows.1.1').key
+
+    form.move('rows', 1, 0)
+
+    expect(form.fields('rows.0.0').key).toBe(cToken)
+    expect(form.fields('rows.0.1').key).toBe(dToken)
+  })
+
+  it('outer swap: inner tokens swap together with their parent rows', () => {
+    const form = mountOne()
+    const aToken = form.fields('rows.0.0').key
+    const bToken = form.fields('rows.0.1').key
+    const cToken = form.fields('rows.1.0').key
+    const dToken = form.fields('rows.1.1').key
+
+    form.swap('rows', 0, 1)
+
+    expect(form.fields('rows.0.0').key).toBe(cToken)
+    expect(form.fields('rows.0.1').key).toBe(dToken)
+    expect(form.fields('rows.1.0').key).toBe(aToken)
+    expect(form.fields('rows.1.1').key).toBe(bToken)
+  })
+
+  it('outer insert: an inserted row gets a fresh inner-array identity (no leak from old slot)', () => {
+    const form = mountOne()
+    const cToken = form.fields('rows.1.0').key
+
+    form.insert('rows', 1, ['x', 'y'])
+
+    // The inserted row at outer index 1 must get a brand-new inner token;
+    // the surviving 'c' element (now at outer index 2) keeps its original.
+    const newInnerToken = form.fields('rows.1.0').key
+    expect(newInnerToken).not.toBe(cToken)
+    expect(form.fields('rows.2.0').key).toBe(cToken)
+  })
+
+  it('outer replace-at: the new row gets a fresh inner-array identity', () => {
+    const form = mountOne()
+    const originalCToken = form.fields('rows.1.0').key
+
+    form.replace('rows', 1, ['z'])
+
+    expect(form.fields('rows.1.0').key).not.toBe(originalCToken)
+  })
+})


### PR DESCRIPTION
Phase 5 of the [audit remediation plan](/Users/ozzy/.claude/plans/rustling-whistling-planet.md) — six findings clustered around `setValueAtPath`'s blank-mark gate and `create-form-store.ts`'s array-element bookkeeping. Stacked on top of merged Phase 4 (PR #291).

Each commit lands a single finding, red-green discipline: failing repro test first (verified pre-fix output), then the fix, then the post-fix sweep. Full gate green; zero diff on `src/index.ts` / `src/zod.ts` / `src/zod-v3.ts` / `src/zod-v4.ts` — no public entry change.

## Commits

| SHA | Finding | Surface |
| --- | --- | --- |
| `c56184d` | **PASS2-1** (⚠️ P1, behavior) | `setValueAtPath` clears descendant blank-marks on non-blank container write |
| `08e0303` | **PASS2-S1** (⚠️ decision) | `form.clear()` aligns with `setValue(unset)` — both blank, required-validation fires consistently |
| `cf6a629` | **PASS2-7** (⚠️ observable) | Nested-array identity tokens migrate on outer mutation (`ArrayIdentity.applyRemap`) |
| `c478766` | **PASS2-9** | `fieldValidationCounts` migrates alongside the other path-keyed maps |
| `3455176` | **PASS2-6** (⚠️ observable) | `insert(arr, idx, v)` clamps `arrayOp.index` against pre-splice length |
| `29110dd` | **PASS2-8** | Persistence envelope `v=5 → v=6`; `data.blankPaths` switched back to canonical `PathKey` JSON for lossless literal-dot record-key round-trip |
| `12dbe9f` | follow-up | `useForm` union-type cast in the PASS2-9 test (caught at typecheck) |

## ⚠️ API & behavior-change ledger

- **PASS2-1** — `setValue('container', value)` and root-form `setValue({...})` now resolve descendant blank-marks. `handleSubmit` accepts populated containers; descendant `displayValue` shows the written value; `form.meta.errors` is current. The arrayOp branch skips the descendant sweep so `migrateArrayElementState` can carry the marks across the operation's exact permutation.
- **PASS2-S1** — `form.clear(path)` now writes the slim default AND marks the path blank (was: wrote the slim default WITHOUT the mark). Required-validation on a `clear`ed leaf now produces the synthesised "No value supplied" error on submit — was silently silenced. Optional / nullable fields keep their storage value unchanged; the blank-mark is added but `isRequiredAtPath` returns false so no synthesised error fires.
- **PASS2-7** — Nested `v-for :key="form.fields('items.i.j').key"` stays stable across outer remove / move / swap. New `arrayIdentity.applyRemap(arrayPath, remap)` method on the internal `ArrayIdentity` interface (mirrors the existing `migrateMapSubtree` / `migrateSetSubtree` shape).
- **PASS2-6** — `insert(arr, -1, X)` on `['a','b']` now records `op.index: 1` (was: `0`). Storage was already correct via `Array.prototype.splice`'s own normalisation; only the bookkeeping was wrong. Identity tokens, variant memory, and per-element migration now follow the actual permutation.
- **PASS2-8** — Persistence envelope `v=6` stores `data.blankPaths` as the canonical `PathKey` JSON shape (`'["record","foo.bar"]'`), restoring the lossless round-trip for literal-dot record keys. v=5 payloads drop with the existing one-time dev-warn (no back-compat, per [[feedback-no-back-compat]]).

## Full gate
- lint ✓
- typecheck ✓
- `pnpm check:site` ✓
- 3,258 tests passing (Phase 4 baseline was 3,201; +57 new red-green cases across 6 new test files)
- size ✓ (`index.mjs` 46.62 kB / 48 kB budget; +0.21 kB from Phase 4's 46.41 kB)
- bench ✓
- coverage 91.51% lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)