### PR TITLE
Phase 6: Validation lifecycle (PASS2-2/3/S3/14 + CORE-P1a)

### DIFF
--- a/src/runtime/adapters/zod-v3/index.ts
+++ b/src/runtime/adapters/zod-v3/index.ts
@@ -170,8 +170,19 @@ export function zodAdapter<
       }
     }
 
+    // Memoised one-shot walk; `hasContainerOrRootRefine` is queried at
+    // every per-keystroke schedule to pick whole-form vs subtree
+    // scope, so the walk pays for itself within the first few
+    // mutations.
+    let containerRefineFlag: boolean | null = null
+
     const abstractSchema: AbstractSchema<Form, GetValueFormType> = {
       fingerprint: () => fingerprintZodSchema(_zodSchema),
+
+      hasContainerOrRootRefine(): boolean {
+        containerRefineFlag ??= v3HasContainerOrRootRefine(_zodSchema)
+        return containerRefineFlag
+      },
       getDefaultValues(config) {
         const defaultValuesWithoutConstraints = getDefaultValuesFromZodSchema(
           _zodSchema,
@@ -1558,6 +1569,177 @@ function hasChecks(schema: z.ZodTypeAny): boolean {
   if (!Array.isArray(checks)) return false
 
   return checks.length > 0
+}
+
+/**
+ * True iff the v3 schema tree carries a refine / transform / preprocess
+ * (`ZodEffects`) whose effect target is a container — Object / Array
+ * / Tuple / Union / DU / Intersection / Record / Map / Set — or the
+ * root itself. Drives the runtime's per-keystroke scope cut: a tree
+ * with leaf-only effects can be re-validated at the edited subtree
+ * alone (subtree pass catches the leaf effect at the same depth);
+ * a container effect can be moved by sibling writes and forces a
+ * whole-form pass.
+ *
+ * Walks via inline `_def` reads (the introspect-chokepoint refactor
+ * lands in Phase 7 and will collapse this into the unified accessor
+ * surface). Transparent wrappers (Optional / Nullable / Default /
+ * Catch / Readonly / Branded / Lazy) peel through to their inner
+ * before container detection — `.refine` on `.optional()` over a
+ * `z.object(...)` is still a root-scoped effect. Pipelines walk both
+ * sides.
+ *
+ * Bias conservative: an unrecognised wrapper or a malformed leaf
+ * returns `false` for THAT node, but the recurse continues, so
+ * nested container effects still surface. False negatives only lose
+ * the perf win; correctness preserved by the caller's whole-form
+ * default when the predicate isn't reached.
+ */
+function v3HasContainerOrRootRefine(schema: z.ZodTypeAny, seen?: WeakSet<object>): boolean {
+  const visited = seen ?? new WeakSet<object>()
+  const candidate = schema as unknown
+  if (typeof candidate !== 'object' || candidate === null) return false
+  if (visited.has(candidate)) return false
+  visited.add(candidate)
+
+  // ZodEffects: refine / transform / preprocess. Peel transparent
+  // wrappers off the inner so `.refine()` applied to `.optional()`
+  // over a container still flags as a container-level effect.
+  if (isZodSchemaType(schema, 'ZodEffects')) {
+    const inner = (schema._def as unknown as { schema?: z.ZodTypeAny }).schema
+    if (inner === undefined) return false
+    if (v3IsContainerAfterWrapperPeel(inner)) return true
+    return v3HasContainerOrRootRefine(inner, visited)
+  }
+
+  // Transparent wrappers: recurse into the inner without flagging.
+  if (
+    isZodSchemaType(schema, 'ZodOptional') ||
+    isZodSchemaType(schema, 'ZodNullable') ||
+    isZodSchemaType(schema, 'ZodDefault') ||
+    isZodSchemaType(schema, 'ZodCatch') ||
+    isZodSchemaType(schema, 'ZodReadonly')
+  ) {
+    const inner = (schema._def as unknown as { innerType?: z.ZodTypeAny }).innerType
+    return inner !== undefined && v3HasContainerOrRootRefine(inner, visited)
+  }
+  if (isZodSchemaType(schema, 'ZodBranded')) {
+    const inner = (schema._def as unknown as { type?: z.ZodTypeAny }).type
+    return inner !== undefined && v3HasContainerOrRootRefine(inner, visited)
+  }
+  if (isZodSchemaType(schema, 'ZodLazy')) {
+    try {
+      const inner = (schema._def as unknown as { getter?: () => z.ZodTypeAny }).getter?.()
+      return inner !== undefined && v3HasContainerOrRootRefine(inner, visited)
+    } catch {
+      return false
+    }
+  }
+  if (isZodSchemaType(schema, 'ZodPipeline')) {
+    const def = schema._def as unknown as { in?: z.ZodTypeAny; out?: z.ZodTypeAny }
+    if (def.in !== undefined && v3HasContainerOrRootRefine(def.in, visited)) return true
+    if (def.out !== undefined && v3HasContainerOrRootRefine(def.out, visited)) return true
+    return false
+  }
+
+  // Container types: recurse into children.
+  if (isZodSchemaType(schema, 'ZodObject')) {
+    const def = schema._def as unknown as {
+      shape?: (() => Record<string, z.ZodTypeAny>) | Record<string, z.ZodTypeAny>
+    }
+    const shape = typeof def.shape === 'function' ? def.shape() : def.shape
+    if (shape !== undefined) {
+      for (const sub of Object.values(shape)) {
+        if (v3HasContainerOrRootRefine(sub, visited)) return true
+      }
+    }
+    return false
+  }
+  if (isZodSchemaType(schema, 'ZodArray')) {
+    const elem = (schema._def as unknown as { type?: z.ZodTypeAny }).type
+    return elem !== undefined && v3HasContainerOrRootRefine(elem, visited)
+  }
+  if (isZodSchemaType(schema, 'ZodTuple')) {
+    const items = (schema._def as unknown as { items?: z.ZodTypeAny[] }).items
+    if (items !== undefined) {
+      for (const it of items) {
+        if (v3HasContainerOrRootRefine(it, visited)) return true
+      }
+    }
+    return false
+  }
+  if (isZodSchemaType(schema, 'ZodUnion') || isZodSchemaType(schema, 'ZodDiscriminatedUnion')) {
+    const opts = (schema._def as unknown as { options?: z.ZodTypeAny[] }).options
+    if (opts !== undefined) {
+      for (const opt of opts) {
+        if (v3HasContainerOrRootRefine(opt, visited)) return true
+      }
+    }
+    return false
+  }
+  if (isZodSchemaType(schema, 'ZodIntersection')) {
+    const def = schema._def as unknown as { left?: z.ZodTypeAny; right?: z.ZodTypeAny }
+    if (def.left !== undefined && v3HasContainerOrRootRefine(def.left, visited)) return true
+    if (def.right !== undefined && v3HasContainerOrRootRefine(def.right, visited)) return true
+    return false
+  }
+  if (isZodSchemaType(schema, 'ZodRecord')) {
+    const def = schema._def as unknown as { keyType?: z.ZodTypeAny; valueType?: z.ZodTypeAny }
+    if (def.keyType !== undefined && v3HasContainerOrRootRefine(def.keyType, visited)) return true
+    if (def.valueType !== undefined && v3HasContainerOrRootRefine(def.valueType, visited))
+      return true
+    return false
+  }
+  if (isZodSchemaType(schema, 'ZodSet')) {
+    const elem = (schema._def as unknown as { valueType?: z.ZodTypeAny }).valueType
+    return elem !== undefined && v3HasContainerOrRootRefine(elem, visited)
+  }
+
+  // Leaves (ZodString / ZodNumber / ZodBoolean / ZodLiteral / ZodEnum /
+  // ZodNativeEnum / ZodDate / ...) — no descendable structure, no
+  // container effect possible.
+  return false
+}
+
+function v3IsContainerAfterWrapperPeel(schema: z.ZodTypeAny): boolean {
+  let cur: z.ZodTypeAny = schema
+  for (let i = 0; i < MAX_UNWRAP_STEPS; i++) {
+    if (
+      isZodSchemaType(cur, 'ZodOptional') ||
+      isZodSchemaType(cur, 'ZodNullable') ||
+      isZodSchemaType(cur, 'ZodDefault') ||
+      isZodSchemaType(cur, 'ZodCatch') ||
+      isZodSchemaType(cur, 'ZodReadonly')
+    ) {
+      const inner = (cur._def as unknown as { innerType?: z.ZodTypeAny }).innerType
+      if (inner === undefined) return false
+      cur = inner
+    } else if (isZodSchemaType(cur, 'ZodBranded')) {
+      const inner = (cur._def as unknown as { type?: z.ZodTypeAny }).type
+      if (inner === undefined) return false
+      cur = inner
+    } else if (isZodSchemaType(cur, 'ZodLazy')) {
+      try {
+        const inner = (cur._def as unknown as { getter?: () => z.ZodTypeAny }).getter?.()
+        if (inner === undefined) return false
+        cur = inner
+      } catch {
+        return false
+      }
+    } else {
+      break
+    }
+  }
+  return (
+    isZodSchemaType(cur, 'ZodObject') ||
+    isZodSchemaType(cur, 'ZodArray') ||
+    isZodSchemaType(cur, 'ZodTuple') ||
+    isZodSchemaType(cur, 'ZodIntersection') ||
+    isZodSchemaType(cur, 'ZodUnion') ||
+    isZodSchemaType(cur, 'ZodDiscriminatedUnion') ||
+    isZodSchemaType(cur, 'ZodRecord') ||
+    isZodSchemaType(cur, 'ZodSet')
+  )
 }
 
 function stripRefinements<T extends z.ZodTypeAny>(schema: T) {

--- a/src/runtime/adapters/zod-v4/adapter.ts
+++ b/src/runtime/adapters/zod-v4/adapter.ts
@@ -35,6 +35,7 @@ import {
   getSetValueType,
   getTupleItems,
   getUnionOptions,
+  hasContainerOrRootRefine,
   isCoercePrimitive,
   kindOf,
   unwrapInner,
@@ -288,6 +289,11 @@ export function zodV4Adapter<
     // construction and possibly again from devtools, so a single tree
     // traversal earns its keep across the adapter's lifetime.
     let asyncValidationFlag: boolean | null = null
+    // Same lazy-memo pattern as the async flag: the per-keystroke
+    // validation scheduler queries `hasContainerOrRootRefine` on every
+    // keystroke to decide whole-form vs subtree scope, so the walk
+    // pays for itself within the first few mutations.
+    let containerRefineFlag: boolean | null = null
 
     function computeDiscriminator(path: Path): UnionDiscriminatorContext | undefined {
       const candidates =
@@ -339,6 +345,11 @@ export function zodV4Adapter<
         asyncValidationFlag ??=
           containsAsyncRefine(rootSchema) || containsAsyncTransform(rootSchema)
         return asyncValidationFlag
+      },
+
+      hasContainerOrRootRefine(): boolean {
+        containerRefineFlag ??= hasContainerOrRootRefine(rootSchema)
+        return containerRefineFlag
       },
 
       getDefaultValues(

--- a/src/runtime/adapters/zod-v4/introspect.ts
+++ b/src/runtime/adapters/zod-v4/introspect.ts
@@ -464,6 +464,121 @@ export function containsAsyncRefine(schema: z.ZodType, seen?: WeakSet<object>): 
 }
 
 /**
+ * True iff the schema tree carries any refine / check / transform at
+ * the root or at a non-leaf node. False means every check is at a leaf
+ * — a per-keystroke subtree pass will catch the same verdicts as a
+ * whole-form pass, and the runtime can scope leaf validation to the
+ * edited path. True forces whole-form (correct, just slower).
+ *
+ * "Non-leaf" is detected by the presence of descendable children on
+ * `def`: `shape` / `entries` / `element` / `options` / `items` /
+ * `keyType` / `valueType` / `left` / `right`. The root is always
+ * eligible — its checks ARE root refines. Transparent wrappers
+ * (Optional / Nullable / Default / Catch / Readonly / Pipe / Lazy)
+ * peel through to their inner without re-flagging — a `.refine` added
+ * on top of a wrapper lands its check on the WRAPPER node itself, so
+ * the wrapper's own `def.checks` is what's inspected.
+ *
+ * Bias conservative: a missed wrapper variant or an exotic `def`
+ * shape we don't yet recognise returns false ONLY for that node,
+ * but the recursive descent continues, so a container refine
+ * nested inside still triggers `true`. Unknown wrappers we forget
+ * to peel only lose the perf win, never correctness.
+ */
+export function hasContainerOrRootRefine(schema: z.ZodType, seen?: WeakSet<object>): boolean {
+  const visited = seen ?? new WeakSet<object>()
+  const candidate = schema as unknown
+  if (typeof candidate !== 'object' || candidate === null) return false
+  if (visited.has(candidate)) return false
+  visited.add(candidate)
+
+  const def = readDef(schema)
+  if (def === undefined) return false
+
+  // A node is a "container" iff it owns descendable structure. Refines
+  // / checks on such a node fire only when the container is the parse
+  // scope — a leaf-scoped subtree pass beneath it never re-runs them.
+  const isContainer =
+    def.shape !== undefined ||
+    def.entries !== undefined ||
+    def.element !== undefined ||
+    def.options !== undefined ||
+    def.items !== undefined ||
+    def.keyType !== undefined ||
+    def.valueType !== undefined ||
+    def.left !== undefined ||
+    def.right !== undefined
+
+  if (isContainer) {
+    const checks = getChecks(schema)
+    if (checks.length > 0) return true
+  }
+
+  if (
+    def.innerType !== undefined &&
+    hasContainerOrRootRefine(def.innerType as z.ZodType, visited)
+  ) {
+    return true
+  }
+  if (def.element !== undefined && hasContainerOrRootRefine(def.element as z.ZodType, visited)) {
+    return true
+  }
+  if (def.in !== undefined && hasContainerOrRootRefine(def.in as z.ZodType, visited)) {
+    return true
+  }
+  if (def.out !== undefined && hasContainerOrRootRefine(def.out as z.ZodType, visited)) {
+    return true
+  }
+  if (def.left !== undefined && hasContainerOrRootRefine(def.left as z.ZodType, visited)) {
+    return true
+  }
+  if (def.right !== undefined && hasContainerOrRootRefine(def.right as z.ZodType, visited)) {
+    return true
+  }
+  if (def.keyType !== undefined && hasContainerOrRootRefine(def.keyType as z.ZodType, visited)) {
+    return true
+  }
+  if (
+    def.valueType !== undefined &&
+    hasContainerOrRootRefine(def.valueType as z.ZodType, visited)
+  ) {
+    return true
+  }
+  if (def.shape !== undefined) {
+    for (const sub of Object.values(def.shape)) {
+      if (hasContainerOrRootRefine(sub as z.ZodType, visited)) return true
+    }
+  }
+  if (def.entries !== undefined) {
+    for (const sub of Object.values(def.entries)) {
+      if (hasContainerOrRootRefine(sub as z.ZodType, visited)) return true
+    }
+  }
+  if (def.options !== undefined) {
+    for (const sub of def.options) {
+      if (hasContainerOrRootRefine(sub as z.ZodType, visited)) return true
+    }
+  }
+  if (def.items !== undefined) {
+    for (const sub of def.items) {
+      if (hasContainerOrRootRefine(sub as z.ZodType, visited)) return true
+    }
+  }
+  if (typeof def.getter === 'function') {
+    try {
+      const inner = def.getter() as z.ZodType
+      if (hasContainerOrRootRefine(inner, visited)) return true
+    } catch {
+      // Lazy schemas may throw before their inner is constructed;
+      // treat as no detection and let the caller's conservative
+      // default apply.
+    }
+  }
+
+  return false
+}
+
+/**
  * True iff any `ZodTransform` in the schema tree wraps an async
  * function. `z.preprocess(fn, inner)` desugars to a pipe whose
  * `def.in` is a `ZodTransform` with `def.transform = fn`; an async

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -2526,22 +2526,23 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
         }
         throw err
       }
-      // Whole-form revalidation on every leaf change. Sub-schema-only
-      // passes leave ancestor refines (and root refines) stale: a
-      // `.refine()` on `z.object({...})` keys its verdict at the
-      // container path, which is neither the leaf nor a descendant of
-      // it, so a leaf-scoped `applySchemaErrorsForSubtree` doesn't
-      // touch it. Running the whole-form pass and writing via
-      // `applySchemaErrorsForSubtree([], ...)` lets every refine at
-      // every depth re-evaluate against the live form value and
-      // replaces every `schemaErrors` key in one go — stale entries
-      // drop, current ones survive. Per-path debounce / abort keys
-      // (above) still coalesce rapid same-leaf typing into one run;
-      // `validateAsync` / `handleSubmit` cancel pending chains so
-      // their authoritative whole-form writes aren't clobbered by
-      // a late SFV resolution.
+      // Per-keystroke scope. When the schema carries no container or
+      // root refine (predicate returns `false` and the schedule is at
+      // a real path), every verdict it can produce lives at the
+      // edited subtree or below — a subtree-scoped pass is sufficient
+      // and the runtime avoids the O(N) whole-form parse on each
+      // keystroke. Predicate `true` (or missing — adapters that don't
+      // implement detection) keeps the conservative whole-form pass
+      // so ancestor refines (cross-field equality, sum constraints,
+      // etc.) still re-evaluate against the live form value. An
+      // empty `path` (root schedule, mount / reset / explicit
+      // whole-form) also folds to whole-form.
+      const subtreeScope = path.length > 0 && schema.hasContainerOrRootRefine?.() === false
+      const scopePath: Path | undefined = subtreeScope ? path : undefined
+      const dataAtScope: unknown = subtreeScope ? getAtPath(form.value, path) : form.value
+      const scopeKey: PathKey = subtreeScope ? canonicalizePath(path).key : ROOT_PATH_KEY
       void Promise.resolve()
-        .then(() => schema.validateAtPath(form.value, undefined))
+        .then(() => schema.validateAtPath(dataAtScope, scopePath))
         .then((response) => {
           if (controller.signal.aborted) return
           // Form-level epoch gate. If a later-scheduled run has
@@ -2560,12 +2561,8 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
           // run never advances the snapshot, so a later blur with
           // nothing committed for this path still re-validates instead
           // of falsely skipping against a stale-but-uncommitted anchor.
-          //
-          // Keyed under `ROOT_PATH_KEY` while validation scope is
-          // whole-form. Once CORE-P1a's subtree scope lands, this
-          // becomes the canonical key of the actual commit scope.
           if (effectiveMode === 'blur') {
-            pathSnapshots.set(ROOT_PATH_KEY, structuralSnapshot(form.value))
+            pathSnapshots.set(scopeKey, structuralSnapshot(form.value))
           }
           const errors = response.success ? [] : response.errors
           // Drop schema verdicts at preprocess / coerce paths whose
@@ -2578,7 +2575,17 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
           // paths (defaultValues OR schema `.default(...)`) skip the
           // filter; their verdicts ARE legitimate.
           const filtered = filterAuthoredErrors(errors)
-          applySchemaErrorsForSubtree([], filtered)
+          // Subtree-scoped responses carry paths relative to the
+          // subtree; restamp with absolute paths so the storage
+          // convention holds. Whole-form responses are already
+          // absolute — pass through.
+          const restamped: ValidationError[] = subtreeScope
+            ? filtered.map((err) => ({
+                ...err,
+                path: [...path, ...(err.path as Segment[])],
+              }))
+            : filtered
+          applySchemaErrorsForSubtree(scopePath ?? [], restamped)
         })
         .catch(() => {
           // Adapter contract forbids throws — swallow here so a misbehaving

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -3426,6 +3426,16 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     // that reached the controller-aborted branch resolve to a no-op, so
     // the error store stays clean after the reset clears it above.
     cancelFieldValidation()
+    // Reset the per-path blur-dedup snapshots and the form-level epoch
+    // counters. After `cancelFieldValidation` no in-flight run can
+    // commit, so clearing here can't be raced by a late commit
+    // re-populating the map. Survivor snapshots from before the reset
+    // would otherwise match a post-reset value that happens to mirror
+    // a pre-reset state and skip a real revalidation that the reset's
+    // cleared error stores need to repopulate.
+    pathSnapshots.clear()
+    scheduleEpoch = 0
+    lastCommittedEpoch = 0
     // Variant memory is UX state — a fresh start drops the per-variant
     // typed-data cache too. Without this, a post-reset switch would
     // surface stale variant values from before the reset.

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -2491,12 +2491,6 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     const run = () => {
       fresh.timer = null
       if (controller.signal.aborted) return
-      // Record the value this pass validates so a later blur can recognise an
-      // unchanged form and skip. Blur-mode only: the blur guard is the sole
-      // reader, so change-mode never pays for the snapshot.
-      if (effectiveMode === 'blur') {
-        lastValidatedSnapshot = { value: structuralSnapshot(form.value) }
-      }
       // Defense-in-depth: the increments below trigger reactive
       // subscribers (sync watchers on `api.meta.validating` or
       // `api.fields.X.validating`). If one of those subscribers throws,
@@ -2549,6 +2543,16 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
           // would still be a no-op.
           if (myEpoch <= lastCommittedEpoch) return
           lastCommittedEpoch = myEpoch
+          // Record the value this pass validates so a later blur can
+          // recognise an unchanged form and skip. Blur-mode only: the
+          // blur guard is the sole reader, so change-mode never pays
+          // for the snapshot. Lives in the applied branch — an aborted
+          // run never advances the snapshot, so a later blur with
+          // nothing committed for this path still re-validates instead
+          // of falsely skipping against a stale-but-uncommitted anchor.
+          if (effectiveMode === 'blur') {
+            lastValidatedSnapshot = { value: structuralSnapshot(form.value) }
+          }
           const errors = response.success ? [] : response.errors
           // Drop schema verdicts at preprocess / coerce paths whose
           // storage is undefined AND the consumer didn't author a

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -29,6 +29,7 @@ import {
   FORM_ERRORS_PATH_KEY,
   isDangerousSegment,
   isPathPrefix,
+  ROOT_PATH_KEY,
   segmentsForPathKey,
   type Path,
   type PathKey,
@@ -1683,16 +1684,25 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
   const departAttempts = ref(0)
   const submissionGeneration = ref(0)
   const activeValidations = ref(0)
-  // Structural snapshot of the form value as of the last blur-mode validation
-  // pass, `null` before the first. The blur guard skips a re-run only while
-  // the live form still deep-equals this (no leaf differs): a focus/blur cycle
-  // with no net change can't move any verdict, so re-running would only
-  // flicker a settled error through 'pending'. Keying on the value, not a
-  // write count, means editing away and back to the last-validated value
-  // (`"a" -> "ab" -> "a"`) also stays quiet. The `{ value }` box keeps a form
-  // value of `null` / `undefined` distinct from "never validated". Plain
-  // `let`, not a ref: only the blur handler reads it, never reactively.
-  let lastValidatedSnapshot: { readonly value: unknown } | null = null
+  // Per-path snapshots of `form.value` keyed by the canonical
+  // PathKey of the SCOPE each blur-mode `run()` commits at. The
+  // blur-dedup at path P walks from P up to the root and reads the
+  // closest ancestor entry, then compares the subtree-at-P from
+  // that snapshot against the live subtree-at-P — so a sibling-only
+  // edit between blurs leaves A's subtree-at-A unchanged and A's
+  // re-blur correctly skips, without depending on whether B's
+  // commit happened to advance a shared anchor.
+  //
+  // Under today's whole-form validation scope every commit lands at
+  // the root key, so all blurs share a single entry (equivalent
+  // semantics to the old form-wide `let`). Per-path lookup keeps
+  // the design correct once subtree-scope commits land: a commit
+  // at B advances B's entry only; A's blur-dedup walks up to
+  // whatever ancestor scope WAS last committed and uses it.
+  //
+  // Empty Map → no entry → first blur revalidates (matches the
+  // pre-fix `null` initial state).
+  const pathSnapshots = new Map<PathKey, unknown>()
   // Form-level monotonic counters that guard cross-path async races.
   // Per-path AbortControllers cover same-path rapid typing (a fresh
   // schedule cancels its predecessor at the same key), but they don't
@@ -2550,8 +2560,12 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
           // run never advances the snapshot, so a later blur with
           // nothing committed for this path still re-validates instead
           // of falsely skipping against a stale-but-uncommitted anchor.
+          //
+          // Keyed under `ROOT_PATH_KEY` while validation scope is
+          // whole-form. Once CORE-P1a's subtree scope lands, this
+          // becomes the canonical key of the actual commit scope.
           if (effectiveMode === 'blur') {
-            lastValidatedSnapshot = { value: structuralSnapshot(form.value) }
+            pathSnapshots.set(ROOT_PATH_KEY, structuralSnapshot(form.value))
           }
           const errors = response.success ? [] : response.errors
           // Drop schema verdicts at preprocess / coerce paths whose
@@ -3007,11 +3021,35 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     if (!focused && focusMode === 'blur') {
       const firstInteractiveBlur =
         current?.interacted === true && current.blurredAfterInteraction !== true
-      const snapshot = lastValidatedSnapshot
+      // Walk from the blurred path up to the root and pick the first
+      // ancestor scope that's been committed at. The blur-dedup
+      // compares the SUBTREE-AT-PATH of that snapshot against the
+      // live subtree — a sibling-only edit between blurs leaves
+      // this path's subtree unchanged and the dedup correctly
+      // skips. Under whole-form scope today every commit lives at
+      // `ROOT_PATH_KEY`, so the walk falls through to that single
+      // entry; under subtree scope (CORE-P1a) the closest ancestor
+      // entry is the one this leaf was actually validated under.
+      let snapshot: unknown | undefined = undefined
+      for (let i = path.length; i >= 0; i--) {
+        const ancestorKey = canonicalizePath(path.slice(0, i)).key
+        const entry = pathSnapshots.get(ancestorKey)
+        if (entry !== undefined) {
+          snapshot = entry
+          break
+        }
+      }
       let changed = true
-      if (!firstInteractiveBlur && snapshot !== null) {
+      if (!firstInteractiveBlur && snapshot !== undefined) {
+        // Extract the SUBTREE-AT-PATH on both sides — `diffAndApply`'s
+        // `prefix` only labels emitted patch paths, it doesn't scope
+        // the walk. Subtree extraction is what makes a sibling-only
+        // edit between blurs (this path unchanged) read as
+        // `changed === false`.
+        const snapshotSubtree = getAtPath(snapshot, path)
+        const liveSubtree = getAtPath(form.value, path)
         changed = false
-        diffAndApply(snapshot.value, form.value, [], () => {
+        diffAndApply(snapshotSubtree, liveSubtree, path, () => {
           changed = true
         })
       }

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -1693,6 +1693,23 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
   // value of `null` / `undefined` distinct from "never validated". Plain
   // `let`, not a ref: only the blur handler reads it, never reactively.
   let lastValidatedSnapshot: { readonly value: unknown } | null = null
+  // Form-level monotonic counters that guard cross-path async races.
+  // Per-path AbortControllers cover same-path rapid typing (a fresh
+  // schedule cancels its predecessor at the same key), but they don't
+  // cross-invalidate runs scheduled at DIFFERENT paths — and every
+  // run commits a WHOLE-form replacement via
+  // `applySchemaErrorsForSubtree([], …)`. Without an epoch gate, two
+  // concurrent different-path runs both commit in resolution order;
+  // a slow earlier-scheduled run that lands AFTER a faster
+  // later-scheduled one would overwrite the fresher verdict with
+  // pre-edit state. Each `scheduleFieldValidation` call captures a
+  // fresh `myEpoch` from `scheduleEpoch`; the commit branch in `run()`
+  // re-checks `myEpoch > lastCommittedEpoch` before writing, dropping
+  // any run that a fresher one has already overtaken at the commit
+  // site. Plain `let`s — the counters are only read inside `run()`'s
+  // chained `.then`, never reactively.
+  let scheduleEpoch = 0
+  let lastCommittedEpoch = 0
   // Async-defaults lifecycle. `useAbstractForm` writes these on the
   // first call for this key: `defaultValuesFactory` captures the
   // function-form input, `hydrating` flips true until settle
@@ -2465,6 +2482,11 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     const controller = new AbortController()
     const fresh: FieldValidationEntry = { controller, timer: null, settled: false }
     fieldValidationState.set(key, fresh)
+    // Capture a fresh epoch at schedule time. Closed over by `run`
+    // below and re-checked at the commit site so a later-scheduled
+    // run that resolves first protects its verdict from clobber by
+    // an earlier-scheduled run that resolves later (PASS2-2).
+    const myEpoch = ++scheduleEpoch
 
     const run = () => {
       fresh.timer = null
@@ -2518,6 +2540,15 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
         .then(() => schema.validateAtPath(form.value, undefined))
         .then((response) => {
           if (controller.signal.aborted) return
+          // Form-level epoch gate. If a later-scheduled run has
+          // already committed its verdict, dropping this stale
+          // commit prevents an asymmetric-latency race from
+          // overwriting the fresher result. `<=` is conservative
+          // — counter monotonicity makes equality impossible in
+          // practice, but a re-entrant commit at the same epoch
+          // would still be a no-op.
+          if (myEpoch <= lastCommittedEpoch) return
+          lastCommittedEpoch = myEpoch
           const errors = response.success ? [] : response.errors
           // Drop schema verdicts at preprocess / coerce paths whose
           // storage is undefined AND the consumer didn't author a

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -547,6 +547,33 @@ export type AbstractSchema<Form, GetValueFormType> = {
    * answers without a separate top-level overload.
    */
   needsAsyncValidation?(): boolean
+
+  /**
+   * Return `true` iff the schema carries a refine / check / transform
+   * at any NON-LEAF position — a container node (object / array /
+   * tuple / union / intersection / record / map / set) or the root
+   * itself. False means every check this schema runs is leaf-local,
+   * so a per-keystroke `validateAtPath(form, leafPath)` catches the
+   * same verdicts as a whole-form pass — no ancestor refine reads
+   * the form's wider state.
+   *
+   * The runtime uses this at the per-keystroke schedule to scope
+   * field-level validation to the changed subtree when it can,
+   * falling back to a whole-form pass when an ancestor refine
+   * (cross-field equality, sum constraints, etc.) could be moved
+   * by a leaf write. Optional. The runtime treats a missing
+   * implementation as `() => true` — conservative whole-form,
+   * preserving correctness for adapters that don't yet model
+   * container-refine detection.
+   *
+   * Detection is best-effort: false negatives (returning `true`
+   * when no container refine exists) only lose a perf win and
+   * still validate correctly; false positives (returning `false`
+   * when a container refine exists) would let an ancestor verdict
+   * go stale and are the real risk — implementations should bias
+   * toward returning `true` when in doubt.
+   */
+  hasContainerOrRootRefine?(): boolean
 }
 
 /**

--- a/test/composables/aborted-blur-snapshot.test.ts
+++ b/test/composables/aborted-blur-snapshot.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+/**
+ * PASS2-3 — `run()` wrote `lastValidatedSnapshot` at run-START,
+ * BEFORE the post-resolve abort re-check. A path-scoped
+ * `validateAsync(other)` calls `cancelFieldValidation()`
+ * synchronously, aborting the in-flight blur run for the
+ * interactively-blurred path — but the snapshot had already
+ * advanced. The blur-dedup at the next focus/blur cycle then
+ * compared the (unchanged) form value to the advanced snapshot,
+ * SKIPPED revalidation, and surfaced no error for a field that
+ * was actually invalid: `displayState === 'success'` instead of
+ * `'error'`.
+ *
+ * The fix moves the snapshot write past the abort + epoch
+ * checks, into the applied branch — so the snapshot advances
+ * only for verdicts that actually commit.
+ *
+ * Repro forces the race deterministically with async refines:
+ *   1. Type into A so the directive flips `interacted`, then
+ *      blur A. `run()` queues the validate microtask.
+ *   2. SYNCHRONOUSLY call `validateAsync('b')` —
+ *      `cancelFieldValidation()` aborts A's pending run before
+ *      its `.then` ever fires; `validateAsync` writes for B only.
+ *   3. Refocus A, blur unchanged. Without the fix, the snapshot
+ *      from step 1 makes the dedup skip → A shows success.
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, nextTick, withDirectives, type App } from 'vue'
+import { z as zV4 } from 'zod'
+import { z as zV3 } from 'zod-v3'
+import { useForm as useFormV4 } from '../../src/zod-v4'
+import { useForm as useFormV3 } from '../../src/zod-v3'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import { vRegister } from '../../src/runtime/core/directive'
+
+const drainMicrotasks = async (rounds = 8): Promise<void> => {
+  for (let i = 0; i < rounds; i++) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+function buildSchemaV4() {
+  return zV4.object({
+    a: zV4.string().refine(async (v) => v === 'good-a', { message: 'a-invalid' }),
+    b: zV4.string().refine(async (v) => v === 'good-b', { message: 'b-invalid' }),
+  })
+}
+
+function buildSchemaV3() {
+  return zV3.object({
+    a: zV3.string().refine(async (v) => v === 'good-a', { message: 'a-invalid' }),
+    b: zV3.string().refine(async (v) => v === 'good-b', { message: 'b-invalid' }),
+  })
+}
+
+const adapters = [
+  { name: 'v4', useForm: useFormV4, buildSchema: buildSchemaV4 },
+  { name: 'v3', useForm: useFormV3, buildSchema: buildSchemaV3 },
+] as const
+
+describe.each(adapters)('aborted-blur snapshot — $name', ({ useForm, buildSchema }) => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+    document.body.innerHTML = ''
+  })
+
+  it('an aborted blur run does not skip the next blur — invalid A still surfaces error', async () => {
+    const schema = buildSchema()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let api: any
+    const App = defineComponent({
+      setup() {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        api = (useForm as any)({
+          schema,
+          key: 'aborted-snapshot',
+          strict: false,
+          validateOn: 'blur',
+          defaultValues: { a: '', b: '' },
+        })
+        return () =>
+          h('div', [
+            withDirectives(h('input', { 'data-id': 'a', type: 'text' }), [
+              [vRegister, api.register('a')],
+            ]),
+            withDirectives(h('input', { 'data-id': 'b', type: 'text' }), [
+              [vRegister, api.register('b')],
+            ]),
+          ])
+      },
+    })
+    const app = createApp(App).use(createAttaform())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    apps.push(app)
+    await drainMicrotasks()
+
+    const aInput = root.querySelector('input[data-id="a"]') as HTMLInputElement
+
+    // Edit A invalid through the DOM — the directive flips `interacted`
+    // on path 'a', which arms the upcoming blur to be an interactive blur.
+    aInput.dispatchEvent(new FocusEvent('focus'))
+    aInput.value = 'invalid'
+    aInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await nextTick()
+
+    // Blur A: `markFocused(false)` schedules an immediate blur-mode run.
+    // Inside `run()`, the bug writes the snapshot AT THIS POINT, before
+    // the post-resolve abort check. The validate microtask is queued.
+    aInput.dispatchEvent(new FocusEvent('blur'))
+
+    // Synchronously interleave a path-scoped `validateAsync('b')` so
+    // `cancelFieldValidation()` aborts A's pending run before its
+    // `.then` ever fires. `validateAsync('b')` writes only B's bucket.
+    void api.validateAsync('b')
+
+    await drainMicrotasks()
+    // Sanity — A's verdict was aborted, so A's bucket stays empty.
+    expect(api.errors.a).toEqual([])
+
+    // Refocus A and blur without typing. The blur-dedup compares
+    // current form.value against the snapshot. With the bug, the
+    // step-1 snapshot makes the dedup say "no change" and skip; A
+    // stays "success" with no error. With the fix, the snapshot
+    // didn't advance (the aborted run never reached the applied
+    // branch), so the dedup falls through, validation runs, and
+    // A's error commits.
+    aInput.dispatchEvent(new FocusEvent('focus'))
+    aInput.dispatchEvent(new FocusEvent('blur'))
+    await drainMicrotasks()
+
+    expect(api.errors.a.length).toBeGreaterThan(0)
+    expect(api.fields('a').displayState).toBe('error')
+  })
+})

--- a/test/composables/async-race-epoch.test.ts
+++ b/test/composables/async-race-epoch.test.ts
@@ -42,43 +42,52 @@ async function drainMicrotasks(rounds = 8): Promise<void> {
 
 function buildSchemaV4() {
   const resolvers: Array<(v: boolean) => void> = []
-  const schema = zV4.object({
-    a: zV4.string().refine(
-      (_value) =>
-        new Promise<boolean>((r) => {
-          resolvers.push(r)
-        }),
-      { message: 'a-invalid' }
-    ),
-    b: zV4.string().refine(
-      (_value) =>
-        new Promise<boolean>((r) => {
-          resolvers.push(r)
-        }),
-      { message: 'b-invalid' }
-    ),
-  })
+  // Container refine on the root forces the runtime's per-keystroke
+  // scope to stay whole-form (CORE-P1a's predicate returns `true`)
+  // — which is the regime PASS2-2's cross-path clobber lived in.
+  // The trivial sync `() => true` is enough to flip the predicate
+  // without polluting the resolvers queue.
+  const schema = zV4
+    .object({
+      a: zV4.string().refine(
+        (_value) =>
+          new Promise<boolean>((r) => {
+            resolvers.push(r)
+          }),
+        { message: 'a-invalid' }
+      ),
+      b: zV4.string().refine(
+        (_value) =>
+          new Promise<boolean>((r) => {
+            resolvers.push(r)
+          }),
+        { message: 'b-invalid' }
+      ),
+    })
+    .refine(() => true, { message: 'object-invariant' })
   return { schema, resolvers }
 }
 
 function buildSchemaV3() {
   const resolvers: Array<(v: boolean) => void> = []
-  const schema = zV3.object({
-    a: zV3.string().refine(
-      (_value) =>
-        new Promise<boolean>((r) => {
-          resolvers.push(r)
-        }),
-      { message: 'a-invalid' }
-    ),
-    b: zV3.string().refine(
-      (_value) =>
-        new Promise<boolean>((r) => {
-          resolvers.push(r)
-        }),
-      { message: 'b-invalid' }
-    ),
-  })
+  const schema = zV3
+    .object({
+      a: zV3.string().refine(
+        (_value) =>
+          new Promise<boolean>((r) => {
+            resolvers.push(r)
+          }),
+        { message: 'a-invalid' }
+      ),
+      b: zV3.string().refine(
+        (_value) =>
+          new Promise<boolean>((r) => {
+            resolvers.push(r)
+          }),
+        { message: 'b-invalid' }
+      ),
+    })
+    .refine(() => true, { message: 'object-invariant' })
   return { schema, resolvers }
 }
 
@@ -127,7 +136,7 @@ describe.each(adapters)('async-race epoch — $name', ({ useForm, build }) => {
     const constructionRefines = resolvers.length
     // Construction-time refines (if any) resolve TRUE so they don't
     // contaminate the test's error-map assertions.
-    for (let i = 0; i < constructionRefines; i++) resolvers[i](true)
+    for (let i = 0; i < constructionRefines; i++) resolvers[i]?.(true)
     await drainMicrotasks()
 
     // Edit A first; drain so A's run() reads form.value at the
@@ -147,7 +156,7 @@ describe.each(adapters)('async-race epoch — $name', ({ useForm, build }) => {
 
     // Resolve call-2's refines TRUE first → call 2's validateAtPath
     // promise settles with success → empty error map committed.
-    for (let i = afterAEdit; i < resolvers.length; i++) resolvers[i](true)
+    for (let i = afterAEdit; i < resolvers.length; i++) resolvers[i]?.(true)
     await drainMicrotasks()
     expect(api.errors.a).toEqual([])
     expect(api.errors.b).toEqual([])
@@ -156,7 +165,7 @@ describe.each(adapters)('async-race epoch — $name', ({ useForm, build }) => {
     // failure. Without the epoch gate: applySchemaErrorsForSubtree
     // overwrites the empty map with stale failures. With the gate:
     // call 1 is dropped (myEpoch <= lastCommittedEpoch).
-    for (let i = constructionRefines; i < afterAEdit; i++) resolvers[i](false)
+    for (let i = constructionRefines; i < afterAEdit; i++) resolvers[i]?.(false)
     await drainMicrotasks()
 
     expect(api.errors.a).toEqual([])

--- a/test/composables/async-race-epoch.test.ts
+++ b/test/composables/async-race-epoch.test.ts
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+/**
+ * PASS2-2 — concurrent per-path async field validations had only
+ * a per-path AbortController and no form-level epoch counter, so
+ * two runs on DIFFERENT paths could both commit whole-form verdicts.
+ * Whichever Promise settled LAST replaced the previously-committed
+ * error map — even when its verdict was computed against pre-edit
+ * state. Common with slow server-uniqueness refines: type B after A,
+ * B's verdict commits first, then A's slow uniqueness check resolves
+ * with the pre-B form and clobbers B's just-committed errors.
+ *
+ * The fix is a form-level monotonic schedule epoch + a re-check
+ * immediately before `applySchemaErrorsForSubtree([], …)`: a run
+ * whose `myEpoch <= lastCommittedEpoch` is dropped (a fresher
+ * verdict already landed). Per-path abort still guards same-path
+ * rapid typing; the epoch guards cross-path races.
+ *
+ * The race is forced deterministically by handing each `.refine`
+ * a manually-resolvable Promise. Run() chain order:
+ *   1. setValue A → run() → microtask → reads form.value @ pre-B,
+ *      validateAtPath fires refines for a (value='X') and b (value='').
+ *   2. setValue B → run() → microtask → reads form.value @ post-B,
+ *      validateAtPath fires refines for a (value='X') and b (value='Y').
+ *   3. Resolve call-2's refines → call 2 commits empty error map.
+ *   4. Resolve call-1's refines with FAIL → without the epoch gate,
+ *      call 1's commit OVERWRITES with stale failures.
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, nextTick, type App } from 'vue'
+import { z as zV4 } from 'zod'
+import { z as zV3 } from 'zod-v3'
+import { useForm as useFormV4 } from '../../src/zod-v4'
+import { useForm as useFormV3 } from '../../src/zod-v3'
+import { createAttaform } from '../../src/runtime/core/plugin'
+
+async function drainMicrotasks(rounds = 8): Promise<void> {
+  for (let i = 0; i < rounds; i++) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+function buildSchemaV4() {
+  const resolvers: Array<(v: boolean) => void> = []
+  const schema = zV4.object({
+    a: zV4.string().refine(
+      (_value) =>
+        new Promise<boolean>((r) => {
+          resolvers.push(r)
+        }),
+      { message: 'a-invalid' }
+    ),
+    b: zV4.string().refine(
+      (_value) =>
+        new Promise<boolean>((r) => {
+          resolvers.push(r)
+        }),
+      { message: 'b-invalid' }
+    ),
+  })
+  return { schema, resolvers }
+}
+
+function buildSchemaV3() {
+  const resolvers: Array<(v: boolean) => void> = []
+  const schema = zV3.object({
+    a: zV3.string().refine(
+      (_value) =>
+        new Promise<boolean>((r) => {
+          resolvers.push(r)
+        }),
+      { message: 'a-invalid' }
+    ),
+    b: zV3.string().refine(
+      (_value) =>
+        new Promise<boolean>((r) => {
+          resolvers.push(r)
+        }),
+      { message: 'b-invalid' }
+    ),
+  })
+  return { schema, resolvers }
+}
+
+const adapters = [
+  { name: 'v4', useForm: useFormV4, build: buildSchemaV4 },
+  { name: 'v3', useForm: useFormV3, build: buildSchemaV3 },
+] as const
+
+describe.each(adapters)('async-race epoch — $name', ({ useForm, build }) => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+    document.body.innerHTML = ''
+  })
+
+  it('drops a stale call-1 commit that resolves AFTER a fresher call-2 commit', async () => {
+    const { schema, resolvers } = build()
+    // useForm has v3-or-v4 union under describe.each — single inline
+    // cast is the cleanest tool here (mirrors the
+    // field-validation-counts-migration pattern).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let api: any
+    const App = defineComponent({
+      setup() {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        api = (useForm as any)({
+          schema,
+          key: 'async-race-epoch',
+          strict: false,
+          defaultValues: { a: '', b: '' },
+          validateOn: 'change',
+          debounceMs: 0,
+        })
+        return () => h('div')
+      },
+    })
+    const app = createApp(App).use(createAttaform())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    apps.push(app)
+
+    // Drain any construction-time validation refines so the count
+    // below starts from a clean baseline.
+    await drainMicrotasks()
+    const constructionRefines = resolvers.length
+    // Construction-time refines (if any) resolve TRUE so they don't
+    // contaminate the test's error-map assertions.
+    for (let i = 0; i < constructionRefines; i++) resolvers[i](true)
+    await drainMicrotasks()
+
+    // Edit A first; drain so A's run() reads form.value at the
+    // pre-B microtask boundary and fires its refine pair.
+    api.setValue('a', 'X')
+    await drainMicrotasks()
+    const afterAEdit = resolvers.length
+    const callOneRefines = afterAEdit - constructionRefines
+    expect(callOneRefines).toBeGreaterThanOrEqual(2)
+
+    // Edit B; drain so B's run() reads form.value at the post-B
+    // microtask boundary and fires its own refine pair.
+    api.setValue('b', 'Y')
+    await drainMicrotasks()
+    const callTwoRefines = resolvers.length - afterAEdit
+    expect(callTwoRefines).toBeGreaterThanOrEqual(2)
+
+    // Resolve call-2's refines TRUE first → call 2's validateAtPath
+    // promise settles with success → empty error map committed.
+    for (let i = afterAEdit; i < resolvers.length; i++) resolvers[i](true)
+    await drainMicrotasks()
+    expect(api.errors.a).toEqual([])
+    expect(api.errors.b).toEqual([])
+
+    // Resolve call-1's refines FALSE → call 1's promise settles with
+    // failure. Without the epoch gate: applySchemaErrorsForSubtree
+    // overwrites the empty map with stale failures. With the gate:
+    // call 1 is dropped (myEpoch <= lastCommittedEpoch).
+    for (let i = constructionRefines; i < afterAEdit; i++) resolvers[i](false)
+    await drainMicrotasks()
+
+    expect(api.errors.a).toEqual([])
+    expect(api.errors.b).toEqual([])
+  })
+})

--- a/test/composables/per-keystroke-scope.test.ts
+++ b/test/composables/per-keystroke-scope.test.ts
@@ -1,0 +1,239 @@
+// @vitest-environment jsdom
+/**
+ * CORE-P1a — every per-keystroke `scheduleFieldValidation` ran
+ * `validateAtPath(form, undefined)` (whole-form), re-parsing every
+ * leaf on every character. For a 200-field flat schema, typing one
+ * character did 200 leaf parses; for any schema that only carries
+ * leaf-level refines, the ancestor verdicts the whole-form pass
+ * was guarding for didn't exist.
+ *
+ * Fix: route the per-keystroke run through the new adapter
+ * predicate `hasContainerOrRootRefine`. When it returns `false`
+ * (no ancestor or root effect), validate only the edited subtree.
+ * When it returns `true` (or is missing), fall back to whole-form
+ * — ancestor refines stay correct under cross-field writes.
+ *
+ * Red-green: leaf refine on `refined`, an unrefined sibling
+ * `sibling`. Type into `sibling`. Old whole-form pass invokes
+ * `refined`'s refine on every keystroke; new subtree pass at
+ * `['sibling']` doesn't. Counter pinned at the pre-edit value.
+ * A control test mounts a schema WITH a container refine so the
+ * predicate returns `true` and the whole-form behaviour is
+ * preserved.
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, nextTick, type App } from 'vue'
+import { z as zV4 } from 'zod'
+import { z as zV3 } from 'zod-v3'
+import { useForm as useFormV4 } from '../../src/zod-v4'
+import { useForm as useFormV3 } from '../../src/zod-v3'
+import { createAttaform } from '../../src/runtime/core/plugin'
+
+const drainMicrotasks = async (rounds = 8): Promise<void> => {
+  for (let i = 0; i < rounds; i++) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+function buildFlatV4() {
+  let runs = 0
+  const schema = zV4.object({
+    refined: zV4.string().refine(
+      (v) => {
+        runs += 1
+        return v.length > 0
+      },
+      { message: 'refined-invalid' }
+    ),
+    sibling: zV4.string(),
+  })
+  return { schema, runs: () => runs }
+}
+
+function buildFlatV3() {
+  let runs = 0
+  const schema = zV3.object({
+    refined: zV3.string().refine(
+      (v) => {
+        runs += 1
+        return v.length > 0
+      },
+      { message: 'refined-invalid' }
+    ),
+    sibling: zV3.string(),
+  })
+  return { schema, runs: () => runs }
+}
+
+function buildContainerRefineV4() {
+  let runs = 0
+  const inner = zV4.object({
+    refined: zV4.string().refine(
+      (v) => {
+        runs += 1
+        return v.length > 0
+      },
+      { message: 'refined-invalid' }
+    ),
+    sibling: zV4.string(),
+  })
+  // Container refine on the root: predicate returns `true` and the
+  // runtime keeps the whole-form scope so cross-field constraints
+  // re-evaluate.
+  const schema = inner.refine(() => true, { message: 'object-invariant' })
+  return { schema, runs: () => runs }
+}
+
+function buildContainerRefineV3() {
+  let runs = 0
+  const inner = zV3.object({
+    refined: zV3.string().refine(
+      (v) => {
+        runs += 1
+        return v.length > 0
+      },
+      { message: 'refined-invalid' }
+    ),
+    sibling: zV3.string(),
+  })
+  const schema = inner.refine(() => true, { message: 'object-invariant' })
+  return { schema, runs: () => runs }
+}
+
+const flatAdapters = [
+  { name: 'v4', useForm: useFormV4, build: buildFlatV4 },
+  { name: 'v3', useForm: useFormV3, build: buildFlatV3 },
+] as const
+
+const refineAdapters = [
+  { name: 'v4', useForm: useFormV4, build: buildContainerRefineV4 },
+  { name: 'v3', useForm: useFormV3, build: buildContainerRefineV3 },
+] as const
+
+describe.each(flatAdapters)(
+  'per-keystroke scope — flat schema (leaf-only refine) — $name',
+  ({ useForm, build }) => {
+    const apps: App[] = []
+    afterEach(() => {
+      while (apps.length > 0) apps.pop()?.unmount()
+      document.body.innerHTML = ''
+    })
+
+    it('typing into a sibling does NOT re-invoke the leaf refine on a different path', async () => {
+      const { schema, runs } = build()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let api: any
+      const App = defineComponent({
+        setup() {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          api = (useForm as any)({
+            schema,
+            key: 'per-keystroke-flat',
+            strict: false,
+            validateOn: 'change',
+            debounceMs: 0,
+            defaultValues: { refined: 'r', sibling: '' },
+          })
+          return () => h('div')
+        },
+      })
+      const app = createApp(App).use(createAttaform())
+      const root = document.createElement('div')
+      document.body.appendChild(root)
+      app.mount(root)
+      apps.push(app)
+      await drainMicrotasks()
+      const runsAtMount = runs()
+
+      // Type into the sibling field. Under whole-form scope the
+      // refined field's refine fires once per write; under subtree
+      // scope only the sibling subtree is parsed.
+      api.setValue('sibling', 's1')
+      await drainMicrotasks()
+      api.setValue('sibling', 's12')
+      await drainMicrotasks()
+      api.setValue('sibling', 's123')
+      await drainMicrotasks()
+
+      expect(runs()).toBe(runsAtMount)
+    })
+
+    it('typing into the refined field DOES re-invoke its own refine', async () => {
+      const { schema, runs } = build()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let api: any
+      const App = defineComponent({
+        setup() {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          api = (useForm as any)({
+            schema,
+            key: 'per-keystroke-flat-self',
+            strict: false,
+            validateOn: 'change',
+            debounceMs: 0,
+            defaultValues: { refined: 'r', sibling: '' },
+          })
+          return () => h('div')
+        },
+      })
+      const app = createApp(App).use(createAttaform())
+      const root = document.createElement('div')
+      document.body.appendChild(root)
+      app.mount(root)
+      apps.push(app)
+      await drainMicrotasks()
+      const runsAtMount = runs()
+
+      api.setValue('refined', 'rr')
+      await drainMicrotasks()
+
+      expect(runs()).toBeGreaterThan(runsAtMount)
+    })
+  }
+)
+
+describe.each(refineAdapters)(
+  'per-keystroke scope — container refine forces whole-form — $name',
+  ({ useForm, build }) => {
+    const apps: App[] = []
+    afterEach(() => {
+      while (apps.length > 0) apps.pop()?.unmount()
+      document.body.innerHTML = ''
+    })
+
+    it('typing into a sibling DOES still re-invoke the leaf refine when a container refine is present', async () => {
+      const { schema, runs } = build()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let api: any
+      const App = defineComponent({
+        setup() {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          api = (useForm as any)({
+            schema,
+            key: 'per-keystroke-container',
+            strict: false,
+            validateOn: 'change',
+            debounceMs: 0,
+            defaultValues: { refined: 'r', sibling: '' },
+          })
+          return () => h('div')
+        },
+      })
+      const app = createApp(App).use(createAttaform())
+      const root = document.createElement('div')
+      document.body.appendChild(root)
+      app.mount(root)
+      apps.push(app)
+      await drainMicrotasks()
+      const runsAtMount = runs()
+
+      // Container refine present → predicate returns `true` →
+      // whole-form pass → leaf refine re-fires.
+      api.setValue('sibling', 's1')
+      await drainMicrotasks()
+
+      expect(runs()).toBeGreaterThan(runsAtMount)
+    })
+  }
+)

--- a/test/composables/per-path-snapshot.test.ts
+++ b/test/composables/per-path-snapshot.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+/**
+ * PASS2-S3 — the form-wide `lastValidatedSnapshot` `let` was
+ * overwritten by whichever field's run committed last and was
+ * compared whole-form in the blur-dedup. Two real consequences:
+ *   - a programmatic edit to sibling B (between A blurs) made
+ *     the dedup see "form changed" and SPURIOUSLY re-ran A's
+ *     validation even though A's value never moved;
+ *   - once CORE-P1a's subtree scope lands, a commit at B no
+ *     longer validates A — but the shared snapshot would still
+ *     advance, leaving A's dedup falsely skipping a real
+ *     re-validation it needed.
+ *
+ * Fix: per-path snapshot `Map<PathKey, unknown>` keyed by the
+ * commit scope; blur-dedup walks from the blurred path up to
+ * the closest ancestor entry and extracts the subtree-at-path
+ * from it for comparison. Under whole-form scope (today) every
+ * commit lands at the root key, so all blurs share a single
+ * entry — equivalent to the old `let`. Per-path keeps the
+ * design correct under both scopes.
+ *
+ * Red-green: programmatic `setValue('b', …)` between A blurs
+ * leaves A's subtree-at-path unchanged. Today's whole-form diff
+ * spots B's diff and revalidates A; the fix's subtree-scoped
+ * diff finds no change at A and skips. A refine-invocation
+ * counter is the direct proxy.
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, nextTick, withDirectives, type App } from 'vue'
+import { z as zV4 } from 'zod'
+import { z as zV3 } from 'zod-v3'
+import { useForm as useFormV4 } from '../../src/zod-v4'
+import { useForm as useFormV3 } from '../../src/zod-v3'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import { vRegister } from '../../src/runtime/core/directive'
+
+const drainMicrotasks = async (rounds = 8): Promise<void> => {
+  for (let i = 0; i < rounds; i++) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+function buildV4() {
+  let runs = 0
+  const schema = zV4.object({
+    a: zV4.string().refine(
+      (v) => {
+        runs += 1
+        return v === 'good-a'
+      },
+      { message: 'a-invalid' }
+    ),
+    b: zV4.string(),
+  })
+  return { schema, runs: () => runs }
+}
+
+function buildV3() {
+  let runs = 0
+  const schema = zV3.object({
+    a: zV3.string().refine(
+      (v) => {
+        runs += 1
+        return v === 'good-a'
+      },
+      { message: 'a-invalid' }
+    ),
+    b: zV3.string(),
+  })
+  return { schema, runs: () => runs }
+}
+
+const adapters = [
+  { name: 'v4', useForm: useFormV4, build: buildV4 },
+  { name: 'v3', useForm: useFormV3, build: buildV3 },
+] as const
+
+describe.each(adapters)('per-path snapshot — $name', ({ useForm, build }) => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+    document.body.innerHTML = ''
+  })
+
+  it("refocus-blur on A is not revalidated when a sibling's value changed but A's didn't", async () => {
+    const { schema, runs } = build()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let api: any
+    const App = defineComponent({
+      setup() {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        api = (useForm as any)({
+          schema,
+          key: 'per-path-snapshot',
+          strict: false,
+          validateOn: 'blur',
+          defaultValues: { a: '', b: '' },
+        })
+        return () =>
+          withDirectives(h('input', { 'data-id': 'a', type: 'text' }), [
+            [vRegister, api.register('a')],
+          ])
+      },
+    })
+    const app = createApp(App).use(createAttaform())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    apps.push(app)
+    await drainMicrotasks()
+
+    const aInput = root.querySelector('input[data-id="a"]') as HTMLInputElement
+
+    // Type into A, blur A. The first interactive blur runs A's refine
+    // (and the whole-form pass) and commits a snapshot.
+    aInput.dispatchEvent(new FocusEvent('focus'))
+    aInput.value = 'nope'
+    aInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await nextTick()
+    aInput.dispatchEvent(new FocusEvent('blur'))
+    await drainMicrotasks()
+    const runsAfterFirstBlur = runs()
+    expect(runsAfterFirstBlur).toBeGreaterThan(0)
+
+    // Programmatic edit to sibling B — blur-mode forms don't schedule
+    // a validation on setValue, so no commit happens and the snapshot
+    // is left wherever the first blur put it. Today's whole-form
+    // diff would catch B's edit at root scope and revalidate A
+    // spuriously; the per-path / subtree-scoped diff sees no change
+    // at A's path and skips.
+    api.setValue('b', 'changed')
+    await drainMicrotasks()
+
+    // Refocus A and blur with no edit on A. With the fix the dedup
+    // skips; without it the diff sees B's change and re-runs A's refine.
+    aInput.dispatchEvent(new FocusEvent('focus'))
+    aInput.dispatchEvent(new FocusEvent('blur'))
+    await drainMicrotasks()
+
+    expect(runs()).toBe(runsAfterFirstBlur)
+  })
+})

--- a/test/composables/reset-clears-snapshot.test.ts
+++ b/test/composables/reset-clears-snapshot.test.ts
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+/**
+ * PASS2-14 — `reset()` cleared field records, errors, and pending
+ * validations but did NOT clear the per-path snapshot map. A reset
+ * back to a value that happens to equal the pre-reset state then
+ * had a survivor entry in `pathSnapshots` matching the post-reset
+ * form, so the next focus/blur cycle's dedup found "no change"
+ * against a stale snapshot and SKIPPED revalidation — leaving the
+ * cleared error bucket cleared and the refine never re-running.
+ * The audit calls this latent: today's first-interactive-blur
+ * force-run masks it for the most common tab-through, but any
+ * post-reset focus/blur cycle WITHOUT a fresh interactive edit
+ * (still possible: a `setFocus(false)` from a script, a refocus
+ * after an unrelated form action) lands in the wrong-skip branch.
+ *
+ * Fix: `reset()` clears `pathSnapshots` and resets the epoch
+ * counters, so the post-reset blur dedup falls through to a
+ * real revalidation.
+ *
+ * Red-green: pre-reset blur commits `{a:'bad'}` into the snapshot
+ * map. `reset({ a: 'bad' })` mirrors the value so the form's
+ * post-reset state structurally equals the survivor snapshot;
+ * the field records' `interacted` flag is reset to `false` so
+ * the firstInteractiveBlur gate doesn't force the next run. The
+ * next focus/blur dedup either finds nothing (fix) and runs
+ * validation, or finds the stale snapshot (bug) and skips.
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, nextTick, withDirectives, type App } from 'vue'
+import { z as zV4 } from 'zod'
+import { z as zV3 } from 'zod-v3'
+import { useForm as useFormV4 } from '../../src/zod-v4'
+import { useForm as useFormV3 } from '../../src/zod-v3'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import { vRegister } from '../../src/runtime/core/directive'
+
+const drainMicrotasks = async (rounds = 8): Promise<void> => {
+  for (let i = 0; i < rounds; i++) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+function buildV4() {
+  let runs = 0
+  const schema = zV4.object({
+    a: zV4.string().refine(
+      (v) => {
+        runs += 1
+        return v === 'good-a'
+      },
+      { message: 'a-invalid' }
+    ),
+  })
+  return { schema, runs: () => runs }
+}
+
+function buildV3() {
+  let runs = 0
+  const schema = zV3.object({
+    a: zV3.string().refine(
+      (v) => {
+        runs += 1
+        return v === 'good-a'
+      },
+      { message: 'a-invalid' }
+    ),
+  })
+  return { schema, runs: () => runs }
+}
+
+const adapters = [
+  { name: 'v4', useForm: useFormV4, build: buildV4 },
+  { name: 'v3', useForm: useFormV3, build: buildV3 },
+] as const
+
+describe.each(adapters)('reset clears snapshot map — $name', ({ useForm, build }) => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+    document.body.innerHTML = ''
+  })
+
+  it('post-reset blur dedup runs validation even when the value matches a pre-reset snapshot', async () => {
+    const { schema, runs } = build()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let api: any
+    const App = defineComponent({
+      setup() {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        api = (useForm as any)({
+          schema,
+          key: 'reset-clears-snapshot',
+          strict: false,
+          validateOn: 'blur',
+          defaultValues: { a: '' },
+        })
+        return () =>
+          withDirectives(h('input', { 'data-id': 'a', type: 'text' }), [
+            [vRegister, api.register('a')],
+          ])
+      },
+    })
+    const app = createApp(App).use(createAttaform())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    apps.push(app)
+    await drainMicrotasks()
+
+    const aInput = root.querySelector('input[data-id="a"]') as HTMLInputElement
+
+    // Type into A, blur A. The firstInteractiveBlur force-run lands
+    // the validation and writes `{a:'bad'}` into the snapshot map.
+    aInput.dispatchEvent(new FocusEvent('focus'))
+    aInput.value = 'bad'
+    aInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await nextTick()
+    aInput.dispatchEvent(new FocusEvent('blur'))
+    await drainMicrotasks()
+    const runsAfterFirstBlur = runs()
+    expect(runsAfterFirstBlur).toBeGreaterThan(0)
+
+    // Reset to a value matching the post-blur state. The reset
+    // clears errors and zeroes the field's `interacted` flag, so
+    // the next blur is NOT a firstInteractiveBlur — it lands in
+    // the dedup branch. Without the fix the survivor snapshot
+    // matches the live form, and dedup skips.
+    api.reset({ a: 'bad' })
+    await drainMicrotasks()
+
+    aInput.dispatchEvent(new FocusEvent('focus'))
+    aInput.dispatchEvent(new FocusEvent('blur'))
+    await drainMicrotasks()
+
+    // With the fix: snapshot map cleared in `reset()`, the dedup
+    // can't match against anything, and the validation re-runs.
+    expect(runs()).toBeGreaterThan(runsAfterFirstBlur)
+  })
+})


### PR DESCRIPTION
Phase 6 of the audit-driven remediation. Atomic redesign of the
field-level validation lifecycle, closing PASS2-2 / PASS2-3 /
PASS2-S3 / PASS2-14 in the `run()` closure + `lastValidatedSnapshot`
surface, and landing CORE-P1a's per-keystroke scope cut behind a
new adapter predicate.

Full gate green: lint, typecheck, check:site, **3,272 tests** (+14
new red-green cases across 5 new files), check:size, check:bench
(5.6×–9.8× ratios on keystroke benches), check:coverage 91.49%.

## ⚠️ API & behavior-change ledger

All four ⚠️ items surfaced via plan-time AskUserQuestion before
coding. Sign-offs recorded:

  * **Snapshot scope:** "Per-path Map (Recommended)" — keyed by the
    canonical PathKey of the validation commit scope; blur-dedup
    walks ancestors and extracts `getAtPath(snapshot, path)` for a
    subtree-scoped comparison. Today every commit lands at root
    (whole-form), so all blurs share one entry; once CORE-P1a's
    subtree scope is in, each commit advances its own entry.
  * **CORE-P1a strategy:** "Adapter predicate (Recommended)" — new
    `AbstractSchema.hasContainerOrRootRefine?(): boolean` optional
    method drives the per-keystroke scope. `true` (or missing) →
    whole-form (today's behaviour, conservative default). `false`
    → subtree-at-path.
  * **Predicate name:** `hasContainerOrRootRefine` — describes WHAT
    the predicate detects, mirrors the existing
    `needsAsyncValidation` adapter-method idiom.

### Observable behaviour changes

  * **PASS2-2** — concurrent different-path async runs no longer
    clobber by resolution order. A form-level monotonic
    `scheduleEpoch` is captured at each schedule and re-checked at
    each commit; a run whose `myEpoch <= lastCommittedEpoch` drops
    its write. Per-path AbortController still guards same-path
    rapid typing.
  * **PASS2-3** — the blur snapshot now writes ONLY in the applied
    branch (after abort + epoch checks). Aborted runs leave the
    snapshot wherever the last committed run put it.
  * **PASS2-S3** — per-path snapshot map keyed by commit scope;
    blur-dedup at path `P` walks ancestors and compares
    `getAtPath(snapshot, P)` against `getAtPath(form.value, P)`.
    Spurious revalidation on sibling edits between blurs goes
    away.
  * **PASS2-14** — `reset()` clears `pathSnapshots` and resets the
    epoch counters. A reset back to a value that mirrors a
    pre-reset state no longer wrong-skips on the next focus/blur.
  * **CORE-P1a** — for a schema with no container / root refines,
    every per-keystroke `validateAtPath` now scopes to the edited
    subtree rather than re-parsing every leaf. Schemas WITH
    container or root refines (the predicate returns `true`) keep
    today's whole-form pass.

### New public surface

  * `AbstractSchema.hasContainerOrRootRefine?(): boolean` — optional
    adapter method, documented in `types-api.ts`. Implementation
    landed on BOTH adapters (zod-v3 + zod-v4) — v3 inline
    `_def` walker until Phase 7's introspect chokepoint, v4
    via the existing introspect.ts walker pattern.

## Commits

```
71a377a fix(validation): drop stale async commits via form-level epoch guard
5fa7925 fix(validation): write the blur snapshot only on a committed verdict
c501c24 fix(validation): per-path snapshot map + subtree-scoped blur dedup
7ba9575 fix(validation): reset() clears the per-path snapshot map + epoch counters
d3ac711 feat(validation): per-keystroke subtree scope via hasContainerOrRootRefine predicate
```

Each ships a failing repro (red) committed alongside the fix
(green), parameterised across v3 + v4 via `describe.each`. No
amends ([[feedback_never_amend]]).

## Plan reference

Phase 6 of `audit/codebase-review` → `AUDIT-FINDINGS.md`. Next
phase: `refactor/v3-introspect-chokepoint` (Phase 7, ADAPT-F1 /
D18). The v3 inline walker shipped here will get replaced by
the chokepoint helper at the same time the rest of v3's `_def`
reads relocate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)