### PR TITLE
Phase 7: v3 introspect chokepoint (ADAPT-F1 / D18)

### DIFF
--- a/src/runtime/adapters/zod-v3/assert-supported.ts
+++ b/src/runtime/adapters/zod-v3/assert-supported.ts
@@ -1,6 +1,23 @@
 import type { z } from 'zod-v3'
 import { UnsupportedSchemaError } from './errors'
 import { isZodSchemaType } from './helpers'
+import {
+  getArrayElement,
+  getDiscriminatedOptions,
+  getIntersectionLeft,
+  getIntersectionRight,
+  getLazyGetter,
+  getObjectShape,
+  getRecordValueType,
+  getSetValueType,
+  getTupleItems,
+  getTypeName,
+  getUnionOptions,
+  unwrapBranded,
+  unwrapEffectsSource,
+  unwrapInner,
+  unwrapPipeIn,
+} from './introspect'
 
 /**
  * Kinds the v3 adapter does not implement. `z.promise(...)`,
@@ -20,11 +37,6 @@ function labelPath(path: readonly string[]): string {
   return path.length === 0 ? '<root>' : path.join('.')
 }
 
-function getTypeName(schema: z.ZodTypeAny): string | undefined {
-  const def = (schema as { _def?: { typeName?: string } })._def
-  return def?.typeName
-}
-
 /**
  * Walk the schema tree and fail fast on unsupported kinds. Detects
  * recursive `z.lazy(...)` by tracking the *getter function identity*
@@ -34,8 +46,8 @@ function getTypeName(schema: z.ZodTypeAny): string | undefined {
  * This runs once, at adapter construction time, so the cost is paid
  * at app startup rather than per keystroke. Mirrors v4's
  * `assertSupportedKinds`; the dispatch goes through `isZodSchemaType`
- * (typeName comparison) instead of the v4 `kindOf` helper because v3
- * doesn't have an equivalent introspect layer.
+ * (typeName comparison) plus the introspect accessors for the
+ * structural reads.
  */
 export function assertSupportedKinds(
   schema: z.ZodTypeAny,
@@ -50,53 +62,53 @@ export function assertSupportedKinds(
   }
 
   if (isZodSchemaType(schema, 'ZodObject')) {
-    const shape = schema.shape as Record<string, z.ZodTypeAny>
-    for (const [key, sub] of Object.entries(shape)) {
+    for (const [key, sub] of Object.entries(getObjectShape(schema))) {
       assertSupportedKinds(sub, [...path, key], lazyGetters)
     }
     return
   }
 
   if (isZodSchemaType(schema, 'ZodArray')) {
-    const inner = (schema._def as { type?: z.ZodTypeAny }).type
+    const inner = getArrayElement(schema)
     if (inner) assertSupportedKinds(inner, [...path, '*'], lazyGetters)
     return
   }
 
   if (isZodSchemaType(schema, 'ZodSet')) {
-    const inner = (schema._def as { valueType?: z.ZodTypeAny }).valueType
+    const inner = getSetValueType(schema)
     if (inner) assertSupportedKinds(inner, [...path, '*'], lazyGetters)
     return
   }
 
   if (isZodSchemaType(schema, 'ZodRecord')) {
-    const inner = (schema._def as { valueType?: z.ZodTypeAny }).valueType
+    const inner = getRecordValueType(schema)
     if (inner) assertSupportedKinds(inner, [...path, '*'], lazyGetters)
     return
   }
 
   if (isZodSchemaType(schema, 'ZodTuple')) {
-    const items = (schema._def as { items?: z.ZodTypeAny[] }).items ?? []
+    const items = getTupleItems(schema)
     items.forEach((item, i) => assertSupportedKinds(item, [...path, String(i)], lazyGetters))
     return
   }
 
   if (isZodSchemaType(schema, 'ZodUnion')) {
-    const options = (schema._def as { options?: z.ZodTypeAny[] }).options ?? []
+    const options = getUnionOptions(schema)
     options.forEach((opt, i) => assertSupportedKinds(opt, [...path, `|${i}`], lazyGetters))
     return
   }
 
   if (isZodSchemaType(schema, 'ZodDiscriminatedUnion')) {
-    const options = (schema._def as { options?: z.ZodTypeAny[] }).options ?? []
+    const options = getDiscriminatedOptions(schema)
     options.forEach((opt, i) => assertSupportedKinds(opt, [...path, `|${i}`], lazyGetters))
     return
   }
 
   if (isZodSchemaType(schema, 'ZodIntersection')) {
-    const def = schema._def as { left?: z.ZodTypeAny; right?: z.ZodTypeAny }
-    if (def.left) assertSupportedKinds(def.left, [...path, 'left'], lazyGetters)
-    if (def.right) assertSupportedKinds(def.right, [...path, 'right'], lazyGetters)
+    const left = getIntersectionLeft(schema)
+    if (left) assertSupportedKinds(left, [...path, 'left'], lazyGetters)
+    const right = getIntersectionRight(schema)
+    if (right) assertSupportedKinds(right, [...path, 'right'], lazyGetters)
     return
   }
 
@@ -105,30 +117,33 @@ export function assertSupportedKinds(
     isZodSchemaType(schema, 'ZodNullable') ||
     isZodSchemaType(schema, 'ZodDefault') ||
     isZodSchemaType(schema, 'ZodReadonly') ||
-    isZodSchemaType(schema, 'ZodCatch') ||
-    isZodSchemaType(schema, 'ZodBranded')
+    isZodSchemaType(schema, 'ZodCatch')
   ) {
-    const inner =
-      (schema._def as { innerType?: z.ZodTypeAny }).innerType ??
-      (schema._def as { type?: z.ZodTypeAny }).type
+    const inner = unwrapInner(schema)
+    if (inner) assertSupportedKinds(inner, path, lazyGetters)
+    return
+  }
+
+  if (isZodSchemaType(schema, 'ZodBranded')) {
+    const inner = unwrapBranded(schema)
     if (inner) assertSupportedKinds(inner, path, lazyGetters)
     return
   }
 
   if (isZodSchemaType(schema, 'ZodEffects')) {
-    const inner = schema.innerType()
-    assertSupportedKinds(inner, path, lazyGetters)
+    const inner = unwrapEffectsSource(schema)
+    if (inner) assertSupportedKinds(inner, path, lazyGetters)
     return
   }
 
   if (isZodSchemaType(schema, 'ZodPipeline')) {
-    const inner = (schema._def as { in?: z.ZodTypeAny }).in
+    const inner = unwrapPipeIn(schema)
     if (inner) assertSupportedKinds(inner, path, lazyGetters)
     return
   }
 
   if (isZodSchemaType(schema, 'ZodLazy')) {
-    const getter = (schema._def as { getter?: () => z.ZodTypeAny }).getter
+    const getter = getLazyGetter(schema)
     // Recursive z.lazy() is supported. Stop descending on the second
     // encounter (the shape walk only needs each unique getter once);
     // downstream walks cap their descent via `maxRecursionDepth`.
@@ -136,7 +151,7 @@ export function assertSupportedKinds(
     const inner = getter?.()
     if (inner !== undefined) {
       assertSupportedKinds(
-        inner,
+        inner as z.ZodTypeAny,
         path,
         getter === undefined ? lazyGetters : [...lazyGetters, getter]
       )

--- a/src/runtime/adapters/zod-v3/index.ts
+++ b/src/runtime/adapters/zod-v3/index.ts
@@ -80,16 +80,19 @@ import {
   getIntersectionRight,
   getLiteralValue,
   getObjectShape,
+  getRecordKeyType,
   getRecordValueType,
   getSetValueType,
   getTupleItems,
   getTypeName,
   getUnionOptions,
   hasCatchValue,
+  hasChecks,
   hasContainerOrRootRefine,
   unwrapBranded,
   unwrapEffectsSource,
   unwrapInner,
+  unwrapLazy,
   unwrapPipeIn,
 } from './introspect'
 import { slimPrimitivesV3 } from './slim-primitives'
@@ -1582,19 +1585,6 @@ type StripConfig = {
   stripDefaultValues?: boolean | StripConfigCallback
 }
 
-function hasChecks(schema: z.ZodTypeAny): boolean {
-  if (!('_def' in schema)) return false
-
-  const schemaDef = schema._def
-  if (!('checks' in schemaDef)) return false
-
-  const checks = schemaDef['checks'] as unknown
-
-  if (!Array.isArray(checks)) return false
-
-  return checks.length > 0
-}
-
 function stripRefinements<T extends z.ZodTypeAny>(schema: T) {
   // `depth` bounds the recursion at MAX_UNWRAP_STEPS (per branch). For
   // realistic form schemas the structural depth is in single digits;
@@ -1603,28 +1593,29 @@ function stripRefinements<T extends z.ZodTypeAny>(schema: T) {
   // depth is exactly the chain length).
   function _stripRefinements(_schema: z.ZodTypeAny, depth: number): z.ZodTypeAny {
     if (depth >= MAX_UNWRAP_STEPS) return _schema as T
-    if (isZodSchemaType(_schema, 'ZodString') && _schema._def.checks.length > 0) {
+    if (isZodSchemaType(_schema, 'ZodString') && hasChecks(_schema)) {
       // Rebuild a ZodString without checks
       return z.string()
     }
 
-    if (isZodSchemaType(_schema, 'ZodNumber') && _schema._def.checks.length > 0) {
+    if (isZodSchemaType(_schema, 'ZodNumber') && hasChecks(_schema)) {
       // Rebuild a ZodNumber without checks
       return z.number()
     }
 
     if (isZodSchemaType(_schema, 'ZodArray')) {
       // Recursively process the array's inner type
-      return z.array(_stripRefinements(_schema._def.type, depth + 1))
+      const inner = getArrayElement(_schema)
+      if (!inner) return _schema
+      return z.array(_stripRefinements(inner, depth + 1))
     }
 
     if (isZodSchemaType(_schema, 'ZodObject')) {
       // Recursively process each property of the object
-      const shape = _schema.shape
       const strippedShape = Object.fromEntries(
-        Object.entries(shape).map(([key, value]) => [
+        Object.entries(getObjectShape(_schema)).map(([key, value]) => [
           key,
-          _stripRefinements(value as z.ZodTypeAny, depth + 1),
+          _stripRefinements(value, depth + 1),
         ])
       )
       return z.object(strippedShape)
@@ -1632,17 +1623,23 @@ function stripRefinements<T extends z.ZodTypeAny>(schema: T) {
 
     if (isZodSchemaType(_schema, 'ZodEffects')) {
       // Unwrap the inner schema and strip refinements
-      return _stripRefinements(_schema.innerType(), depth + 1)
+      const inner = unwrapEffectsSource(_schema)
+      if (!inner) return _schema
+      return _stripRefinements(inner, depth + 1)
     }
 
     if (isZodSchemaType(_schema, 'ZodOptional')) {
       // Recursively strip optional's inner type
-      return z.optional(_stripRefinements(_schema.unwrap(), depth + 1))
+      const inner = unwrapInner(_schema)
+      if (!inner) return _schema
+      return z.optional(_stripRefinements(inner, depth + 1))
     }
 
     if (isZodSchemaType(_schema, 'ZodNullable')) {
       // Recursively strip nullable's inner type
-      return z.nullable(_stripRefinements(_schema.unwrap(), depth + 1))
+      const inner = unwrapInner(_schema)
+      if (!inner) return _schema
+      return z.nullable(_stripRefinements(inner, depth + 1))
     }
 
     // Newer transparent wrappers — descend into their inner schema and
@@ -1650,19 +1647,19 @@ function stripRefinements<T extends z.ZodTypeAny>(schema: T) {
     // refinement/branding/pipeline metadata isn't load-bearing for the
     // slim-parse pass that consumes the stripped schema.
     if (isZodSchemaType(_schema, 'ZodReadonly')) {
-      const inner = (_schema._def as { innerType?: z.ZodTypeAny }).innerType
+      const inner = unwrapInner(_schema)
       if (!inner) return _schema
       return _stripRefinements(inner, depth + 1)
     }
 
     if (isZodSchemaType(_schema, 'ZodBranded')) {
-      const inner = (_schema._def as { type?: z.ZodTypeAny }).type
+      const inner = unwrapBranded(_schema)
       if (!inner) return _schema
       return _stripRefinements(inner, depth + 1)
     }
 
     if (isZodSchemaType(_schema, 'ZodPipeline')) {
-      const inner = (_schema._def as { in?: z.ZodTypeAny }).in
+      const inner = unwrapPipeIn(_schema)
       if (!inner) return _schema
       return _stripRefinements(inner, depth + 1)
     }
@@ -1674,69 +1671,66 @@ function stripRefinements<T extends z.ZodTypeAny>(schema: T) {
     // contract, no fix-up needed.
 
     if (isZodSchemaType(_schema, 'ZodSet')) {
-      const valueType = (_schema._def as { valueType?: z.ZodTypeAny }).valueType
+      const valueType = getSetValueType(_schema)
       if (!valueType) return _schema
       return z.set(_stripRefinements(valueType, depth + 1))
     }
 
     if (isZodSchemaType(_schema, 'ZodTuple')) {
-      const items = (_schema._def as { items?: z.ZodTypeAny[] }).items
-      if (!items) return _schema
+      const items = getTupleItems(_schema)
+      if (items.length === 0) return _schema
       const stripped = items.map((it) => _stripRefinements(it, depth + 1))
       return z.tuple(stripped as [z.ZodTypeAny, ...z.ZodTypeAny[]])
     }
 
     if (isZodSchemaType(_schema, 'ZodRecord')) {
-      const def = _schema._def as { keyType?: z.ZodTypeAny; valueType?: z.ZodTypeAny }
-      if (!def.valueType) return _schema
-      const value = _stripRefinements(def.valueType, depth + 1)
+      const valueType = getRecordValueType(_schema)
+      if (!valueType) return _schema
+      const value = _stripRefinements(valueType, depth + 1)
       // z.record's two-arg form preserves the key schema; one-arg form
       // assumes z.string(). Forward the key type unchanged — refinements
       // on record keys aren't load-bearing for slim-schema concerns.
-      if (def.keyType) {
-        return z.record(def.keyType as z.ZodString, value)
+      const keyType = getRecordKeyType(_schema)
+      if (keyType) {
+        return z.record(keyType as z.ZodString, value)
       }
       return z.record(value)
     }
 
     if (isZodSchemaType(_schema, 'ZodUnion')) {
-      const options = (_schema._def as { options?: z.ZodTypeAny[] }).options
-      if (!options) return _schema
+      const options = getUnionOptions(_schema)
+      if (options.length === 0) return _schema
       const stripped = options.map((o) => _stripRefinements(o, depth + 1))
       return z.union(stripped as [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]])
     }
 
     if (isZodSchemaType(_schema, 'ZodDiscriminatedUnion')) {
-      const def = _schema._def as {
-        discriminator?: string
-        options?: z.ZodObject<z.ZodRawShape>[]
-      }
-      if (def.discriminator === undefined || !def.options) return _schema
-      const stripped = def.options.map(
+      const discKey = getDiscriminator(_schema)
+      const options = getDiscriminatedOptions(_schema)
+      if (discKey === undefined || options.length === 0) return _schema
+      const stripped = options.map(
         (o) => _stripRefinements(o, depth + 1) as z.ZodObject<z.ZodRawShape>
       )
       return z.discriminatedUnion(
-        def.discriminator,
+        discKey,
         stripped as [z.ZodObject<z.ZodRawShape>, ...z.ZodObject<z.ZodRawShape>[]]
       )
     }
 
     if (isZodSchemaType(_schema, 'ZodIntersection')) {
-      const def = _schema._def as { left?: z.ZodTypeAny; right?: z.ZodTypeAny }
-      if (!def.left || !def.right) return _schema
-      return z.intersection(
-        _stripRefinements(def.left, depth + 1),
-        _stripRefinements(def.right, depth + 1)
-      )
+      const left = getIntersectionLeft(_schema)
+      const right = getIntersectionRight(_schema)
+      if (!left || !right) return _schema
+      return z.intersection(_stripRefinements(left, depth + 1), _stripRefinements(right, depth + 1))
     }
 
     if (isZodSchemaType(_schema, 'ZodLazy')) {
-      const getter = (_schema._def as { getter?: () => z.ZodTypeAny }).getter
-      if (!getter) return _schema
+      const inner = unwrapLazy(_schema)
+      if (!inner) return _schema
       // Eagerly resolve once and capture the stripped target so the
       // returned lazy resolves to a stable schema. assertSupportedKinds
       // has already rejected self-referencing lazies, so this is finite.
-      const stripped = _stripRefinements(getter(), depth + 1)
+      const stripped = _stripRefinements(inner, depth + 1)
       return z.lazy(() => stripped)
     }
 
@@ -1774,7 +1768,8 @@ function stripRootSchema(schema: z.ZodSchema, stripConfig: StripConfig) {
       getStripInstruction(stripConfig.stripDefaultValues, _schema) &&
       isZodSchemaType(_schema, 'ZodDefault')
     ) {
-      return recursion(_schema._def.innerType, true)
+      const inner = unwrapInner(_schema)
+      if (inner) return recursion(inner as z.ZodSchema, true)
     }
 
     if (getStripInstruction(stripConfig.stripZodRefinements, _schema) && hasChecks(_schema)) {
@@ -1809,38 +1804,42 @@ function getSlimSchema<RS extends z.ZodRawShape, Schema extends z.ZodSchema>(
   function _getSlimSchema(_schema: z.ZodSchema): z.ZodSchema {
     if (isZodSchemaType(_schema, 'ZodObject')) {
       const newShape: z.ZodRawShape = {}
-
-      for (const key in _schema.shape) {
-        const value = _schema.shape[key]
-        newShape[key] = _getSlimSchema(value)
+      for (const [key, value] of Object.entries(getObjectShape(_schema))) {
+        newShape[key] = _getSlimSchema(value as z.ZodSchema)
       }
-
       return z.object(newShape)
     }
 
     if (isZodSchemaType(_schema, 'ZodArray')) {
-      return z.array(_getSlimSchema(_schema.element))
+      const inner = getArrayElement(_schema)
+      if (!inner) return _schema
+      return z.array(_getSlimSchema(inner as z.ZodSchema))
     }
 
     if (isZodSchemaType(_schema, 'ZodRecord')) {
-      const key = _getSlimSchema(_schema._def.keyType)
-      const value = _getSlimSchema(_schema._def.valueType)
-      return z.record(key, value)
+      const keyType = getRecordKeyType(_schema)
+      const valueType = getRecordValueType(_schema)
+      if (!keyType || !valueType) return _schema
+      const key = _getSlimSchema(keyType as z.ZodSchema)
+      const value = _getSlimSchema(valueType as z.ZodSchema)
+      return z.record(key as z.ZodString, value)
     }
 
     // same way we go into records, objects, and arrays, go into discriminated unions
     if (isZodSchemaType(_schema, 'ZodDiscriminatedUnion')) {
       const slimmedSchemas = []
+      const discKey = getDiscriminator(_schema)
+      if (discKey === undefined) return _schema
 
-      for (const option of _schema._def.options) {
-        const slimmedSchema = _getSlimSchema(option)
+      for (const option of getDiscriminatedOptions(_schema)) {
+        const slimmedSchema = _getSlimSchema(option as unknown as z.ZodSchema)
         // slimmedSchema will be a structurally deep object, so break pointer refs to prevent recursion bugs
         const deepCloneSlimmedSchema = cloneDeep(slimmedSchema)
         slimmedSchemas.push(deepCloneSlimmedSchema)
       }
 
       return z.discriminatedUnion(
-        _schema._def.discriminator,
+        discKey,
         slimmedSchemas as unknown as readonly [
           z.ZodDiscriminatedUnionOption<string>,
           ...z.ZodDiscriminatedUnionOption<string>[],
@@ -1852,21 +1851,24 @@ function getSlimSchema<RS extends z.ZodRawShape, Schema extends z.ZodSchema>(
       getStripInstruction(config.stripConfig.stripZodEffects, _schema) &&
       isZodSchemaType(_schema, 'ZodEffects')
     ) {
-      return _getSlimSchema(_schema.innerType())
+      const inner = unwrapEffectsSource(_schema)
+      if (inner) return _getSlimSchema(inner as z.ZodSchema)
     }
 
     if (
       getStripInstruction(config.stripConfig.stripNullable, _schema) &&
       isZodSchemaType(_schema, 'ZodNullable')
     ) {
-      return _getSlimSchema(_schema._def.innerType)
+      const inner = unwrapInner(_schema)
+      if (inner) return _getSlimSchema(inner as z.ZodSchema)
     }
 
     if (
       getStripInstruction(config.stripConfig.stripOptional, _schema) &&
       isZodSchemaType(_schema, 'ZodOptional')
     ) {
-      return _getSlimSchema(_schema._def.innerType)
+      const inner = unwrapInner(_schema)
+      if (inner) return _getSlimSchema(inner as z.ZodSchema)
     }
 
     if (
@@ -1880,7 +1882,8 @@ function getSlimSchema<RS extends z.ZodRawShape, Schema extends z.ZodSchema>(
       getStripInstruction(config.stripConfig.stripDefaultValues, _schema) &&
       isZodSchemaType(_schema, 'ZodDefault')
     ) {
-      return _getSlimSchema(_schema._def.innerType)
+      const inner = unwrapInner(_schema)
+      if (inner) return _getSlimSchema(inner as z.ZodSchema)
     }
 
     // Attempt to unwrap a schema to find a discriminated union (bail if you hit another valid schema type)

--- a/src/runtime/adapters/zod-v3/index.ts
+++ b/src/runtime/adapters/zod-v3/index.ts
@@ -64,6 +64,7 @@ import type { TypeWithNullableDynamicKeys, ZodTypeWithInnerType } from './types-
 import { assertSupportedKinds } from './assert-supported'
 import { fingerprintZodSchema } from './fingerprint'
 import { isZodSchemaType } from './helpers'
+import { hasContainerOrRootRefine } from './introspect'
 import { slimPrimitivesV3 } from './slim-primitives'
 
 let warnedZodCodeMissing = false
@@ -180,7 +181,7 @@ export function zodAdapter<
       fingerprint: () => fingerprintZodSchema(_zodSchema),
 
       hasContainerOrRootRefine(): boolean {
-        containerRefineFlag ??= v3HasContainerOrRootRefine(_zodSchema)
+        containerRefineFlag ??= hasContainerOrRootRefine(_zodSchema)
         return containerRefineFlag
       },
       getDefaultValues(config) {
@@ -1569,177 +1570,6 @@ function hasChecks(schema: z.ZodTypeAny): boolean {
   if (!Array.isArray(checks)) return false
 
   return checks.length > 0
-}
-
-/**
- * True iff the v3 schema tree carries a refine / transform / preprocess
- * (`ZodEffects`) whose effect target is a container — Object / Array
- * / Tuple / Union / DU / Intersection / Record / Map / Set — or the
- * root itself. Drives the runtime's per-keystroke scope cut: a tree
- * with leaf-only effects can be re-validated at the edited subtree
- * alone (subtree pass catches the leaf effect at the same depth);
- * a container effect can be moved by sibling writes and forces a
- * whole-form pass.
- *
- * Walks via inline `_def` reads (the introspect-chokepoint refactor
- * lands in Phase 7 and will collapse this into the unified accessor
- * surface). Transparent wrappers (Optional / Nullable / Default /
- * Catch / Readonly / Branded / Lazy) peel through to their inner
- * before container detection — `.refine` on `.optional()` over a
- * `z.object(...)` is still a root-scoped effect. Pipelines walk both
- * sides.
- *
- * Bias conservative: an unrecognised wrapper or a malformed leaf
- * returns `false` for THAT node, but the recurse continues, so
- * nested container effects still surface. False negatives only lose
- * the perf win; correctness preserved by the caller's whole-form
- * default when the predicate isn't reached.
- */
-function v3HasContainerOrRootRefine(schema: z.ZodTypeAny, seen?: WeakSet<object>): boolean {
-  const visited = seen ?? new WeakSet<object>()
-  const candidate = schema as unknown
-  if (typeof candidate !== 'object' || candidate === null) return false
-  if (visited.has(candidate)) return false
-  visited.add(candidate)
-
-  // ZodEffects: refine / transform / preprocess. Peel transparent
-  // wrappers off the inner so `.refine()` applied to `.optional()`
-  // over a container still flags as a container-level effect.
-  if (isZodSchemaType(schema, 'ZodEffects')) {
-    const inner = (schema._def as unknown as { schema?: z.ZodTypeAny }).schema
-    if (inner === undefined) return false
-    if (v3IsContainerAfterWrapperPeel(inner)) return true
-    return v3HasContainerOrRootRefine(inner, visited)
-  }
-
-  // Transparent wrappers: recurse into the inner without flagging.
-  if (
-    isZodSchemaType(schema, 'ZodOptional') ||
-    isZodSchemaType(schema, 'ZodNullable') ||
-    isZodSchemaType(schema, 'ZodDefault') ||
-    isZodSchemaType(schema, 'ZodCatch') ||
-    isZodSchemaType(schema, 'ZodReadonly')
-  ) {
-    const inner = (schema._def as unknown as { innerType?: z.ZodTypeAny }).innerType
-    return inner !== undefined && v3HasContainerOrRootRefine(inner, visited)
-  }
-  if (isZodSchemaType(schema, 'ZodBranded')) {
-    const inner = (schema._def as unknown as { type?: z.ZodTypeAny }).type
-    return inner !== undefined && v3HasContainerOrRootRefine(inner, visited)
-  }
-  if (isZodSchemaType(schema, 'ZodLazy')) {
-    try {
-      const inner = (schema._def as unknown as { getter?: () => z.ZodTypeAny }).getter?.()
-      return inner !== undefined && v3HasContainerOrRootRefine(inner, visited)
-    } catch {
-      return false
-    }
-  }
-  if (isZodSchemaType(schema, 'ZodPipeline')) {
-    const def = schema._def as unknown as { in?: z.ZodTypeAny; out?: z.ZodTypeAny }
-    if (def.in !== undefined && v3HasContainerOrRootRefine(def.in, visited)) return true
-    if (def.out !== undefined && v3HasContainerOrRootRefine(def.out, visited)) return true
-    return false
-  }
-
-  // Container types: recurse into children.
-  if (isZodSchemaType(schema, 'ZodObject')) {
-    const def = schema._def as unknown as {
-      shape?: (() => Record<string, z.ZodTypeAny>) | Record<string, z.ZodTypeAny>
-    }
-    const shape = typeof def.shape === 'function' ? def.shape() : def.shape
-    if (shape !== undefined) {
-      for (const sub of Object.values(shape)) {
-        if (v3HasContainerOrRootRefine(sub, visited)) return true
-      }
-    }
-    return false
-  }
-  if (isZodSchemaType(schema, 'ZodArray')) {
-    const elem = (schema._def as unknown as { type?: z.ZodTypeAny }).type
-    return elem !== undefined && v3HasContainerOrRootRefine(elem, visited)
-  }
-  if (isZodSchemaType(schema, 'ZodTuple')) {
-    const items = (schema._def as unknown as { items?: z.ZodTypeAny[] }).items
-    if (items !== undefined) {
-      for (const it of items) {
-        if (v3HasContainerOrRootRefine(it, visited)) return true
-      }
-    }
-    return false
-  }
-  if (isZodSchemaType(schema, 'ZodUnion') || isZodSchemaType(schema, 'ZodDiscriminatedUnion')) {
-    const opts = (schema._def as unknown as { options?: z.ZodTypeAny[] }).options
-    if (opts !== undefined) {
-      for (const opt of opts) {
-        if (v3HasContainerOrRootRefine(opt, visited)) return true
-      }
-    }
-    return false
-  }
-  if (isZodSchemaType(schema, 'ZodIntersection')) {
-    const def = schema._def as unknown as { left?: z.ZodTypeAny; right?: z.ZodTypeAny }
-    if (def.left !== undefined && v3HasContainerOrRootRefine(def.left, visited)) return true
-    if (def.right !== undefined && v3HasContainerOrRootRefine(def.right, visited)) return true
-    return false
-  }
-  if (isZodSchemaType(schema, 'ZodRecord')) {
-    const def = schema._def as unknown as { keyType?: z.ZodTypeAny; valueType?: z.ZodTypeAny }
-    if (def.keyType !== undefined && v3HasContainerOrRootRefine(def.keyType, visited)) return true
-    if (def.valueType !== undefined && v3HasContainerOrRootRefine(def.valueType, visited))
-      return true
-    return false
-  }
-  if (isZodSchemaType(schema, 'ZodSet')) {
-    const elem = (schema._def as unknown as { valueType?: z.ZodTypeAny }).valueType
-    return elem !== undefined && v3HasContainerOrRootRefine(elem, visited)
-  }
-
-  // Leaves (ZodString / ZodNumber / ZodBoolean / ZodLiteral / ZodEnum /
-  // ZodNativeEnum / ZodDate / ...) — no descendable structure, no
-  // container effect possible.
-  return false
-}
-
-function v3IsContainerAfterWrapperPeel(schema: z.ZodTypeAny): boolean {
-  let cur: z.ZodTypeAny = schema
-  for (let i = 0; i < MAX_UNWRAP_STEPS; i++) {
-    if (
-      isZodSchemaType(cur, 'ZodOptional') ||
-      isZodSchemaType(cur, 'ZodNullable') ||
-      isZodSchemaType(cur, 'ZodDefault') ||
-      isZodSchemaType(cur, 'ZodCatch') ||
-      isZodSchemaType(cur, 'ZodReadonly')
-    ) {
-      const inner = (cur._def as unknown as { innerType?: z.ZodTypeAny }).innerType
-      if (inner === undefined) return false
-      cur = inner
-    } else if (isZodSchemaType(cur, 'ZodBranded')) {
-      const inner = (cur._def as unknown as { type?: z.ZodTypeAny }).type
-      if (inner === undefined) return false
-      cur = inner
-    } else if (isZodSchemaType(cur, 'ZodLazy')) {
-      try {
-        const inner = (cur._def as unknown as { getter?: () => z.ZodTypeAny }).getter?.()
-        if (inner === undefined) return false
-        cur = inner
-      } catch {
-        return false
-      }
-    } else {
-      break
-    }
-  }
-  return (
-    isZodSchemaType(cur, 'ZodObject') ||
-    isZodSchemaType(cur, 'ZodArray') ||
-    isZodSchemaType(cur, 'ZodTuple') ||
-    isZodSchemaType(cur, 'ZodIntersection') ||
-    isZodSchemaType(cur, 'ZodUnion') ||
-    isZodSchemaType(cur, 'ZodDiscriminatedUnion') ||
-    isZodSchemaType(cur, 'ZodRecord') ||
-    isZodSchemaType(cur, 'ZodSet')
-  )
 }
 
 function stripRefinements<T extends z.ZodTypeAny>(schema: T) {

--- a/src/runtime/adapters/zod-v3/index.ts
+++ b/src/runtime/adapters/zod-v3/index.ts
@@ -60,11 +60,38 @@ function constraintsAreSlimValid(slimSchema: z.ZodSchema, constraints: unknown):
 
 import { __DEV__ } from '../../core/dev'
 import { AttaformErrorCode } from '../../core/error-codes'
-import type { TypeWithNullableDynamicKeys, ZodTypeWithInnerType } from './types-zod'
+import type { TypeWithNullableDynamicKeys } from './types-zod'
+// `ZodTypeWithInnerType` lives in types-zod.ts and is re-exported from
+// `attaform/zod-v3` as a narrow accessor type for custom-adapter
+// authors. Phase 7's introspect chokepoint means the v3 adapter no
+// longer reads `_def` directly inline; the public type stays available
+// for downstream consumers writing adapter-shaped code.
 import { assertSupportedKinds } from './assert-supported'
 import { fingerprintZodSchema } from './fingerprint'
 import { isZodSchemaType } from './helpers'
-import { hasContainerOrRootRefine } from './introspect'
+import {
+  getArrayElement,
+  getCatchDefault,
+  getDefaultValue as getDefaultValueFromIntrospect,
+  getDiscriminatedOptions,
+  getDiscriminator,
+  getEffectsKind,
+  getIntersectionLeft,
+  getIntersectionRight,
+  getLiteralValue,
+  getObjectShape,
+  getRecordValueType,
+  getSetValueType,
+  getTupleItems,
+  getTypeName,
+  getUnionOptions,
+  hasCatchValue,
+  hasContainerOrRootRefine,
+  unwrapBranded,
+  unwrapEffectsSource,
+  unwrapInner,
+  unwrapPipeIn,
+} from './introspect'
 import { slimPrimitivesV3 } from './slim-primitives'
 
 let warnedZodCodeMissing = false
@@ -106,7 +133,7 @@ export function zodAdapter<
         stripZodRefinements: true,
       })
       if (!isZodSchemaType(_schema, 'ZodObject')) {
-        const name = (_schema as ZodTypeWithInnerType)._def.typeName
+        const name = getTypeName(_schema)
         throw new Error(`ZodAdapter: expected ZodObject, got ${name}`)
       }
     }
@@ -139,18 +166,15 @@ export function zodAdapter<
         matchedUnion = peeled
       }
       if (matchedUnion === undefined) return undefined
-      const discKey = (
-        matchedUnion as z.ZodDiscriminatedUnion<string, z.ZodDiscriminatedUnionOption<string>[]>
-      )._def.discriminator
-      const options = (
-        matchedUnion as z.ZodDiscriminatedUnion<string, z.ZodDiscriminatedUnionOption<string>[]>
-      )._def.options
+      const discKey = getDiscriminator(matchedUnion)
+      if (discKey === undefined) return undefined
+      const options = getDiscriminatedOptions(matchedUnion)
       const literalSet = new Set<unknown>()
       for (const opt of options) {
         const litSchema = opt.shape[discKey] as z.ZodTypeAny | undefined
         if (!litSchema) continue
         if (!isZodSchemaType(litSchema, 'ZodLiteral')) continue
-        literalSet.add(litSchema._def.value)
+        literalSet.add(getLiteralValue(litSchema))
       }
       return {
         discriminatorKey: discKey,
@@ -159,7 +183,7 @@ export function zodAdapter<
             const litSchema = opt.shape[discKey] as z.ZodTypeAny | undefined
             if (!litSchema) continue
             if (!isZodSchemaType(litSchema, 'ZodLiteral')) continue
-            if (litSchema._def.value === value) {
+            if (getLiteralValue(litSchema) === value) {
               return getDefaultValuesFromZodSchema(opt as unknown as z.ZodSchema, true, _formKey)
             }
           }
@@ -457,13 +481,12 @@ export function zodAdapter<
         let peeled = peelV3Wrappers(leaf)
         for (let i = 0; i < MAX_UNWRAP_STEPS; i++) {
           if (!isZodSchemaType(peeled, 'ZodCatch')) break
-          const inner = (peeled._def as { innerType?: z.ZodTypeAny }).innerType
+          const inner = unwrapInner(peeled)
           if (!inner) break
           peeled = peelV3Wrappers(inner)
         }
         if (isZodSchemaType(peeled, 'ZodTuple')) {
-          const items = (peeled._def as { items?: readonly z.ZodTypeAny[] }).items
-          return Array.isArray(items) ? items.length : undefined
+          return getTupleItems(peeled).length
         }
         if (isZodSchemaType(peeled, 'ZodArray')) return null
         return undefined
@@ -585,8 +608,7 @@ export function zodAdapter<
               : (getNestedZodSchemasAtPath(_zodSchema, prefix) as z.ZodTypeAny[])
           for (const candidate of candidates) {
             if (!isZodSchemaType(candidate, 'ZodEffects')) continue
-            const def = candidate._def as { effect?: { type?: string } }
-            if (def.effect?.type === 'preprocess') {
+            if (getEffectsKind(candidate) === 'preprocess') {
               hit = true
               break
             }
@@ -803,10 +825,10 @@ function getNestedZodSchemasAtPath<Schema extends z.ZodSchema>(
     Options extends readonly z.ZodDiscriminatedUnionOption<Discriminator>[],
   >(schema: z.ZodDiscriminatedUnion<Discriminator, Options>, key: string) {
     const successfulOptions = []
-    const options = schema._def.options
+    const options = getDiscriminatedOptions(schema)
     for (const option of options) {
       if (!(key in option.shape)) continue
-      successfulOptions.push(option)
+      successfulOptions.push(option as Options[number])
     }
 
     return successfulOptions
@@ -820,20 +842,20 @@ function getNestedZodSchemasAtPath<Schema extends z.ZodSchema>(
       currentSchema = peelV3Wrappers(currentSchema) as z.ZodSchema
     }
     if (isZodSchemaType(currentSchema, 'ZodObject')) {
-      const shape = currentSchema._def.shape() as z.ZodRawShape
+      const shape = getObjectShape(currentSchema)
       // Own-property check: a bare `shape[key]` returns
       // `Object.prototype.toString` etc. for any user lookup of those
       // keys, which then walks as an "unknown schema" and reports a
       // permissive slim-primitive set. Filter to OWN keys.
-      currentSchema = Object.hasOwn(shape, key) ? shape[key] : undefined
+      currentSchema = Object.hasOwn(shape, key) ? (shape[key] as z.ZodSchema) : undefined
     } else if (isZodSchemaType(currentSchema, 'ZodArray')) {
-      currentSchema = currentSchema._def.type
+      currentSchema = getArrayElement(currentSchema) as z.ZodSchema
     } else if (isZodSchemaType(currentSchema, 'ZodSet')) {
       // Sets aren't position-indexed; the segment is a synthetic
       // indexer used to query the element type via `[...path, 0]`.
-      currentSchema = currentSchema._def.valueType
+      currentSchema = getSetValueType(currentSchema) as z.ZodSchema
     } else if (isZodSchemaType(currentSchema, 'ZodRecord')) {
-      currentSchema = currentSchema._def.valueType
+      currentSchema = getRecordValueType(currentSchema) as z.ZodSchema
     } else if (isZodSchemaType(currentSchema, 'ZodDiscriminatedUnion')) {
       const optionalSchemas = getOptionSchemasFromDiscriminatorByArbitraryKey(currentSchema, key)
 
@@ -882,7 +904,7 @@ function unwrapStructuralLeafV3(schema: z.ZodTypeAny): z.ZodTypeAny {
     if (!(isZodSchemaType(current, 'ZodOptional') || isZodSchemaType(current, 'ZodNullable'))) {
       break
     }
-    const inner = current._def.innerType as z.ZodTypeAny | undefined
+    const inner = unwrapInner(current)
     if (!inner) return current
     if (!isStructuralV3Kind(inner)) break
     current = inner
@@ -944,18 +966,18 @@ function peelV3Wrappers(schema: z.ZodTypeAny): z.ZodTypeAny {
     if (
       isZodSchemaType(current, 'ZodOptional') ||
       isZodSchemaType(current, 'ZodNullable') ||
-      isZodSchemaType(current, 'ZodDefault')
+      isZodSchemaType(current, 'ZodDefault') ||
+      isZodSchemaType(current, 'ZodReadonly')
     ) {
-      const inner = (current._def as { innerType?: z.ZodTypeAny }).innerType
+      const inner = unwrapInner(current)
       if (!inner) return current
       current = inner
       continue
     }
     if (isZodSchemaType(current, 'ZodEffects')) {
-      // v3 ZodEffects: source schema is at `_def.schema`; v4 parity'd
-      // helpers also expose `.innerType()` on some shapes. Prefer the
+      // v3 ZodEffects: source schema is at `_def.schema`. Prefer the
       // structural source.
-      const inner = (current._def as { schema?: z.ZodTypeAny }).schema
+      const inner = unwrapEffectsSource(current)
       if (!inner) return current
       current = inner
       continue
@@ -965,13 +987,7 @@ function peelV3Wrappers(schema: z.ZodTypeAny): z.ZodTypeAny {
       // structural traversal, the input schema is the right anchor —
       // it's what the consumer wrote, and the output is a derived
       // shape they don't construct values for directly.
-      const inner = (current._def as { in?: z.ZodTypeAny }).in
-      if (!inner) return current
-      current = inner
-      continue
-    }
-    if (isZodSchemaType(current, 'ZodReadonly')) {
-      const inner = (current._def as { innerType?: z.ZodTypeAny }).innerType
+      const inner = unwrapPipeIn(current)
       if (!inner) return current
       current = inner
       continue
@@ -979,7 +995,7 @@ function peelV3Wrappers(schema: z.ZodTypeAny): z.ZodTypeAny {
     if (isZodSchemaType(current, 'ZodBranded')) {
       // ZodBranded annotates a brand at the type level; runtime is the
       // wrapped schema unchanged.
-      const inner = (current._def as { type?: z.ZodTypeAny }).type
+      const inner = unwrapBranded(current)
       if (!inner) return current
       current = inner
       continue
@@ -1017,33 +1033,32 @@ function walkV3ToLeafSchema(
     const key = String(segments[i] ?? '')
 
     if (isZodSchemaType(current, 'ZodObject')) {
-      const shape = current._def.shape() as z.ZodRawShape
+      const shape = getObjectShape(current)
       current = Object.hasOwn(shape, key) ? shape[key] : undefined
       i++
       continue
     }
     if (isZodSchemaType(current, 'ZodArray')) {
-      current = current._def.type as z.ZodTypeAny
+      current = getArrayElement(current)
       i++
       continue
     }
     if (isZodSchemaType(current, 'ZodRecord')) {
-      current = current._def.valueType as z.ZodTypeAny
+      current = getRecordValueType(current)
       i++
       continue
     }
     if (isZodSchemaType(current, 'ZodTuple')) {
       const idx = Number(key)
       if (!Number.isInteger(idx) || idx < 0) return undefined
-      const items = current._def.items as readonly z.ZodTypeAny[]
-      const item = items[idx]
+      const item = getTupleItems(current)[idx]
       if (!item) return undefined
       current = item
       i++
       continue
     }
     if (isZodSchemaType(current, 'ZodDiscriminatedUnion')) {
-      const options = current._def.options as readonly z.AnyZodObject[]
+      const options = getDiscriminatedOptions(current)
       const matching = options.filter((o) => key in o.shape)
       const candidates = matching.length > 0 ? matching : options
       const first = candidates[0]
@@ -1053,8 +1068,7 @@ function walkV3ToLeafSchema(
       continue
     }
     if (isZodSchemaType(current, 'ZodUnion')) {
-      const options = current._def.options as readonly z.ZodTypeAny[]
-      const first = options[0]
+      const first = getUnionOptions(current)[0]
       if (!first) return undefined
       current = first
       // Don't advance i — re-process this segment within the option.
@@ -1097,32 +1111,35 @@ function isLeafRequiredV3(schema: z.ZodTypeAny, depth = 0): boolean {
     return false
   }
   // Transparent wrappers — peel and re-check.
-  if (isZodSchemaType(schema, 'ZodReadonly') || isZodSchemaType(schema, 'ZodBranded')) {
-    const inner = (schema._def as { innerType?: z.ZodTypeAny; type?: z.ZodTypeAny }).innerType
-    const branded = (schema._def as { type?: z.ZodTypeAny }).type
-    const next = inner ?? branded
-    return next === undefined ? true : isLeafRequiredV3(next, depth + 1)
+  if (isZodSchemaType(schema, 'ZodReadonly')) {
+    const inner = unwrapInner(schema)
+    return inner === undefined ? true : isLeafRequiredV3(inner, depth + 1)
+  }
+  if (isZodSchemaType(schema, 'ZodBranded')) {
+    const inner = unwrapBranded(schema)
+    return inner === undefined ? true : isLeafRequiredV3(inner, depth + 1)
   }
   if (isZodSchemaType(schema, 'ZodPipeline')) {
     // Use the input side: blank is a write-time concern.
-    const inner = (schema._def as { in?: z.ZodTypeAny }).in
+    const inner = unwrapPipeIn(schema)
     return inner === undefined ? true : isLeafRequiredV3(inner, depth + 1)
   }
   if (isZodSchemaType(schema, 'ZodEffects')) {
-    const inner = (schema._def as { schema?: z.ZodTypeAny }).schema
+    const inner = unwrapEffectsSource(schema)
     return inner === undefined ? true : isLeafRequiredV3(inner, depth + 1)
   }
   // Union — required only if EVERY branch is required.
   if (isZodSchemaType(schema, 'ZodUnion') || isZodSchemaType(schema, 'ZodDiscriminatedUnion')) {
-    const options = (schema._def as { options?: readonly z.ZodTypeAny[] }).options ?? []
+    const options = getUnionOptions(schema)
     if (options.length === 0) return true
     return options.every((opt) => isLeafRequiredV3(opt, depth + 1))
   }
   // Intersection — required if either side rejects empty.
   if (isZodSchemaType(schema, 'ZodIntersection')) {
-    const def = schema._def as { left?: z.ZodTypeAny; right?: z.ZodTypeAny }
-    const leftReq = def.left === undefined ? true : isLeafRequiredV3(def.left, depth + 1)
-    const rightReq = def.right === undefined ? true : isLeafRequiredV3(def.right, depth + 1)
+    const left = getIntersectionLeft(schema)
+    const right = getIntersectionRight(schema)
+    const leftReq = left === undefined ? true : isLeafRequiredV3(left, depth + 1)
+    const rightReq = right === undefined ? true : isLeafRequiredV3(right, depth + 1)
     return leftReq || rightReq
   }
   // Direct primitive / unsupported leaf — required by default.
@@ -1149,25 +1166,27 @@ function unwrapToDiscriminatedUnion(
       isZodSchemaType(currentSchema, 'ZodOptional') ||
       isZodSchemaType(currentSchema, 'ZodNullable')
     ) {
-      currentSchema = (currentSchema._def as { innerType: z.ZodTypeAny }).innerType
+      const inner = unwrapInner(currentSchema)
+      if (!inner) return undefined
+      currentSchema = inner
       continue
     }
     // Newer transparent wrappers — peel through to expose any
     // discriminated union that lives at the structural core.
     if (isZodSchemaType(currentSchema, 'ZodReadonly')) {
-      const inner = (currentSchema._def as { innerType?: z.ZodTypeAny }).innerType
+      const inner = unwrapInner(currentSchema)
       if (!inner) return undefined
       currentSchema = inner
       continue
     }
     if (isZodSchemaType(currentSchema, 'ZodBranded')) {
-      const inner = (currentSchema._def as { type?: z.ZodTypeAny }).type
+      const inner = unwrapBranded(currentSchema)
       if (!inner) return undefined
       currentSchema = inner
       continue
     }
     if (isZodSchemaType(currentSchema, 'ZodPipeline')) {
-      const inner = (currentSchema._def as { in?: z.ZodTypeAny }).in
+      const inner = unwrapPipeIn(currentSchema)
       if (!inner) return undefined
       currentSchema = inner
       continue
@@ -1253,8 +1272,7 @@ function unwrapDefault(schema: z.ZodTypeAny): [unknown, boolean] {
   let current: z.ZodTypeAny = schema
   for (let i = 0; i < MAX_UNWRAP_STEPS; i++) {
     if (isZodSchemaType(current, 'ZodDefault')) {
-      const defaultValue = (current._def as { defaultValue: () => unknown }).defaultValue()
-      return [defaultValue, true]
+      return [getDefaultValueFromIntrospect(current), true]
     }
     if (isZodSchemaType(current, 'ZodCatch')) {
       // ZodCatch supplies a fallback value when its inner schema rejects
@@ -1263,52 +1281,55 @@ function unwrapDefault(schema: z.ZodTypeAny): [unknown, boolean] {
       // statement of "this is what to render when nothing else fits."
       // Preserves the value across submit failures, hydration, and
       // history (a `.catch()` should resurface the same fallback).
-      const catchValue = (current._def as { catchValue?: (ctx: unknown) => unknown }).catchValue
-      if (typeof catchValue === 'function') {
-        return [catchValue({ error: null, input: undefined }), true]
-      }
+      // `hasCatchValue` lets us distinguish a legitimate `undefined`
+      // return from a missing wrapper — both surface as `undefined`
+      // from `getCatchDefault` alone.
+      if (hasCatchValue(current)) return [getCatchDefault(current), true]
       // Defensive: fall through to the inner schema if the field is
       // missing on this v3 minor version.
-      const inner = (current._def as { innerType?: z.ZodTypeAny }).innerType
+      const inner = unwrapInner(current)
       if (!inner) break
       current = inner
       continue
     }
     if (isZodSchemaType(current, 'ZodNullable') || isZodSchemaType(current, 'ZodOptional')) {
-      current = (current._def as { innerType: z.ZodTypeAny }).innerType
+      const inner = unwrapInner(current)
+      if (!inner) break
+      current = inner
       continue
     }
     if (isZodSchemaType(current, 'ZodReadonly')) {
-      const inner = (current._def as { innerType?: z.ZodTypeAny }).innerType
+      const inner = unwrapInner(current)
       if (!inner) break
       current = inner
       continue
     }
     if (isZodSchemaType(current, 'ZodBranded')) {
-      const inner = (current._def as { type?: z.ZodTypeAny }).type
+      const inner = unwrapBranded(current)
       if (!inner) break
       current = inner
       continue
     }
     if (isZodSchemaType(current, 'ZodPipeline')) {
-      const inner = (current._def as { in?: z.ZodTypeAny }).in
+      const inner = unwrapPipeIn(current)
       if (!inner) break
       current = inner
       continue
     }
     if (isZodSchemaType(current, 'ZodEffects')) {
-      // ZodEffects's structural source lives at `_def.effect` when the
-      // effect itself was constructed from a ZodType (older v3 shape),
-      // otherwise at `.innerType()` (newer v3). Probe both — whichever
-      // resolves to a ZodTypeAny is the schema we keep unwrapping.
-      const effect = (current._def as { effect?: unknown }).effect
-      if (effect !== null && typeof effect === 'object' && '_def' in effect) {
-        current = effect as z.ZodTypeAny
-        continue
-      }
-      const inner = (current as { innerType?: () => z.ZodTypeAny }).innerType?.()
+      // v3 ZodEffects' structural source lives on `_def.schema`
+      // (preferred); older v3 builds exposed `.innerType()` on the
+      // instance as an alternative resolver. The introspect helper
+      // reads `_def.schema`, and falling back to the instance method
+      // here preserves the historical robustness.
+      const inner = unwrapEffectsSource(current)
       if (inner) {
         current = inner
+        continue
+      }
+      const innerFromMethod = (current as { innerType?: () => z.ZodTypeAny }).innerType?.()
+      if (innerFromMethod) {
+        current = innerFromMethod
         continue
       }
       break
@@ -1535,7 +1556,7 @@ function getSchemaByDiscriminatorKey(
 
   // return first/default option schema if no key is provided
   if (key === undefined) {
-    const options = unionSchema._def.options
+    const options = getDiscriminatedOptions(unionSchema)
     if (!options.length) {
       throw new TypeError('Provided ZodDiscriminatedUnion does not have any options')
     }
@@ -1543,9 +1564,11 @@ function getSchemaByDiscriminatorKey(
   }
 
   // Find the schema with the matching discriminator value
-  return unionSchema._def.options.find((schema: z.ZodObject<z.ZodRawShape>) => {
-    const discriminator = schema.shape[unionSchema._def.discriminator]
-    return discriminator?._def.value === key
+  const discKey = getDiscriminator(unionSchema)
+  if (discKey === undefined) return undefined
+  return getDiscriminatedOptions(unionSchema).find((schema) => {
+    const discriminator = schema.shape[discKey] as z.ZodTypeAny | undefined
+    return discriminator !== undefined && getLiteralValue(discriminator) === key
   })
 }
 

--- a/src/runtime/adapters/zod-v3/index.ts
+++ b/src/runtime/adapters/zod-v3/index.ts
@@ -79,6 +79,7 @@ import {
   getIntersectionLeft,
   getIntersectionRight,
   getLiteralValue,
+  getNativeEnumValues,
   getObjectShape,
   getRecordKeyType,
   getRecordValueType,
@@ -952,12 +953,14 @@ function isStructuralV3Kind(schema: z.ZodTypeAny): boolean {
  * Bounded by `MAX_UNWRAP_STEPS` as a cycle/runaway guard. Returns the
  * original schema unchanged if it has no peelable wrapper.
  *
- * Peeled wrappers:
- *   - `ZodOptional` / `ZodNullable` / `ZodDefault` — `_def.innerType`
- *   - `ZodEffects` — `_def.schema` (the structural source)
- *   - `ZodPipeline` — `_def.in` (input shape; consumers see structural form)
- *   - `ZodReadonly` — `_def.innerType`
- *   - `ZodBranded` — `_def.type`
+ * Peeled wrappers (each kind reads through its matching introspect
+ * accessor — see `./introspect.ts`):
+ *   - `ZodOptional` / `ZodNullable` / `ZodDefault` / `ZodReadonly` —
+ *     `unwrapInner`
+ *   - `ZodEffects` — `unwrapEffectsSource` (structural source)
+ *   - `ZodPipeline` — `unwrapPipeIn` (input shape; consumers see
+ *     structural form)
+ *   - `ZodBranded` — `unwrapBranded`
  *
  * `ZodCatch` is intentionally NOT peeled here — its presence carries
  * load-bearing semantic (the caught fallback), and `unwrapDefault`
@@ -1421,7 +1424,7 @@ function getDefaultValuesFromZodSchema<
 
     // Handle literals
     if (isZodSchemaType(schema, 'ZodLiteral')) {
-      return schema._def.value
+      return getLiteralValue(schema)
     }
 
     // Handle optional
@@ -1431,12 +1434,13 @@ function getDefaultValuesFromZodSchema<
 
     // Handle unions (use the first option as the default)
     if (isZodSchemaType(schema, 'ZodUnion')) {
-      return generateValue(schema._def.options[0])
+      const first = getUnionOptions(schema)[0]
+      return first === undefined ? undefined : generateValue(first)
     }
 
     // Handle tuples
     if (isZodSchemaType(schema, 'ZodTuple')) {
-      return schema._def.items.map((item: z.ZodTypeAny) => generateValue(item))
+      return getTupleItems(schema).map((item) => generateValue(item))
     }
 
     // Handle records
@@ -1447,11 +1451,13 @@ function getDefaultValuesFromZodSchema<
     // Finding ZodDefault here means we should suppress defaults
     // Can only happen if useDefaultSchemaValues is false
     if (isZodSchemaType(schema, 'ZodDefault')) {
-      return generateValue(schema._def.innerType)
+      const inner = unwrapInner(schema)
+      if (inner) return generateValue(inner)
     }
 
     if (isZodSchemaType(schema, 'ZodEffects')) {
-      return generateValue(schema.innerType())
+      const inner = unwrapEffectsSource(schema)
+      if (inner) return generateValue(inner)
     }
 
     if (isZodSchemaType(schema, 'ZodDiscriminatedUnion')) {
@@ -1464,13 +1470,11 @@ function getDefaultValuesFromZodSchema<
     // (`useDefaultSchemaValues=false`), the consumer-supplied fallback
     // is the most reasonable construction-time value to surface; the
     // alternative is the inner schema's bare default, which the
-    // .catch() author specifically chose to override.
+    // .catch() author specifically chose to override. `hasCatchValue`
+    // preserves the legitimate-undefined-return path.
     if (isZodSchemaType(schema, 'ZodCatch')) {
-      const catchValue = (schema._def as { catchValue?: (ctx: unknown) => unknown }).catchValue
-      if (typeof catchValue === 'function') {
-        return catchValue({ error: null, input: undefined })
-      }
-      const inner = (schema._def as { innerType?: z.ZodTypeAny }).innerType
+      if (hasCatchValue(schema)) return getCatchDefault(schema)
+      const inner = unwrapInner(schema)
       if (inner) return generateValue(inner)
     }
 
@@ -1478,17 +1482,17 @@ function getDefaultValuesFromZodSchema<
     // pre-existed). Each wraps a single inner schema with no structural
     // impact at value-construction time.
     if (isZodSchemaType(schema, 'ZodReadonly')) {
-      const inner = (schema._def as { innerType?: z.ZodTypeAny }).innerType
+      const inner = unwrapInner(schema)
       if (inner) return generateValue(inner)
     }
     if (isZodSchemaType(schema, 'ZodBranded')) {
-      const inner = (schema._def as { type?: z.ZodTypeAny }).type
+      const inner = unwrapBranded(schema)
       if (inner) return generateValue(inner)
     }
     if (isZodSchemaType(schema, 'ZodPipeline')) {
       // Pipeline transforms in -> out; pre-transform default is the
       // input schema's natural default.
-      const inner = (schema._def as { in?: z.ZodTypeAny }).in
+      const inner = unwrapPipeIn(schema)
       if (inner) return generateValue(inner)
     }
 
@@ -1496,7 +1500,7 @@ function getDefaultValuesFromZodSchema<
     // Resolve the getter once; the inner schema's own ZodOptional /
     // base-case branch terminates the recursion.
     if (isZodSchemaType(schema, 'ZodLazy')) {
-      const inner = (schema._def as { getter?: () => z.ZodTypeAny }).getter?.()
+      const inner = unwrapLazy(schema)
       if (inner) return generateValue(inner)
     }
 
@@ -1505,9 +1509,10 @@ function getDefaultValuesFromZodSchema<
     // `merge` mutates its first arg, so seed an empty record. Leaves on
     // either side replace; nested records merge recursively.
     if (isZodSchemaType(schema, 'ZodIntersection')) {
-      const def = schema._def as { left?: z.ZodTypeAny; right?: z.ZodTypeAny }
-      const left = def.left ? generateValue(def.left) : undefined
-      const right = def.right ? generateValue(def.right) : undefined
+      const leftSchema = getIntersectionLeft(schema)
+      const rightSchema = getIntersectionRight(schema)
+      const left = leftSchema ? generateValue(leftSchema) : undefined
+      const right = rightSchema ? generateValue(rightSchema) : undefined
       return merge({}, left, right)
     }
 
@@ -1517,15 +1522,14 @@ function getDefaultValuesFromZodSchema<
     // number. String enums have no reverse mapping, so every key is
     // valid. Pick the first valid value as the default.
     if (isZodSchemaType(schema, 'ZodNativeEnum')) {
-      const values = (schema._def as { values?: Record<string, unknown> }).values
+      const values = getNativeEnumValues(schema)
       if (values) {
-        const lookup = values as Record<string, unknown>
-        const validKeys = Object.keys(lookup).filter(
-          (k) => typeof lookup[lookup[k] as string] !== 'number'
+        const validKeys = Object.keys(values).filter(
+          (k) => typeof values[values[k] as string] !== 'number'
         )
         if (validKeys.length > 0) {
           const first = validKeys[0]
-          if (first !== undefined) return lookup[first]
+          if (first !== undefined) return values[first]
         }
       }
     }
@@ -1761,7 +1765,8 @@ function stripRootSchema(schema: z.ZodSchema, stripConfig: StripConfig) {
       getStripInstruction(stripConfig.stripZodEffects, _schema) &&
       isZodSchemaType(_schema, 'ZodEffects')
     ) {
-      return recursion(_schema.innerType(), true)
+      const inner = unwrapEffectsSource(_schema)
+      if (inner) return recursion(inner as z.ZodSchema, true)
     }
 
     if (

--- a/src/runtime/adapters/zod-v3/introspect.ts
+++ b/src/runtime/adapters/zod-v3/introspect.ts
@@ -438,6 +438,10 @@ export function getDefaultValue(schema: z.ZodTypeAny): unknown {
  * during default-values derivation are rare — if the function throws,
  * we surface `undefined` and let the validate-then-fix loop find a
  * fallback.
+ *
+ * Pairs with `hasCatchValue` for callers that need to distinguish a
+ * legitimate `undefined` return from a missing wrapper; this helper
+ * alone collapses both into `undefined`.
  */
 export function getCatchDefault(schema: z.ZodTypeAny): unknown {
   const def = readDef(schema)
@@ -448,6 +452,12 @@ export function getCatchDefault(schema: z.ZodTypeAny): unknown {
   } catch {
     return undefined
   }
+}
+
+/** True iff the schema carries a callable `_def.catchValue` (ZodCatch wrapper). */
+export function hasCatchValue(schema: z.ZodTypeAny): boolean {
+  const def = readDef(schema)
+  return typeof def?.catchValue === 'function'
 }
 
 // ---------- Refinement payload ----------

--- a/src/runtime/adapters/zod-v3/introspect.ts
+++ b/src/runtime/adapters/zod-v3/introspect.ts
@@ -1,0 +1,627 @@
+/**
+ * The single file that reads Zod v3's internal `_def` shape. Every
+ * other file in the zod-v3 adapter uses these public-shaped accessors
+ * — future Zod v3 minor bumps that reshape internals touch only this
+ * file. Mirrors the v4 adapter's introspect surface, with v3-only
+ * accessors for kinds the v3 line carries that v4 dropped
+ * (`ZodEffects`, `ZodPipeline`, `ZodBranded`, `ZodNativeEnum`).
+ *
+ * Design principle: treat `schema._def.*` as an unstable surface, even
+ * when Zod's docs say otherwise. Each helper returns a narrow,
+ * well-typed slice; no adapter code outside this file does
+ * shape-based pattern matching on `_def`.
+ */
+import type { z } from 'zod-v3'
+import { isZodSchemaType } from './helpers'
+
+// Shared cap for every wrapper-peeling helper. Pathological schemas
+// (deep `.refine()` chains, self-referential lazy loops) would
+// otherwise stack-overflow or hang. 64 is generous for any realistic
+// form schema; past it we bail conservatively rather than crash.
+const MAX_UNWRAP_STEPS = 64
+
+/**
+ * Stable kind discriminant for a Zod v3 schema. Mirrors the v4
+ * adapter's `ZodKind` for the kinds both versions carry, with the
+ * v3-only additions (`'effects'`, `'pipeline'`, `'branded'`,
+ * `'native-enum'`, `'function'`, `'map'`, `'symbol'`, `'promise'`)
+ * for kinds the v3 line still exposes that v4 dropped or renamed.
+ * Useful when building a custom integration that needs to branch on
+ * schema shape — most consumers don't need this.
+ */
+export type ZodKind =
+  | 'object'
+  | 'array'
+  | 'set'
+  | 'record'
+  | 'tuple'
+  | 'union'
+  | 'discriminated-union'
+  | 'string'
+  | 'number'
+  | 'boolean'
+  | 'bigint'
+  | 'date'
+  | 'enum'
+  | 'native-enum'
+  | 'literal'
+  | 'null'
+  | 'undefined'
+  | 'optional'
+  | 'nullable'
+  | 'default'
+  | 'catch'
+  | 'readonly'
+  | 'branded'
+  | 'effects'
+  | 'pipeline'
+  | 'lazy'
+  | 'intersection'
+  | 'any'
+  | 'unknown'
+  | 'never'
+  | 'nan'
+  | 'void'
+  | 'promise'
+  | 'function'
+  | 'map'
+  | 'symbol'
+
+// Narrow accessor for the unstable `_def` surface. All reads from this
+// object go through helpers below — never inline.
+interface ZodV3InternalShape {
+  _def?: {
+    typeName?: string
+    // Wrapper inners.
+    innerType?: unknown
+    type?: unknown // ZodBranded inner; ZodArray element
+    schema?: unknown // ZodEffects structural source
+    effect?: { type?: string; refinement?: unknown; transform?: unknown }
+    in?: unknown // ZodPipeline input side
+    out?: unknown // ZodPipeline output side
+    getter?: () => unknown // ZodLazy resolver
+    // Containers.
+    shape?: (() => Record<string, unknown>) | Record<string, unknown>
+    valueType?: unknown // ZodRecord value / ZodSet element
+    keyType?: unknown // ZodRecord key
+    items?: readonly unknown[] // ZodTuple
+    options?: readonly unknown[] // ZodUnion / ZodDiscriminatedUnion / ZodEnum
+    discriminator?: string // ZodDiscriminatedUnion
+    left?: unknown // ZodIntersection
+    right?: unknown // ZodIntersection
+    // Value carriers.
+    value?: unknown // ZodLiteral
+    values?: Record<string, unknown> // ZodNativeEnum
+    defaultValue?: () => unknown // ZodDefault thunk
+    catchValue?: (ctx: { error: unknown; input: unknown }) => unknown
+    // Refinement payload.
+    checks?: readonly unknown[]
+  }
+}
+
+function readDef(schema: unknown): ZodV3InternalShape['_def'] | undefined {
+  if (schema === null || typeof schema !== 'object') return undefined
+  return (schema as ZodV3InternalShape)._def
+}
+
+/**
+ * Inspect a Zod v3 schema and return its `ZodKind`. Returns
+ * `'unknown'` for non-Zod inputs and unrecognised shapes (collides
+ * with `ZodUnknown` → `'unknown'` by design; `ZodUnknown` is rarely
+ * used in form schemas).
+ */
+export function kindOf(schema: unknown): ZodKind {
+  const def = readDef(schema)
+  const typeName = def?.typeName
+  if (typeName === undefined) return 'unknown'
+  switch (typeName) {
+    case 'ZodObject':
+      return 'object'
+    case 'ZodArray':
+      return 'array'
+    case 'ZodSet':
+      return 'set'
+    case 'ZodRecord':
+      return 'record'
+    case 'ZodTuple':
+      return 'tuple'
+    case 'ZodUnion':
+      return 'union'
+    case 'ZodDiscriminatedUnion':
+      return 'discriminated-union'
+    case 'ZodString':
+      return 'string'
+    case 'ZodNumber':
+      return 'number'
+    case 'ZodBoolean':
+      return 'boolean'
+    case 'ZodBigInt':
+      return 'bigint'
+    case 'ZodDate':
+      return 'date'
+    case 'ZodEnum':
+      return 'enum'
+    case 'ZodNativeEnum':
+      return 'native-enum'
+    case 'ZodLiteral':
+      return 'literal'
+    case 'ZodNull':
+      return 'null'
+    case 'ZodUndefined':
+      return 'undefined'
+    case 'ZodOptional':
+      return 'optional'
+    case 'ZodNullable':
+      return 'nullable'
+    case 'ZodDefault':
+      return 'default'
+    case 'ZodCatch':
+      return 'catch'
+    case 'ZodReadonly':
+      return 'readonly'
+    case 'ZodBranded':
+      return 'branded'
+    case 'ZodEffects':
+      return 'effects'
+    case 'ZodPipeline':
+      return 'pipeline'
+    case 'ZodLazy':
+      return 'lazy'
+    case 'ZodIntersection':
+      return 'intersection'
+    case 'ZodAny':
+      return 'any'
+    case 'ZodUnknown':
+      return 'unknown'
+    case 'ZodNever':
+      return 'never'
+    case 'ZodNaN':
+      return 'nan'
+    case 'ZodVoid':
+      return 'void'
+    case 'ZodPromise':
+      return 'promise'
+    case 'ZodFunction':
+      return 'function'
+    case 'ZodMap':
+      return 'map'
+    case 'ZodSymbol':
+      return 'symbol'
+    default:
+      return 'unknown'
+  }
+}
+
+/** Read the typeName discriminant directly. Convenience for callers that already branch on the raw string. */
+export function getTypeName(schema: unknown): string | undefined {
+  return readDef(schema)?.typeName
+}
+
+/**
+ * Verify a schema is Zod v3. Throws a clear error if it's a v4
+ * schema (which carries `def.type` instead of `_def.typeName`) or a
+ * non-Zod value mistakenly imported through `attaform/zod-v3`.
+ *
+ * Most consumers never call this directly — the v3 adapter calls it
+ * internally on every schema. Reach for it only when wiring a custom
+ * adapter that needs the same guard.
+ */
+export function assertZodVersion(schema: unknown): void {
+  const def = readDef(schema)
+  if (def?.typeName === undefined) {
+    throw new Error(
+      '[attaform/zod-v3] Schema is not a Zod v3 schema. The `attaform/zod-v3` adapter requires ' +
+        'zod@^3. Either: (a) install zod@^3 in your project; (b) import from `attaform/zod`, ' +
+        'which auto-detects the Zod version (and tree-shakes to a single adapter when the ' +
+        '`attaform/vite` plugin is active); or (c) import from `attaform/zod-v4` if you are ' +
+        'on Zod v4.'
+    )
+  }
+}
+
+// ---------- Container accessors ----------
+
+/**
+ * Returns the object's `Record<string, ZodTypeAny>` shape. v3 stores
+ * shape as a thunk on `_def.shape` (lazy evaluation for self-referential
+ * schemas); the instance's `.shape` getter and the thunk both resolve
+ * to the same record. Prefers the thunk so cases without an instance
+ * getter (rare; defensive) still resolve.
+ */
+export function getObjectShape(schema: z.ZodTypeAny): Record<string, z.ZodTypeAny> {
+  const def = readDef(schema)
+  const raw = def?.shape
+  if (typeof raw === 'function') return raw() as Record<string, z.ZodTypeAny>
+  if (raw !== undefined) return raw as Record<string, z.ZodTypeAny>
+  // Fallback to the instance getter — only reached when the schema was
+  // constructed via a path that didn't populate `_def.shape`.
+  return (schema as unknown as { shape?: Record<string, z.ZodTypeAny> }).shape ?? {}
+}
+
+/**
+ * Returns the element schema of a `z.array(...)`. v3 stores the
+ * element on `_def.type` (not `_def.element` — that's v4's name).
+ */
+export function getArrayElement(schema: z.ZodTypeAny): z.ZodTypeAny | undefined {
+  const def = readDef(schema)
+  return def?.type as z.ZodTypeAny | undefined
+}
+
+/**
+ * Returns the element schema of a `z.set(...)`. v3 stores it on
+ * `_def.valueType` (parity with v4).
+ */
+export function getSetValueType(schema: z.ZodTypeAny): z.ZodTypeAny | undefined {
+  const def = readDef(schema)
+  return def?.valueType as z.ZodTypeAny | undefined
+}
+
+export function getRecordKeyType(schema: z.ZodTypeAny): z.ZodTypeAny | undefined {
+  const def = readDef(schema)
+  return def?.keyType as z.ZodTypeAny | undefined
+}
+
+export function getRecordValueType(schema: z.ZodTypeAny): z.ZodTypeAny | undefined {
+  const def = readDef(schema)
+  return def?.valueType as z.ZodTypeAny | undefined
+}
+
+export function getTupleItems(schema: z.ZodTypeAny): readonly z.ZodTypeAny[] {
+  const def = readDef(schema)
+  return (def?.items as readonly z.ZodTypeAny[] | undefined) ?? []
+}
+
+export function getUnionOptions(schema: z.ZodTypeAny): readonly z.ZodTypeAny[] {
+  const def = readDef(schema)
+  return (def?.options as readonly z.ZodTypeAny[] | undefined) ?? []
+}
+
+/** ZodDiscriminatedUnion options typed narrowly as ZodObject (v3's DU options are always objects). */
+export function getDiscriminatedOptions(schema: z.ZodTypeAny): readonly z.AnyZodObject[] {
+  const def = readDef(schema)
+  return (def?.options as readonly z.AnyZodObject[] | undefined) ?? []
+}
+
+/** ZodDiscriminatedUnion: the discriminator key (e.g. 'status'). */
+export function getDiscriminator(schema: z.ZodTypeAny): string | undefined {
+  const def = readDef(schema)
+  return def?.discriminator
+}
+
+export function getIntersectionLeft(schema: z.ZodTypeAny): z.ZodTypeAny | undefined {
+  const def = readDef(schema)
+  return def?.left as z.ZodTypeAny | undefined
+}
+
+export function getIntersectionRight(schema: z.ZodTypeAny): z.ZodTypeAny | undefined {
+  const def = readDef(schema)
+  return def?.right as z.ZodTypeAny | undefined
+}
+
+// ---------- Wrapper unwrap (return inner schema) ----------
+
+/**
+ * Reads `_def.innerType` — the inner schema for transparent wrappers
+ * (Optional / Nullable / Default / Catch / Readonly). Returns
+ * undefined for kinds that don't carry an inner (Branded uses
+ * `_def.type`; use `unwrapBranded` instead; Effects uses
+ * `_def.schema`, use `unwrapEffectsSource`).
+ */
+export function unwrapInner(schema: z.ZodTypeAny): z.ZodTypeAny | undefined {
+  const def = readDef(schema)
+  return def?.innerType as z.ZodTypeAny | undefined
+}
+
+/**
+ * `ZodBranded`'s inner schema lives on `_def.type` (v3 quirk; v4 uses
+ * `_def.innerType` for branded). Returns undefined for non-Branded.
+ */
+export function unwrapBranded(schema: z.ZodTypeAny): z.ZodTypeAny | undefined {
+  const def = readDef(schema)
+  return def?.type as z.ZodTypeAny | undefined
+}
+
+/**
+ * `ZodEffects` structural source — the inner schema being refined /
+ * transformed / preprocessed. v3 stores this on `_def.schema`
+ * (v4 has no ZodEffects equivalent; refinements live on the schema
+ * directly).
+ */
+export function unwrapEffectsSource(schema: z.ZodTypeAny): z.ZodTypeAny | undefined {
+  const def = readDef(schema)
+  return def?.schema as z.ZodTypeAny | undefined
+}
+
+/**
+ * Kind of effect carried by a `ZodEffects` — `'refinement'`,
+ * `'transform'`, `'preprocess'`, or undefined when the def shape is
+ * malformed. Used by the preprocess-or-coerce-leaf detector to scope
+ * the slim-primitive write gate.
+ */
+export function getEffectsKind(
+  schema: z.ZodTypeAny
+): 'refinement' | 'transform' | 'preprocess' | undefined {
+  const def = readDef(schema)
+  const type = def?.effect?.type
+  if (type === 'refinement' || type === 'transform' || type === 'preprocess') return type
+  return undefined
+}
+
+/** ZodPipeline input schema. */
+export function unwrapPipeIn(schema: z.ZodTypeAny): z.ZodTypeAny | undefined {
+  const def = readDef(schema)
+  return def?.in as z.ZodTypeAny | undefined
+}
+
+/** ZodPipeline output schema. */
+export function unwrapPipeOut(schema: z.ZodTypeAny): z.ZodTypeAny | undefined {
+  const def = readDef(schema)
+  return def?.out as z.ZodTypeAny | undefined
+}
+
+/**
+ * Convenience: returns the pipeline's input side, falling back to the
+ * output side. Mirrors v4's `unwrapPipe`. For most adapter call sites
+ * the input side is the right anchor (consumers write values for
+ * the input schema; the output is derived).
+ */
+export function unwrapPipe(schema: z.ZodTypeAny): z.ZodTypeAny | undefined {
+  return unwrapPipeIn(schema) ?? unwrapPipeOut(schema)
+}
+
+/**
+ * Resolve a `z.lazy(() => inner)` to its inner schema by invoking the
+ * getter. Each invocation runs the factory fresh, so the returned
+ * schema may be a distinct object per call — cycle detection should
+ * track the getter function identity (see `getLazyGetter`), not the
+ * resulting schema. Returns undefined when the getter is absent or
+ * throws.
+ */
+export function unwrapLazy(schema: z.ZodTypeAny): z.ZodTypeAny | undefined {
+  const def = readDef(schema)
+  const getter = def?.getter
+  if (typeof getter !== 'function') return undefined
+  try {
+    return getter() as z.ZodTypeAny
+  } catch {
+    return undefined
+  }
+}
+
+/** Getter function reference on a `z.lazy()` — used for recursion detection. */
+export function getLazyGetter(schema: z.ZodTypeAny): (() => unknown) | undefined {
+  const def = readDef(schema)
+  return typeof def?.getter === 'function' ? def.getter : undefined
+}
+
+// ---------- Value carriers ----------
+
+export function getLiteralValue(schema: z.ZodTypeAny): unknown {
+  const def = readDef(schema)
+  return def?.value
+}
+
+/**
+ * Raw values object on a `z.nativeEnum(E)` — the TypeScript enum
+ * object itself. Numeric enums have a reverse mapping
+ * (`enum E { A } → { A: 0, '0': 'A' }`); callers that need the valid
+ * runtime members must filter the reverse-mapped numeric keys
+ * themselves.
+ */
+export function getNativeEnumValues(schema: z.ZodTypeAny): Record<string, unknown> | undefined {
+  const def = readDef(schema)
+  return def?.values
+}
+
+/**
+ * Resolve a `z.default(...)` wrapper's value by invoking the v3
+ * `_def.defaultValue` thunk. v3 stores the default as a function
+ * (lazy evaluation, useful for `new Date()` defaults); v4 stores the
+ * value directly. Returns undefined when the field is missing.
+ */
+export function getDefaultValue(schema: z.ZodTypeAny): unknown {
+  const def = readDef(schema)
+  const thunk = def?.defaultValue
+  if (typeof thunk !== 'function') return undefined
+  try {
+    return thunk()
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Materialise the fallback value of a `z.catch(inner, value)` wrapper.
+ * v3 stores the catch as a function `(ctx) => value` on
+ * `_def.catchValue` (parity with v4); we invoke it with a placeholder
+ * context. Consumer catch functions that inspect `ctx.input` / `ctx.error`
+ * during default-values derivation are rare — if the function throws,
+ * we surface `undefined` and let the validate-then-fix loop find a
+ * fallback.
+ */
+export function getCatchDefault(schema: z.ZodTypeAny): unknown {
+  const def = readDef(schema)
+  const cv = def?.catchValue
+  if (typeof cv !== 'function') return undefined
+  try {
+    return cv({ error: null, input: undefined })
+  } catch {
+    return undefined
+  }
+}
+
+// ---------- Refinement payload ----------
+
+/** True if the schema's `_def` carries refinement checks (e.g. `.min(3)`). */
+export function hasChecks(schema: z.ZodTypeAny): boolean {
+  const def = readDef(schema)
+  const checks = def?.checks
+  return Array.isArray(checks) && checks.length > 0
+}
+
+/** Raw checks array. Empty when the schema has no refinements. */
+export function getChecks(schema: z.ZodTypeAny): readonly unknown[] {
+  const def = readDef(schema)
+  const checks = def?.checks
+  return Array.isArray(checks) ? (checks as readonly unknown[]) : []
+}
+
+// ---------- Walkers ----------
+
+/**
+ * True iff the v3 schema tree carries a refine / transform / preprocess
+ * (`ZodEffects`) whose effect target is a container — Object / Array /
+ * Tuple / Union / DU / Intersection / Record / Set — or the root
+ * itself. Drives the runtime's per-keystroke scope cut: a tree with
+ * leaf-only effects can be re-validated at the edited subtree alone
+ * (subtree pass catches the leaf effect at the same depth); a
+ * container effect can be moved by sibling writes and forces a
+ * whole-form pass.
+ *
+ * Transparent wrappers (Optional / Nullable / Default / Catch /
+ * Readonly / Branded / Lazy) peel through to their inner before
+ * container detection — `.refine` on `.optional()` over a
+ * `z.object(...)` is still a root-scoped effect. Pipelines walk both
+ * sides.
+ *
+ * Bias conservative: an unrecognised wrapper or a malformed leaf
+ * returns `false` for THAT node, but the recurse continues, so
+ * nested container effects still surface. False negatives only lose
+ * the perf win; correctness preserved by the caller's whole-form
+ * default when the predicate isn't reached.
+ */
+export function hasContainerOrRootRefine(schema: z.ZodTypeAny, seen?: WeakSet<object>): boolean {
+  const visited = seen ?? new WeakSet<object>()
+  const candidate = schema as unknown
+  if (typeof candidate !== 'object' || candidate === null) return false
+  if (visited.has(candidate)) return false
+  visited.add(candidate)
+
+  // ZodEffects: refine / transform / preprocess. Peel transparent
+  // wrappers off the inner so `.refine()` applied to `.optional()`
+  // over a container still flags as a container-level effect.
+  if (isZodSchemaType(schema, 'ZodEffects')) {
+    const inner = unwrapEffectsSource(schema)
+    if (inner === undefined) return false
+    if (isContainerAfterWrapperPeel(inner)) return true
+    return hasContainerOrRootRefine(inner, visited)
+  }
+
+  // Transparent wrappers: recurse into the inner without flagging.
+  if (
+    isZodSchemaType(schema, 'ZodOptional') ||
+    isZodSchemaType(schema, 'ZodNullable') ||
+    isZodSchemaType(schema, 'ZodDefault') ||
+    isZodSchemaType(schema, 'ZodCatch') ||
+    isZodSchemaType(schema, 'ZodReadonly')
+  ) {
+    const inner = unwrapInner(schema)
+    return inner !== undefined && hasContainerOrRootRefine(inner, visited)
+  }
+  if (isZodSchemaType(schema, 'ZodBranded')) {
+    const inner = unwrapBranded(schema)
+    return inner !== undefined && hasContainerOrRootRefine(inner, visited)
+  }
+  if (isZodSchemaType(schema, 'ZodLazy')) {
+    const inner = unwrapLazy(schema)
+    return inner !== undefined && hasContainerOrRootRefine(inner, visited)
+  }
+  if (isZodSchemaType(schema, 'ZodPipeline')) {
+    const inSide = unwrapPipeIn(schema)
+    if (inSide !== undefined && hasContainerOrRootRefine(inSide, visited)) return true
+    const outSide = unwrapPipeOut(schema)
+    if (outSide !== undefined && hasContainerOrRootRefine(outSide, visited)) return true
+    return false
+  }
+
+  // Container types: recurse into children.
+  if (isZodSchemaType(schema, 'ZodObject')) {
+    for (const sub of Object.values(getObjectShape(schema))) {
+      if (hasContainerOrRootRefine(sub, visited)) return true
+    }
+    return false
+  }
+  if (isZodSchemaType(schema, 'ZodArray')) {
+    const elem = getArrayElement(schema)
+    return elem !== undefined && hasContainerOrRootRefine(elem, visited)
+  }
+  if (isZodSchemaType(schema, 'ZodTuple')) {
+    for (const it of getTupleItems(schema)) {
+      if (hasContainerOrRootRefine(it, visited)) return true
+    }
+    return false
+  }
+  if (isZodSchemaType(schema, 'ZodUnion') || isZodSchemaType(schema, 'ZodDiscriminatedUnion')) {
+    for (const opt of getUnionOptions(schema)) {
+      if (hasContainerOrRootRefine(opt, visited)) return true
+    }
+    return false
+  }
+  if (isZodSchemaType(schema, 'ZodIntersection')) {
+    const left = getIntersectionLeft(schema)
+    if (left !== undefined && hasContainerOrRootRefine(left, visited)) return true
+    const right = getIntersectionRight(schema)
+    if (right !== undefined && hasContainerOrRootRefine(right, visited)) return true
+    return false
+  }
+  if (isZodSchemaType(schema, 'ZodRecord')) {
+    const keyType = getRecordKeyType(schema)
+    if (keyType !== undefined && hasContainerOrRootRefine(keyType, visited)) return true
+    const valueType = getRecordValueType(schema)
+    if (valueType !== undefined && hasContainerOrRootRefine(valueType, visited)) return true
+    return false
+  }
+  if (isZodSchemaType(schema, 'ZodSet')) {
+    const elem = getSetValueType(schema)
+    return elem !== undefined && hasContainerOrRootRefine(elem, visited)
+  }
+
+  // Leaves (ZodString / ZodNumber / ZodBoolean / ZodLiteral / ZodEnum /
+  // ZodNativeEnum / ZodDate / ...) — no descendable structure, no
+  // container effect possible.
+  return false
+}
+
+/**
+ * Peel transparent wrappers off a v3 schema up to MAX_UNWRAP_STEPS,
+ * then report whether the result is a container kind (Object / Array
+ * / Tuple / Intersection / Union / DU / Record / Set). Used by
+ * `hasContainerOrRootRefine` to classify the inner side of a
+ * ZodEffects.
+ */
+export function isContainerAfterWrapperPeel(schema: z.ZodTypeAny): boolean {
+  let cur: z.ZodTypeAny = schema
+  for (let i = 0; i < MAX_UNWRAP_STEPS; i++) {
+    if (
+      isZodSchemaType(cur, 'ZodOptional') ||
+      isZodSchemaType(cur, 'ZodNullable') ||
+      isZodSchemaType(cur, 'ZodDefault') ||
+      isZodSchemaType(cur, 'ZodCatch') ||
+      isZodSchemaType(cur, 'ZodReadonly')
+    ) {
+      const inner = unwrapInner(cur)
+      if (inner === undefined) return false
+      cur = inner
+    } else if (isZodSchemaType(cur, 'ZodBranded')) {
+      const inner = unwrapBranded(cur)
+      if (inner === undefined) return false
+      cur = inner
+    } else if (isZodSchemaType(cur, 'ZodLazy')) {
+      const inner = unwrapLazy(cur)
+      if (inner === undefined) return false
+      cur = inner
+    } else {
+      break
+    }
+  }
+  return (
+    isZodSchemaType(cur, 'ZodObject') ||
+    isZodSchemaType(cur, 'ZodArray') ||
+    isZodSchemaType(cur, 'ZodTuple') ||
+    isZodSchemaType(cur, 'ZodIntersection') ||
+    isZodSchemaType(cur, 'ZodUnion') ||
+    isZodSchemaType(cur, 'ZodDiscriminatedUnion') ||
+    isZodSchemaType(cur, 'ZodRecord') ||
+    isZodSchemaType(cur, 'ZodSet')
+  )
+}

--- a/test/adapters/zod-v3/introspect.test.ts
+++ b/test/adapters/zod-v3/introspect.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod-v3'
+import {
+  assertZodVersion,
+  getArrayElement,
+  getCatchDefault,
+  getChecks,
+  getDefaultValue,
+  getDiscriminatedOptions,
+  getDiscriminator,
+  getEffectsKind,
+  getIntersectionLeft,
+  getIntersectionRight,
+  getLazyGetter,
+  getLiteralValue,
+  getNativeEnumValues,
+  getObjectShape,
+  getRecordKeyType,
+  getRecordValueType,
+  getSetValueType,
+  getTupleItems,
+  getTypeName,
+  getUnionOptions,
+  hasChecks,
+  hasContainerOrRootRefine,
+  isContainerAfterWrapperPeel,
+  kindOf,
+  unwrapBranded,
+  unwrapEffectsSource,
+  unwrapInner,
+  unwrapLazy,
+  unwrapPipe,
+  unwrapPipeIn,
+  unwrapPipeOut,
+} from '../../../src/runtime/adapters/zod-v3/introspect'
+
+/*
+ * Version-pin tests for the zod v3 internals layer. If zod v3 ever changes
+ * its `_def.typeName` strings or accessor shapes, this file fails first
+ * and localises the breakage to introspect.ts — every other adapter file
+ * speaks kindOf() + the stable-shape accessors.
+ */
+
+describe('kindOf', () => {
+  it('recognises scalar types', () => {
+    expect(kindOf(z.string())).toBe('string')
+    expect(kindOf(z.number())).toBe('number')
+    expect(kindOf(z.boolean())).toBe('boolean')
+    expect(kindOf(z.bigint())).toBe('bigint')
+    expect(kindOf(z.date())).toBe('date')
+    expect(kindOf(z.null())).toBe('null')
+    expect(kindOf(z.undefined())).toBe('undefined')
+    expect(kindOf(z.void())).toBe('void')
+    expect(kindOf(z.never())).toBe('never')
+    expect(kindOf(z.any())).toBe('any')
+  })
+
+  it('recognises composite types', () => {
+    expect(kindOf(z.object({ a: z.string() }))).toBe('object')
+    expect(kindOf(z.array(z.number()))).toBe('array')
+    expect(kindOf(z.tuple([z.string(), z.number()]))).toBe('tuple')
+    expect(kindOf(z.union([z.string(), z.number()]))).toBe('union')
+    expect(kindOf(z.record(z.string(), z.number()))).toBe('record')
+    expect(kindOf(z.set(z.string()))).toBe('set')
+    expect(kindOf(z.intersection(z.object({ a: z.string() }), z.object({ b: z.number() })))).toBe(
+      'intersection'
+    )
+  })
+
+  it('recognises wrapper types', () => {
+    expect(kindOf(z.string().optional())).toBe('optional')
+    expect(kindOf(z.string().nullable())).toBe('nullable')
+    expect(kindOf(z.string().default('x'))).toBe('default')
+    expect(kindOf(z.string().readonly())).toBe('readonly')
+    expect(kindOf(z.string().catch('fallback'))).toBe('catch')
+    expect(kindOf(z.string().brand('X'))).toBe('branded')
+  })
+
+  it('recognises v3-specific composites', () => {
+    expect(kindOf(z.string().refine(() => true))).toBe('effects')
+    expect(kindOf(z.string().pipe(z.string()))).toBe('pipeline')
+    expect(kindOf(z.lazy(() => z.string()))).toBe('lazy')
+  })
+
+  it('recognises literal and enums', () => {
+    expect(kindOf(z.literal('x'))).toBe('literal')
+    expect(kindOf(z.enum(['a', 'b']))).toBe('enum')
+    enum NumericEnum {
+      A,
+      B,
+    }
+    expect(kindOf(z.nativeEnum(NumericEnum))).toBe('native-enum')
+  })
+
+  it('returns "unknown" for non-zod values', () => {
+    expect(kindOf({})).toBe('unknown')
+    expect(kindOf(null)).toBe('unknown')
+    expect(kindOf('not a schema')).toBe('unknown')
+  })
+})
+
+describe('container accessors', () => {
+  it('getObjectShape returns the shape map (via thunk)', () => {
+    const shape = getObjectShape(z.object({ a: z.string(), b: z.number() }))
+    expect(Object.keys(shape)).toEqual(['a', 'b'])
+    expect(kindOf(shape['a'])).toBe('string')
+    expect(kindOf(shape['b'])).toBe('number')
+  })
+
+  it('getArrayElement reads from _def.type (v3 quirk)', () => {
+    const element = getArrayElement(z.array(z.string()))
+    expect(kindOf(element)).toBe('string')
+  })
+
+  it('getSetValueType returns the element schema', () => {
+    expect(kindOf(getSetValueType(z.set(z.number())))).toBe('number')
+  })
+
+  it('getRecordKeyType / getRecordValueType return the key / value schemas', () => {
+    const record = z.record(z.string(), z.number())
+    expect(kindOf(getRecordKeyType(record))).toBe('string')
+    expect(kindOf(getRecordValueType(record))).toBe('number')
+  })
+
+  it('getTupleItems returns items in order', () => {
+    const items = getTupleItems(z.tuple([z.string(), z.number(), z.boolean()]))
+    expect(items).toHaveLength(3)
+    expect(kindOf(items[0])).toBe('string')
+    expect(kindOf(items[1])).toBe('number')
+    expect(kindOf(items[2])).toBe('boolean')
+  })
+
+  it('getUnionOptions returns the branches', () => {
+    const options = getUnionOptions(z.union([z.string(), z.number()]))
+    expect(options).toHaveLength(2)
+  })
+
+  it('getDiscriminator + getDiscriminatedOptions return the DU shape', () => {
+    const du = z.discriminatedUnion('kind', [
+      z.object({ kind: z.literal('a'), value: z.string() }),
+      z.object({ kind: z.literal('b'), value: z.number() }),
+    ])
+    expect(getDiscriminator(du)).toBe('kind')
+    expect(getDiscriminatedOptions(du)).toHaveLength(2)
+  })
+
+  it('getIntersectionLeft / getIntersectionRight return the two sides', () => {
+    const inter = z.intersection(z.object({ a: z.string() }), z.object({ b: z.number() }))
+    expect(kindOf(getIntersectionLeft(inter))).toBe('object')
+    expect(kindOf(getIntersectionRight(inter))).toBe('object')
+  })
+})
+
+describe('wrapper unwrap', () => {
+  it('unwrapInner peels Optional / Nullable / Default / Catch / Readonly', () => {
+    expect(kindOf(unwrapInner(z.string().optional()))).toBe('string')
+    expect(kindOf(unwrapInner(z.string().nullable()))).toBe('string')
+    expect(kindOf(unwrapInner(z.string().default('x')))).toBe('string')
+    expect(kindOf(unwrapInner(z.string().catch('x')))).toBe('string')
+    expect(kindOf(unwrapInner(z.string().readonly()))).toBe('string')
+  })
+
+  it('unwrapBranded reads from _def.type (v3 quirk)', () => {
+    expect(kindOf(unwrapBranded(z.string().brand('X')))).toBe('string')
+  })
+
+  it('unwrapEffectsSource reads ZodEffects structural source', () => {
+    const refined = z.string().refine(() => true)
+    expect(kindOf(unwrapEffectsSource(refined))).toBe('string')
+  })
+
+  it('getEffectsKind reports the effect type', () => {
+    expect(getEffectsKind(z.string().refine(() => true))).toBe('refinement')
+    expect(getEffectsKind(z.string().transform((v) => v))).toBe('transform')
+    expect(getEffectsKind(z.preprocess((v) => v, z.string()))).toBe('preprocess')
+    expect(getEffectsKind(z.string())).toBeUndefined()
+  })
+
+  it('unwrapPipe / unwrapPipeIn / unwrapPipeOut walk pipeline sides', () => {
+    const piped = z.string().pipe(z.number())
+    expect(kindOf(unwrapPipeIn(piped))).toBe('string')
+    expect(kindOf(unwrapPipeOut(piped))).toBe('number')
+    expect(kindOf(unwrapPipe(piped))).toBe('string')
+  })
+
+  it('unwrapLazy / getLazyGetter resolve the inner schema and getter', () => {
+    const inner = z.string()
+    const getter = () => inner
+    const lazy = z.lazy(getter)
+    expect(kindOf(unwrapLazy(lazy))).toBe('string')
+    expect(getLazyGetter(lazy)).toBe(getter)
+  })
+
+  it('unwrapLazy returns undefined when the getter throws', () => {
+    const lazy = z.lazy(() => {
+      throw new Error('boom')
+    })
+    expect(unwrapLazy(lazy)).toBeUndefined()
+  })
+})
+
+describe('value carriers', () => {
+  it('getLiteralValue returns the literal payload', () => {
+    expect(getLiteralValue(z.literal('x'))).toBe('x')
+    expect(getLiteralValue(z.literal(42))).toBe(42)
+  })
+
+  it('getNativeEnumValues returns the enum object', () => {
+    enum NumericEnum {
+      A,
+      B,
+    }
+    const values = getNativeEnumValues(z.nativeEnum(NumericEnum))
+    expect(values?.['A']).toBe(0)
+    expect(values?.['B']).toBe(1)
+  })
+
+  it('getDefaultValue invokes the v3 thunk', () => {
+    expect(getDefaultValue(z.string().default('hi'))).toBe('hi')
+    expect(getDefaultValue(z.number().default(42))).toBe(42)
+  })
+
+  it('getCatchDefault returns the catch fallback', () => {
+    expect(getCatchDefault(z.string().catch('fallback'))).toBe('fallback')
+  })
+
+  it('getCatchDefault returns undefined when the fn throws', () => {
+    const catched = z.string().catch(() => {
+      throw new Error('boom')
+    })
+    expect(getCatchDefault(catched)).toBeUndefined()
+  })
+})
+
+describe('refinement payload', () => {
+  it('hasChecks + getChecks return refinement state on strings/numbers', () => {
+    expect(hasChecks(z.string())).toBe(false)
+    expect(hasChecks(z.string().min(3))).toBe(true)
+    expect(getChecks(z.string().min(3))).toHaveLength(1)
+    expect(getChecks(z.string())).toHaveLength(0)
+  })
+})
+
+describe('hasContainerOrRootRefine', () => {
+  it('returns false for a flat schema with only leaf refines', () => {
+    const schema = z.object({
+      name: z.string().refine((v) => v.length > 0, 'name-invalid'),
+      age: z.number().refine((v) => v >= 0, 'age-invalid'),
+    })
+    expect(hasContainerOrRootRefine(schema)).toBe(false)
+  })
+
+  it('returns true when the root carries a refine', () => {
+    const schema = z
+      .object({ name: z.string(), other: z.string() })
+      .refine(() => true, 'root-invariant')
+    expect(hasContainerOrRootRefine(schema)).toBe(true)
+  })
+
+  it('returns true when a nested container carries a refine', () => {
+    const schema = z.object({
+      profile: z.object({ first: z.string() }).refine(() => true, 'profile-invariant'),
+    })
+    expect(hasContainerOrRootRefine(schema)).toBe(true)
+  })
+
+  it('isContainerAfterWrapperPeel sees through Optional/Nullable/Default to a container', () => {
+    expect(isContainerAfterWrapperPeel(z.object({}).optional())).toBe(true)
+    expect(isContainerAfterWrapperPeel(z.array(z.string()).nullable())).toBe(true)
+    expect(isContainerAfterWrapperPeel(z.string().optional())).toBe(false)
+  })
+})
+
+describe('assertZodVersion', () => {
+  it('accepts a genuine zod v3 schema', () => {
+    expect(() => assertZodVersion(z.string())).not.toThrow()
+  })
+
+  it('rejects a non-zod value with a helpful message', () => {
+    expect(() => assertZodVersion({})).toThrow(/zod v3/i)
+  })
+
+  it('rejects a v4-like def shape', () => {
+    // Simulates accidentally passing a zod-v4 schema into the v3 adapter.
+    // v4 schemas expose `def.type`, not `_def.typeName`.
+    const v4Like = { def: { type: 'string' } }
+    expect(() => assertZodVersion(v4Like)).toThrow(/zod v3/i)
+  })
+})
+
+describe('getTypeName', () => {
+  it('exposes the raw v3 typeName discriminant', () => {
+    expect(getTypeName(z.string())).toBe('ZodString')
+    expect(getTypeName(z.object({}))).toBe('ZodObject')
+    expect(getTypeName({})).toBeUndefined()
+    expect(getTypeName(null)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Phase 7 — v3 introspect chokepoint (`refactor/v3-introspect-chokepoint`)

Pure-internal, behavior-preserving refactor. Mirrors v4's accessor surface (`zod-v4/introspect.ts`) on the v3 side, then routes the ~106 inline `_def.<key>` reads in `zod-v3/index.ts` through the new helpers. Sets up Phase 8 (v3 walker unification), Phase 9 (per-method parity), Phase 10 (async contract), and Phase 12 (adapter dedup factory) to be written against ONE accessor surface across both adapters.

Closes ADAPT-F1 / D18 from `AUDIT-FINDINGS.md`.

## Commit series (one logical cluster per commit)

1. **`311eea9`** — `add introspect.ts shim mirroring v4's accessor surface` — scaffolding only; no callers wired yet. 525 LOC of accessors + ~400 LOC of unit tests (35 cases, version-pinning the v3 typeName strings).
2. **`1f0af30`** — `route walkers + assert-supported through introspect` — Phase 6's `v3HasContainerOrRootRefine` + `v3IsContainerAfterWrapperPeel` relocate to introspect.ts; `assert-supported.ts` migrates (14 → 0 inline reads).
3. **`5f83c0a`** — `route walker chains through introspect accessors` — `computeDiscriminator`, `getNestedZodSchemasAtPath`, `walkV3ToLeafSchema`, `isLeafRequiredV3`, `unwrapToDiscriminatedUnion`, `unwrapDefault`, `peelV3Wrappers`, `getSchemaByDiscriminatorKey`. Index.ts `_def` count 90 → 44. Adds `hasCatchValue` for the legitimate-undefined-return path through `unwrapDefault`'s ZodCatch branch.
4. **`a8f05c0`** — `route slim/strip helpers through introspect` — `stripRefinements`, `stripRootSchema`, `_getSlimSchema`. Deletes the local `hasChecks` in favor of the introspect version. Index.ts `_def` count 44 → 21.
5. **`9d76d98`** — `route generateValue + remainder through introspect` — defaults derivation (`ZodLiteral` / `ZodUnion` / `ZodTuple` / `ZodDefault` / `ZodEffects` / `ZodCatch` / `ZodReadonly` / `ZodBranded` / `ZodPipeline` / `ZodLazy` / `ZodIntersection` / `ZodNativeEnum`), plus the last straggler in `stripRootSchema`. Index.ts `_def` count 21 → 0 inline reads (9 prose mentions remain in docblocks).

## New surface (internal — `src/runtime/adapters/zod-v3/introspect.ts`)

All exports are internal to the v3 adapter (no `dist` surface). Mirrors v4's accessor names where the field aligns, with v3-specific accessors for kinds v4 dropped or renamed:

**Common with v4:** `kindOf`, `getObjectShape`, `getArrayElement`, `getRecordKeyType`, `getRecordValueType`, `getSetValueType`, `getTupleItems`, `getUnionOptions`, `getDiscriminator`, `getDiscriminatedOptions`, `getIntersectionLeft`, `getIntersectionRight`, `unwrapInner`, `unwrapLazy`, `getLazyGetter`, `getLiteralValue`, `getDefaultValue`, `getCatchDefault`, `hasChecks`, `getChecks`, `assertZodVersion`.

**v3-only:** `unwrapBranded` (v3 stores branded inner on `_def.type`, not `innerType`), `unwrapEffectsSource` + `getEffectsKind` (`ZodEffects` doesn't exist in v4), `unwrapPipeIn` / `unwrapPipeOut` / `unwrapPipe` (v3 has `ZodPipeline`), `getNativeEnumValues` (`ZodNativeEnum` is v3-only), `hasCatchValue` (preserves the legitimate-undefined-return distinction the v3 codebase relied on; v4 doesn't carry the equivalent semantic).

**Walkers relocated from Phase 6:** `hasContainerOrRootRefine`, `isContainerAfterWrapperPeel`.

## API & behavior-change ledger

**None.** Phase 7 is plan-marked behavior-neutral and the migration preserves every observable outcome:

- v3 test suite (`test/adapters/zod-v3/`): 158 files / 1,908 cases, unchanged.
- v4 test suite stays green (no v4 surface touched).
- Composables suite (`test/composables/`): 2,184 cases, unchanged.
- Full gate (`pnpm check`): 3,307 tests green.

The `ZodTypeWithInnerType` public re-export from `attaform/zod-v3` stays in place — it's still consumable by custom adapter authors. The v3 adapter just no longer needs it internally.

Subtle behavior preserved in code, not changed:
- `unwrapDefault`'s ZodCatch branch — the introspect `hasCatchValue` distinguishes "wrapper carries an undefined return" from "wrapper missing"; the old `typeof catchValue === 'function'` check had the same semantic.
- `unwrapDefault`'s ZodEffects branch — keeps the `.innerType()` instance-method fallback alongside the `_def.schema`-reading `unwrapEffectsSource` so older v3 builds without the modern shape still resolve.
- `stripRefinements`'s tuple branch — the empty-items guard flips from `if (!items)` (defensive against undefined `_def.items`) to `if (items.length === 0)` after `getTupleItems` normalises undefined → `[]`. `z.tuple([])` was already invalid at the v3 type level; the practical path takes the same early return as before.

## Full gate

```
lint        ✓
typecheck   ✓
check:site  ✓
test        ✓  3,307 tests (262 files)
check:size  ✓  index 46.76/48 · zod 59.89/60 · zod-v4 53.66/54 · zod-v3 52.88/53 (tight — see below)
check:bench ✓  5.11× keystroke ratio held
check:coverage ✓  91.45% lines
```

**Size note:** the three Zod entry bundles (`zod.mjs`, `zod-v4.mjs`, `zod-v3.mjs`) sit within ~0.5 KB of their caps because the introspect.ts accessors don't always inline cross-module after esbuild bundling. Phase 12's adapter-dedup factory (ADAPT-D1) will shrink this back by collapsing the 13 structurally-parallel `AbstractSchema` methods across both adapters; the tight squeeze is temporary, plan-acknowledged.

## What this unblocks

Every downstream phase reads the v3 schema tree through the same accessor surface as v4. Concretely:

- **Phase 8** (v3 walker unification) — D1/D15/D16/R1 — `getNestedZodSchemasAtPath` becomes a single walker calling `unwrapInner` / `getUnionOptions` / `getTupleItems` / etc., descending into union/tuple/intersection/lazy/catch the same way v4 does.
- **Phase 9** (per-method v3 parity) — D5-D19 — the per-kind branches (fingerprint, generateValue, required, discriminator) all read through this surface.
- **Phase 10** (v3 async contract) — A1/D14/D2/D4 — `containsAsyncRefine` / `containsAsyncTransform` walkers add to introspect.ts and the runtime construction-time seed wires them.
- **Phase 12** (adapter dedup factory) — ADAPT-D1-D6 — `createAbstractSchema(introspector)` takes a unified-shape introspector; v3 and v4 each provide one matching this surface.

## Working agreement check

- ✓ Phase ran on one branch per phase (`refactor/v3-introspect-chokepoint`) off `main`.
- ✓ One logical cluster per commit. Five reviewable commits.
- ✓ Every commit ends with the Co-Authored-By trailer.
- ✓ No `git commit --amend`; corrections (the `ZodTypeWithInnerType` over-deletion mid-walker-chain commit) became follow-up edits within the same in-progress commit.
- ✓ Behavior-preserving — no API or behavior delta surfaces.
- ✓ Sign-off not required per the plan (internal-only), but flagged here for review given the surface size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
