### PR TITLE
fix(zod-v3): unify path walker against introspect, retire walkV3ToLeafSchema (Phase 8 / D1 / D15 / D16 / R1)

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -401,7 +401,20 @@ export default [
     //
     // Raised 50 → 53 KB tracking index.mjs's validation-signals bump
     // (PRs #278-#281): same shared core chunk. Measured at 51.13 KB.
-    limit: '53 KB',
+    //
+    // Raised 53 → 54 KB on the v3-walker-unification branch (Phase 8
+    // of the audit-remediation series, D1 / D15 / D16 / R1). The v3
+    // adapter's `getNestedZodSchemasAtPath` becomes a kind-switch
+    // mirror of v4's `walkSegments` — descends ZodUnion / ZodTuple /
+    // ZodIntersection / ZodLazy and peels ZodCatch transparently,
+    // closing the five parity gaps the audit flagged. The structural
+    // parallelism with v4 (now sharing the same accessor surface and
+    // walker shape) is the unblocker for Phase 12's adapter dedup
+    // factory (ADAPT-D1), which will collapse the parallel methods
+    // into one and reclaim this slot and more. Matches v4's 54 KB
+    // cap exactly — symmetry is honest, both adapters carry the
+    // same surface area now. Measured at 53.24 KB.
+    limit: '54 KB',
     gzip: true,
     ignore: ['zod', 'lodash-es'],
     modifyEsbuildConfig: asEsm,

--- a/src/runtime/adapters/zod-v3/index.ts
+++ b/src/runtime/adapters/zod-v3/index.ts
@@ -454,7 +454,7 @@ export function zodAdapter<
         if (path.length === 0) {
           return getDefaultValuesFromZodSchema(_zodSchema, true, _formKey)
         }
-        const leaf = walkV3ToLeafSchema(_zodSchema, path)
+        const [leaf] = getNestedZodSchemasAtPath(_zodSchema, path, _maxRecursionDepth)
         if (!leaf) return undefined
         // STRUCTURAL default: peel `.optional()` / `.nullable()` at the
         // leaf so partial-object writes through optional sub-schemas
@@ -475,29 +475,18 @@ export function zodAdapter<
         if (path.length === 0) {
           return getDefaultValuesFromZodSchema(_zodSchema, false, _formKey)
         }
-        const leaf = walkV3ToLeafSchema(_zodSchema, path)
+        const [leaf] = getNestedZodSchemasAtPath(_zodSchema, path, _maxRecursionDepth)
         if (!leaf) return undefined
         return getDefaultValuesFromZodSchema(leaf as z.ZodSchema, false, _formKey)
       },
       arrayShapeAtPath(path) {
         if (path.length === 0) return undefined
-        const leaf = walkV3ToLeafSchema(_zodSchema, path)
+        const [leaf] = getNestedZodSchemasAtPath(_zodSchema, path, _maxRecursionDepth)
         if (!leaf) return undefined
-        // Peel transparent wrappers down to the underlying shape.
-        // peelV3Wrappers handles optional / nullable / default /
-        // effects / pipeline / readonly / branded. ZodCatch is left
-        // by that helper for default-value reasons — peel it here
-        // since arrayShapeAtPath only needs the structural kind.
-        let peeled = peelV3Wrappers(leaf)
-        for (let i = 0; i < MAX_UNWRAP_STEPS; i++) {
-          if (!isZodSchemaType(peeled, 'ZodCatch')) break
-          const inner = unwrapInner(peeled)
-          if (!inner) break
-          peeled = peelV3Wrappers(inner)
-        }
-        if (isZodSchemaType(peeled, 'ZodTuple')) {
-          return getTupleItems(peeled).length
-        }
+        // The walker preserves the TERMINAL wrapper at the leaf — peel
+        // every transparent wrapper here so we see the structural kind.
+        const peeled = peelAllV3Wrappers(leaf)
+        if (isZodSchemaType(peeled, 'ZodTuple')) return getTupleItems(peeled).length
         if (isZodSchemaType(peeled, 'ZodArray')) return null
         return undefined
       },
@@ -531,17 +520,17 @@ export function zodAdapter<
         // The required-empty check tracks primitive leaves only, so this
         // branch is academic for the call sites that matter.
         if (path.length === 0) return true
-        // walkV3ToLeafSchema descends through structural shapes and peels
-        // wrappers between segments, but preserves the leaf's wrapper at
-        // the path's terminal position — so `path: ['name']` against
+        // The unified walker descends through structural shapes and peels
+        // wrappers between segments while preserving the terminal
+        // wrapper at the path's leaf — `path: ['name']` against
         // `z.object({ name: z.optional(z.string()) })` returns the
         // optional wrapper itself, which is what we need to inspect.
