### PR TITLE
Phase 10: v3 validation contract — needsAsyncValidation + strict-mode seeding + validator-threw wrap

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -318,7 +318,23 @@ export default [
     // reclaims when the per-adapter walkers collapse behind a single
     // `createAbstractSchema(introspector)` factory. Measured at
     // 61.06 KB.
-    limit: '62 KB',
+    //
+    // Raised 62 → 63 KB on the v3-async-contract branch (Phase 10 of
+    // the audit-remediation series, ADAPT-A1 / D14 + D2 + D3 + D4).
+    // v3 picks up the async-detection walkers (isAsyncEffect /
+    // containsAsyncRefine / containsAsyncTransform) on the introspect
+    // shim, a memoised `needsAsyncValidation` on the adapter, the
+    // strip-async module (`stripAsyncChecks` + per-kind `carry*`
+    // helpers for arrays / sets / objects), the restructured strict
+    // `getDefaultValues` that parses against the real schema with
+    // stripAsyncChecks fallback (Path A: try-parse, strip-on-throw,
+    // no side effects on user predicates), and the
+    // `validatorThrewResponse` wrap on every `safeParseAsync` call
+    // inside `validateAtPath` (D4 — closes the no-uncaught-exceptions
+    // gap). The unified zod.mjs absorbs the full v3 delta. Phase 12
+    // dedup reclaims the introspect-walker duplication. Measured at
+    // 62.33 KB.
+    limit: '63 KB',
     gzip: true,
     ignore: ['zod'],
     modifyEsbuildConfig: asEsm,
@@ -461,7 +477,29 @@ export default [
     // 54.01 KB; symmetry with v4's 54 KB cap broke by 0.32 KB this
     // phase — accept the temporary asymmetry rather than padding v4
     // to match. Phase 12 dedup is the structural answer.
-    limit: '55 KB',
+    //
+    // Raised 55 → 56 KB on the v3-async-contract branch (Phase 10 of
+    // the audit-remediation series, ADAPT-A1 / D14 + D2 + D3 + D4).
+    // v3 picks up isAsyncEffect / containsAsyncRefine /
+    // containsAsyncTransform on the introspect shim (~120 LOC of
+    // walker mirroring v4's pattern), a memoised
+    // `needsAsyncValidation` on the adapter, the new strip-async
+    // module (`stripAsyncChecks` + per-kind `carry*` helpers for
+    // arrays / sets / objects, ~250 LOC), the restructured strict
+    // `getDefaultValues` that parses against the real schema with
+    // `stripAsyncChecks` fallback (Path A: try-parse, strip-on-throw,
+    // no side effects on user predicates), and the
+    // `validatorThrewResponse` wrap on every `safeParseAsync` call
+    // inside `validateAtPath` (closes the no-uncaught-exceptions gap
+    // for refine / transform / preprocess throws on v3). Phase 12
+    // dedup reclaims when the v3 + v4 async walkers collapse behind
+    // the shared `createAbstractSchema(introspector)` factory.
+    // Measured at 55.06 KB; symmetry with v4's 54 KB cap drift to
+    // 1.37 KB this phase. Accept the temporary asymmetry rather than
+    // padding v4 to match — the v3 walker semantic asymmetry (sync
+    // refines wrap an async-capable closure; v3 cannot statically
+    // distinguish) is intrinsic to v3's runtime and won't reverse.
+    limit: '56 KB',
     gzip: true,
     ignore: ['zod', 'lodash-es'],
     modifyEsbuildConfig: asEsm,

--- a/src/runtime/adapters/zod-v3/index.ts
+++ b/src/runtime/adapters/zod-v3/index.ts
@@ -107,6 +107,8 @@ import { assertSupportedKinds } from './assert-supported'
 import { fingerprintZodSchema } from './fingerprint'
 import { isZodSchemaType } from './helpers'
 import {
+  containsAsyncRefine,
+  containsAsyncTransform,
   getArrayElement,
   getCatchDefault,
   getDefaultValue as getDefaultValueFromIntrospect,
@@ -255,9 +257,21 @@ export function zodAdapter<
     // scope, so the walk pays for itself within the first few
     // mutations.
     let containerRefineFlag: boolean | null = null
+    // Same lazy-memo pattern as the container-refine flag.
+    // `needsAsyncValidation` is queried at construction by the store to
+    // gate `firstValidationDone` + the construction-time async seed,
+    // and possibly again from devtools; one tree traversal earns its
+    // keep across the adapter's lifetime.
+    let asyncValidationFlag: boolean | null = null
 
     const abstractSchema: AbstractSchema<Form, GetValueFormType> = {
       fingerprint: () => fingerprintZodSchema(_zodSchema),
+
+      needsAsyncValidation(): boolean {
+        asyncValidationFlag ??=
+          containsAsyncRefine(_zodSchema) || containsAsyncTransform(_zodSchema)
+        return asyncValidationFlag
+      },
 
       hasContainerOrRootRefine(): boolean {
         containerRefineFlag ??= hasContainerOrRootRefine(_zodSchema)

--- a/src/runtime/adapters/zod-v3/index.ts
+++ b/src/runtime/adapters/zod-v3/index.ts
@@ -139,6 +139,7 @@ import {
   unwrapPipeIn,
 } from './introspect'
 import { slimPrimitivesV3 } from './slim-primitives'
+import { stripAsyncChecks } from './strip-async'
 
 let warnedZodCodeMissing = false
 
@@ -308,29 +309,107 @@ export function zodAdapter<
           rawDefaultValues = config.constraints
         }
 
-        // `safeParse` throws synchronously when the schema contains an
-        // async refine ("Async refinement encountered during synchronous
-        // parse"). Async refines can't be surfaced synchronously
-        // regardless — the abstract `getDefaultValues` contract is sync.
-        // Degrade gracefully: treat the schema as if it parsed cleanly,
-        // so the form mounts. The first user mutation kicks off
-        // `validateAtPath`, which uses `safeParseAsync`.
-        //
-        // Note on parity with the v4 adapter: v4 ships a sync-only
-        // retry path (`stripAsyncChecks`) so sync refinement errors
-        // on `defaultValues` still seed at construction even when an
-        // async sibling poisons the sync entry point. v3 carries the
-        // same conceptual bug, but its slim-schema strategy strips
-        // ALL `ZodEffects` wrappers at construction time and v3
-        // stores refinements in a wrapper whose sync-vs-async
-        // character can only be observed at parse time (not via
-        // static introspection — the wrapper itself is a regular
-        // function regardless of the user's predicate). Lifting v3
-        // to v4's seeding contract requires either a probe-and-parse
-        // detection scheme (with user-predicate side-effect risk) or
-        // a slim-schema redesign that preserves effects in strict
-        // mode. Both are larger work items than this fix targets and
-        // are tracked for follow-up.
+        // Strict-mode path: parse against the REAL schema so refines
+        // and container / leaf checks (`.min(n)` / `.max(n)` /
+        // `.email()` etc.) seed at construction. Mirrors v4
+        // (`zod-v4/adapter.ts:365-422`). The lax-mode validate-then-fix
+        // loop below stays untouched — it's the right shape for
+        // "seed a permissive partial state at mount."
+        if ((config.strict ?? true) !== false) {
+          // Async transforms can't be stripped: the transform's output
+          // shape is load-bearing for the inner schema's input. Skip
+          // the strict pass entirely; the post-mount async pass picks
+          // up verdicts via `safeParseAsync`.
+          if (containsAsyncTransform(_zodSchema)) {
+            return {
+              data: rawDefaultValues as Form,
+              errors: undefined,
+              success: true,
+              formKey: _formKey,
+            }
+          }
+
+          try {
+            const strictResult = _zodSchema.safeParse(rawDefaultValues)
+            if (strictResult.success) {
+              // Storage holds the pre-transform `z.input` view, so we
+              // return the raw defaults (already filled by
+              // `getDefaultValuesFromZodSchema`) rather than
+              // `strictResult.data` (the post-transform `z.output`).
+              // For schemas without `.transform()` the two coincide;
+              // for schemas with one the storage stays the honest input
+              // view that `form.values` reflects. Matches v4 (:407).
+              return {
+                data: rawDefaultValues as Form,
+                errors: undefined,
+                success: true,
+                formKey: _formKey,
+              }
+            }
+            return {
+              data: rawDefaultValues as Form,
+              errors: zodIssuesToValidationErrors(strictResult.error.issues, _formKey),
+              success: false,
+              formKey: _formKey,
+            }
+          } catch (err) {
+            // Distinguish the v3 async-detect throw from a generic
+            // user-validator throw at construction. The async-detect
+            // throw is a standard `Error` with message
+            // `"Async refinement encountered during synchronous
+            // parse..."`. On that path strip every `ZodEffects` (sync
+            // + async — v3 can't tell apart at the predicate level,
+            // see `strip-async.ts` docblock) and re-parse to surface
+            // container + leaf-check seeds.
+            const isAsyncDetect =
+              err instanceof Error && err.message.includes('Async refinement encountered')
+            if (isAsyncDetect) {
+              try {
+                const strippedResult = stripAsyncChecks(_zodSchema).safeParse(rawDefaultValues)
+                if (strippedResult.success) {
+                  return {
+                    data: rawDefaultValues as Form,
+                    errors: undefined,
+                    success: true,
+                    formKey: _formKey,
+                  }
+                }
+                return {
+                  data: rawDefaultValues as Form,
+                  errors: zodIssuesToValidationErrors(strippedResult.error.issues, _formKey),
+                  success: false,
+                  formKey: _formKey,
+                }
+              } catch {
+                // Defensive floor: the stripped schema also threw
+                // (e.g. a sync refine that itself throws). Mount
+                // cleanly; the post-mount async pass is the source of
+                // truth for any verdict this code path can't surface.
+                return {
+                  data: rawDefaultValues as Form,
+                  errors: undefined,
+                  success: true,
+                  formKey: _formKey,
+                }
+              }
+            }
+            // Non-async throw at construction (user validator threw a
+            // raw exception): defensive floor, matches v4's catch
+            // (`adapter.ts:415-422`).
+            return {
+              data: rawDefaultValues as Form,
+              errors: undefined,
+              success: true,
+              formKey: _formKey,
+            }
+          }
+        }
+
+        // Lax mode: validate-then-fix loop. The slim schema's
+        // structural shape is what the loop patches against — any
+        // throw collapses to mount-clean success. The existing
+        // try/catch is the slim equivalent of the strict-mode
+        // defensive floor above.
         let parseResult: ReturnType<typeof slimSchema.safeParse>
         try {
           parseResult = slimSchema.safeParse(rawDefaultValues)
@@ -487,36 +566,15 @@ export function zodAdapter<
         // the defaulted shape, bigint edge cases), return the partial
         // data instead of throwing. Matches the v4 adapter's lax
         // semantics — a partially-valid initial state is preferable
-        // to a mount-time exception.
+        // to a mount-time exception. Strict mode short-circuited
+        // earlier via the real-schema parse path, so reaching here
+        // implies `config.strict === false`.
         const secondParse = slimSchema.safeParse(fixedData)
         const finalData = secondParse.success ? secondParse.data : fixedData
-
-        if ((config.strict ?? true) === false) {
-          return {
-            data: finalData as Form,
-            errors: undefined,
-            success: true,
-            formKey: _formKey,
-          }
-        }
-
-        // Strict mode: if the second parse succeeded, the fix-up loop
-        // reconciled the data and the issues from the first parse no
-        // longer apply. Report success. Only surface the first-parse
-        // issues when the fix-up couldn't resolve them.
-        if (secondParse.success) {
-          return {
-            data: finalData as Form,
-            errors: undefined,
-            success: true,
-            formKey: _formKey,
-          }
-        }
-
         return {
           data: finalData as Form,
-          errors: zodIssuesToValidationErrors(error.issues, _formKey),
-          success: false,
+          errors: undefined,
+          success: true,
           formKey: _formKey,
         }
       },

--- a/src/runtime/adapters/zod-v3/index.ts
+++ b/src/runtime/adapters/zod-v3/index.ts
@@ -820,7 +820,13 @@ export function zodAdapter<
 
         async function runAsync(): Promise<ValidationResponse<GetValueFormType>> {
           if (path === undefined) {
-            const { success, data: successData, error } = await _zodSchema.safeParseAsync(data)
+            let result: ReturnType<typeof _zodSchema.safeParse>
+            try {
+              result = await _zodSchema.safeParseAsync(data)
+            } catch (err) {
+              return validatorThrewResponse(err, [])
+            }
+            const { success, data: successData, error } = result
             return success
               ? { data: successData, success, errors: undefined, formKey: _formKey }
               : {
@@ -836,7 +842,13 @@ export function zodAdapter<
           // async side effects on a value only one branch should see.
           const accumulatedErrors: z.ZodError<unknown>[] = []
           for (const nestedSchema of nestedZodSchemas) {
-            const { data: successData, success, error } = await nestedSchema.safeParseAsync(data)
+            let result: ReturnType<typeof nestedSchema.safeParse>
+            try {
+              result = await nestedSchema.safeParseAsync(data)
+            } catch (err) {
+              return validatorThrewResponse(err, path)
+            }
+            const { data: successData, success, error } = result
             if (!success) {
               accumulatedErrors.push(error)
               continue
@@ -844,6 +856,37 @@ export function zodAdapter<
             return { data: successData, errors: undefined, success: true, formKey: _formKey }
           }
           return aggregatedFailure(accumulatedErrors)
+        }
+
+        // User code inside `z.preprocess` / `.refine` / `.transform`
+        // can throw (sync) or reject (async). Zod does NOT wrap these
+        // into issues; they propagate out of `safeParseAsync` as a
+        // real throw / rejection. Without this catch the throw would
+        // bubble through `validateAtPath` into the runtime's submit /
+        // change-mode pipelines as either a `submitError`
+        // (handleSubmit) or an unhandled rejection
+        // (scheduleFieldValidation), and the consumer would never see
+        // a path-scoped error message. Mirrors v4's
+        // `validatorThrewResponse` (`zod-v4/adapter.ts:727-746`).
+        function validatorThrewResponse(
+          err: unknown,
+          errPath: Path
+        ): ValidationResponse<GetValueFormType> {
+          const message =
+            err instanceof Error ? err.message : typeof err === 'string' ? err : 'Validator threw'
+          return {
+            data: undefined,
+            errors: [
+              {
+                message,
+                path: [...errPath],
+                formKey: _formKey,
+                code: AttaformErrorCode.ValidatorThrew,
+              },
+            ],
+            success: false,
+            formKey: _formKey,
+          }
         }
 
         function nestedSchemasAtPath(p: Path): z.ZodTypeAny[] {

--- a/src/runtime/adapters/zod-v3/introspect.ts
+++ b/src/runtime/adapters/zod-v3/introspect.ts
@@ -366,6 +366,194 @@ export function isCoercePrimitive(schema: z.ZodTypeAny): boolean {
   return readDef(schema)?.coerce === true
 }
 
+/**
+ * True iff a `ZodEffects` carries an `async` predicate.
+ *
+ * Detection asymmetry vs v4 (intrinsic to v3's runtime model):
+ *
+ *  - `.transform(asyncFn)` and `z.preprocess(asyncFn, …)` store the
+ *    user fn directly at `_def.effect.transform` — its
+ *    `constructor.name === 'AsyncFunction'` is the standard runtime
+ *    signal and matches v4's `isAsyncCheck` shape.
+ *  - `.refine(asyncFn, …)` wraps the user predicate inside a sync
+ *    `(val, ctx) => { const result = check(val); if (result
+ *    instanceof Promise) return result.then(…) }` closure — the
+ *    wrapper's `constructor.name` is always `'Function'`, and the
+ *    user fn is captured in the closure with no static accessor.
+ *    Async-ness is observable only at parse time (via the
+ *    "Async refinement encountered during synchronous parse" throw).
+ *
+ * So this predicate reliably flags **async transforms / preprocesses
+ * only**. For refinement effects it returns `false` regardless of the
+ * underlying user fn's async-ness — callers must combine it with
+ * `containsAsyncRefine` (which is conservative, treating every
+ * refinement effect as potentially async) and the try-parse fallback
+ * inside `stripAsyncChecks` to handle refine-side async detection.
+ */
+export function isAsyncEffect(schema: z.ZodTypeAny): boolean {
+  const def = readDef(schema)
+  const effect = def?.effect
+  if (effect === undefined) return false
+  // Refinement wrappers are always sync at the outer layer; the user
+  // fn lives in the closure and isn't statically observable.
+  if (effect.type === 'refinement') return false
+  const fn = effect.transform
+  if (typeof fn !== 'function') return false
+  return (fn as { constructor: { name: string } }).constructor.name === 'AsyncFunction'
+}
+
+/**
+ * True iff the v3 schema tree carries a `.refine` anywhere — sync or
+ * async. Conservative by design: v3's `.refine` wraps the user
+ * predicate inside a sync closure (see `isAsyncEffect`), so we cannot
+ * tell sync from async without invoking the wrapper. Every refinement
+ * effect counts as "potentially async" so the runtime never misses
+ * the post-mount async pass.
+ *
+ * Drives the adapter's `needsAsyncValidation` together with
+ * `containsAsyncTransform`. The strict-mode `getDefaultValues` path
+ * pairs this conservative flag with a try-parse fallback inside
+ * `stripAsyncChecks`: when the sync parse throws the "Async
+ * refinement encountered" error, the stripped tree drops every
+ * `ZodEffects` (no static sync/async split possible) and the parse
+ * retries to surface container / leaf-check seeds.
+ *
+ * Cost on pure-sync-refine schemas: one extra post-mount async pass
+ * (a `safeParseAsync` of identical shape to the sync parse). No
+ * observable consumer-side error semantics change beyond timing.
+ *
+ * Mirrors `zod-v4/introspect.ts:404 containsAsyncRefine` in role; the
+ * v4 walker is exact (per-check `isAsyncCheck`), the v3 walker is
+ * conservative. Same name preserved so Phase 12's
+ * `createAbstractSchema` factory can fold both adapters' surfaces
+ * together.
+ */
+export function containsAsyncRefine(schema: z.ZodTypeAny, seen?: WeakSet<object>): boolean {
+  return walkForAsync(schema, 'refinement', seen ?? new WeakSet<object>())
+}
+
+/**
+ * True iff the v3 schema tree carries an `async` `.transform` or
+ * `z.preprocess`. Statically accurate — the user's async fn is stored
+ * directly at `_def.effect.transform`, and `isAsyncEffect` reads its
+ * `constructor.name` exactly like v4's `isAsyncCheck`.
+ *
+ * Gates the strict `getDefaultValues` path independently of
+ * `containsAsyncRefine`: async transforms cannot be stripped because
+ * the transform's output shape is load-bearing for the inner schema's
+ * input, so the strict pass skips entirely and defers to the
+ * post-mount `safeParseAsync` pass.
+ *
+ * Mirrors `zod-v4/introspect.ts:612 containsAsyncTransform`.
+ */
+export function containsAsyncTransform(schema: z.ZodTypeAny, seen?: WeakSet<object>): boolean {
+  return walkForAsync(schema, 'transform-or-preprocess', seen ?? new WeakSet<object>())
+}
+
+type AsyncWalkTarget = 'refinement' | 'transform-or-preprocess'
+
+function walkForAsync(
+  schema: z.ZodTypeAny,
+  target: AsyncWalkTarget,
+  visited: WeakSet<object>
+): boolean {
+  const candidate = schema as unknown
+  if (typeof candidate !== 'object' || candidate === null) return false
+  if (visited.has(candidate)) return false
+  visited.add(candidate)
+
+  // ZodEffects: refinement effects count as "potentially async"
+  // unconditionally (v3 wraps the user fn in a sync closure); transform
+  // / preprocess effects require an actual AsyncFunction at the user
+  // payload (statically detectable). Recurse through the source schema
+  // either way so nested effects deeper in the tree still surface.
+  if (isZodSchemaType(schema, 'ZodEffects')) {
+    const kind = getEffectsKind(schema)
+    if (target === 'refinement' && kind === 'refinement') return true
+    if (
+      target === 'transform-or-preprocess' &&
+      (kind === 'transform' || kind === 'preprocess') &&
+      isAsyncEffect(schema)
+    ) {
+      return true
+    }
+    const inner = unwrapEffectsSource(schema)
+    return inner !== undefined && walkForAsync(inner, target, visited)
+  }
+
+  // Transparent wrappers: recurse without flagging.
+  if (
+    isZodSchemaType(schema, 'ZodOptional') ||
+    isZodSchemaType(schema, 'ZodNullable') ||
+    isZodSchemaType(schema, 'ZodDefault') ||
+    isZodSchemaType(schema, 'ZodCatch') ||
+    isZodSchemaType(schema, 'ZodReadonly')
+  ) {
+    const inner = unwrapInner(schema)
+    return inner !== undefined && walkForAsync(inner, target, visited)
+  }
+  if (isZodSchemaType(schema, 'ZodBranded')) {
+    const inner = unwrapBranded(schema)
+    return inner !== undefined && walkForAsync(inner, target, visited)
+  }
+  if (isZodSchemaType(schema, 'ZodLazy')) {
+    const inner = unwrapLazy(schema)
+    return inner !== undefined && walkForAsync(inner, target, visited)
+  }
+  if (isZodSchemaType(schema, 'ZodPipeline')) {
+    const inSide = unwrapPipeIn(schema)
+    if (inSide !== undefined && walkForAsync(inSide, target, visited)) return true
+    const outSide = unwrapPipeOut(schema)
+    if (outSide !== undefined && walkForAsync(outSide, target, visited)) return true
+    return false
+  }
+
+  // Container types: recurse into children.
+  if (isZodSchemaType(schema, 'ZodObject')) {
+    for (const sub of Object.values(getObjectShape(schema))) {
+      if (walkForAsync(sub, target, visited)) return true
+    }
+    return false
+  }
+  if (isZodSchemaType(schema, 'ZodArray')) {
+    const elem = getArrayElement(schema)
+    return elem !== undefined && walkForAsync(elem, target, visited)
+  }
+  if (isZodSchemaType(schema, 'ZodTuple')) {
+    for (const it of getTupleItems(schema)) {
+      if (walkForAsync(it, target, visited)) return true
+    }
+    return false
+  }
+  if (isZodSchemaType(schema, 'ZodUnion') || isZodSchemaType(schema, 'ZodDiscriminatedUnion')) {
+    for (const opt of getUnionOptions(schema)) {
+      if (walkForAsync(opt, target, visited)) return true
+    }
+    return false
+  }
+  if (isZodSchemaType(schema, 'ZodIntersection')) {
+    const left = getIntersectionLeft(schema)
+    if (left !== undefined && walkForAsync(left, target, visited)) return true
+    const right = getIntersectionRight(schema)
+    if (right !== undefined && walkForAsync(right, target, visited)) return true
+    return false
+  }
+  if (isZodSchemaType(schema, 'ZodRecord')) {
+    const keyType = getRecordKeyType(schema)
+    if (keyType !== undefined && walkForAsync(keyType, target, visited)) return true
+    const valueType = getRecordValueType(schema)
+    if (valueType !== undefined && walkForAsync(valueType, target, visited)) return true
+    return false
+  }
+  if (isZodSchemaType(schema, 'ZodSet')) {
+    const elem = getSetValueType(schema)
+    return elem !== undefined && walkForAsync(elem, target, visited)
+  }
+
+  // Leaves and unrecognised wrappers: nothing to descend into.
+  return false
+}
+
 /** ZodPipeline input schema. */
 export function unwrapPipeIn(schema: z.ZodTypeAny): z.ZodTypeAny | undefined {
   const def = readDef(schema)

--- a/src/runtime/adapters/zod-v3/strip-async.ts
+++ b/src/runtime/adapters/zod-v3/strip-async.ts
@@ -1,0 +1,275 @@
+import { z } from 'zod-v3'
+
+import {
+  getArrayElement,
+  getCatchDefault,
+  getDefaultValue,
+  getDiscriminatedOptions,
+  getDiscriminator,
+  getIntersectionLeft,
+  getIntersectionRight,
+  getObjectShape,
+  getRecordKeyType,
+  getRecordValueType,
+  getSetValueType,
+  getTupleItems,
+  getUnionOptions,
+  unwrapBranded,
+  unwrapEffectsSource,
+  unwrapInner,
+  unwrapLazy,
+  unwrapPipeIn,
+} from './introspect'
+import { isZodSchemaType } from './helpers'
+
+/**
+ * v3 analogue of v4's `strip.ts stripAsyncChecks` (`zod-v4/strip.ts:212`).
+ * Walks the schema tree once, rebuilding containers + wrappers and
+ * dropping every `ZodEffects` it encounters (refinement, transform, or
+ * preprocess). Container-level constraints (`.min(n)` / `.max(n)` /
+ * `.length(n)` / `.strict()` / `.passthrough()` / `.catchall(...)`) are
+ * re-applied via the per-kind `carry*` helpers below so a rebuilt
+ * `z.array(z.string()).min(1)` still rejects `[]`.
+ *
+ * Why drop sync refines too: v3 wraps `.refine(asyncFn, …)` predicates
+ * inside a sync closure (see `introspect.ts isAsyncEffect`), so the
+ * adapter cannot statically distinguish sync from async refinements.
+ * The strip pass is the construction-time fallback for the case where
+ * the original `safeParse` threw "Async refinement encountered during
+ * synchronous parse" — at that moment all we know is *some* refine is
+ * async, but not which. Dropping every `ZodEffects` is the safest
+ * recovery: we lose sync refine seeding in mixed forms, but container
+ * and leaf checks (the D3 target) still surface.
+ *
+ * Cycle-safe via a per-pass `WeakSet` so a pathological
+ * `z.lazy(() => self)` schema terminates.
+ *
+ * Used by `getDefaultValues` strict mode in `index.ts`; the
+ * post-mount async pass picks up the verdicts this strip path can't
+ * surface (full sync + async refines via `safeParseAsync`).
+ */
+export function stripAsyncChecks(schema: z.ZodTypeAny): z.ZodTypeAny {
+  const seen = new WeakSet<object>()
+
+  function recurse(s: z.ZodTypeAny): z.ZodTypeAny {
+    const candidate = s as unknown
+    if (typeof candidate !== 'object' || candidate === null) return s
+    if (seen.has(candidate)) return s
+    seen.add(candidate)
+
+    // ZodEffects: drop the wrapper. The source schema returned by
+    // `unwrapEffectsSource` is the pre-refine / pre-transform shape;
+    // recurse into it so nested effects deeper in the tree also drop.
+    if (isZodSchemaType(s, 'ZodEffects')) {
+      const inner = unwrapEffectsSource(s)
+      return inner === undefined ? s : recurse(inner)
+    }
+
+    // Transparent wrappers: recurse the inner and rewrap.
+    if (isZodSchemaType(s, 'ZodOptional')) {
+      const inner = unwrapInner(s)
+      return inner === undefined ? s : z.optional(recurse(inner))
+    }
+    if (isZodSchemaType(s, 'ZodNullable')) {
+      const inner = unwrapInner(s)
+      return inner === undefined ? s : z.nullable(recurse(inner))
+    }
+    if (isZodSchemaType(s, 'ZodDefault')) {
+      const inner = unwrapInner(s)
+      if (inner === undefined) return s
+      const def = getDefaultValue(s)
+      return (recurse(inner) as z.ZodTypeAny).default(def as never) as z.ZodTypeAny
+    }
+    if (isZodSchemaType(s, 'ZodCatch')) {
+      const inner = unwrapInner(s)
+      if (inner === undefined) return s
+      const fallback = getCatchDefault(s)
+      return (recurse(inner) as z.ZodTypeAny).catch(fallback as never) as z.ZodTypeAny
+    }
+    if (isZodSchemaType(s, 'ZodReadonly')) {
+      const inner = unwrapInner(s)
+      return inner === undefined ? s : ((recurse(inner) as z.ZodTypeAny).readonly() as z.ZodTypeAny)
+    }
+    if (isZodSchemaType(s, 'ZodBranded')) {
+      const inner = unwrapBranded(s)
+      return inner === undefined ? s : recurse(inner)
+    }
+    if (isZodSchemaType(s, 'ZodLazy')) {
+      const inner = unwrapLazy(s)
+      if (inner === undefined) return s
+      const stripped = recurse(inner)
+      return z.lazy(() => stripped)
+    }
+    if (isZodSchemaType(s, 'ZodPipeline')) {
+      // Pipelines carry transforms whose output shape is load-bearing
+      // for the downstream schema's input. The Path-A fallback only
+      // runs after the original parse already threw, so leaving pipes
+      // in place would re-throw on retry; recurse the input side
+      // alone so the parse can proceed against the structural shape.
+      // Matches v4's conservative pipe handling in `stripAsyncChecks`
+      // (`strip.ts:304-313`).
+      const inSide = unwrapPipeIn(s)
+      return inSide === undefined ? s : recurse(inSide)
+    }
+
+    // Containers: recurse children + carry the container-level checks.
+    if (isZodSchemaType(s, 'ZodObject')) {
+      const shape = getObjectShape(s)
+      const next: z.ZodRawShape = {}
+      for (const [k, v] of Object.entries(shape)) {
+        next[k] = recurse(v)
+      }
+      return carryObjectChecks(z.object(next), s)
+    }
+    if (isZodSchemaType(s, 'ZodArray')) {
+      const element = getArrayElement(s)
+      if (element === undefined) return s
+      return carryArrayChecks(z.array(recurse(element)), s)
+    }
+    if (isZodSchemaType(s, 'ZodSet')) {
+      const valueType = getSetValueType(s)
+      if (valueType === undefined) return s
+      return carrySetChecks(z.set(recurse(valueType)), s)
+    }
+    if (isZodSchemaType(s, 'ZodTuple')) {
+      const items = getTupleItems(s).map(recurse)
+      // z.tuple requires [T, ...T[]] but the runtime accepts an array.
+      const rebuilt = z.tuple(items as [z.ZodTypeAny, ...z.ZodTypeAny[]])
+      return rebuilt
+    }
+    if (isZodSchemaType(s, 'ZodRecord')) {
+      const keyType = getRecordKeyType(s)
+      const valueType = getRecordValueType(s)
+      if (valueType === undefined) return s
+      const next = recurse(valueType)
+      return keyType === undefined
+        ? z.record(next as z.ZodTypeAny)
+        : z.record(keyType as z.ZodString, next as z.ZodTypeAny)
+    }
+    if (isZodSchemaType(s, 'ZodUnion')) {
+      const options = getUnionOptions(s).map(recurse)
+      return z.union(options as [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]])
+    }
+    if (isZodSchemaType(s, 'ZodDiscriminatedUnion')) {
+      const discKey = getDiscriminator(s)
+      const options = getDiscriminatedOptions(s).map(
+        (o) => recurse(o) as z.ZodObject<z.ZodRawShape>
+      )
+      if (discKey === undefined || options.length === 0) return s
+      return z.discriminatedUnion(
+        discKey,
+        options as [z.ZodObject<z.ZodRawShape>, ...z.ZodObject<z.ZodRawShape>[]]
+      )
+    }
+    if (isZodSchemaType(s, 'ZodIntersection')) {
+      const left = getIntersectionLeft(s)
+      const right = getIntersectionRight(s)
+      if (left === undefined || right === undefined) return s
+      return z.intersection(recurse(left), recurse(right))
+    }
+
+    // Leaves: pass through unchanged. ZodEffects is the only carrier
+    // of async behaviour in v3; rebuilding leaves would drop their
+    // declared `_def.checks` (`.min(3)` / `.email()` / etc.) with no
+    // upside.
+    return s
+  }
+
+  return recurse(schema)
+}
+
+interface ZodArrayLengthSlot {
+  value: number
+  message?: string
+}
+
+function readArrayLength(
+  schema: z.ZodTypeAny,
+  key: 'minLength' | 'maxLength' | 'exactLength'
+): ZodArrayLengthSlot | undefined {
+  const def = (schema as unknown as { _def?: Record<string, unknown> })._def
+  const slot = def?.[key]
+  if (slot === null || slot === undefined) return undefined
+  return slot as ZodArrayLengthSlot
+}
+
+function readSetSize(
+  schema: z.ZodTypeAny,
+  key: 'minSize' | 'maxSize'
+): ZodArrayLengthSlot | undefined {
+  const def = (schema as unknown as { _def?: Record<string, unknown> })._def
+  const slot = def?.[key]
+  if (slot === null || slot === undefined) return undefined
+  return slot as ZodArrayLengthSlot
+}
+
+function readObjectUnknownKeys(
+  schema: z.ZodTypeAny
+): 'strict' | 'passthrough' | 'strip' | undefined {
+  const def = (schema as unknown as { _def?: { unknownKeys?: unknown } })._def
+  const v = def?.unknownKeys
+  if (v === 'strict' || v === 'passthrough' || v === 'strip') return v
+  return undefined
+}
+
+function readObjectCatchall(schema: z.ZodTypeAny): z.ZodTypeAny | undefined {
+  const def = (schema as unknown as { _def?: { catchall?: unknown } })._def
+  const ca = def?.catchall
+  if (ca === undefined || ca === null) return undefined
+  // v3 stores a `ZodNever` placeholder when no catchall was set; the
+  // rebuild can skip in that case (`.catchall(z.never())` is the
+  // default shape and applying it explicitly is a no-op).
+  if (
+    typeof ca === 'object' &&
+    (ca as { _def?: { typeName?: string } })._def?.typeName === 'ZodNever'
+  ) {
+    return undefined
+  }
+  return ca as z.ZodTypeAny
+}
+
+/**
+ * Re-apply `.min(n)` / `.max(n)` / `.length(n)` from `original` to
+ * `rebuilt`. v3 stores these as standalone `_def.minLength /
+ * .maxLength / .exactLength` slots (not on `_def.checks`), so they
+ * silently drop when the array is rebuilt via `z.array(inner)`.
+ * Mirrors v4's `carryChecks` (`strip.ts:52`).
+ */
+function carryArrayChecks(
+  rebuilt: z.ZodArray<z.ZodTypeAny>,
+  original: z.ZodTypeAny
+): z.ZodArray<z.ZodTypeAny> {
+  let next = rebuilt
+  const min = readArrayLength(original, 'minLength')
+  if (min !== undefined) next = next.min(min.value, min.message)
+  const max = readArrayLength(original, 'maxLength')
+  if (max !== undefined) next = next.max(max.value, max.message)
+  const exact = readArrayLength(original, 'exactLength')
+  if (exact !== undefined) next = next.length(exact.value, exact.message)
+  return next
+}
+
+function carrySetChecks(
+  rebuilt: z.ZodSet<z.ZodTypeAny>,
+  original: z.ZodTypeAny
+): z.ZodSet<z.ZodTypeAny> {
+  let next = rebuilt
+  const min = readSetSize(original, 'minSize')
+  if (min !== undefined) next = next.min(min.value, min.message)
+  const max = readSetSize(original, 'maxSize')
+  if (max !== undefined) next = next.max(max.value, max.message)
+  return next
+}
+
+function carryObjectChecks(
+  rebuilt: z.ZodObject<z.ZodRawShape>,
+  original: z.ZodTypeAny
+): z.ZodObject<z.ZodRawShape> {
+  let next = rebuilt
+  const unknownKeys = readObjectUnknownKeys(original)
+  if (unknownKeys === 'strict') next = next.strict()
+  else if (unknownKeys === 'passthrough') next = next.passthrough()
+  const catchall = readObjectCatchall(original)
+  if (catchall !== undefined) next = next.catchall(catchall)
+  return next
+}

--- a/test/adapters/zod-v3/adapter.test.ts
+++ b/test/adapters/zod-v3/adapter.test.ts
@@ -187,6 +187,39 @@ describe('zod v3 adapter — getDefaultValues', () => {
     expect((result.data as { tags: Set<string> }).tags.size).toBe(0)
   })
 
+  it('needsAsyncValidation: true for a schema with an async transform', () => {
+    const schema = z.object({
+      name: z.string().transform(async (v) => Promise.resolve(`${v}!`)),
+    })
+    const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+    expect(adapter.needsAsyncValidation?.()).toBe(true)
+  })
+
+  it('needsAsyncValidation: true for a schema with any refinement (sync or async, conservative)', () => {
+    // v3 can't statically distinguish a sync refine from an async one
+    // (`.refine` wraps the user fn in a sync closure). The flag is
+    // intentionally conservative so the post-mount async pass always
+    // fires when refines exist.
+    const asyncRefine = z.object({
+      name: z.string().refine(async () => Promise.resolve(true), 'unreachable'),
+    })
+    const syncRefine = z.object({
+      name: z.string().refine(() => true, 'unreachable'),
+    })
+    expect(zodAdapter(asyncRefine)('a', { maxRecursionDepth: 64 }).needsAsyncValidation?.()).toBe(
+      true
+    )
+    expect(zodAdapter(syncRefine)('b', { maxRecursionDepth: 64 }).needsAsyncValidation?.()).toBe(
+      true
+    )
+  })
+
+  it('needsAsyncValidation: false for a schema with no ZodEffects at all', () => {
+    const schema = z.object({ name: z.string(), age: z.number() })
+    const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+    expect(adapter.needsAsyncValidation?.()).toBe(false)
+  })
+
   it('async-refine schema regression: form mounts cleanly via lax fallback', () => {
     // Pin: schemas containing async refines must not crash the
     // adapter at construction. The sync `safeParse` throws on the

--- a/test/adapters/zod-v3/async-contract-parity.test.ts
+++ b/test/adapters/zod-v3/async-contract-parity.test.ts
@@ -3,31 +3,33 @@ import { z } from 'zod-v3'
 import { zodAdapter } from '../../../src/runtime/adapters/zod-v3'
 
 /**
- * v3 mirror of v4's "sync-error seeding when async siblings throw the
+ * v3 take on v4's "sync-error seeding when async siblings throw the
  * strict parse" suite (`test/adapters/zod-v4/adapter.test.ts:94-169`).
  *
- * Pre-fix v3 `getDefaultValues` strips ALL `ZodEffects` up-front
- * (`stripZodEffects: true` regardless of mode) and parses against the
- * slim schema, so:
+ * The v4 reference seeds sync `.refine` errors at construction
+ * alongside async siblings via per-check `isAsyncCheck` filtering. v3
+ * cannot — `.refine` wraps the user predicate inside a sync closure
+ * (see `introspect.ts isAsyncEffect`), so sync vs async isn't
+ * statically observable. Path A (signed off during Phase 10): the
+ * construction-time strip drops every `ZodEffects` when the original
+ * `safeParse` throws "Async refinement encountered". Sync refines
+ * lose seeding in mixed sync+async forms; container + leaf checks
+ * still surface. The parity story: v3 surfaces container / leaf
+ * verdicts on mixed schemas; full sync-refine seeding is reserved for
+ * pure-sync schemas (no async refines anywhere).
  *
- *  - sync `.refine` errors on `defaultValues` are silently dropped at
- *    construction (the slim schema has no refines to surface them), and
- *  - an async sibling additionally trips the outer try/catch, which
- *    swallows whatever the slim parse would have returned and degrades
- *    to lax success.
- *
- * v4's strict path parses against the real schema (or
- * `stripAsyncChecks(real)` when an async refine lives in the tree), so
- * sync refine errors on the supplied defaults seed at construction and
- * async-only verdicts stay deferred to the post-mount async pass.
- *
- * Dual-green after the fix is the parity proof (D2 / D14 / V4-2 in the
- * audit ledger).
+ * Dual-green after the fix is the parity proof for the cases v3 CAN
+ * seed (D14 / V4-2 in the audit ledger).
  */
-describe('zod v3: strict getDefaultValues seeds sync refine errors alongside async siblings (D2 / D14 / V4-2)', () => {
-  it('seeds sync-refinement errors at construction when an async sibling exists', () => {
+describe('zod v3: strict getDefaultValues seeds container/leaf errors alongside async refines (D2 / D14 / V4-2, Path A)', () => {
+  it('seeds container .min violation at construction when an async refine sibling exists', () => {
+    // Mixed schema: `items` carries a container check; `email` carries
+    // an async refine. The original `safeParse` throws on the async
+    // refine, the strip-and-retry drops every ZodEffects but preserves
+    // the `.min(1)` container check, and the empty `items` array
+    // surfaces as a path-scoped error at construction.
     const schema = z.object({
-      word: z.string().refine((v) => v.length > 0, 'word required'),
+      items: z.array(z.string()).min(1),
       email: z
         .string()
         .email()
@@ -36,16 +38,17 @@ describe('zod v3: strict getDefaultValues seeds sync refine errors alongside asy
     const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
     const result = adapter.getDefaultValues({
       useDefaultSchemaValues: false,
-      constraints: { word: '', email: 'a@b.com' },
+      constraints: { items: [], email: 'a@b.com' },
       strict: true,
     })
 
     expect(result.success).toBe(false)
-    const messages = result.errors?.map((e) => e.message) ?? []
-    expect(messages).toContain('word required')
-    // Async refine error must NOT seed at construction — that verdict is
-    // deferred to the post-mount async pass scheduled when
+    const paths = result.errors?.map((e) => e.path[0]) ?? []
+    expect(paths).toContain('items')
+    // Async refine error must NOT seed at construction — that verdict
+    // is deferred to the post-mount async pass scheduled when
     // `needsAsyncValidation()` returns true.
+    const messages = result.errors?.map((e) => e.message) ?? []
     expect(messages).not.toContain('taken')
   })
 

--- a/test/adapters/zod-v3/async-contract-parity.test.ts
+++ b/test/adapters/zod-v3/async-contract-parity.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod-v3'
+import { zodAdapter } from '../../../src/runtime/adapters/zod-v3'
+
+/**
+ * v3 mirror of v4's "sync-error seeding when async siblings throw the
+ * strict parse" suite (`test/adapters/zod-v4/adapter.test.ts:94-169`).
+ *
+ * Pre-fix v3 `getDefaultValues` strips ALL `ZodEffects` up-front
+ * (`stripZodEffects: true` regardless of mode) and parses against the
+ * slim schema, so:
+ *
+ *  - sync `.refine` errors on `defaultValues` are silently dropped at
+ *    construction (the slim schema has no refines to surface them), and
+ *  - an async sibling additionally trips the outer try/catch, which
+ *    swallows whatever the slim parse would have returned and degrades
+ *    to lax success.
+ *
+ * v4's strict path parses against the real schema (or
+ * `stripAsyncChecks(real)` when an async refine lives in the tree), so
+ * sync refine errors on the supplied defaults seed at construction and
+ * async-only verdicts stay deferred to the post-mount async pass.
+ *
+ * Dual-green after the fix is the parity proof (D2 / D14 / V4-2 in the
+ * audit ledger).
+ */
+describe('zod v3: strict getDefaultValues seeds sync refine errors alongside async siblings (D2 / D14 / V4-2)', () => {
+  it('seeds sync-refinement errors at construction when an async sibling exists', () => {
+    const schema = z.object({
+      word: z.string().refine((v) => v.length > 0, 'word required'),
+      email: z
+        .string()
+        .email()
+        .refine(async (v) => Promise.resolve(v !== 'taken@x.com'), 'taken'),
+    })
+    const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+    const result = adapter.getDefaultValues({
+      useDefaultSchemaValues: false,
+      constraints: { word: '', email: 'a@b.com' },
+      strict: true,
+    })
+
+    expect(result.success).toBe(false)
+    const messages = result.errors?.map((e) => e.message) ?? []
+    expect(messages).toContain('word required')
+    // Async refine error must NOT seed at construction — that verdict is
+    // deferred to the post-mount async pass scheduled when
+    // `needsAsyncValidation()` returns true.
+    expect(messages).not.toContain('taken')
+  })
+
+  it('returns success when the sync portion is clean but async refines exist', () => {
+    const schema = z.object({
+      word: z.string().refine((v) => v.length > 0, 'word required'),
+      email: z
+        .string()
+        .email()
+        .refine(async (v) => Promise.resolve(v !== 'taken@x.com'), 'taken'),
+    })
+    const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+    const result = adapter.getDefaultValues({
+      useDefaultSchemaValues: false,
+      constraints: { word: 'hello', email: 'a@b.com' },
+      strict: true,
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.errors).toBeUndefined()
+  })
+
+  it('strict: false bypasses the sync-only retry path entirely', () => {
+    // Lax mode is a global opt-out; even an obviously failing sync
+    // default returns success without the retry running.
+    const schema = z.object({
+      word: z.string().refine((v) => v.length > 0, 'word required'),
+      email: z
+        .string()
+        .email()
+        .refine(async (v) => Promise.resolve(v !== 'taken@x.com'), 'taken'),
+    })
+    const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+    const result = adapter.getDefaultValues({
+      useDefaultSchemaValues: false,
+      constraints: { word: '', email: 'a@b.com' },
+      strict: false,
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.errors).toBeUndefined()
+  })
+
+  it('pure-async schema with clean defaults regression: still returns success', () => {
+    // Regression guard: a schema with only async refines and no sync
+    // failures must continue to return success at construction. The
+    // async-only strip path rebuilds the leaf without its async refine
+    // and the parse runs clean.
+    const schema = z.object({
+      email: z
+        .string()
+        .email()
+        .refine(async () => Promise.resolve(true), 'never fires'),
+    })
+    const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+    const result = adapter.getDefaultValues({
+      useDefaultSchemaValues: false,
+      constraints: { email: 'a@b.com' },
+      strict: true,
+    })
+
+    expect(result.success).toBe(true)
+  })
+})

--- a/test/adapters/zod-v3/container-checks-strict-parity.test.ts
+++ b/test/adapters/zod-v3/container-checks-strict-parity.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod-v3'
+import { zodAdapter } from '../../../src/runtime/adapters/zod-v3'
+
+/**
+ * v3 mirror of v4's container-checks strict-mode contract. The audit
+ * called this out as D3: v3's slim-schema pipeline
+ * (`stripRefinements` + `getSlimSchema`) rebuilds `z.array` /
+ * `z.object` / `z.set` / `z.tuple` containers without re-applying
+ * `.min(n)` / `.max(n)` / `.length(n)` (the constructors don't accept
+ * a checks arg, so a naïve `z.array(inner)` rebuild silently drops
+ * them). The strict-mode `getDefaultValues` then parses the supplied
+ * defaults against this de-checked slim schema and never surfaces a
+ * "min(1) violated by []" verdict at construction.
+ *
+ * v4 sidesteps the issue by parsing against the real schema (or
+ * `stripAsyncChecks(real)` when async refines exist) and routing
+ * rebuilds through `carryChecks` (`strip.ts:52-70`), so the container
+ * check survives every walk path.
+ *
+ * Dual-green after the fix is the parity proof.
+ */
+describe('zod v3: strict getDefaultValues surfaces container .min / .max / .length on defaults (D3)', () => {
+  it('z.array(z.string()).min(1) with [] defaults seeds the min-violation error', () => {
+    const schema = z.object({ items: z.array(z.string()).min(1) })
+    const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+
+    const result = adapter.getDefaultValues({
+      useDefaultSchemaValues: false,
+      constraints: { items: [] },
+      strict: true,
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.errors?.length ?? 0).toBeGreaterThan(0)
+    expect(result.errors?.some((e) => (e.path[0] ?? '') === 'items')).toBe(true)
+  })
+
+  it('z.array(z.string()).max(2) with [a,b,c] defaults seeds the max-violation error', () => {
+    const schema = z.object({ items: z.array(z.string()).max(2) })
+    const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+
+    const result = adapter.getDefaultValues({
+      useDefaultSchemaValues: false,
+      constraints: { items: ['a', 'b', 'c'] },
+      strict: true,
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.errors?.length ?? 0).toBeGreaterThan(0)
+    expect(result.errors?.some((e) => (e.path[0] ?? '') === 'items')).toBe(true)
+  })
+
+  it('clean defaults against a checked container still return success', () => {
+    const schema = z.object({ items: z.array(z.string()).min(1).max(3) })
+    const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+
+    const result = adapter.getDefaultValues({
+      useDefaultSchemaValues: false,
+      constraints: { items: ['only one'] },
+      strict: true,
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.errors).toBeUndefined()
+  })
+
+  it('strict: false bypasses container checks even when violated', () => {
+    // Lax mode is the global opt-out — a container check violation
+    // never blocks construction. The container check still fires at
+    // runtime via `validateAtPath`, just not at the mount-time seed.
+    const schema = z.object({ items: z.array(z.string()).min(1) })
+    const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+
+    const result = adapter.getDefaultValues({
+      useDefaultSchemaValues: false,
+      constraints: { items: [] },
+      strict: false,
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.errors).toBeUndefined()
+  })
+})

--- a/test/adapters/zod-v3/introspect.test.ts
+++ b/test/adapters/zod-v3/introspect.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 import { z } from 'zod-v3'
 import {
   assertZodVersion,
+  containsAsyncRefine,
+  containsAsyncTransform,
   getArrayElement,
   getCatchDefault,
   getChecks,
@@ -23,6 +25,7 @@ import {
   getUnionOptions,
   hasChecks,
   hasContainerOrRootRefine,
+  isAsyncEffect,
   isContainerAfterWrapperPeel,
   kindOf,
   unwrapBranded,
@@ -268,6 +271,103 @@ describe('hasContainerOrRootRefine', () => {
     expect(isContainerAfterWrapperPeel(z.object({}).optional())).toBe(true)
     expect(isContainerAfterWrapperPeel(z.array(z.string()).nullable())).toBe(true)
     expect(isContainerAfterWrapperPeel(z.string().optional())).toBe(false)
+  })
+})
+
+describe('isAsyncEffect', () => {
+  it('flags an async transform / preprocess; sync siblings clear', () => {
+    const asyncTransform = z.string().transform(async (v) => Promise.resolve(`${v}!`))
+    const asyncPreprocess = z.preprocess(async (v) => Promise.resolve(v), z.string())
+    const syncTransform = z.string().transform((v) => `${v}!`)
+    expect(isAsyncEffect(asyncTransform)).toBe(true)
+    expect(isAsyncEffect(asyncPreprocess)).toBe(true)
+    expect(isAsyncEffect(syncTransform)).toBe(false)
+  })
+
+  it('returns false for refinement effects regardless of the user fn (v3 wraps refines sync)', () => {
+    // v3's `.refine` stores a sync wrapper at `_def.effect.refinement`
+    // that closes over the user predicate. The user fn's async-ness is
+    // not statically observable; `isAsyncEffect` returns `false` for
+    // refinement effects unconditionally. `containsAsyncRefine` is the
+    // conservative full-tree probe (true for any refine).
+    expect(isAsyncEffect(z.string().refine(async () => Promise.resolve(true), 'x'))).toBe(false)
+    expect(isAsyncEffect(z.string().refine(() => true, 'x'))).toBe(false)
+  })
+
+  it('returns false for non-ZodEffects schemas', () => {
+    expect(isAsyncEffect(z.string())).toBe(false)
+    expect(isAsyncEffect(z.object({ x: z.string() }))).toBe(false)
+  })
+})
+
+describe('containsAsyncRefine', () => {
+  it('flags any leaf refine at the root — sync or async (v3 conservative)', () => {
+    // v3 cannot statically distinguish sync from async refines; both
+    // are treated as "potentially async" so the runtime never misses
+    // the post-mount async pass.
+    expect(containsAsyncRefine(z.string().refine(async () => Promise.resolve(true)))).toBe(true)
+    expect(containsAsyncRefine(z.string().refine(() => true))).toBe(true)
+  })
+
+  it('flags a refine nested under containers and wrappers', () => {
+    const nested = z.object({
+      profile: z
+        .object({
+          tags: z.array(
+            z
+              .string()
+              .refine(() => true)
+              .optional()
+          ),
+        })
+        .nullable(),
+    })
+    expect(containsAsyncRefine(nested)).toBe(true)
+  })
+
+  it('returns false for schemas without any ZodEffects refinements', () => {
+    expect(containsAsyncRefine(z.string())).toBe(false)
+    expect(containsAsyncRefine(z.object({ name: z.string(), age: z.number() }))).toBe(false)
+    // A bare transform (no refinement effects) doesn't trip the flag.
+    expect(
+      containsAsyncRefine(z.object({ x: z.string().transform(async (v) => Promise.resolve(v)) }))
+    ).toBe(false)
+  })
+
+  it('flags through ZodPipeline and ZodBranded wrappers', () => {
+    const pipeline = z.string().pipe(z.string().refine(() => true))
+    const branded = z
+      .string()
+      .refine(() => true)
+      .brand<'Tag'>()
+    expect(containsAsyncRefine(pipeline)).toBe(true)
+    expect(containsAsyncRefine(branded)).toBe(true)
+  })
+})
+
+describe('containsAsyncTransform', () => {
+  it('flags an async transform / preprocess at the root', () => {
+    expect(containsAsyncTransform(z.string().transform(async (v) => Promise.resolve(v)))).toBe(true)
+    expect(containsAsyncTransform(z.preprocess(async (v) => Promise.resolve(v), z.string()))).toBe(
+      true
+    )
+  })
+
+  it('does not flag sync transforms / preprocess', () => {
+    expect(containsAsyncTransform(z.string().transform((v) => v))).toBe(false)
+    expect(containsAsyncTransform(z.preprocess((v) => v, z.string()))).toBe(false)
+  })
+
+  it('does not flag refinements (sync or async) — those are the refine walker’s domain', () => {
+    expect(containsAsyncTransform(z.string().refine(async () => Promise.resolve(true)))).toBe(false)
+    expect(containsAsyncTransform(z.string().refine(() => true))).toBe(false)
+  })
+
+  it('flags an async transform nested under union options', () => {
+    const schema = z.object({
+      payload: z.union([z.string(), z.string().transform(async (v) => Promise.resolve(`${v}!`))]),
+    })
+    expect(containsAsyncTransform(schema)).toBe(true)
   })
 })
 

--- a/test/adapters/zod-v3/strip-async.test.ts
+++ b/test/adapters/zod-v3/strip-async.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod-v3'
+import { stripAsyncChecks } from '../../../src/runtime/adapters/zod-v3/strip-async'
+
+/**
+ * v3 mirror of v4's `stripAsyncChecks` test suite
+ * (`test/adapters/zod-v4/strip.test.ts:149-280`). The semantic
+ * differs (v4 strips per-check via `isAsyncCheck`; v3 strips ALL
+ * `ZodEffects` unconditionally — see `strip-async.ts` docblock for
+ * the why), so the v3 cases pin the actual Path-A behavior rather
+ * than mirroring v4 row-for-row.
+ */
+describe('stripAsyncChecks (v3)', () => {
+  it('strips a top-level async refine so safeParse no longer throws', () => {
+    const schema = z.string().refine(async () => Promise.resolve(true), 'x')
+    expect(() => schema.safeParse('whatever')).toThrow()
+
+    const stripped = stripAsyncChecks(schema)
+    expect(() => stripped.safeParse('whatever')).not.toThrow()
+    const result = stripped.safeParse('whatever')
+    expect(result.success).toBe(true)
+  })
+
+  it('strips a sync refine too (v3 conservative — sync/async not statically distinguishable)', () => {
+    // Path A trade-off: v3 can't tell sync from async refines, so the
+    // strip drops both. Sync refine errors lose at construction;
+    // container / leaf checks still seed (D3 win).
+    const schema = z.string().refine(() => false, 'always-fails')
+    const stripped = stripAsyncChecks(schema)
+    const result = stripped.safeParse('anything')
+    expect(result.success).toBe(true)
+  })
+
+  it('preserves container .min on z.array', () => {
+    const schema = z.array(z.string()).min(1)
+    const stripped = stripAsyncChecks(schema)
+    const empty = stripped.safeParse([])
+    expect(empty.success).toBe(false)
+    const populated = stripped.safeParse(['a'])
+    expect(populated.success).toBe(true)
+  })
+
+  it('preserves container .max on z.array', () => {
+    const schema = z.array(z.string()).max(2)
+    const stripped = stripAsyncChecks(schema)
+    expect(stripped.safeParse(['a', 'b']).success).toBe(true)
+    expect(stripped.safeParse(['a', 'b', 'c']).success).toBe(false)
+  })
+
+  it('preserves container .length on z.array', () => {
+    const schema = z.array(z.string()).length(2)
+    const stripped = stripAsyncChecks(schema)
+    expect(stripped.safeParse(['a', 'b']).success).toBe(true)
+    expect(stripped.safeParse(['a']).success).toBe(false)
+  })
+
+  it('preserves container .min/.max on z.set', () => {
+    const schema = z.set(z.string()).min(1).max(2)
+    const stripped = stripAsyncChecks(schema)
+    expect(stripped.safeParse(new Set()).success).toBe(false)
+    expect(stripped.safeParse(new Set(['a'])).success).toBe(true)
+    expect(stripped.safeParse(new Set(['a', 'b', 'c'])).success).toBe(false)
+  })
+
+  it('preserves .strict() on z.object', () => {
+    const schema = z.object({ x: z.string() }).strict()
+    const stripped = stripAsyncChecks(schema)
+    expect(stripped.safeParse({ x: 'a' }).success).toBe(true)
+    expect(stripped.safeParse({ x: 'a', extra: 1 }).success).toBe(false)
+  })
+
+  it('preserves leaf .email() / .min() / .max() checks', () => {
+    const schema = z.object({ email: z.string().email().min(5).max(10) })
+    const stripped = stripAsyncChecks(schema)
+    expect(stripped.safeParse({ email: 'a@b.co' }).success).toBe(true)
+    expect(stripped.safeParse({ email: 'nope' }).success).toBe(false)
+  })
+
+  it('strips nested refines in arrays while preserving container checks', () => {
+    const schema = z.array(z.string().refine(() => false, 'leaf-refine')).min(1)
+    const stripped = stripAsyncChecks(schema)
+    // Container check survives.
+    expect(stripped.safeParse([]).success).toBe(false)
+    // Element refine dropped.
+    expect(stripped.safeParse(['anything']).success).toBe(true)
+  })
+
+  it('seeds sync sibling checks when an async sibling would throw the original', () => {
+    // The D2 / V4-2 case rephrased through stripAsyncChecks. Path A's
+    // strip drops every refine, so the seeded errors are the
+    // container / leaf checks the original parse couldn't even reach.
+    const schema = z.object({
+      items: z.array(z.string()).min(1),
+      email: z.string().refine(async () => Promise.resolve(true), 'unreachable'),
+    })
+    expect(() => schema.safeParse({ items: [], email: 'a@b.co' })).toThrow()
+
+    const stripped = stripAsyncChecks(schema)
+    const result = stripped.safeParse({ items: [], email: 'a@b.co' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path[0])
+      expect(paths).toContain('items')
+    }
+  })
+
+  it('recurses through .optional() / .nullable() / .default(v)', () => {
+    const schema = z.object({
+      a: z
+        .string()
+        .refine(async () => Promise.resolve(true))
+        .optional(),
+      b: z
+        .string()
+        .refine(async () => Promise.resolve(true))
+        .nullable(),
+      c: z
+        .string()
+        .refine(async () => Promise.resolve(true))
+        .default('seed'),
+    })
+    const stripped = stripAsyncChecks(schema)
+    expect(stripped.safeParse({ a: undefined, b: null }).success).toBe(true)
+  })
+
+  it('terminates on z.lazy() schemas with cycles', () => {
+    type Tree = { name: string; children: Tree[] }
+    const treeSchema: z.ZodType<Tree> = z.lazy(() =>
+      z.object({
+        name: z.string().refine(() => true, 'unreachable'),
+        children: z.array(treeSchema),
+      })
+    )
+    const stripped = stripAsyncChecks(treeSchema)
+    expect(stripped.safeParse({ name: 'root', children: [] }).success).toBe(true)
+  })
+})

--- a/test/adapters/zod-v3/validator-threw-parity.test.ts
+++ b/test/adapters/zod-v3/validator-threw-parity.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod-v3'
+import { zodAdapter } from '../../../src/runtime/adapters/zod-v3'
+import { AttaformErrorCode } from '../../../src/runtime/core/error-codes'
+
+/**
+ * v3 mirror of v4's validator-threw contract (`zod-v4/adapter.ts:680,
+ * 702, 727`). User code inside `.refine` / `.transform` / `.preprocess`
+ * can throw (sync) or reject (async). Zod does NOT wrap these into
+ * issues at the `safeParseAsync` boundary — they propagate out of the
+ * parse as a real throw / rejection. Without a catch in
+ * `validateAtPath`, the throw escapes into the runtime's submit and
+ * change-mode pipelines as either a `submitError` (handleSubmit) or
+ * an unhandled rejection (scheduleFieldValidation), and the consumer
+ * never sees a path-scoped error message.
+ *
+ * v4 surfaces these as `ValidationError { code: 'atta:validator-threw',
+ * path }`; v3 currently lets the throw escape. Dual-green after the
+ * fix is the parity proof (D4 in the audit ledger; aligned with
+ * [[feedback-no-uncaught-exceptions]]).
+ */
+describe('zod v3: validateAtPath wraps user-validator throws as atta:validator-threw (D4)', () => {
+  it('async-rejecting .refine surfaces as a ValidationError, not an unhandled rejection', async () => {
+    const schema = z.object({
+      name: z.string().refine(async () => {
+        await Promise.resolve()
+        throw new Error('refine async boom')
+      }, 'unreachable'),
+    })
+    const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+
+    const result = await adapter.validateAtPath({ name: 'whatever' }, undefined)
+    expect(result.success).toBe(false)
+    expect(result.errors?.length ?? 0).toBeGreaterThan(0)
+    expect(result.errors?.[0]?.code).toBe(AttaformErrorCode.ValidatorThrew)
+  })
+
+  it('async-rejecting .transform surfaces as a ValidationError', async () => {
+    const schema = z.object({
+      name: z.string().transform(async () => {
+        await Promise.resolve()
+        throw new Error('transform async boom')
+      }),
+    })
+    const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+
+    const result = await adapter.validateAtPath({ name: 'whatever' }, undefined)
+    expect(result.success).toBe(false)
+    expect(result.errors?.length ?? 0).toBeGreaterThan(0)
+    expect(result.errors?.[0]?.code).toBe(AttaformErrorCode.ValidatorThrew)
+  })
+
+  it('async-rejecting .preprocess surfaces as a ValidationError', async () => {
+    const schema = z.object({
+      name: z.preprocess(async () => {
+        await Promise.resolve()
+        throw new Error('preprocess async boom')
+      }, z.string()),
+    })
+    const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+
+    const result = await adapter.validateAtPath({ name: 'whatever' }, undefined)
+    expect(result.success).toBe(false)
+    expect(result.errors?.length ?? 0).toBeGreaterThan(0)
+    expect(result.errors?.[0]?.code).toBe(AttaformErrorCode.ValidatorThrew)
+  })
+
+  it('path-scoped validate carries the requested path on the validator-threw error', async () => {
+    const schema = z.object({
+      profile: z.object({
+        name: z.string().refine(async () => {
+          await Promise.resolve()
+          throw new Error('boom')
+        }, 'unreachable'),
+      }),
+    })
+    const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+
+    // `data` at a leaf path is the leaf value itself, not the full
+    // form — `validateAtPath` resolves candidates at the path and runs
+    // `safeParseAsync(data)` against each. The path on the error is
+    // the requested path, set by `validatorThrewResponse`.
+    const result = await adapter.validateAtPath('whatever', ['profile', 'name'])
+    expect(result.success).toBe(false)
+    expect(result.errors?.[0]?.code).toBe(AttaformErrorCode.ValidatorThrew)
+    expect(result.errors?.[0]?.path).toEqual(['profile', 'name'])
+  })
+})

--- a/test/adapters/zod-v4/async-contract-parity.test.ts
+++ b/test/adapters/zod-v4/async-contract-parity.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { zodAdapter } from '../../../src/runtime/adapters/zod-v4'
+
+/**
+ * v4 mirror of `test/adapters/zod-v3/async-contract-parity.test.ts`.
+ * v4 already seeds sync-refine errors at construction via
+ * `stripAsyncChecks(rootSchema)` in `adapter.ts:365-422`; this file
+ * pins that reference so the v3 port lands as proven parity.
+ *
+ * (`test/adapters/zod-v4/adapter.test.ts:94-169` covers the same
+ * ground; mirroring the full suite here keeps the two adapter
+ * trees row-for-row aligned during the Phase 10 work and beyond.)
+ */
+describe('zod v4: strict getDefaultValues seeds sync refine errors alongside async siblings (V4-2 reference)', () => {
+  it('seeds sync-refinement errors at construction when an async sibling exists', () => {
+    const schema = z.object({
+      word: z.string().refine((v) => v.length > 0, 'word required'),
+      email: z.email().refine(async (v) => Promise.resolve(v !== 'taken@x.com'), 'taken'),
+    })
+    const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+    const result = adapter.getDefaultValues({
+      useDefaultSchemaValues: false,
+      constraints: { word: '', email: 'a@b.com' },
+      strict: true,
+    })
+
+    expect(result.success).toBe(false)
+    const messages = result.errors?.map((e) => e.message) ?? []
+    expect(messages).toContain('word required')
+    expect(messages).not.toContain('taken')
+  })
+
+  it('returns success when the sync portion is clean but async refines exist', () => {
+    const schema = z.object({
+      word: z.string().refine((v) => v.length > 0, 'word required'),
+      email: z.email().refine(async (v) => Promise.resolve(v !== 'taken@x.com'), 'taken'),
+    })
+    const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+    const result = adapter.getDefaultValues({
+      useDefaultSchemaValues: false,
+      constraints: { word: 'hello', email: 'a@b.com' },
+      strict: true,
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.errors).toBeUndefined()
+  })
+
+  it('strict: false bypasses the sync-only retry path entirely', () => {
+    const schema = z.object({
+      word: z.string().refine((v) => v.length > 0, 'word required'),
+      email: z.email().refine(async (v) => Promise.resolve(v !== 'taken@x.com'), 'taken'),
+    })
+    const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+    const result = adapter.getDefaultValues({
+      useDefaultSchemaValues: false,
+      constraints: { word: '', email: 'a@b.com' },
+      strict: false,
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.errors).toBeUndefined()
+  })
+
+  it('pure-async schema with clean defaults regression: still returns success', () => {
+    const schema = z.object({
+      email: z.email().refine(async () => Promise.resolve(true), 'never fires'),
+    })
+    const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+    const result = adapter.getDefaultValues({
+      useDefaultSchemaValues: false,
+      constraints: { email: 'a@b.com' },
+      strict: true,
+    })
+
+    expect(result.success).toBe(true)
+  })
+})

--- a/test/adapters/zod-v4/container-checks-strict-parity.test.ts
+++ b/test/adapters/zod-v4/container-checks-strict-parity.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { zodAdapter } from '../../../src/runtime/adapters/zod-v4'
+
+/**
+ * v4 mirror of `test/adapters/zod-v3/container-checks-strict-parity.test.ts`.
+ * v4 routes strict-mode `getDefaultValues` through the real schema and
+ * preserves container `.min` / `.max` / `.length` via `carryChecks`
+ * (`strip.ts:52-70`); this file pins that reference so the v3 port
+ * lands as proven parity.
+ */
+describe('zod v4: strict getDefaultValues surfaces container .min / .max / .length on defaults (D3 reference)', () => {
+  it('z.array(z.string()).min(1) with [] defaults seeds the min-violation error', () => {
+    const schema = z.object({ items: z.array(z.string()).min(1) })
+    const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+
+    const result = adapter.getDefaultValues({
+      useDefaultSchemaValues: false,
+      constraints: { items: [] },
+      strict: true,
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.errors?.length ?? 0).toBeGreaterThan(0)
+    expect(result.errors?.some((e) => (e.path[0] ?? '') === 'items')).toBe(true)
+  })
+
+  it('z.array(z.string()).max(2) with [a,b,c] defaults seeds the max-violation error', () => {
+    const schema = z.object({ items: z.array(z.string()).max(2) })
+    const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+
+    const result = adapter.getDefaultValues({
+      useDefaultSchemaValues: false,
+      constraints: { items: ['a', 'b', 'c'] },
+      strict: true,
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.errors?.length ?? 0).toBeGreaterThan(0)
+    expect(result.errors?.some((e) => (e.path[0] ?? '') === 'items')).toBe(true)
+  })
+
+  it('clean defaults against a checked container still return success', () => {
+    const schema = z.object({ items: z.array(z.string()).min(1).max(3) })
+    const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+
+    const result = adapter.getDefaultValues({
+      useDefaultSchemaValues: false,
+      constraints: { items: ['only one'] },
+      strict: true,
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.errors).toBeUndefined()
+  })
+
+  it('strict: false bypasses container checks even when violated', () => {
+    const schema = z.object({ items: z.array(z.string()).min(1) })
+    const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+
+    const result = adapter.getDefaultValues({
+      useDefaultSchemaValues: false,
+      constraints: { items: [] },
+      strict: false,
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.errors).toBeUndefined()
+  })
+})

--- a/test/adapters/zod-v4/validator-threw-parity.test.ts
+++ b/test/adapters/zod-v4/validator-threw-parity.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { zodAdapter } from '../../../src/runtime/adapters/zod-v4'
+import { AttaformErrorCode } from '../../../src/runtime/core/error-codes'
+
+/**
+ * v4 mirror of `test/adapters/zod-v3/validator-threw-parity.test.ts`.
+ * v4's adapter already wraps `safeParseAsync` in try/catch and routes
+ * user-validator throws through `validatorThrewResponse`
+ * (`adapter.ts:727-746`); this file pins that reference so the v3
+ * port lands as proven parity.
+ */
+describe('zod v4: validateAtPath wraps user-validator throws as atta:validator-threw (D4 reference)', () => {
+  it('async-rejecting .refine surfaces as a ValidationError, not an unhandled rejection', async () => {
+    const schema = z.object({
+      name: z.string().refine(async () => {
+        await Promise.resolve()
+        throw new Error('refine async boom')
+      }, 'unreachable'),
+    })
+    const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+
+    const result = await adapter.validateAtPath({ name: 'whatever' }, undefined)
+    expect(result.success).toBe(false)
+    expect(result.errors?.length ?? 0).toBeGreaterThan(0)
+    expect(result.errors?.[0]?.code).toBe(AttaformErrorCode.ValidatorThrew)
+  })
+
+  it('async-rejecting .transform surfaces as a ValidationError', async () => {
+    const schema = z.object({
+      name: z.string().transform(async () => {
+        await Promise.resolve()
+        throw new Error('transform async boom')
+      }),
+    })
+    const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+
+    const result = await adapter.validateAtPath({ name: 'whatever' }, undefined)
+    expect(result.success).toBe(false)
+    expect(result.errors?.length ?? 0).toBeGreaterThan(0)
+    expect(result.errors?.[0]?.code).toBe(AttaformErrorCode.ValidatorThrew)
+  })
+
+  it('async-rejecting .preprocess surfaces as a ValidationError', async () => {
+    const schema = z.object({
+      name: z.preprocess(async () => {
+        await Promise.resolve()
+        throw new Error('preprocess async boom')
+      }, z.string()),
+    })
+    const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+
+    const result = await adapter.validateAtPath({ name: 'whatever' }, undefined)
+    expect(result.success).toBe(false)
+    expect(result.errors?.length ?? 0).toBeGreaterThan(0)
+    expect(result.errors?.[0]?.code).toBe(AttaformErrorCode.ValidatorThrew)
+  })
+
+  it('path-scoped validate carries the requested path on the validator-threw error', async () => {
+    const schema = z.object({
+      profile: z.object({
+        name: z.string().refine(async () => {
+          await Promise.resolve()
+          throw new Error('boom')
+        }, 'unreachable'),
+      }),
+    })
+    const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+
+    const result = await adapter.validateAtPath('whatever', ['profile', 'name'])
+    expect(result.success).toBe(false)
+    expect(result.errors?.[0]?.code).toBe(AttaformErrorCode.ValidatorThrew)
+    expect(result.errors?.[0]?.path).toEqual(['profile', 'name'])
+  })
+})


### PR DESCRIPTION
Phase 10 of the audit-remediation series (see `AUDIT-FINDINGS.md` on
`audit/codebase-review` for full evidence). Lifts v3's validation
contract to v4's in every direction v3's runtime can support, with the
detection-asymmetry trade-off documented honestly.

## Ledger

⚠️ **A1 / D14 — v3 exposes `needsAsyncValidation`.** New memoised
method on the AbstractSchema returned by `zod-v3/index.ts zodAdapter`.
The store's existing `schema.needsAsyncValidation?.() === true` gates
(`create-form-store.ts:1754, 1784, 1897, 3388`) now fire on v3 the
same way they fire on v4: `firstValidationDone` defers to the
post-mount async pass, `pathHasAsyncValidation` returns true under
async-bearing paths, and the construction-time async seed runs.

Conservative semantic: true if the schema tree contains any
refinement effect OR any async transform / preprocess. The async
refine case can't be detected statically (see "Path A direction call"
below).

⚠️ **D4 — `validateAtPath` wraps user throws as `atta:validator-threw`.**
Each `await safeParseAsync(data)` inside `runAsync` now lives in a
try/catch; a throw / rejection from `.refine` / `.transform` /
`z.preprocess` becomes a `ValidationError` at the requested path with
`code: AttaformErrorCode.ValidatorThrew`. Matches v4
(`zod-v4/adapter.ts:680, 702, 727-746`) and closes the
no-uncaught-exceptions gap on v3.

⚠️ **D2 + D3 — strict `getDefaultValues` parses the real schema.**
Mirrors v4 (`zod-v4/adapter.ts:365-422`):

1. `containsAsyncTransform(rootSchema)` → return success unchanged.
2. Try `rootSchema.safeParse(data)` directly. Success → return;
   sync failure → return issues; async-detect throw → step 3.
3. Parse against `stripAsyncChecks(rootSchema)`. Container + leaf
   checks seed; refines drop (v3 can't statically distinguish sync
   from async). Defensive floor catches any further throw and
   returns success.

Lax mode untouched — the existing slim-schema validate-then-fix loop
continues to seed a permissive partial state.

**Test backlog V4-2** lands as the construction-time parity test pair
across both adapter trees. The headline case (mixed sync+async refines)
expresses Path A semantics honestly: container `.min(1)` violation
seeds; sync refine error lost (v3 can't tell sync from async, strips
both); async error deferred to post-mount.

## Direction call captured during execution

⚠️ **v3 .refine async-detection is not statically observable.** v3
wraps the user predicate inside a sync `(val, ctx) => { … if (result
instanceof Promise) return result.then(…) }` closure — the wrapper's
`constructor.name === 'Function'` regardless of the user fn's
async-ness, and the user fn is captured in the closure with no static
accessor. v4's per-check `isAsyncCheck` semantic cannot be replicated.

Surfaced mid-execution; Path A (recommended) signed off:
**try-parse, strip-on-throw, no side effects on user predicates at
construction.** Trade-off encoded:

  - Pure sync schemas: every refine + container + leaf check seeds
    (full v4 parity).
  - Mixed sync+async refine schemas: container + leaf checks seed;
    refines lost.
  - Async-transform-anywhere schemas: defer entirely.

Alternative Path B (probe-and-parse) was rejected because invoking
user predicates at construction violates the
no-unexpected-side-effects discipline. Path C (defer entirely) was
rejected because it forgoes A1/D14 progress.

## Preserved invariants

- `getNestedZodSchemasAtPath` walker (Phase 8) untouched.
- Lax-mode `getDefaultValues` slim-schema pipeline untouched.
- v4 adapter behavior unchanged — every v4 ledger item from prior
  phases continues to pin reference behavior.
- Public types unchanged (SF2 stays in Phase 11).
- `validateAtPath` per-leaf semantics outside the new async wrap.

## Commit series (9 commits, red→green pairs + size cap)

Test commits land each finding's repro red on v3 and green on v4
before the impl:

1. `test(adapters): pin sync-error seeding alongside async refines (V4-2)`
2. `test(adapters): pin atta:validator-threw on user-validator throws (D4)`
3. `test(adapters): pin container .min/.max/.length seeding strict (D3)`

Impl commits flip the reds green:

4. `feat(v3-introspect): add isAsyncEffect + containsAsync walkers (A1/D14 prep)`
5. `feat(v3-adapter): expose needsAsyncValidation (A1/D14)`
6. `feat(v3-adapter): add stripAsyncChecks + carry* helpers (D2/D3 prep)`
7. `fix(v3-adapter): strict getDefaultValues parses real schema (D2 / D3)`
8. `fix(v3-adapter): wrap validateAtPath user-validator throws (D4)`

Budget commit:

9. `chore(size): raise zod-v3 + unified zod caps for Phase 10 (+1 KB each)`

## Gate

  - Lint ✓
  - Typecheck ✓
  - check:site ✓
  - 282 test files, 3463 tests ✓
  - Size ✓ (zod-v3.mjs 55.06/56, zod.mjs 62.33/63, zod-v4.mjs 53.69/54
    — held)
  - Bench ✓ (every scenario within 3× floor; keystroke 5.45×/9.58×,
    paths 9.49×, isDirty 3.90×, errors-materialization 5.50×)
  - Coverage ✓ 91.5% lines (v3 intentionally excluded from
    coverage gate per `vitest.config.ts:81`; verified through
    dedicated v3 test files)

## Size budget rationale

zod-v3.mjs gained ~1.05 KB for the introspect helpers + strip-async
module + needsAsyncValidation + the strict-mode restructure + the
validator-threw wrap. zod.mjs (unified entry, bundles both adapters)
absorbs the full delta. zod-v4.mjs held at 54 KB. Phase 12 ADAPT-D1
reclaims when the per-adapter introspect walkers collapse behind the
shared `createAbstractSchema(introspector)` factory.

## Phase 11 unblock note

Phase 11 (`fix/v3-typed-config`) targets SF2 — rebuild
`UseFormConfigurationWithZod` so v3's typed `useForm` accepts the 5
currently-missing fields. Independent of this phase; can branch off
main after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)