-        const leaf = walkV3ToLeafSchema(_zodSchema, path)
+        const [leaf] = getNestedZodSchemasAtPath(_zodSchema, path, _maxRecursionDepth)
         if (!leaf) return false
         return isLeafRequiredV3(leaf)
       },
       getFieldMetaAtPath(path): ResolvedFieldMeta {
-        return resolveFieldMetaAtPathV3(_zodSchema, path)
+        return resolveFieldMetaAtPathV3(_zodSchema, path, _maxRecursionDepth)
       },
 
       getUnionDiscriminatorAtPath(path): UnionDiscriminatorContext | undefined {
@@ -1113,76 +1102,42 @@ function peelV3Wrappers(schema: z.ZodTypeAny): z.ZodTypeAny {
 }
 
 /**
- * Walk a structured path through a v3 schema, peeling wrappers at each
- * step before descending. Returns the schema at the final segment, or
- * `undefined` if the path doesn't exist in the schema (object key
- * missing, tuple index out of range, leaf with segments remaining).
+ * Peel every transparent wrapper (optional / nullable / default / readonly
+ * / catch / pipeline / branded / effects / lazy) off `schema`. Stops on
+ * the first non-wrapper kind. Used by `arrayShapeAtPath` where we want the
+ * inner structural kind regardless of what the default-value semantic is
+ * — different from `peelV3Wrappers`, which preserves `.catch()` so
+ * `unwrapDefault` can read it directly.
  *
- * Discriminated and plain unions: takes the first matching option (or
- * first option when no match). Matches `validateAtPath`'s first-success
- * semantic at the path-walker layer.
+ * Mirrors v4's `peelAllWrappers` (`zod-v4/adapter.ts`). Bounded by
+ * `MAX_UNWRAP_STEPS` as a runaway guard.
  */
-function walkV3ToLeafSchema(
-  schema: z.ZodTypeAny,
-  segments: readonly (string | number)[]
-): z.ZodTypeAny | undefined {
-  let current: z.ZodTypeAny | undefined = schema
-  let i = 0
-  // Iteration cap prevents pathological unions / lazy loops from hanging.
-  let safetyTicks = 0
-  while (
-    i < segments.length &&
-    current &&
-    safetyTicks < segments.length * MAX_UNWRAP_STEPS + MAX_UNWRAP_STEPS
-  ) {
-    safetyTicks++
-    current = peelV3Wrappers(current)
-    const key = String(segments[i] ?? '')
-
-    if (isZodSchemaType(current, 'ZodObject')) {
-      const shape = getObjectShape(current)
-      current = Object.hasOwn(shape, key) ? shape[key] : undefined
-      i++
-      continue
+function peelAllV3Wrappers(schema: z.ZodTypeAny): z.ZodTypeAny {
+  let current: z.ZodTypeAny = schema
+  for (let i = 0; i < MAX_UNWRAP_STEPS; i++) {
+    const k = kindOf(current)
+    let inner: z.ZodTypeAny | undefined
+    if (
+      k === 'optional' ||
+      k === 'nullable' ||
+      k === 'default' ||
+      k === 'readonly' ||
+      k === 'catch'
+    ) {
+      inner = unwrapInner(current)
+    } else if (k === 'pipeline') {
+      inner = unwrapPipeIn(current)
+    } else if (k === 'branded') {
+      inner = unwrapBranded(current)
+    } else if (k === 'effects') {
+      inner = unwrapEffectsSource(current)
+    } else if (k === 'lazy') {
+      inner = unwrapLazy(current)
+    } else {
+      return current
     }
-    if (isZodSchemaType(current, 'ZodArray')) {
-      current = getArrayElement(current)
-      i++
-      continue
-    }
-    if (isZodSchemaType(current, 'ZodRecord')) {
-      current = getRecordValueType(current)
-      i++
-      continue
-    }
-    if (isZodSchemaType(current, 'ZodTuple')) {
-      const idx = Number(key)
-      if (!Number.isInteger(idx) || idx < 0) return undefined
-      const item = getTupleItems(current)[idx]
-      if (!item) return undefined
-      current = item
-      i++
-      continue
-    }
-    if (isZodSchemaType(current, 'ZodDiscriminatedUnion')) {
-      const options = getDiscriminatedOptions(current)
-      const matching = options.filter((o) => key in o.shape)
-      const candidates = matching.length > 0 ? matching : options
-      const first = candidates[0]
-      if (!first) return undefined
-      current = first
-      // Don't advance i — re-process this segment within the option.
-      continue
-    }
-    if (isZodSchemaType(current, 'ZodUnion')) {
-      const first = getUnionOptions(current)[0]
-      if (!first) return undefined
-      current = first
-      // Don't advance i — re-process this segment within the option.
-      continue
-    }
-    // Leaf type with segments remaining — can't descend.
-    return undefined
+    if (inner === undefined) return current
+    current = inner
   }
   return current
 }
@@ -2018,14 +1973,20 @@ function getSlimSchema<RS extends z.ZodRawShape, Schema extends z.ZodSchema>(
  *   - placeholder: registry → undefined
  *   - meta: registry payload (frozen) — empty object when absent
  *
- * Walks via `walkV3ToLeafSchema` (descends through wrappers
+ * Walks via `getNestedZodSchemasAtPath` (descends through wrappers
  * transparently) then peels the terminal wrapper via `peelV3Wrappers`
  * — symmetric with the v4 walker's terminal behavior.
  */
-function resolveFieldMetaAtPathV3(rootSchema: z.ZodSchema, path: Path): ResolvedFieldMeta {
+function resolveFieldMetaAtPathV3(
+  rootSchema: z.ZodSchema,
+  path: Path,
+  maxRecursionDepth: number
+): ResolvedFieldMeta {
   const lastSegment = path.length === 0 ? '' : (path[path.length - 1] as string | number)
   const target =
-    path.length === 0 ? (rootSchema as z.ZodTypeAny) : walkV3ToLeafSchema(rootSchema, path)
+    path.length === 0
+      ? (rootSchema as z.ZodTypeAny)
+      : getNestedZodSchemasAtPath(rootSchema, path, maxRecursionDepth)[0]
   if (target === undefined) {
     return {
       label: humanize(lastSegment),

--- a/src/runtime/adapters/zod-v3/index.ts
+++ b/src/runtime/adapters/zod-v3/index.ts
@@ -90,6 +90,7 @@ import {
   hasCatchValue,
   hasChecks,
   hasContainerOrRootRefine,
+  kindOf,
   unwrapBranded,
   unwrapEffectsSource,
   unwrapInner,
@@ -120,7 +121,8 @@ export function zodAdapter<
   function getAbstractSchema(
     _formKey: FormKey,
     _zodSchema: FormSchema,
-    _isRootSchema: boolean
+    _isRootSchema: boolean,
+    _maxRecursionDepth: number
   ): AbstractSchema<Form, GetValueFormType> {
     if (_isRootSchema) {
       // Walk the original schema (not the stripped one) so the assert
@@ -161,7 +163,7 @@ export function zodAdapter<
       const candidates =
         path.length === 0
           ? [_zodSchema as z.ZodTypeAny]
-          : (getNestedZodSchemasAtPath(_zodSchema, path) as z.ZodTypeAny[])
+          : (getNestedZodSchemasAtPath(_zodSchema, path, _maxRecursionDepth) as z.ZodTypeAny[])
       let matchedUnion: z.ZodTypeAny | undefined
       for (const candidate of candidates) {
         const peeled = peelV3Wrappers(candidate)
@@ -306,7 +308,11 @@ export function zodAdapter<
         // code under one check.
         {
           for (const issue of error.issues) {
-            const schemasAtPath = getNestedZodSchemasAtPath(slimSchema, issue.path)
+            const schemasAtPath = getNestedZodSchemasAtPath(
+              slimSchema,
+              issue.path,
+              _maxRecursionDepth
+            )
             // `set` from lodash accepts a Segment[] directly; keeps the
             // literal-dot case (`['user.name']`) from being flattened
             // into two key accesses. Coerce in case a custom check
@@ -509,7 +515,7 @@ export function zodAdapter<
             stripZodEffects: true,
           },
         })
-        const nestedZodSchemas = getNestedZodSchemasAtPath(slimSchema, path)
+        const nestedZodSchemas = getNestedZodSchemasAtPath(slimSchema, path, _maxRecursionDepth)
 
         // Empty list is a valid result for paths the schema doesn't
         // declare — callers (getValue / register / custom introspection)
@@ -517,7 +523,7 @@ export function zodAdapter<
         if (!nestedZodSchemas.length) return []
 
         return nestedZodSchemas.map((n) =>
-          getAbstractSchema(_formKey, n as unknown as FormSchema, false)
+          getAbstractSchema(_formKey, n as unknown as FormSchema, false, _maxRecursionDepth)
         ) as unknown as AbstractSchema<unknown, GetValueFormType>[]
       },
       isRequiredAtPath(path) {
@@ -563,7 +569,7 @@ export function zodAdapter<
           schema: strippedSchema,
           stripConfig: { stripDefaultValues: true, stripZodEffects: true },
         })
-        const resolved = getNestedZodSchemasAtPath(slimSchema, path)
+        const resolved = getNestedZodSchemasAtPath(slimSchema, path, _maxRecursionDepth)
         // Path doesn't resolve in the schema → no kinds accepted.
         // The gate's membership check rejects every kind against an
         // empty set, blocking writes to typo / unknown paths.
@@ -609,7 +615,11 @@ export function zodAdapter<
           const candidates: z.ZodTypeAny[] =
             prefix.length === 0
               ? [_zodSchema as z.ZodTypeAny]
-              : (getNestedZodSchemasAtPath(_zodSchema, prefix) as z.ZodTypeAny[])
+              : (getNestedZodSchemasAtPath(
+                  _zodSchema,
+                  prefix,
+                  _maxRecursionDepth
+                ) as z.ZodTypeAny[])
           for (const candidate of candidates) {
             if (!isZodSchemaType(candidate, 'ZodEffects')) continue
             if (getEffectsKind(candidate) === 'preprocess') {
@@ -705,7 +715,7 @@ export function zodAdapter<
           // at re-creation sites — appropriate for "here's a
           // permissive shape to seed defaults," wrong for "here's
           // the schema we should validate against."
-          return getNestedZodSchemasAtPath(_zodSchema, p)
+          return getNestedZodSchemasAtPath(_zodSchema, p, _maxRecursionDepth)
         }
 
         function pathNotFound(p: Path): ValidationResponse<GetValueFormType> {
@@ -734,14 +744,13 @@ export function zodAdapter<
     return abstractSchema
   }
 
-  // `options.maxRecursionDepth` is accepted for parity with the v4
-  // adapter and the typed entry-point factory contract. The v3 walks
-  // already carry their own bounded loops (`MAX_UNWRAP_STEPS`), so
-  // today the cap doesn't drive different behaviour — wiring it
-  // through keeps the option-bag honest for future v3 walks that
-  // descend through `z.lazy()`.
+  // `options.maxRecursionDepth` caps `z.lazy(...)` descent in
+  // `getNestedZodSchemasAtPath` — once the walker has crossed
+  // `maxRecursionDepth + 1` lazy boundaries it returns `[]`, so writes
+  // at recursive paths deeper than the cap fall back to a permissive
+  // type gate. Matches the v4 adapter's path-walker contract.
   return (formKey: FormKey, _options: SchemaFactoryOptions) =>
-    getAbstractSchema(formKey, zodSchema, true)
+    getAbstractSchema(formKey, zodSchema, true, _options.maxRecursionDepth)
 }
 
 function zodIssuesToValidationErrors(issues: z.ZodIssue[], formKey: FormKey): ValidationError[] {
@@ -818,76 +827,168 @@ const NO_SCHEMAS_FOUND_AT_PATH_OF_CONCRETE_SCHEMA = (path: (string | number)[], 
 // substitutes, `.refine(...)` runs the predicate). For path = []
 // (no segments) the original schema is returned unchanged so
 // whole-form `validateAtPath` keeps the root's refine intact.
-function getNestedZodSchemasAtPath<Schema extends z.ZodSchema>(
-  zodSchema: Schema,
-  segments: readonly (string | number)[]
-): z.ZodType<unknown, z.ZodTypeDef, unknown>[] {
-  // ZodDiscriminator has multiple schemas in the options array
-  // Check all of them for the key, and probe all possibilities
-  function getOptionSchemasFromDiscriminatorByArbitraryKey<
-    Discriminator extends string,
-    Options extends readonly z.ZodDiscriminatedUnionOption<Discriminator>[],
-  >(schema: z.ZodDiscriminatedUnion<Discriminator, Options>, key: string) {
-    const successfulOptions = []
-    const options = getDiscriminatedOptions(schema)
-    for (const option of options) {
-      if (!(key in option.shape)) continue
-      successfulOptions.push(option as Options[number])
+/**
+ * Walk a structured path through a Zod v3 schema tree and return the
+ * subschema(s) that live at that path.
+ *
+ * - Unions return multiple candidates (caller tries each).
+ * - Discriminated unions filter options to those whose shape contains the
+ *   next segment, so a path into `{ status: 'error', message: string }`
+ *   resolves only to the 'error' branch.
+ * - Wrappers (optional / nullable / default / readonly / catch / effects /
+ *   pipeline / branded) are transparent — the walker descends into the
+ *   inner schema without consuming a path segment.
+ * - Leaf types (string / number / literal / ...) return `[]` when there's
+ *   still path left, so a caller that asked for `firstName.middle` against
+ *   a string schema gets an empty resolution rather than a wrong schema.
+ *
+ * `maxRecursionDepth` caps descent through `z.lazy()`. Once the walker has
+ * crossed `maxRecursionDepth + 1` lazy boundaries it returns `[]`, so
+ * writes at recursive paths deeper than the cap fall back to a permissive
+ * type gate.
+ *
+ * Mirrors v4's `walkSegments` (`zod-v4/path-walker.ts`) — same kind-switch
+ * structure, same Own-property check on objects, same lazy depth gate, so
+ * `getSchemasAtPath` / `getSlimPrimitiveTypesAtPath` / `validateAtPath`
+ * resolve identically across both adapters.
+ */
+function getNestedZodSchemasAtPath(
+  schema: z.ZodTypeAny,
+  segments: readonly (string | number)[],
+  maxRecursionDepth: number
+): z.ZodTypeAny[] {
+  if (segments.length === 0) return [schema]
+  return walkSegments(schema, segments.map(String), maxRecursionDepth, 0)
+}
+
+function walkSegments(
+  schema: z.ZodTypeAny,
+  segments: readonly string[],
+  maxDepth: number,
+  lazyDepth: number
+): z.ZodTypeAny[] {
+  if (segments.length === 0) return [schema]
+  const [head, ...rest] = segments
+  if (head === undefined) return [schema]
+  const kind = kindOf(schema)
+  switch (kind) {
+    case 'object': {
+      const shape = getObjectShape(schema)
+      // Own-property check: `shape` is a plain object whose prototype is
+      // `Object.prototype`, so a bare `shape[head]` for `head ===
+      // 'toString'` / `'valueOf'` / `'hasOwnProperty'` etc. returns the
+      // inherited Function and the walker treats it as a schema. Filter
+      // to OWN keys so unknown segments resolve to "doesn't exist."
+      if (!Object.hasOwn(shape, head)) return []
+      const next = shape[head]
+      return next === undefined ? [] : walkSegments(next, rest, maxDepth, lazyDepth)
     }
-
-    return successfulOptions
-  }
-
-  let currentSchema: z.ZodSchema | undefined = zodSchema
-
-  for (let index = 0; index < segments.length; index++) {
-    const key = String(segments[index] ?? '')
-    if (currentSchema !== undefined) {
-      currentSchema = peelV3Wrappers(currentSchema) as z.ZodSchema
+    case 'array': {
+      const inner = getArrayElement(schema)
+      return inner === undefined ? [] : walkSegments(inner, rest, maxDepth, lazyDepth)
     }
-    if (isZodSchemaType(currentSchema, 'ZodObject')) {
-      const shape = getObjectShape(currentSchema)
-      // Own-property check: a bare `shape[key]` returns
-      // `Object.prototype.toString` etc. for any user lookup of those
-      // keys, which then walks as an "unknown schema" and reports a
-      // permissive slim-primitive set. Filter to OWN keys.
-      currentSchema = Object.hasOwn(shape, key) ? (shape[key] as z.ZodSchema) : undefined
-    } else if (isZodSchemaType(currentSchema, 'ZodArray')) {
-      currentSchema = getArrayElement(currentSchema) as z.ZodSchema
-    } else if (isZodSchemaType(currentSchema, 'ZodSet')) {
-      // Sets aren't position-indexed; the segment is a synthetic
-      // indexer used to query the element type via `[...path, 0]`.
-      currentSchema = getSetValueType(currentSchema) as z.ZodSchema
-    } else if (isZodSchemaType(currentSchema, 'ZodRecord')) {
-      currentSchema = getRecordValueType(currentSchema) as z.ZodSchema
-    } else if (isZodSchemaType(currentSchema, 'ZodDiscriminatedUnion')) {
-      const optionalSchemas = getOptionSchemasFromDiscriminatorByArbitraryKey(currentSchema, key)
-
-      const remainingSegments = segments.slice(index)
-      if (!remainingSegments.length) return optionalSchemas
-
-      // recursively check the option schemas
-      const foundSchemas: z.ZodType<unknown, z.ZodTypeDef, unknown>[] = []
-      for (const optionSchema of optionalSchemas) {
-        getNestedZodSchemasAtPath(optionSchema, remainingSegments).forEach((schema) => {
-          foundSchemas.push(schema)
-        })
-      }
-
-      return foundSchemas
-    } else {
-      // Hit a non-container (leaf primitive, wrapper, union — anything
-      // we don't recognise as descendable) but more segments remain.
-      // The path goes deeper than the schema admits; return empty
-      // so callers (slim-gate, validateAtPath, getDefaultAtPath)
-      // treat it as unresolvable rather than falsely binding to the
-      // last container's leaf. Mirrors v4's path-walker leaf branches.
+    case 'set': {
+      // Sets aren't position-indexed; the head segment is a synthetic
+      // indexer (`[...path, 0]`) used to query the element type. Descend
+      // into the value schema and consume the segment.
+      const inner = getSetValueType(schema)
+      return inner === undefined ? [] : walkSegments(inner, rest, maxDepth, lazyDepth)
+    }
+    case 'record': {
+      const inner = getRecordValueType(schema)
+      return inner === undefined ? [] : walkSegments(inner, rest, maxDepth, lazyDepth)
+    }
+    case 'tuple': {
+      const index = Number(head)
+      if (!Number.isInteger(index)) return []
+      const items = getTupleItems(schema)
+      const item = items[index]
+      return item === undefined ? [] : walkSegments(item, rest, maxDepth, lazyDepth)
+    }
+    case 'union':
+      return getUnionOptions(schema).flatMap((opt) =>
+        walkSegments(opt, segments, maxDepth, lazyDepth)
+      )
+    case 'discriminated-union': {
+      // Filter options whose shape contains this segment. Fallback: if no
+      // option matches (e.g. the discriminator key itself), try every
+      // option. `Object.hasOwn` (not `in`) so `Object.prototype` keys
+      // don't leak.
+      const options = getDiscriminatedOptions(schema)
+      const matching = options.filter((opt) => Object.hasOwn(getObjectShape(opt), head))
+      const candidates = matching.length > 0 ? matching : options
+      return candidates.flatMap((opt) => walkSegments(opt, segments, maxDepth, lazyDepth))
+    }
+    case 'optional':
+    case 'nullable':
+    case 'default':
+    case 'readonly':
+    case 'catch': {
+      // `catch` peels like a wrapper — descend into the inner schema. The
+      // catch fallback only matters at parse time, not path lookup.
+      const inner = unwrapInner(schema)
+      return inner === undefined ? [] : walkSegments(inner, segments, maxDepth, lazyDepth)
+    }
+    case 'branded': {
+      const inner = unwrapBranded(schema)
+      return inner === undefined ? [] : walkSegments(inner, segments, maxDepth, lazyDepth)
+    }
+    case 'effects': {
+      const inner = unwrapEffectsSource(schema)
+      return inner === undefined ? [] : walkSegments(inner, segments, maxDepth, lazyDepth)
+    }
+    case 'pipeline': {
+      const inner = unwrapPipeIn(schema)
+      return inner === undefined ? [] : walkSegments(inner, segments, maxDepth, lazyDepth)
+    }
+    case 'lazy': {
+      // Bump the lazy counter. Past the cap, return [] so callers fall
+      // back to permissive behaviour at recursive paths beyond the cap.
+      if (lazyDepth >= maxDepth) return []
+      const inner = unwrapLazy(schema)
+      return inner === undefined ? [] : walkSegments(inner, segments, maxDepth, lazyDepth + 1)
+    }
+    case 'intersection': {
+      // Union of both sides' resolutions — callers try each candidate,
+      // matching parse-time semantics where a value must satisfy both.
+      const left = getIntersectionLeft(schema)
+      const right = getIntersectionRight(schema)
+      const leftResults =
+        left === undefined ? [] : walkSegments(left, segments, maxDepth, lazyDepth)
+      const rightResults =
+        right === undefined ? [] : walkSegments(right, segments, maxDepth, lazyDepth)
+      return [...leftResults, ...rightResults]
+    }
+    // Leaf types — can't descend further. The unsupported kinds
+    // (`promise` / `function` / `map` / `symbol`) are rejected at
+    // adapter construction by `assertSupportedKinds`; this fallthrough
+    // keeps the walker defensive in case construction is skipped (e.g.
+    // a downstream test instantiates a subschema directly).
+    case 'string':
+    case 'number':
+    case 'boolean':
+    case 'bigint':
+    case 'date':
+    case 'enum':
+    case 'native-enum':
+    case 'literal':
+    case 'null':
+    case 'undefined':
+    case 'void':
+    case 'never':
+    case 'any':
+    case 'unknown':
+    case 'nan':
+    case 'promise':
+    case 'function':
+    case 'map':
+    case 'symbol':
       return []
+    default: {
+      const _exhaustive: never = kind
+      throw new Error(`walkSegments (v3): unhandled ZodKind '${_exhaustive as string}'`)
     }
   }
-
-  if (!currentSchema) return []
-  return [currentSchema]
 }
 
 /**

--- a/src/runtime/adapters/zod-v3/index.ts
+++ b/src/runtime/adapters/zod-v3/index.ts
@@ -485,7 +485,16 @@ export function zodAdapter<
         if (!leaf) return undefined
         // The walker preserves the TERMINAL wrapper at the leaf — peel
         // every transparent wrapper here so we see the structural kind.
-        const peeled = peelAllV3Wrappers(leaf)
+        // `peelV3Wrappers` peels Optional / Nullable / Default / Readonly
+        // / Effects / Pipeline / Branded; catch is peeled by hand since
+        // `peelV3Wrappers` preserves it for `unwrapDefault`'s use.
+        let peeled = peelV3Wrappers(leaf)
+        for (let i = 0; i < MAX_UNWRAP_STEPS; i++) {
+          if (!isZodSchemaType(peeled, 'ZodCatch')) break
+          const inner = unwrapInner(peeled)
+          if (!inner) break
+          peeled = peelV3Wrappers(inner)
+        }
         if (isZodSchemaType(peeled, 'ZodTuple')) return getTupleItems(peeled).length
         if (isZodSchemaType(peeled, 'ZodArray')) return null
         return undefined
@@ -1097,47 +1106,6 @@ function peelV3Wrappers(schema: z.ZodTypeAny): z.ZodTypeAny {
       continue
     }
     break
-  }
-  return current
-}
-
-/**
- * Peel every transparent wrapper (optional / nullable / default / readonly
- * / catch / pipeline / branded / effects / lazy) off `schema`. Stops on
- * the first non-wrapper kind. Used by `arrayShapeAtPath` where we want the
- * inner structural kind regardless of what the default-value semantic is
- * — different from `peelV3Wrappers`, which preserves `.catch()` so
- * `unwrapDefault` can read it directly.
- *
- * Mirrors v4's `peelAllWrappers` (`zod-v4/adapter.ts`). Bounded by
- * `MAX_UNWRAP_STEPS` as a runaway guard.
- */
-function peelAllV3Wrappers(schema: z.ZodTypeAny): z.ZodTypeAny {
-  let current: z.ZodTypeAny = schema
-  for (let i = 0; i < MAX_UNWRAP_STEPS; i++) {
-    const k = kindOf(current)
-    let inner: z.ZodTypeAny | undefined
-    if (
-      k === 'optional' ||
-      k === 'nullable' ||
-      k === 'default' ||
-      k === 'readonly' ||
-      k === 'catch'
-    ) {
-      inner = unwrapInner(current)
-    } else if (k === 'pipeline') {
-      inner = unwrapPipeIn(current)
-    } else if (k === 'branded') {
-      inner = unwrapBranded(current)
-    } else if (k === 'effects') {
-      inner = unwrapEffectsSource(current)
-    } else if (k === 'lazy') {
-      inner = unwrapLazy(current)
-    } else {
-      return current
-    }
-    if (inner === undefined) return current
-    current = inner
   }
   return current
 }

--- a/test/adapters/zod-v3/path-walker.test.ts
+++ b/test/adapters/zod-v3/path-walker.test.ts
@@ -102,7 +102,7 @@ describe('zod v3: path-walker parity for union/tuple/intersection/lazy/catch', (
 
   describe('ZodLazy', () => {
     it('descends one lazy layer for a recursive shape', () => {
-      type Tree = { name: string; children?: Tree[] }
+      type Tree = { name: string; children?: Tree[] | undefined }
       const treeSchema: z.ZodType<Tree> = z.lazy(() =>
         z.object({
           name: z.string(),
@@ -118,7 +118,7 @@ describe('zod v3: path-walker parity for union/tuple/intersection/lazy/catch', (
     })
 
     it('caps descent at maxRecursionDepth so recursive paths beyond the cap fall back to permissive', () => {
-      type Tree = { name: string; children?: Tree[] }
+      type Tree = { name: string; children?: Tree[] | undefined }
       const treeSchema: z.ZodType<Tree> = z.lazy(() =>
         z.object({
           name: z.string(),

--- a/test/adapters/zod-v3/path-walker.test.ts
+++ b/test/adapters/zod-v3/path-walker.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod-v3'
+import { zodAdapter } from '../../../src/runtime/adapters/zod-v3'
+
+/**
+ * v3 path-walker parity tests for ZodUnion / ZodTuple / ZodIntersection /
+ * ZodLazy / ZodCatch — the five kinds where v3's pre-unification walker
+ * returned `[]` and the v4 walker resolves correctly. Exercises the walker
+ * through the public adapter surface (`getSchemasAtPath`, `arrayShapeAtPath`,
+ * `getDefaultAtPath`, `getSlimPrimitiveTypesAtPath`, `validateAtPath`) so
+ * the tests describe what a consumer observes, not the private walker shape.
+ *
+ * Mirror of `test/adapters/zod-v4/path-walker.test.ts` (v4 already passes
+ * every case here at the time of writing); the dual-green at the end of
+ * Phase 8 is the parity proof.
+ */
+describe('zod v3: path-walker parity for union/tuple/intersection/lazy/catch', () => {
+  describe('ZodUnion', () => {
+    it('resolves field paths into union branches via getSchemasAtPath', () => {
+      const schema = z.object({
+        value: z.union([
+          z.object({ kind: z.literal('a'), x: z.string() }),
+          z.object({ kind: z.literal('b'), x: z.number() }),
+        ]),
+      })
+      const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+      const resolved = adapter.getSchemasAtPath(['value', 'x'])
+      // Both branches expose `x` — both should resolve.
+      expect(resolved.length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('tightens slim gate to declared kinds under a union field', () => {
+      const schema = z.object({
+        value: z.union([
+          z.object({ kind: z.literal('a'), x: z.string() }),
+          z.object({ kind: z.literal('b'), y: z.number() }),
+        ]),
+      })
+      const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+      // `x` lives only in the first branch → declared kind is `string`.
+      const xKinds = adapter.getSlimPrimitiveTypesAtPath(['value', 'x'])
+      expect(xKinds.has('string')).toBe(true)
+      expect(xKinds.has('number')).toBe(false)
+      // `y` lives only in the second branch → declared kind is `number`.
+      const yKinds = adapter.getSlimPrimitiveTypesAtPath(['value', 'y'])
+      expect(yKinds.has('number')).toBe(true)
+      expect(yKinds.has('string')).toBe(false)
+    })
+  })
+
+  describe('ZodTuple', () => {
+    it('resolves tuple element by index via getSchemasAtPath', () => {
+      const schema = z.object({
+        pair: z.tuple([z.string(), z.number()]),
+      })
+      const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+      const first = adapter.getSchemasAtPath(['pair', '0'])
+      const second = adapter.getSchemasAtPath(['pair', '1'])
+      expect(first).toHaveLength(1)
+      expect(second).toHaveLength(1)
+    })
+
+    it('arrayShapeAtPath returns the tuple length', () => {
+      const schema = z.object({
+        coords: z.tuple([z.number(), z.number(), z.number()]),
+      })
+      const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+      expect(adapter.arrayShapeAtPath(['coords'])).toBe(3)
+    })
+
+    it('slim gate accepts the declared kind at each tuple index', () => {
+      const schema = z.object({
+        pair: z.tuple([z.string(), z.number()]),
+      })
+      const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+      expect(adapter.getSlimPrimitiveTypesAtPath(['pair', '0']).has('string')).toBe(true)
+      expect(adapter.getSlimPrimitiveTypesAtPath(['pair', '1']).has('number')).toBe(true)
+    })
+  })
+
+  describe('ZodIntersection', () => {
+    it('resolves field paths into intersected sides via getSchemasAtPath', () => {
+      const schema = z.object({
+        merged: z.intersection(z.object({ a: z.string() }), z.object({ b: z.number() })),
+      })
+      const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+      expect(adapter.getSchemasAtPath(['merged', 'a'])).toHaveLength(1)
+      expect(adapter.getSchemasAtPath(['merged', 'b'])).toHaveLength(1)
+    })
+
+    it('slim gate tightens to the side that declares the field', () => {
+      const schema = z.object({
+        merged: z.intersection(z.object({ a: z.string() }), z.object({ b: z.number() })),
+      })
+      const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+      expect(adapter.getSlimPrimitiveTypesAtPath(['merged', 'a']).has('string')).toBe(true)
+      expect(adapter.getSlimPrimitiveTypesAtPath(['merged', 'a']).has('number')).toBe(false)
+      expect(adapter.getSlimPrimitiveTypesAtPath(['merged', 'b']).has('number')).toBe(true)
+      expect(adapter.getSlimPrimitiveTypesAtPath(['merged', 'b']).has('string')).toBe(false)
+    })
+  })
+
+  describe('ZodLazy', () => {
+    it('descends one lazy layer for a recursive shape', () => {
+      type Tree = { name: string; children?: Tree[] }
+      const treeSchema: z.ZodType<Tree> = z.lazy(() =>
+        z.object({
+          name: z.string(),
+          children: z.array(treeSchema).optional(),
+        })
+      )
+      const schema = z.object({ root: treeSchema })
+      const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+      // `root.name` reaches a string through one lazy layer.
+      const resolved = adapter.getSchemasAtPath(['root', 'name'])
+      expect(resolved).toHaveLength(1)
+      expect(adapter.getSlimPrimitiveTypesAtPath(['root', 'name']).has('string')).toBe(true)
+    })
+
+    it('caps descent at maxRecursionDepth so recursive paths beyond the cap fall back to permissive', () => {
+      type Tree = { name: string; children?: Tree[] }
+      const treeSchema: z.ZodType<Tree> = z.lazy(() =>
+        z.object({
+          name: z.string(),
+          children: z.array(treeSchema).optional(),
+        })
+      )
+      const schema = z.object({ root: treeSchema })
+      const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 2 })
+      // Two-level recursion: root.children.0.children.0.name — within depth 2 still resolves.
+      const within = adapter.getSchemasAtPath(['root', 'children', '0', 'name'])
+      expect(within.length).toBeGreaterThanOrEqual(1)
+      // Past the cap, the walker returns []; the slim gate falls back to
+      // permissive (empty set) so descendant writes don't get tightened.
+      const beyond = adapter.getSchemasAtPath([
+        'root',
+        'children',
+        '0',
+        'children',
+        '0',
+        'children',
+        '0',
+        'children',
+        '0',
+        'name',
+      ])
+      expect(beyond).toHaveLength(0)
+    })
+  })
+
+  describe('ZodCatch', () => {
+    it('peels catch transparently when resolving a sub-path', () => {
+      const schema = z.object({
+        config: z.object({ retries: z.number(), label: z.string() }).catch({
+          retries: 3,
+          label: 'fallback',
+        }),
+      })
+      const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+      expect(adapter.getSchemasAtPath(['config', 'retries'])).toHaveLength(1)
+      expect(adapter.getSchemasAtPath(['config', 'label'])).toHaveLength(1)
+    })
+
+    it('arrayShapeAtPath returns null for a catch-wrapped array', () => {
+      const schema = z.object({
+        items: z.array(z.string()).catch([]),
+      })
+      const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+      // `null` is the AbstractSchema contract's "unbounded array" sentinel
+      // (distinct from tuple's numeric length and non-array's `undefined`).
+      expect(adapter.arrayShapeAtPath(['items'])).toBe(null)
+    })
+
+    it('arrayShapeAtPath returns the tuple length through catch', () => {
+      const schema = z.object({
+        coords: z.tuple([z.number(), z.number()]).catch([0, 0] as [number, number]),
+      })
+      const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+      expect(adapter.arrayShapeAtPath(['coords'])).toBe(2)
+    })
+
+    it('slim gate tightens to the declared kind under catch', () => {
+      const schema = z.object({
+        config: z.object({ retries: z.number() }).catch({ retries: 3 }),
+      })
+      const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+      expect(adapter.getSlimPrimitiveTypesAtPath(['config', 'retries']).has('number')).toBe(true)
+    })
+  })
+})

--- a/test/adapters/zod-v4/path-walker-parity.test.ts
+++ b/test/adapters/zod-v4/path-walker-parity.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { zodAdapter } from '../../../src/runtime/adapters/zod-v4'
+
+/**
+ * v4 mirror of `test/adapters/zod-v3/path-walker.test.ts` — same scenarios
+ * across the same public adapter surface. v4 already resolves these paths
+ * correctly; this file pins the reference so the v3 unification in Phase 8
+ * lands as proven parity (dual-green = the gap closed).
+ */
+describe('zod v4: path-walker parity for union/tuple/intersection/lazy/catch', () => {
+  describe('ZodUnion', () => {
+    it('resolves field paths into union branches via getSchemasAtPath', () => {
+      const schema = z.object({
+        value: z.union([
+          z.object({ kind: z.literal('a'), x: z.string() }),
+          z.object({ kind: z.literal('b'), x: z.number() }),
+        ]),
+      })
+      const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+      const resolved = adapter.getSchemasAtPath(['value', 'x'])
+      expect(resolved.length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('tightens slim gate to declared kinds under a union field', () => {
+      const schema = z.object({
+        value: z.union([
+          z.object({ kind: z.literal('a'), x: z.string() }),
+          z.object({ kind: z.literal('b'), y: z.number() }),
+        ]),
+      })
+      const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+      const xKinds = adapter.getSlimPrimitiveTypesAtPath(['value', 'x'])
+      expect(xKinds.has('string')).toBe(true)
+      expect(xKinds.has('number')).toBe(false)
+      const yKinds = adapter.getSlimPrimitiveTypesAtPath(['value', 'y'])
+      expect(yKinds.has('number')).toBe(true)
+      expect(yKinds.has('string')).toBe(false)
+    })
+  })
+
+  describe('ZodTuple', () => {
+    it('resolves tuple element by index via getSchemasAtPath', () => {
+      const schema = z.object({
+        pair: z.tuple([z.string(), z.number()]),
+      })
+      const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+      expect(adapter.getSchemasAtPath(['pair', '0'])).toHaveLength(1)
+      expect(adapter.getSchemasAtPath(['pair', '1'])).toHaveLength(1)
+    })
+
+    it('arrayShapeAtPath returns the tuple length', () => {
+      const schema = z.object({
+        coords: z.tuple([z.number(), z.number(), z.number()]),
+      })
+      const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+      expect(adapter.arrayShapeAtPath(['coords'])).toBe(3)
+    })
+
+    it('slim gate accepts the declared kind at each tuple index', () => {
+      const schema = z.object({
+        pair: z.tuple([z.string(), z.number()]),
+      })
+      const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+      expect(adapter.getSlimPrimitiveTypesAtPath(['pair', '0']).has('string')).toBe(true)
+      expect(adapter.getSlimPrimitiveTypesAtPath(['pair', '1']).has('number')).toBe(true)
+    })
+  })
+
+  describe('ZodIntersection', () => {
+    it('resolves field paths into intersected sides via getSchemasAtPath', () => {
+      const schema = z.object({
+        merged: z.intersection(z.object({ a: z.string() }), z.object({ b: z.number() })),
+      })
+      const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+      expect(adapter.getSchemasAtPath(['merged', 'a'])).toHaveLength(1)
+      expect(adapter.getSchemasAtPath(['merged', 'b'])).toHaveLength(1)
+    })
+
+    it('slim gate tightens to the side that declares the field', () => {
+      const schema = z.object({
+        merged: z.intersection(z.object({ a: z.string() }), z.object({ b: z.number() })),
+      })
+      const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+      expect(adapter.getSlimPrimitiveTypesAtPath(['merged', 'a']).has('string')).toBe(true)
+      expect(adapter.getSlimPrimitiveTypesAtPath(['merged', 'a']).has('number')).toBe(false)
+      expect(adapter.getSlimPrimitiveTypesAtPath(['merged', 'b']).has('number')).toBe(true)
+      expect(adapter.getSlimPrimitiveTypesAtPath(['merged', 'b']).has('string')).toBe(false)
+    })
+  })
+
+  describe('ZodLazy', () => {
+    it('descends one lazy layer for a recursive shape', () => {
+      type Tree = { name: string; children?: Tree[] }
+      const treeSchema: z.ZodType<Tree> = z.lazy(() =>
+        z.object({
+          name: z.string(),
+          children: z.array(treeSchema).optional(),
+        })
+      )
+      const schema = z.object({ root: treeSchema })
+      const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+      const resolved = adapter.getSchemasAtPath(['root', 'name'])
+      expect(resolved).toHaveLength(1)
+      expect(adapter.getSlimPrimitiveTypesAtPath(['root', 'name']).has('string')).toBe(true)
+    })
+
+    it('caps descent at maxRecursionDepth so recursive paths beyond the cap fall back to permissive', () => {
+      type Tree = { name: string; children?: Tree[] }
+      const treeSchema: z.ZodType<Tree> = z.lazy(() =>
+        z.object({
+          name: z.string(),
+          children: z.array(treeSchema).optional(),
+        })
+      )
+      const schema = z.object({ root: treeSchema })
+      const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 2 })
+      const within = adapter.getSchemasAtPath(['root', 'children', '0', 'name'])
+      expect(within.length).toBeGreaterThanOrEqual(1)
+      const beyond = adapter.getSchemasAtPath([
+        'root',
+        'children',
+        '0',
+        'children',
+        '0',
+        'children',
+        '0',
+        'children',
+        '0',
+        'name',
+      ])
+      expect(beyond).toHaveLength(0)
+    })
+  })
+
+  describe('ZodCatch', () => {
+    it('peels catch transparently when resolving a sub-path', () => {
+      const schema = z.object({
+        config: z.object({ retries: z.number(), label: z.string() }).catch({
+          retries: 3,
+          label: 'fallback',
+        }),
+      })
+      const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+      expect(adapter.getSchemasAtPath(['config', 'retries'])).toHaveLength(1)
+      expect(adapter.getSchemasAtPath(['config', 'label'])).toHaveLength(1)
+    })
+
+    it('arrayShapeAtPath returns null for a catch-wrapped array', () => {
+      const schema = z.object({
+        items: z.array(z.string()).catch([]),
+      })
+      const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+      expect(adapter.arrayShapeAtPath(['items'])).toBe(null)
+    })
+
+    it('arrayShapeAtPath returns the tuple length through catch', () => {
+      const schema = z.object({
+        coords: z.tuple([z.number(), z.number()]).catch([0, 0] as [number, number]),
+      })
+      const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+      expect(adapter.arrayShapeAtPath(['coords'])).toBe(2)
+    })
+
+    it('slim gate tightens to the declared kind under catch', () => {
+      const schema = z.object({
+        config: z.object({ retries: z.number() }).catch({ retries: 3 }),
+      })
+      const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+      expect(adapter.getSlimPrimitiveTypesAtPath(['config', 'retries']).has('number')).toBe(true)
+    })
+  })
+})

--- a/test/adapters/zod-v4/path-walker-parity.test.ts
+++ b/test/adapters/zod-v4/path-walker-parity.test.ts
@@ -91,7 +91,7 @@ describe('zod v4: path-walker parity for union/tuple/intersection/lazy/catch', (
 
   describe('ZodLazy', () => {
     it('descends one lazy layer for a recursive shape', () => {
-      type Tree = { name: string; children?: Tree[] }
+      type Tree = { name: string; children?: Tree[] | undefined }
       const treeSchema: z.ZodType<Tree> = z.lazy(() =>
         z.object({
           name: z.string(),
@@ -106,7 +106,7 @@ describe('zod v4: path-walker parity for union/tuple/intersection/lazy/catch', (
     })
 
     it('caps descent at maxRecursionDepth so recursive paths beyond the cap fall back to permissive', () => {
-      type Tree = { name: string; children?: Tree[] }
+      type Tree = { name: string; children?: Tree[] | undefined }
       const treeSchema: z.ZodType<Tree> = z.lazy(() =>
         z.object({
           name: z.string(),


### PR DESCRIPTION
## Phase 8 of the audit-remediation series

⚠️ **Behavior change**: closes the v3 ↔ v4 parity gap for path resolution through `ZodUnion` / `ZodTuple` / `ZodIntersection` / `ZodLazy` / `ZodCatch`. Pre-sign-off confirmed at plan time ([recap](#)).

Stacks on Phase 7's chokepoint (`refactor/v3-introspect-chokepoint`, merged). Written against the introspect accessor surface that Phase 7 built; no fresh `_def.<key>` reads here.

## What changed

### 1. Parity gap → red tests (`171c675`)

New `test/adapters/zod-v3/path-walker.test.ts` + `test/adapters/zod-v4/path-walker-parity.test.ts` — same 13 scenarios across both adapter surfaces. Before the unification: v3 **10/13 fail** (5 kinds, exercised through `getSchemasAtPath` / `getSlimPrimitiveTypesAtPath` / `arrayShapeAtPath`), v4 **13/13 pass** (the reference). The red proves the gap is real per the plan's parity discipline.

### 2. Walker unification (`c6ce5df`) — D1 + D16

`getNestedZodSchemasAtPath` rewritten to mirror v4's `walkSegments`: single recursive kind-switch over `kindOf(schema)`, routed through the Phase 7 accessors. Adds the five missing arms:

| Kind | Before (v3) | After (v3 == v4) |
| --- | --- | --- |
| `ZodUnion` | `[]` | `flatMap` over `getUnionOptions` |
| `ZodTuple` | `[]` | index lookup via `getTupleItems` |
| `ZodIntersection` | `[]` | concat `getIntersectionLeft` + `getIntersectionRight` |
| `ZodLazy` | `[]` | `lazyDepth`-counted descent via `unwrapLazy` |
| `ZodCatch` | `[]` | transparent peel via `unwrapInner` (joined with the other wrappers) |

Internal signature change: `getNestedZodSchemasAtPath(schema, segments, maxRecursionDepth: number)`. `maxRecursionDepth` is threaded from `_options.maxRecursionDepth` through `getAbstractSchema` — the existing docblock at the factory return anticipated "future v3 walks that descend through `z.lazy()`," and this is that future.

After this commit, the v3 parity tests turn green (13/13); v4 stays green (13/13).

### 3. `walkV3ToLeafSchema` retired (`a0aa1bc`) — D15 + R1

The secondary walker subsumed by the unified one. **-65 LOC.** Six callers inlined to `const [first] = getNestedZodSchemasAtPath(rootSchema, path, maxRecursionDepth)` (mirrors v4's `adapter.ts:436/465/472` pattern):

- `getDefaultAtPath`
- `getEmptyValueAtPath`
- `arrayShapeAtPath` (also drops the manual catch-peel loop the new walker makes redundant during descent; terminal-wrapper peel inlined since the helper costs more than the inline at one site)
- `isRequiredAtPath`
- `resolveFieldMetaAtPathV3` (gains a `maxRecursionDepth` parameter to thread through)

`peelV3Wrappers` docblock note "ZodCatch is intentionally NOT peeled here" stands — that's the semantic-preserving variant `unwrapDefault` still reads directly.

### 4. Size cap bump (`55aebbb`)

`zod-v3.mjs`: 53.24 KB / 53 KB → bump cap to **54 KB**, matching v4's exact cap. Symmetric: both adapters now share the same accessor surface and walker shape, so identical caps are honest. Phase 12 (ADAPT-D1 dedup factory) will collapse the parallel methods into one and reclaim this slot and more.

## Behavior delta (the ⚠️ items)

**Pre-approved per [plan ledger](Phase 8 row).** Sign-off given at sign-off question.

Observable v3 behaviors that change (all align to v4):

- `validateAtPath('union.field')` for any union branch — now **validates** instead of skipping
- `validateAtPath('tuple.0')` — now validates the item schema
- `validateAtPath('intersection.field')` — now validates against both sides
- `validateAtPath('lazy.field')` — now descends (capped by `maxRecursionDepth`)
- `validateAtPath('catch.field')` — now validates the inner schema; the catch fallback still applies at parse time, not at path lookup
- Same observable shift applies to: slim-gate kind acceptance, `getSlimPrimitiveTypesAtPath`, `getDefaultAtPath`, `getEmptyValueAtPath`, `arrayShapeAtPath`, `isRequiredAtPath`, `getFieldMetaAtPath`, and error routing

Anything that fails on v3 after this change would have failed on v4 already.

## What did NOT change (preserved invariants)

- **`peelV3Wrappers` behavior** — still skips ZodCatch (load-bearing for `unwrapDefault`'s direct read)
- **`generateValue` ZodCatch branch** — still distinguishes "no catch wrapper" from "catch returns undefined" via `hasCatchValue` (Phase 7's preserved subtle behavior)
- **Public type re-exports** from `attaform/zod-v3` — `ZodTypeWithInnerType`, `UnsupportedSchemaError`, etc. unchanged
- **All other adapter methods** — `validateAtPath`, `getDefaultValues`, `fingerprint`, `needsAsyncValidation`, `hasContainerOrRootRefine`, etc. all stay byte-equivalent
- **`MAX_UNWRAP_STEPS`** (64) — bound preserved across all peel loops

## Gate

- ✅ lint
- ✅ typecheck
- ✅ check:site
- ✅ **3,333 tests passing** (264 files; +26 net from new parity tests)
- ✅ check:size (zod.mjs 59.97 / 60, zod-v4.mjs 53.66 / 54, **zod-v3.mjs 53.24 / 54** [bumped])
- ✅ check:bench
- ✅ check:coverage (91.45% lines)

## Commit series

1. `171c675` — `test(zod-v3): pin the path-walker parity gap as red tests`
2. `c6ce5df` — `fix(zod-v3): unify path walker against introspect (D1, D16)`
3. `a0aa1bc` — `refactor(zod-v3): retire walkV3ToLeafSchema, inline 6 callers (D15, R1)`
4. `55aebbb` — `build(size-limit): bump zod-v3.mjs cap 53 → 54 KB for walker unification`

## Unblocks

- **Phase 9** (`fix/v3-parity`) — per-method gap closures (D5-D19, fingerprint cluster) now have one walker to ride on
- **Phase 10** (`fix/v3-async-contract`) — `needsAsyncValidation` (ADAPT-A1 / D14) implementation can use the unified walker's `walkSchemaTree`-shaped traversal
- **Phase 12** (`refactor/adapter-factory`) — ADAPT-D1 dedup factory now sees structurally-identical walkers in v3 + v4; the factory can collapse them. Will reclaim the 1 KB size budget bumped here and more.

## What I'd review for

- Spot the kind-switch in the new `walkSegments` against `zod-v4/path-walker.ts` line-by-line — every arm should be the same shape; v3-only arms (`branded`/`effects`/`pipeline`) read through the v3-specific introspect accessors
- Verify `arrayShapeAtPath`'s inline catch-peel still distinguishes catch-wrapped array (returns `null`) vs catch-wrapped tuple (returns length) vs catch-wrapped non-array (returns `undefined`)
- Confirm the 4 commits read as a clean RED → GREEN → CLEANUP → BUMP series

🤖 Generated with [Claude Code](https://claude.com/claude-code)