### PR TITLE
refactor(adapters): createAbstractSchema factory + D6/B3 dedup (Phase 12, part 1 of 2)

### DIFF
--- a/src/runtime/adapters/zod-v3/index.ts
+++ b/src/runtime/adapters/zod-v3/index.ts
@@ -6,13 +6,18 @@ import { cloneDeep, isFunction } from 'lodash-es'
 import { z } from 'zod-v3'
 import type {
   AbstractSchema,
+  DefaultValuesResponse,
   FormKey,
+  GetDefaultValuesConfig,
   ResolvedFieldMeta,
-  SlimPrimitiveKind,
-  UnionDiscriminatorContext,
   ValidationError,
-  ValidationResponse,
 } from '../../types/types-api'
+import {
+  createAbstractSchema,
+  type AbstractSchemaServices,
+  type SchemaIntrospector,
+  type SharedZodKind,
+} from '../../core/abstract-schema-factory'
 import { getAtPath, isPlainRecord, setAtPath } from '../../core/path-walker'
 import type { SchemaFactoryOptions } from '../../core/get-computed-schema'
 import { humanize } from '../../core/humanize'
@@ -20,6 +25,7 @@ import { canonicalizePath, type Path, type PathKey } from '../../core/paths'
 import { slimKindOf } from '../../core/slim-primitive-gate'
 import type { FieldMetaPayload } from '../../core/field-meta'
 import { getFieldMeta, getFieldMetaList } from './field-meta'
+import type { GenericForm } from '../../types/types-core'
 
 // The adapter exchanges dotted-string paths with core at the
 // AbstractSchema boundary (`validateAtPath`, `getSchemasAtPath`).
@@ -96,7 +102,6 @@ function mergeDeepV3(base: unknown, override: unknown): unknown {
 }
 
 import { __DEV__ } from '../../core/dev'
-import { AttaformErrorCode } from '../../core/error-codes'
 import type { TypeWithNullableDynamicKeys } from './types-zod'
 // `ZodTypeWithInnerType` lives in types-zod.ts and is re-exported from
 // `attaform/zod-v3` as a narrow accessor type for custom-adapter
@@ -131,6 +136,7 @@ import {
   hasChecks,
   hasContainerOrRootRefine,
   isCoercePrimitive,
+  isPreprocessNode,
   kindOf,
   unwrapBranded,
   unwrapEffectsSource,
@@ -160,776 +166,22 @@ export function zodAdapter<
 >(
   zodSchema: FormSchema
 ): (formKey: FormKey, options: SchemaFactoryOptions) => AbstractSchema<Form, GetValueFormType> {
-  function getAbstractSchema(
-    _formKey: FormKey,
-    _zodSchema: FormSchema,
-    _isRootSchema: boolean,
-    _maxRecursionDepth: number
-  ): AbstractSchema<Form, GetValueFormType> {
-    if (_isRootSchema) {
-      // Walk the original schema (not the stripped one) so the assert
-      // descends through user-declared wrappers (`.optional()`,
-      // `.nullable()`, `.default()`) before checking each leaf. Throws
-      // for kinds we can't represent — `z.promise`, `z.function`,
-      // `z.map`, `z.symbol` — and for self-referencing `z.lazy(...)`.
-      assertSupportedKinds(_zodSchema)
-      const [_schema] = stripRootSchema(_zodSchema, {
-        stripDefaultValues: true,
-        stripNullable: true,
-        stripOptional: true,
-        stripZodEffects: true,
-        stripZodRefinements: true,
-      })
-      if (!isZodSchemaType(_schema, 'ZodObject')) {
-        const name = getTypeName(_schema)
-        throw new Error(`ZodAdapter: expected ZodObject, got ${name}`)
-      }
-    }
-    // Per-adapter `isLeafAtPath` cache. Lifetime = one adapter instance
-    // (one per `useForm()` call). Memoises the slim-primitive walk so
-    // the leaf-aware proxy traps don't re-walk the schema on every read.
-    const leafCache = new Map<PathKey, boolean>()
-    // Per-adapter cache for the preprocess predicate. The slim-primitive
-    // write gate consults it at every level of value-tree descent.
-    const preprocessOrCoerceCache = new Map<PathKey, boolean>()
-    // Per-adapter cache for `getUnionDiscriminatorAtPath`. The walker
-    // path is consulted on every `setValue` and every `form.meta` read
-    // (every ancestor segment, every time), and the result is a pure
-    // function of (schema, path) — once computed it never changes for
-    // the lifetime of the adapter. Caches both positive and negative
-    // (no-DU) results so the common no-DU schema pays the walk cost
-    // once per path instead of per keystroke.
-    const discriminatorCache = new Map<PathKey, UnionDiscriminatorContext | undefined>()
-
-    function computeDiscriminator(path: Path): UnionDiscriminatorContext | undefined {
-      const candidates =
-        path.length === 0
-          ? [_zodSchema as z.ZodTypeAny]
-          : (getNestedZodSchemasAtPath(_zodSchema, path, _maxRecursionDepth) as z.ZodTypeAny[])
-      // `unwrapToDiscriminatedUnion` peels every transparent wrapper
-      // (Optional / Nullable / Default / Readonly / Catch / Effects /
-      // Pipeline / Branded) and descends ZodIntersection sides looking
-      // for a single discriminated union. Ambiguous resolutions (two
-      // distinct DUs both reachable across candidates) bail — the
-      // runtime then falls back to a plain write.
-      let matchedUnion: z.ZodTypeAny | undefined
-      for (const candidate of candidates) {
-        const du = unwrapToDiscriminatedUnion(candidate)
-        if (du === undefined) continue
-        if (matchedUnion !== undefined && matchedUnion !== du) return undefined
-        matchedUnion = du
-      }
-      if (matchedUnion === undefined) return undefined
-      const discKey = getDiscriminator(matchedUnion)
-      if (discKey === undefined) return undefined
-      const options = getDiscriminatedOptions(matchedUnion)
-      const literalSet = new Set<unknown>()
-      for (const opt of options) {
-        const litSchema = opt.shape[discKey] as z.ZodTypeAny | undefined
-        if (!litSchema) continue
-        if (!isZodSchemaType(litSchema, 'ZodLiteral')) continue
-        // `getLiteralValues` returns every value the literal admits as
-        // an array, so multi-value `z.literal(['a','b'])` registers
-        // both 'a' and 'b' as selectable variants.
-        for (const v of getLiteralValues(litSchema)) literalSet.add(v)
-      }
-      return {
-        discriminatorKey: discKey,
-        getVariantDefault(value: unknown): unknown {
-          for (const opt of options) {
-            const litSchema = opt.shape[discKey] as z.ZodTypeAny | undefined
-            if (!litSchema) continue
-            if (!isZodSchemaType(litSchema, 'ZodLiteral')) continue
-            const values = getLiteralValues(litSchema)
-            if (values.includes(value)) {
-              return getDefaultValuesFromZodSchema(opt as unknown as z.ZodSchema, true, _formKey)
-            }
-          }
-          return undefined
-        },
-        isVariantSelected(value: unknown): boolean {
-          return literalSet.has(value)
-        },
-      }
-    }
-
-    // Memoised one-shot walk; `hasContainerOrRootRefine` is queried at
-    // every per-keystroke schedule to pick whole-form vs subtree
-    // scope, so the walk pays for itself within the first few
-    // mutations.
-    let containerRefineFlag: boolean | null = null
-    // Same lazy-memo pattern as the container-refine flag.
-    // `needsAsyncValidation` is queried at construction by the store to
-    // gate `firstValidationDone` + the construction-time async seed,
-    // and possibly again from devtools; one tree traversal earns its
-    // keep across the adapter's lifetime.
-    let asyncValidationFlag: boolean | null = null
-
-    const abstractSchema: AbstractSchema<Form, GetValueFormType> = {
-      fingerprint: () => fingerprintZodSchema(_zodSchema),
-
-      needsAsyncValidation(): boolean {
-        asyncValidationFlag ??=
-          containsAsyncRefine(_zodSchema) || containsAsyncTransform(_zodSchema)
-        return asyncValidationFlag
-      },
-
-      hasContainerOrRootRefine(): boolean {
-        containerRefineFlag ??= hasContainerOrRootRefine(_zodSchema)
-        return containerRefineFlag
-      },
-      getDefaultValues(config) {
-        const defaultValuesWithoutConstraints = getDefaultValuesFromZodSchema(
-          _zodSchema,
-          config.useDefaultSchemaValues,
-          _formKey
-        )
-
-        const slimSchema = getSlimSchema({
-          schema: _zodSchema,
-          stripConfig: {
-            stripZodEffects: true,
-            stripDefaultValues: true,
-            // `strict: false` strips refinements (so empty defaults
-            // pass); strict keeps them so the slim parse below
-            // surfaces refinement errors. Async refines are guarded
-            // by the try/catch below — they can't be surfaced
-            // synchronously regardless.
-            stripZodRefinements: (config.strict ?? true) === false,
-          },
-        })
-
-        let rawDefaultValues = defaultValuesWithoutConstraints
-        if (!isPrimitive(rawDefaultValues)) {
-          // `mergeDeepV3` (NOT lodash `merge`) so arrays replace
-          // wholesale and explicit `null`/`undefined` overrides survive,
-          // matching v4's `mergeDeep` semantic.
-          rawDefaultValues = mergeDeepV3(defaultValuesWithoutConstraints, config.constraints)
-        } else if (constraintsAreSlimValid(slimSchema, config.constraints)) {
-          rawDefaultValues = config.constraints
-        }
-
-        // Strict-mode path: parse against the REAL schema so refines
-        // and container / leaf checks (`.min(n)` / `.max(n)` /
-        // `.email()` etc.) seed at construction. Mirrors v4
-        // (`zod-v4/adapter.ts:365-422`). The lax-mode validate-then-fix
-        // loop below stays untouched — it's the right shape for
-        // "seed a permissive partial state at mount."
-        if ((config.strict ?? true) !== false) {
-          // Async transforms can't be stripped: the transform's output
-          // shape is load-bearing for the inner schema's input. Skip
-          // the strict pass entirely; the post-mount async pass picks
-          // up verdicts via `safeParseAsync`.
-          if (containsAsyncTransform(_zodSchema)) {
-            return {
-              data: rawDefaultValues as Form,
-              errors: undefined,
-              success: true,
-              formKey: _formKey,
-            }
-          }
-
-          try {
-            const strictResult = _zodSchema.safeParse(rawDefaultValues)
-            if (strictResult.success) {
-              // Storage holds the pre-transform `z.input` view, so we
-              // return the raw defaults (already filled by
-              // `getDefaultValuesFromZodSchema`) rather than
-              // `strictResult.data` (the post-transform `z.output`).
-              // For schemas without `.transform()` the two coincide;
-              // for schemas with one the storage stays the honest input
-              // view that `form.values` reflects. Matches v4 (:407).
-              return {
-                data: rawDefaultValues as Form,
-                errors: undefined,
-                success: true,
-                formKey: _formKey,
-              }
-            }
-            return {
-              data: rawDefaultValues as Form,
-              errors: zodIssuesToValidationErrors(strictResult.error.issues, _formKey),
-              success: false,
-              formKey: _formKey,
-            }
-          } catch (err) {
-            // Distinguish the v3 async-detect throw from a generic
-            // user-validator throw at construction. The async-detect
-            // throw is a standard `Error` with message
-            // `"Async refinement encountered during synchronous
-            // parse..."`. On that path strip every `ZodEffects` (sync
-            // + async — v3 can't tell apart at the predicate level,
-            // see `strip-async.ts` docblock) and re-parse to surface
-            // container + leaf-check seeds.
-            const isAsyncDetect =
-              err instanceof Error && err.message.includes('Async refinement encountered')
-            if (isAsyncDetect) {
-              try {
-                const strippedResult = stripAsyncChecks(_zodSchema).safeParse(rawDefaultValues)
-                if (strippedResult.success) {
-                  return {
-                    data: rawDefaultValues as Form,
-                    errors: undefined,
-                    success: true,
-                    formKey: _formKey,
-                  }
-                }
-                return {
-                  data: rawDefaultValues as Form,
-                  errors: zodIssuesToValidationErrors(strippedResult.error.issues, _formKey),
-                  success: false,
-                  formKey: _formKey,
-                }
-              } catch {
-                // Defensive floor: the stripped schema also threw
-                // (e.g. a sync refine that itself throws). Mount
-                // cleanly; the post-mount async pass is the source of
-                // truth for any verdict this code path can't surface.
-                return {
-                  data: rawDefaultValues as Form,
-                  errors: undefined,
-                  success: true,
-                  formKey: _formKey,
-                }
-              }
-            }
-            // Non-async throw at construction (user validator threw a
-            // raw exception): defensive floor, matches v4's catch
-            // (`adapter.ts:415-422`).
-            return {
-              data: rawDefaultValues as Form,
-              errors: undefined,
-              success: true,
-              formKey: _formKey,
-            }
-          }
-        }
-
-        // Lax mode: validate-then-fix loop. The slim schema's
-        // structural shape is what the loop patches against — any
-        // throw collapses to mount-clean success. The existing
-        // try/catch is the slim equivalent of the strict-mode
-        // defensive floor above.
-        let parseResult: ReturnType<typeof slimSchema.safeParse>
-        try {
-          parseResult = slimSchema.safeParse(rawDefaultValues)
-        } catch {
-          return {
-            data: rawDefaultValues as Form,
-            errors: undefined,
-            success: true,
-            formKey: _formKey,
-          }
-        }
-        const { data, success, error } = parseResult
-
-        if (success) {
-          return {
-            data: data as Form,
-            errors: undefined,
-            success,
-            formKey: _formKey,
-          }
-        }
-
-        let fixedData = {}
-
-        // `if (success) return ...` above handles the happy path; below we're
-        // always in the failure case.
-        //
-        // Under the slim-primitive write contract, the validate-then-fix
-        // loop only patches issues that violate STRUCTURAL or PRIMITIVE-TYPE
-        // shape. Refinement-level issues (invalid_enum_value, invalid_literal,
-        // invalid_string, too_small, too_big, custom, unrecognized_keys)
-        // pass THROUGH unchanged — the user's defaultValues are preserved
-        // verbatim and the strict-mode validation pass downstream surfaces
-        // the error at construction.
-        //
-        // The classifier: look up the actual offending value at the issue's
-        // path and check its slim primitive kind against the candidate
-        // schema's slim primitive set. If the value's kind IS in the set,
-        // the issue is refinement-level → skip. If it's NOT in the set,
-        // the issue is primitive/structural → fix. Unifies every issue
-        // code under one check.
-        {
-          for (const issue of error.issues) {
-            const schemasAtPath = getNestedZodSchemasAtPath(
-              slimSchema,
-              issue.path,
-              _maxRecursionDepth
-            )
-            // `set` from lodash accepts a Segment[] directly; keeps the
-            // literal-dot case (`['user.name']`) from being flattened
-            // into two key accesses. Coerce in case a custom check
-            // smuggled a Symbol — `path.join` would throw on it.
-            const path = coercePathSegments(issue.path)
-            if (!schemasAtPath.length) {
-              console.error(
-                `[attaform] zod-v3 adapter: no schema at path ` +
-                  `'${path.join(PATH_SEPARATOR)}' for key '${_formKey}'. ` +
-                  `Skipping the issue. (This is a library-internal invariant — please file a bug.)`
-              )
-              continue
-            }
-
-            // Refinement-vs-primitive classification.
-            const candidate = schemasAtPath[0]
-            if (candidate !== undefined) {
-              const valueAtPath = getAtPath(rawDefaultValues, path)
-              const slimKinds = slimPrimitivesV3(candidate as z.ZodTypeAny)
-              if (slimKinds.size > 0 && slimKinds.has(slimKindOf(valueAtPath))) {
-                // Refinement-level: pass through unchanged.
-                continue
-              }
-            }
-
-            for (const schemaAtPath of schemasAtPath) {
-              if (issue.code === 'invalid_type') {
-                const isDiscriminatedUnion = isZodSchemaType(schemaAtPath, 'ZodDiscriminatedUnion')
-                const defaultValueContext: DefaultValueContext = isDiscriminatedUnion
-                  ? {
-                      formKey: _formKey,
-                      discriminator: {
-                        isDiscriminatorKey: true,
-                        schema: schemaAtPath,
-                        useDefaultSchemaValues: false,
-                      },
-                    }
-                  : {
-                      formKey: _formKey,
-                      discriminator: {
-                        isDiscriminatorKey: false,
-                        schema: undefined,
-                        useDefaultSchemaValues: false,
-                      },
-                    }
-                const defaultValue = getDefaultValue(issue.expected, defaultValueContext)
-                fixedData = setAtPath(fixedData, path, defaultValue) as Record<string, unknown>
-                continue
-              }
-
-              // Wrong-primitive issues with non-invalid_type codes (e.g.,
-              // invalid_enum_value where the offending value is a number
-              // against a string-enum). Fall back to the schema's default.
-              const [defaultValue, found] = unwrapDefault(schemaAtPath)
-              if (found) {
-                fixedData = setAtPath(fixedData, path, defaultValue) as Record<string, unknown>
-                continue
-              }
-              // Last-ditch: derive a default for the schema kind at this
-              // path. Skips if no useful default emerges.
-              const ctx: DefaultValueContext = {
-                formKey: _formKey,
-                discriminator: {
-                  isDiscriminatorKey: false,
-                  schema: undefined,
-                  useDefaultSchemaValues: false,
-                },
-              }
-              // Use the slim primitive's first kind to derive a default.
-              const slimKinds = slimPrimitivesV3(schemaAtPath as z.ZodTypeAny)
-              const firstKind = [...slimKinds][0]
-              if (firstKind !== undefined) {
-                const expected =
-                  firstKind === 'string'
-                    ? 'string'
-                    : firstKind === 'number'
-                      ? 'number'
-                      : firstKind === 'boolean'
-                        ? 'boolean'
-                        : firstKind === 'bigint'
-                          ? 'bigint'
-                          : firstKind === 'date'
-                            ? 'date'
-                            : firstKind === 'array'
-                              ? 'array'
-                              : firstKind === 'object'
-                                ? 'object'
-                                : null
-                if (expected !== null) {
-                  fixedData = setAtPath(fixedData, path, getDefaultValue(expected, ctx)) as Record<
-                    string,
-                    unknown
-                  >
-                }
-              }
-            }
-          }
-          // `mergeDeepV3` so the fix-up overrides the raw defaults
-          // with copy-on-write semantics matching v4 (array replace,
-          // null/undefined clears honored).
-          fixedData = mergeDeepV3(rawDefaultValues, fixedData) as Record<string, unknown>
-        }
-
-        // Best-effort re-parse: if the fix-up loop couldn't fully
-        // reconcile the data (nested unions whose branches don't match
-        // the defaulted shape, bigint edge cases), return the partial
-        // data instead of throwing. Matches the v4 adapter's lax
-        // semantics — a partially-valid initial state is preferable
-        // to a mount-time exception. Strict mode short-circuited
-        // earlier via the real-schema parse path, so reaching here
-        // implies `config.strict === false`.
-        const secondParse = slimSchema.safeParse(fixedData)
-        const finalData = secondParse.success ? secondParse.data : fixedData
-        return {
-          data: finalData as Form,
-          errors: undefined,
-          success: true,
-          formKey: _formKey,
-        }
-      },
-      getDefaultAtPath(path) {
-        // Empty path → root default. Reuses the same generator used at
-        // form construction so refines / wrappers behave consistently.
-        if (path.length === 0) {
-          return getDefaultValuesFromZodSchema(_zodSchema, true, _formKey)
-        }
-        const [leaf] = getNestedZodSchemasAtPath(_zodSchema, path, _maxRecursionDepth)
-        if (!leaf) return undefined
-        // STRUCTURAL default: peel `.optional()` / `.nullable()` at the
-        // leaf so partial-object writes through optional sub-schemas
-        // (`{ profile: z.object({...}).optional() }`) get the inner
-        // shape's defaults filled in. `.default(x)` is preserved so
-        // `getDefaultValuesFromZodSchema` returns the explicit default.
-        const peeled = unwrapStructuralLeafV3(leaf)
-        return getDefaultValuesFromZodSchema(peeled as z.ZodSchema, true, _formKey)
-      },
-      getEmptyValueAtPath(path) {
-        // `clear`'s underlying value lookup. Same path-resolution flow
-        // as `getDefaultAtPath` but with `useDefaultSchemaValues=false`
-        // so `.default(x)` / `.catch(x)` wrappers are skipped — the
-        // walker yields the inner-schema's empty concrete instead.
-        // Structural wrappers (`.optional()` / `.nullable()`) are NOT
-        // peeled here: clearing an `.optional()` slot is legitimately
-        // `undefined`, clearing a `.nullable()` slot is `null`.
-        if (path.length === 0) {
-          return getDefaultValuesFromZodSchema(_zodSchema, false, _formKey)
-        }
-        const [leaf] = getNestedZodSchemasAtPath(_zodSchema, path, _maxRecursionDepth)
-        if (!leaf) return undefined
-        return getDefaultValuesFromZodSchema(leaf as z.ZodSchema, false, _formKey)
-      },
-      arrayShapeAtPath(path) {
-        if (path.length === 0) return undefined
-        const [leaf] = getNestedZodSchemasAtPath(_zodSchema, path, _maxRecursionDepth)
-        if (!leaf) return undefined
-        // The walker preserves the TERMINAL wrapper at the leaf — peel
-        // every transparent wrapper here so we see the structural kind.
-        // `peelV3Wrappers` peels Optional / Nullable / Default / Readonly
-        // / Effects / Pipeline / Branded; catch is peeled by hand since
-        // `peelV3Wrappers` preserves it for `unwrapDefault`'s use.
-        let peeled = peelV3Wrappers(leaf)
-        for (let i = 0; i < MAX_UNWRAP_STEPS; i++) {
-          if (!isZodSchemaType(peeled, 'ZodCatch')) break
-          const inner = unwrapInner(peeled)
-          if (!inner) break
-          peeled = peelV3Wrappers(inner)
-        }
-        if (isZodSchemaType(peeled, 'ZodTuple')) return getTupleItems(peeled).length
-        if (isZodSchemaType(peeled, 'ZodArray')) return null
-        return undefined
-      },
-      getSchemasAtPath(path) {
-        const [strippedSchema] = stripRootSchema(_zodSchema, {
-          stripDefaultValues: true,
-          stripNullable: true,
-          stripOptional: true,
-          stripZodEffects: true,
-        })
-        const slimSchema = getSlimSchema({
-          schema: strippedSchema,
-          stripConfig: {
-            stripDefaultValues: true,
-            stripZodEffects: true,
-          },
-        })
-        const nestedZodSchemas = getNestedZodSchemasAtPath(slimSchema, path, _maxRecursionDepth)
-
-        // Empty list is a valid result for paths the schema doesn't
-        // declare — callers (getValue / register / custom introspection)
-        // treat `[]` as "no sub-schema here". No warning needed.
-        if (!nestedZodSchemas.length) return []
-
-        return nestedZodSchemas.map((n) =>
-          getAbstractSchema(_formKey, n as unknown as FormSchema, false, _maxRecursionDepth)
-        ) as unknown as AbstractSchema<unknown, GetValueFormType>[]
-      },
-      isRequiredAtPath(path) {
-        // Root form is structurally required (it's the parsed object).
-        // The required-empty check tracks primitive leaves only, so this
-        // branch is academic for the call sites that matter.
-        if (path.length === 0) return true
-        // The unified walker descends through structural shapes and peels
-        // wrappers between segments while preserving the terminal
-        // wrapper at the path's leaf — `path: ['name']` against
-        // `z.object({ name: z.optional(z.string()) })` returns the
-        // optional wrapper itself, which is what we need to inspect.
-        //
-        // For paths that traverse a union the walker returns one
-        // resolution per branch. The slot is required only if EVERY
-        // branch is required at that path — any permissive branch
-        // makes the union permissive at parse time. Mirrors v4's
-        // `resolved.every(isLeafRequired)`.
-        const resolved = getNestedZodSchemasAtPath(_zodSchema, path, _maxRecursionDepth)
-        if (resolved.length === 0) return false
-        return resolved.every((candidate) => isLeafRequiredV3(candidate))
-      },
-      getFieldMetaAtPath(path): ResolvedFieldMeta {
-        return resolveFieldMetaAtPathV3(_zodSchema, path, _maxRecursionDepth)
-      },
-
-      getUnionDiscriminatorAtPath(path): UnionDiscriminatorContext | undefined {
-        // Resolve every candidate at `path`; pick the unique one that
-        // is (or wraps) a discriminated union. `peelV3Wrappers` peels
-        // optional / nullable / default / effects / pipeline / readonly
-        // / branded.
-        const cacheKey = canonicalizePath(path).key
-        if (discriminatorCache.has(cacheKey)) {
-          return discriminatorCache.get(cacheKey)
-        }
-        const result = computeDiscriminator(path)
-        discriminatorCache.set(cacheKey, result)
-        return result
-      },
-      getSlimPrimitiveTypesAtPath(path) {
-        if (path.length === 0) return new Set(['object'])
-        const [strippedSchema] = stripRootSchema(_zodSchema, {
-          stripDefaultValues: true,
-          stripNullable: true,
-          stripOptional: true,
-          stripZodEffects: true,
-        })
-        const slimSchema = getSlimSchema({
-          schema: strippedSchema,
-          stripConfig: { stripDefaultValues: true, stripZodEffects: true },
-        })
-        const resolved = getNestedZodSchemasAtPath(slimSchema, path, _maxRecursionDepth)
-        // Path doesn't resolve in the schema → no kinds accepted.
-        // The gate's membership check rejects every kind against an
-        // empty set, blocking writes to typo / unknown paths.
-        if (resolved.length === 0) return new Set()
-        const out = new Set<SlimPrimitiveKind>()
-        for (const candidate of resolved) {
-          for (const k of slimPrimitivesV3(candidate as z.ZodTypeAny)) out.add(k)
-        }
-        return out
-      },
-      isLeafAtPath(path) {
-        const cacheKey = canonicalizePath(path).key
-        const cached = leafCache.get(cacheKey)
-        if (cached !== undefined) return cached
-        const prim = abstractSchema.getSlimPrimitiveTypesAtPath(path)
-        // Empty set → path doesn't exist in schema → descend permissively
-        // (treat as container so schema-named reserved keys at depth 2+
-        // don't shadow). Any container kind in the set → descend.
-        // Otherwise every kind is a primitive → leaf.
-        const isLeaf =
-          prim.size > 0 &&
-          !prim.has('object') &&
-          !prim.has('array') &&
-          !prim.has('map') &&
-          !prim.has('set')
-        leafCache.set(cacheKey, isLeaf)
-        return isLeaf
-      },
-      isPreprocessOrCoerceLeaf(path) {
-        // Walks prefixes of `path` looking for either shape v3 uses for
-        // schema-side input normalizers:
-        //   - `z.preprocess(fn, inner)` — a `ZodEffects` whose
-        //     `effect.type === 'preprocess'` (`getEffectsKind`).
-        //   - `z.coerce.X()` — a primitive schema (ZodString /
-        //     ZodNumber / etc.) carrying `_def.coerce === true`
-        //     (`isCoercePrimitive`). v3's coerce is a flag on the
-        //     wrapped primitive's def rather than a wrapper, so the
-        //     typeName stays `ZodString` etc.; the gate still needs to
-        //     recognise the coerce intent so raw consumer writes pass
-        //     through verbatim, matching v4.
-        // Returns true at such a node OR anywhere underneath it; the
-        // slim-primitive gate uses this to accept raw consumer writes
-        // verbatim throughout that subtree.
-        const cacheKey = canonicalizePath(path).key
-        const cached = preprocessOrCoerceCache.get(cacheKey)
-        if (cached !== undefined) return cached
-        let hit = false
-        for (let i = 0; i <= path.length && !hit; i++) {
-          const prefix = path.slice(0, i)
-          const candidates: z.ZodTypeAny[] =
-            prefix.length === 0
-              ? [_zodSchema as z.ZodTypeAny]
-              : (getNestedZodSchemasAtPath(
-                  _zodSchema,
-                  prefix,
-                  _maxRecursionDepth
-                ) as z.ZodTypeAny[])
-          for (const candidate of candidates) {
-            if (isCoercePrimitive(candidate)) {
-              hit = true
-              break
-            }
-            if (!isZodSchemaType(candidate, 'ZodEffects')) continue
-            if (getEffectsKind(candidate) === 'preprocess') {
-              hit = true
-              break
-            }
-          }
-        }
-        preprocessOrCoerceCache.set(cacheKey, hit)
-        return hit
-      },
-      validateAtPath(data, path, options) {
-        // Sync attempt: when `options.sync === true`, try `safeParse`
-        // (synchronous). It throws on async refines / pipes /
-        // transforms; we catch and fall through to `safeParseAsync`.
-        // Without the flag the adapter goes straight to async — the
-        // historical contract every non-reshape callsite expects.
-        const trySync = options?.sync === true
-        if (trySync) {
-          try {
-            return runSync()
-          } catch {
-            // Async-only schema. Fall through to the async path.
-          }
-        }
-        return runAsync()
-
-        function runSync(): ValidationResponse<GetValueFormType> {
-          if (path === undefined) {
-            const { success, data: successData, error } = _zodSchema.safeParse(data)
-            return success
-              ? { data: successData, success, errors: undefined, formKey: _formKey }
-              : {
-                  success,
-                  data: undefined,
-                  errors: zodIssuesToValidationErrors(error.issues, _formKey),
-                  formKey: _formKey,
-                }
-          }
-          const nestedZodSchemas = nestedSchemasAtPath(path)
-          if (!nestedZodSchemas.length) return pathNotFound(path)
-          const accumulatedErrors: z.ZodError<unknown>[] = []
-          for (const nestedSchema of nestedZodSchemas) {
-            const { data: successData, success, error } = nestedSchema.safeParse(data)
-            if (!success) {
-              accumulatedErrors.push(error)
-              continue
-            }
-            return { data: successData, errors: undefined, success: true, formKey: _formKey }
-          }
-          return aggregatedFailure(accumulatedErrors)
-        }
-
-        async function runAsync(): Promise<ValidationResponse<GetValueFormType>> {
-          if (path === undefined) {
-            let result: ReturnType<typeof _zodSchema.safeParse>
-            try {
-              result = await _zodSchema.safeParseAsync(data)
-            } catch (err) {
-              return validatorThrewResponse(err, [])
-            }
-            const { success, data: successData, error } = result
-            return success
-              ? { data: successData, success, errors: undefined, formKey: _formKey }
-              : {
-                  success,
-                  data: undefined,
-                  errors: zodIssuesToValidationErrors(error.issues, _formKey),
-                  formKey: _formKey,
-                }
-          }
-          const nestedZodSchemas = nestedSchemasAtPath(path)
-          if (!nestedZodSchemas.length) return pathNotFound(path)
-          // Sequential await — parallelising would run every branch's
-          // async side effects on a value only one branch should see.
-          const accumulatedErrors: z.ZodError<unknown>[] = []
-          for (const nestedSchema of nestedZodSchemas) {
-            let result: ReturnType<typeof nestedSchema.safeParse>
-            try {
-              result = await nestedSchema.safeParseAsync(data)
-            } catch (err) {
-              return validatorThrewResponse(err, path)
-            }
-            const { data: successData, success, error } = result
-            if (!success) {
-              accumulatedErrors.push(error)
-              continue
-            }
-            return { data: successData, errors: undefined, success: true, formKey: _formKey }
-          }
-          return aggregatedFailure(accumulatedErrors)
-        }
-
-        // User code inside `z.preprocess` / `.refine` / `.transform`
-        // can throw (sync) or reject (async). Zod does NOT wrap these
-        // into issues; they propagate out of `safeParseAsync` as a
-        // real throw / rejection. Without this catch the throw would
-        // bubble through `validateAtPath` into the runtime's submit /
-        // change-mode pipelines as either a `submitError`
-        // (handleSubmit) or an unhandled rejection
-        // (scheduleFieldValidation), and the consumer would never see
-        // a path-scoped error message. Mirrors v4's
-        // `validatorThrewResponse` (`zod-v4/adapter.ts:727-746`).
-        function validatorThrewResponse(
-          err: unknown,
-          errPath: Path
-        ): ValidationResponse<GetValueFormType> {
-          const message =
-            err instanceof Error ? err.message : typeof err === 'string' ? err : 'Validator threw'
-          return {
-            data: undefined,
-            errors: [
-              {
-                message,
-                path: [...errPath],
-                formKey: _formKey,
-                code: AttaformErrorCode.ValidatorThrew,
-              },
-            ],
-            success: false,
-            formKey: _formKey,
-          }
-        }
-
-        function nestedSchemasAtPath(p: Path): z.ZodTypeAny[] {
-          // Walk the ORIGINAL schema. The walker peels transparent
-          // wrappers (optional / nullable / default / effects /
-          // pipeline / readonly / branded) inline as it descends,
-          // preserving every check (`.min` / `.max` / `.length` /
-          // `.nonempty` / `.refine` / etc.) at the target path so
-          // path-targeted re-validation surfaces issues that depend
-          // on the schema node itself (e.g. an array's `.min(1)`
-          // after a structural mutation, or a leaf's `.min(1)` when
-          // the parent has a refine). The slim-schema pipeline used
-          // for default-value derivation deliberately strips checks
-          // at re-creation sites — appropriate for "here's a
-          // permissive shape to seed defaults," wrong for "here's
-          // the schema we should validate against."
-          return getNestedZodSchemasAtPath(_zodSchema, p, _maxRecursionDepth)
-        }
-
-        function pathNotFound(p: Path): ValidationResponse<GetValueFormType> {
-          return {
-            data: undefined,
-            errors: NO_SCHEMAS_FOUND_AT_PATH_OF_CONCRETE_SCHEMA([...p], _formKey),
-            success: false,
-            formKey: _formKey,
-          }
-        }
-
-        function aggregatedFailure(
-          errors: z.ZodError<unknown>[]
-        ): ValidationResponse<GetValueFormType> {
-          const allIssues = errors.reduce<z.ZodIssue[]>((acc, e) => [...acc, ...e.issues], [])
-          return {
-            data: undefined,
-            errors: zodIssuesToValidationErrors(allIssues, _formKey),
-            success: false,
-            formKey: _formKey,
-          }
-        }
-      },
-    }
-
-    return abstractSchema
+  // Walk the original schema (not the stripped one) so the assert
+  // descends through user-declared wrappers (`.optional()`,
+  // `.nullable()`, `.default()`) before checking each leaf. Throws
+  // for kinds we can't represent — `z.promise`, `z.function`,
+  // `z.map`, `z.symbol` — and for self-referencing `z.lazy(...)`.
+  assertSupportedKinds(zodSchema)
+  const [_strippedRoot] = stripRootSchema(zodSchema, {
+    stripDefaultValues: true,
+    stripNullable: true,
+    stripOptional: true,
+    stripZodEffects: true,
+    stripZodRefinements: true,
+  })
+  if (!isZodSchemaType(_strippedRoot, 'ZodObject')) {
+    const name = getTypeName(_strippedRoot)
+    throw new Error(`ZodAdapter: expected ZodObject, got ${name}`)
   }
 
   // `options.maxRecursionDepth` caps `z.lazy(...)` descent in
@@ -937,8 +189,95 @@ export function zodAdapter<
   // `maxRecursionDepth + 1` lazy boundaries it returns `[]`, so writes
   // at recursive paths deeper than the cap fall back to a permissive
   // type gate. Matches the v4 adapter's path-walker contract.
-  return (formKey: FormKey, _options: SchemaFactoryOptions) =>
-    getAbstractSchema(formKey, zodSchema, true, _options.maxRecursionDepth)
+  return (formKey: FormKey, options: SchemaFactoryOptions) =>
+    createAbstractSchema<z.ZodTypeAny, Form, GetValueFormType>(
+      zodSchema,
+      V3_INTROSPECTOR,
+      buildV3Services<Form, GetValueFormType>(),
+      formKey,
+      options
+    )
+}
+
+/**
+ * Module-level `SchemaIntrospector` for the v3 adapter. Pure schema
+ * accessors with no closure state — shared across every \`useForm()\`
+ * that ships a v3 schema. Mirrors the v4 \`V4_INTROSPECTOR\` shape.
+ */
+const V3_INTROSPECTOR: SchemaIntrospector<z.ZodTypeAny> = {
+  kindOf: (schema) => kindOf(schema) as SharedZodKind | string,
+  getObjectShape: (schema) => getObjectShape(schema),
+  getTupleItems: (schema) => getTupleItems(schema),
+  getDiscriminatedOptions: (schema) => getDiscriminatedOptions(schema) as readonly z.ZodTypeAny[],
+  getDiscriminator: (schema) => getDiscriminator(schema),
+  getLiteralValues: (schema) => getLiteralValues(schema),
+  isPreprocessNode: (schema) => isPreprocessNode(schema),
+  isCoercePrimitive: (schema) => isCoercePrimitive(schema),
+  containsAsyncRefine: (schema) => containsAsyncRefine(schema),
+  containsAsyncTransform: (schema) => containsAsyncTransform(schema),
+  hasContainerOrRootRefine: (schema) => hasContainerOrRootRefine(schema),
+}
+
+/**
+ * Build the v3 `AbstractSchemaServices` instance. Services are stateless
+ * — every method receives the schema it acts on plus the factory-supplied
+ * `formKey` / `maxRecursionDepth`. Generic in `Form` / `GetValueFormType`
+ * so the typed methods (`runStrictGetDefaults` / `makeSubSchema`)
+ * propagate the form shape correctly.
+ */
+function buildV3Services<
+  Form extends GenericForm,
+  GetValueFormType extends GenericForm,
+>(): AbstractSchemaServices<z.ZodTypeAny, Form, GetValueFormType> {
+  return {
+    fingerprint: (schema) => fingerprintZodSchema(schema as z.ZodSchema),
+    getNestedSchemasAtPath: (schema, path, maxRecursionDepth) =>
+      getNestedZodSchemasAtPath(schema as z.ZodSchema, path, maxRecursionDepth),
+    // v3 pre-strips refinements / defaults / wrappers off the root for
+    // slim-mode walks — `getSlimPrimitiveTypesAtPath` and
+    // `getSchemasAtPath` both consume this variant so the yielded
+    // candidates reflect the slim shape.
+    getNestedSchemasInSlimMode: (schema, path, maxRecursionDepth) =>
+      getNestedSchemasInSlimModeV3(schema as z.ZodSchema, path, maxRecursionDepth),
+    slimPrimitivesOf: (schema, _maxRecursionDepth) => slimPrimitivesV3(schema),
+    deriveDefault: (schema, useDefault, _maxRecursionDepth, formKey) =>
+      getDefaultValuesFromZodSchema(schema as z.ZodSchema, useDefault, formKey),
+    runStrictGetDefaults: (schema, config, formKey, maxRecursionDepth) =>
+      runStrictGetDefaultsV3<Form>(schema as z.ZodSchema, config, formKey, maxRecursionDepth),
+    unwrapStructuralWrappers: (schema) => unwrapStructuralLeafV3(schema),
+    unwrapToDiscriminatedUnion: (schema) =>
+      unwrapToDiscriminatedUnion(schema) as z.ZodTypeAny | undefined,
+    peelAllWrappers: (schema) => peelAllV3Wrappers(schema),
+    isLeafRequired: (schema) => isLeafRequiredV3(schema),
+    resolveFieldMetaAtPath: (schema, path, maxRecursionDepth) =>
+      resolveFieldMetaAtPathV3(schema as z.ZodSchema, path, maxRecursionDepth),
+    issuesToValidationErrors: (issues, formKey) =>
+      zodIssuesToValidationErrors(issues as z.ZodIssue[], formKey),
+    safeParseSync: (schema, data) => {
+      const result = schema.safeParse(data)
+      return result.success
+        ? { success: true, data: result.data }
+        : { success: false, issues: result.error.issues }
+    },
+    safeParseAsync: async (schema, data) => {
+      const result = await schema.safeParseAsync(data)
+      return result.success
+        ? { success: true, data: result.data }
+        : { success: false, issues: result.error.issues }
+    },
+    // v3 returns the full recursive AbstractSchema for sub-schemas (the
+    // historical shape) — `getSchemasAtPath` consumers may probe any
+    // method on the result. The factory call rebuilds the full surface
+    // against the sub-schema with its own per-form caches.
+    makeSubSchema: (sub, formKey, maxRecursionDepth) =>
+      createAbstractSchema<z.ZodTypeAny, unknown, GetValueFormType>(
+        sub,
+        V3_INTROSPECTOR,
+        buildV3Services<GenericForm, GetValueFormType>(),
+        formKey,
+        { maxRecursionDepth }
+      ),
+  }
 }
 
 function zodIssuesToValidationErrors(issues: z.ZodIssue[], formKey: FormKey): ValidationError[] {
@@ -987,16 +326,6 @@ function coercePathSegments(path: readonly (string | number | symbol)[]): (strin
   }
   return out
 }
-
-const NO_SCHEMAS_FOUND_AT_PATH_OF_CONCRETE_SCHEMA = (path: (string | number)[], formKey: FormKey) =>
-  [
-    {
-      message: `Programming Error: useForm.validateAtPath failed to find 1 or more schemas corresponding to the path ${path} in the concrete schema. Does the nested schema exist on form with key '${formKey}'?`,
-      path,
-      formKey,
-      code: AttaformErrorCode.PathNotFound,
-    },
-  ] satisfies ValidationError[]
 
 // Walks a canonical `Segment[]` directly — every literal-dot key is
 // treated as a single segment, so a field named `"user.email"` no
@@ -2530,4 +1859,350 @@ function resolveFieldMetaAtPathV3(
     placeholder: payload?.placeholder ?? undefined,
     meta: Object.freeze({ ...(payload ?? {}) }),
   }
+}
+
+/**
+ * v3's construction-time `getDefaultValues` flow. Extracted from the
+ * pre-factory inline adapter body. Builds the slim default-value seed
+ * via `getDefaultValuesFromZodSchema`, merges constraints, then runs:
+ *
+ *   - Strict mode (default): parse against the REAL schema so refines
+ *     and container / leaf checks surface at construction. If a sync
+ *     parse throws because of an async refine, strip every ZodEffects
+ *     and re-parse (v3 cannot tell sync from async refines without
+ *     invoking the wrapper). If a user refine throws raw, fall back
+ *     to mount-clean success.
+ *
+ *   - Lax mode: validate-then-fix loop against the slim schema —
+ *     primitive / structural mismatches get patched with the slim
+ *     default; refinement-level issues pass through unchanged so the
+ *     downstream strict validation pass surfaces them.
+ *
+ * Both arms compose with `mergeDeepV3` (NOT lodash merge) so arrays
+ * replace wholesale and explicit `null` / `undefined` overrides
+ * survive — matching v4's `mergeDeep` semantic.
+ */
+function runStrictGetDefaultsV3<Form>(
+  rootSchema: z.ZodSchema,
+  config: GetDefaultValuesConfig<Form>,
+  formKey: FormKey,
+  maxRecursionDepth: number
+): DefaultValuesResponse<Form> {
+  const defaultValuesWithoutConstraints = getDefaultValuesFromZodSchema(
+    rootSchema,
+    config.useDefaultSchemaValues,
+    formKey
+  )
+
+  const slimSchema = getSlimSchema({
+    schema: rootSchema,
+    stripConfig: {
+      stripZodEffects: true,
+      stripDefaultValues: true,
+      // `strict: false` strips refinements (so empty defaults pass);
+      // strict keeps them so the slim parse below surfaces refinement
+      // errors. Async refines are guarded by the try/catch — they
+      // can't be surfaced synchronously regardless.
+      stripZodRefinements: (config.strict ?? true) === false,
+    },
+  })
+
+  let rawDefaultValues = defaultValuesWithoutConstraints
+  if (!isPrimitive(rawDefaultValues)) {
+    // `mergeDeepV3` (NOT lodash `merge`) so arrays replace wholesale
+    // and explicit `null`/`undefined` overrides survive, matching v4's
+    // `mergeDeep` semantic.
+    rawDefaultValues = mergeDeepV3(defaultValuesWithoutConstraints, config.constraints)
+  } else if (constraintsAreSlimValid(slimSchema, config.constraints)) {
+    rawDefaultValues = config.constraints
+  }
+
+  // Strict-mode path: parse against the REAL schema so refines and
+  // container / leaf checks (`.min(n)` / `.max(n)` / `.email()` etc.)
+  // seed at construction. Mirrors v4 (`zod-v4/adapter.ts`'s strict
+  // arm). The lax-mode validate-then-fix loop below stays untouched
+  // — it's the right shape for "seed a permissive partial state at
+  // mount."
+  if ((config.strict ?? true) !== false) {
+    // Async transforms can't be stripped: the transform's output shape
+    // is load-bearing for the inner schema's input. Skip the strict
+    // pass entirely; the post-mount async pass picks up verdicts via
+    // `safeParseAsync`.
+    if (containsAsyncTransform(rootSchema)) {
+      return {
+        data: rawDefaultValues as Form,
+        errors: undefined,
+        success: true,
+        formKey,
+      }
+    }
+
+    try {
+      const strictResult = rootSchema.safeParse(rawDefaultValues)
+      if (strictResult.success) {
+        // Storage holds the pre-transform `z.input` view, so we return
+        // the raw defaults (already filled by
+        // `getDefaultValuesFromZodSchema`) rather than
+        // `strictResult.data` (the post-transform `z.output`). For
+        // schemas without `.transform()` the two coincide; for schemas
+        // with one the storage stays the honest input view that
+        // `form.values` reflects.
+        return {
+          data: rawDefaultValues as Form,
+          errors: undefined,
+          success: true,
+          formKey,
+        }
+      }
+      return {
+        data: rawDefaultValues as Form,
+        errors: zodIssuesToValidationErrors(strictResult.error.issues, formKey),
+        success: false,
+        formKey,
+      }
+    } catch (err) {
+      // Distinguish the v3 async-detect throw from a generic
+      // user-validator throw at construction. The async-detect throw
+      // is a standard `Error` with message `"Async refinement
+      // encountered during synchronous parse..."`. On that path strip
+      // every `ZodEffects` (sync + async — v3 can't tell apart at the
+      // predicate level, see `strip-async.ts` docblock) and re-parse
+      // to surface container + leaf-check seeds.
+      const isAsyncDetect =
+        err instanceof Error && err.message.includes('Async refinement encountered')
+      if (isAsyncDetect) {
+        try {
+          const strippedResult = stripAsyncChecks(rootSchema).safeParse(rawDefaultValues)
+          if (strippedResult.success) {
+            return {
+              data: rawDefaultValues as Form,
+              errors: undefined,
+              success: true,
+              formKey,
+            }
+          }
+          return {
+            data: rawDefaultValues as Form,
+            errors: zodIssuesToValidationErrors(strippedResult.error.issues, formKey),
+            success: false,
+            formKey,
+          }
+        } catch {
+          // Defensive floor: the stripped schema also threw (e.g. a
+          // sync refine that itself throws). Mount cleanly; the
+          // post-mount async pass is the source of truth for any
+          // verdict this code path can't surface.
+          return {
+            data: rawDefaultValues as Form,
+            errors: undefined,
+            success: true,
+            formKey,
+          }
+        }
+      }
+      // Non-async throw at construction (user validator threw a raw
+      // exception): defensive floor, matches v4's catch.
+      return {
+        data: rawDefaultValues as Form,
+        errors: undefined,
+        success: true,
+        formKey,
+      }
+    }
+  }
+
+  // Lax mode: validate-then-fix loop. The slim schema's structural
+  // shape is what the loop patches against — any throw collapses to
+  // mount-clean success. The existing try/catch is the slim equivalent
+  // of the strict-mode defensive floor above.
+  let parseResult: ReturnType<typeof slimSchema.safeParse>
+  try {
+    parseResult = slimSchema.safeParse(rawDefaultValues)
+  } catch {
+    return {
+      data: rawDefaultValues as Form,
+      errors: undefined,
+      success: true,
+      formKey,
+    }
+  }
+  const { data, success, error } = parseResult
+
+  if (success) {
+    return {
+      data: data as Form,
+      errors: undefined,
+      success,
+      formKey,
+    }
+  }
+
+  let fixedData: Record<string, unknown> = {}
+
+  // `if (success) return ...` above handles the happy path; below
+  // we're always in the failure case.
+  //
+  // Under the slim-primitive write contract, the validate-then-fix
+  // loop only patches issues that violate STRUCTURAL or
+  // PRIMITIVE-TYPE shape. Refinement-level issues
+  // (invalid_enum_value, invalid_literal, invalid_string, too_small,
+  // too_big, custom, unrecognized_keys) pass THROUGH unchanged — the
+  // user's defaultValues are preserved verbatim and the strict-mode
+  // validation pass downstream surfaces the error at construction.
+  //
+  // The classifier: look up the actual offending value at the issue's
+  // path and check its slim primitive kind against the candidate
+  // schema's slim primitive set. If the value's kind IS in the set,
+  // the issue is refinement-level → skip. If it's NOT in the set, the
+  // issue is primitive/structural → fix. Unifies every issue code
+  // under one check.
+  for (const issue of error.issues) {
+    const schemasAtPath = getNestedZodSchemasAtPath(slimSchema, issue.path, maxRecursionDepth)
+    // `setAtPath` accepts a Segment[] directly; keeps the literal-dot
+    // case (`['user.name']`) from being flattened into two key
+    // accesses. Coerce in case a custom check smuggled a Symbol —
+    // `path.join` would throw on it.
+    const path = coercePathSegments(issue.path)
+    if (!schemasAtPath.length) {
+      console.error(
+        `[attaform] zod-v3 adapter: no schema at path ` +
+          `'${path.join(PATH_SEPARATOR)}' for key '${formKey}'. ` +
+          `Skipping the issue. (This is a library-internal invariant — please file a bug.)`
+      )
+      continue
+    }
+
+    // Refinement-vs-primitive classification.
+    const candidate = schemasAtPath[0]
+    if (candidate !== undefined) {
+      const valueAtPath = getAtPath(rawDefaultValues, path)
+      const slimKinds = slimPrimitivesV3(candidate as z.ZodTypeAny)
+      if (slimKinds.size > 0 && slimKinds.has(slimKindOf(valueAtPath))) {
+        // Refinement-level: pass through unchanged.
+        continue
+      }
+    }
+
+    for (const schemaAtPath of schemasAtPath) {
+      if (issue.code === 'invalid_type') {
+        const isDiscriminatedUnion = isZodSchemaType(schemaAtPath, 'ZodDiscriminatedUnion')
+        const defaultValueContext: DefaultValueContext = isDiscriminatedUnion
+          ? {
+              formKey,
+              discriminator: {
+                isDiscriminatorKey: true,
+                schema: schemaAtPath as z.ZodDiscriminatedUnion<
+                  string,
+                  readonly z.ZodDiscriminatedUnionOption<string>[]
+                >,
+                useDefaultSchemaValues: false,
+              },
+            }
+          : {
+              formKey,
+              discriminator: {
+                isDiscriminatorKey: false,
+                schema: undefined,
+                useDefaultSchemaValues: false,
+              },
+            }
+        const defaultValue = getDefaultValue(issue.expected, defaultValueContext)
+        fixedData = setAtPath(fixedData, path, defaultValue) as Record<string, unknown>
+        continue
+      }
+
+      // Wrong-primitive issues with non-invalid_type codes (e.g.,
+      // invalid_enum_value where the offending value is a number
+      // against a string-enum). Fall back to the schema's default.
+      const [defaultValue, found] = unwrapDefault(schemaAtPath)
+      if (found) {
+        fixedData = setAtPath(fixedData, path, defaultValue) as Record<string, unknown>
+        continue
+      }
+      // Last-ditch: derive a default for the schema kind at this path.
+      // Skips if no useful default emerges.
+      const ctx: DefaultValueContext = {
+        formKey,
+        discriminator: {
+          isDiscriminatorKey: false,
+          schema: undefined,
+          useDefaultSchemaValues: false,
+        },
+      }
+      // Use the slim primitive's first kind to derive a default.
+      const slimKinds = slimPrimitivesV3(schemaAtPath as z.ZodTypeAny)
+      const firstKind = [...slimKinds][0]
+      if (firstKind !== undefined) {
+        const expected =
+          firstKind === 'string'
+            ? 'string'
+            : firstKind === 'number'
+              ? 'number'
+              : firstKind === 'boolean'
+                ? 'boolean'
+                : firstKind === 'bigint'
+                  ? 'bigint'
+                  : firstKind === 'date'
+                    ? 'date'
+                    : firstKind === 'array'
+                      ? 'array'
+                      : firstKind === 'object'
+                        ? 'object'
+                        : null
+        if (expected !== null) {
+          fixedData = setAtPath(fixedData, path, getDefaultValue(expected, ctx)) as Record<
+            string,
+            unknown
+          >
+        }
+      }
+    }
+  }
+  // `mergeDeepV3` so the fix-up overrides the raw defaults with
+  // copy-on-write semantics matching v4 (array replace, null/undefined
+  // clears honored).
+  fixedData = mergeDeepV3(rawDefaultValues, fixedData) as Record<string, unknown>
+
+  // Best-effort re-parse: if the fix-up loop couldn't fully reconcile
+  // the data (nested unions whose branches don't match the defaulted
+  // shape, bigint edge cases), return the partial data instead of
+  // throwing. Matches the v4 adapter's lax semantics — a partially-
+  // valid initial state is preferable to a mount-time exception.
+  // Strict mode short-circuited earlier via the real-schema parse
+  // path, so reaching here implies `config.strict === false`.
+  const secondParse = slimSchema.safeParse(fixedData)
+  const finalData = secondParse.success ? secondParse.data : fixedData
+  return {
+    data: finalData as Form,
+    errors: undefined,
+    success: true,
+    formKey,
+  }
+}
+
+/**
+ * v3's slim-mode path walk for `getSlimPrimitiveTypesAtPath` and
+ * `getSchemasAtPath`. Strips refinements / defaults / wrappers off the
+ * root, then derives the slim shape, then walks. Yielded candidates
+ * reflect the slim shape — which is what the slim-primitive gate
+ * consults at write time and what consumers expect when introspecting
+ * sub-schemas. v4's introspector aliases this to the unstripped walk
+ * because its path walker already inlines wrapper peeling.
+ */
+function getNestedSchemasInSlimModeV3(
+  rootSchema: z.ZodSchema,
+  path: Path,
+  maxRecursionDepth: number
+): z.ZodTypeAny[] {
+  const [strippedSchema] = stripRootSchema(rootSchema, {
+    stripDefaultValues: true,
+    stripNullable: true,
+    stripOptional: true,
+    stripZodEffects: true,
+  })
+  const slimSchema = getSlimSchema({
+    schema: strippedSchema,
+    stripConfig: { stripDefaultValues: true, stripZodEffects: true },
+  })
+  return getNestedZodSchemasAtPath(slimSchema, path, maxRecursionDepth)
 }

--- a/src/runtime/adapters/zod-v3/introspect.ts
+++ b/src/runtime/adapters/zod-v3/introspect.ts
@@ -367,6 +367,18 @@ export function isCoercePrimitive(schema: z.ZodTypeAny): boolean {
 }
 
 /**
+ * Detect `z.preprocess(fn, inner)` — v3 wraps preprocess in a
+ * `ZodEffects` with `effect.type === 'preprocess'`. The factory's
+ * `isPreprocessOrCoerceLeaf` consults this alongside
+ * `isCoercePrimitive` to gate raw consumer writes verbatim through the
+ * wrapped subtree.
+ */
+export function isPreprocessNode(schema: z.ZodTypeAny): boolean {
+  if (!isZodSchemaType(schema, 'ZodEffects')) return false
+  return getEffectsKind(schema) === 'preprocess'
+}
+
+/**
  * True iff a `ZodEffects` carries an `async` predicate.
  *
  * Detection asymmetry vs v4 (intrinsic to v3's runtime model):

--- a/src/runtime/adapters/zod-v3/slim-primitives.ts
+++ b/src/runtime/adapters/zod-v3/slim-primitives.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod-v3'
 import type { SlimPrimitiveKind } from '../../types/types-api'
+import { slimKindOf } from '../../core/slim-primitive-gate'
 import { isZodSchemaType } from './helpers'
 
 /**
@@ -92,7 +93,7 @@ function walk(schema: z.ZodTypeAny, depth: number): ReadonlySet<SlimPrimitiveKin
   }
   if (isZodSchemaType(schema, 'ZodLiteral')) {
     const value = (schema as z.ZodLiteral<unknown>).value
-    return new Set([slimKindOfRawV3(value)])
+    return new Set([slimKindOf(value)])
   }
   if (isZodSchemaType(schema, 'ZodObject') || typeName === 'ZodRecord') {
     return KIND_OBJECT
@@ -163,32 +164,4 @@ function walk(schema: z.ZodTypeAny, depth: number): ReadonlySet<SlimPrimitiveKin
   if (typeName === 'ZodAny' || typeName === 'ZodUnknown') return PERMISSIVE_V3
 
   return PERMISSIVE_V3
-}
-
-function slimKindOfRawV3(value: unknown): SlimPrimitiveKind {
-  if (value === null) return 'null'
-  if (value === undefined) return 'undefined'
-  if (Array.isArray(value)) return 'array'
-  if (value instanceof Date) return 'date'
-  const t = typeof value
-  switch (t) {
-    case 'string':
-      return 'string'
-    case 'number':
-      return 'number'
-    case 'boolean':
-      return 'boolean'
-    case 'bigint':
-      return 'bigint'
-    case 'symbol':
-      return 'symbol'
-    case 'function':
-      return 'function'
-    case 'undefined':
-      return 'undefined'
-    case 'object':
-      return 'object'
-    default:
-      return 'object'
-  }
 }

--- a/src/runtime/adapters/zod-v4/adapter.ts
+++ b/src/runtime/adapters/zod-v4/adapter.ts
@@ -310,9 +310,10 @@ function buildV4Services<
     fingerprint: (schema) => fingerprintZodSchema(schema),
     getNestedSchemasAtPath: (schema, path, maxRecursionDepth) =>
       getNestedZodSchemasAtPath(schema as z.ZodObject, path, maxRecursionDepth),
-    // v4 doesn't pre-strip before slim-kind queries — the path walker
-    // already peels every transparent wrapper inline.
-    getNestedSchemasForSlimQuery: (schema, path, maxRecursionDepth) =>
+    // v4 doesn't pre-strip for the slim-mode walk — its path walker
+    // already peels every transparent wrapper inline, so the slim and
+    // unstripped walks coincide.
+    getNestedSchemasInSlimMode: (schema, path, maxRecursionDepth) =>
       getNestedZodSchemasAtPath(schema as z.ZodObject, path, maxRecursionDepth),
     slimPrimitivesOf: (schema, maxRecursionDepth) => slimPrimitivesOf(schema, maxRecursionDepth),
     deriveDefault: (schema, useDefault, maxRecursionDepth) =>

--- a/src/runtime/adapters/zod-v4/adapter.ts
+++ b/src/runtime/adapters/zod-v4/adapter.ts
@@ -1,15 +1,18 @@
 import type { z } from 'zod'
 import type {
   AbstractSchema,
+  DefaultValuesResponse,
   FieldMetaPayload,
   FormKey,
+  GetDefaultValuesConfig,
   ResolvedFieldMeta,
-  SlimPrimitiveKind,
-  UnionDiscriminatorContext,
-  ValidationError,
-  ValidationResponse,
 } from '../../types/types-api'
-import { AttaformErrorCode } from '../../core/error-codes'
+import {
+  createAbstractSchema,
+  type AbstractSchemaServices,
+  type SchemaIntrospector,
+  type SharedZodKind,
+} from '../../core/abstract-schema-factory'
 import { getFieldMeta, getFieldMetaList } from './field-meta'
 import type { SchemaFactoryOptions } from '../../core/get-computed-schema'
 import { humanize } from '../../core/humanize'
@@ -37,11 +40,11 @@ import {
   getUnionOptions,
   hasContainerOrRootRefine,
   isCoercePrimitive,
+  isPreprocessNode,
   kindOf,
   unwrapInner,
   unwrapLazy,
   unwrapPipe,
-  unwrapPipeIn,
 } from './introspect'
 import { getNestedZodSchemasAtPath } from './path-walker'
 import { slimPrimitivesOf } from './slim-primitives'
@@ -61,8 +64,6 @@ import { stripAsyncChecks } from './strip'
  * - getSchemasAtPath: discriminated-union-aware path walker.
  * - validateAtPath: per-union-branch parse with aggregated errors.
  */
-
-const PATH_SEPARATOR = '.'
 
 /**
  * Peel `.optional()` / `.nullable()` wrappers off a leaf schema ONLY
@@ -264,505 +265,206 @@ export function zodV4Adapter<
   // runtime walks cap their descent via `maxRecursionDepth`.
   assertSupportedKinds(rootSchema)
 
-  return (
-    formKey: FormKey,
-    options: SchemaFactoryOptions
-  ): AbstractSchema<Form, GetValueFormType> => {
-    const maxRecursionDepth = options.maxRecursionDepth
-    // Per-adapter `isLeafAtPath` cache. Lifetime = one adapter instance
-    // (one per `useForm()` call). Memoises the slim-primitive walk so the
-    // leaf-aware proxy traps don't re-walk the schema on every read.
-    const leafCache = new Map<PathKey, boolean>()
-    // Per-adapter cache for the preprocess/coerce predicate. The slim-
-    // primitive write gate consults it at every level of value-tree
-    // descent; the prefix walk is cheap but adds up across deep writes.
-    const preprocessOrCoerceCache = new Map<PathKey, boolean>()
-    // Per-adapter cache for `getUnionDiscriminatorAtPath`. The walker
-    // path is consulted on every `setValue` and every `form.meta` read
-    // (every ancestor segment, every time), and the result is a pure
-    // function of (schema, path) — once computed it never changes for
-    // the lifetime of the adapter. Caches both positive and negative
-    // (no-DU) results so the common no-DU schema pays the walk cost
-    // once per path instead of per keystroke.
-    const discriminatorCache = new Map<PathKey, UnionDiscriminatorContext | undefined>()
-    // Memoised one-shot walk; `needsAsyncValidation` is queried at
-    // construction and possibly again from devtools, so a single tree
-    // traversal earns its keep across the adapter's lifetime.
-    let asyncValidationFlag: boolean | null = null
-    // Same lazy-memo pattern as the async flag: the per-keystroke
-    // validation scheduler queries `hasContainerOrRootRefine` on every
-    // keystroke to decide whole-form vs subtree scope, so the walk
-    // pays for itself within the first few mutations.
-    let containerRefineFlag: boolean | null = null
+  return (formKey: FormKey, options: SchemaFactoryOptions) =>
+    createAbstractSchema<z.ZodType, Form, GetValueFormType>(
+      rootSchema,
+      V4_INTROSPECTOR,
+      buildV4Services<Form, GetValueFormType>(),
+      formKey,
+      options
+    )
+}
 
-    function computeDiscriminator(path: Path): UnionDiscriminatorContext | undefined {
-      const candidates =
-        path.length === 0
-          ? [rootSchema as z.ZodType]
-          : getNestedZodSchemasAtPath(rootSchema, path, maxRecursionDepth)
-      let matchedUnion: z.ZodType | undefined
-      for (const candidate of candidates) {
-        const du = unwrapToDiscriminatedUnion(candidate)
-        if (du === undefined) continue
-        if (matchedUnion !== undefined && matchedUnion !== du) return undefined
-        matchedUnion = du
-      }
-      if (matchedUnion === undefined) return undefined
-      const discKey = getDiscriminator(matchedUnion)
-      if (discKey === undefined) return undefined
-      const options = getDiscriminatedOptions(matchedUnion)
-      const literalSet = new Set<unknown>()
-      for (const opt of options) {
-        const shape = getObjectShape(opt)
-        const litSchema = shape[discKey]
-        if (litSchema === undefined) continue
-        if (kindOf(litSchema) !== 'literal') continue
-        for (const v of getLiteralValues(litSchema)) literalSet.add(v)
+/**
+ * Module-level `SchemaIntrospector` for the v4 adapter. Pure schema
+ * accessors with no closure state — shared across every `useForm()`
+ * that ships a v4 schema.
+ */
+const V4_INTROSPECTOR: SchemaIntrospector<z.ZodType> = {
+  kindOf: (schema) => kindOf(schema) as SharedZodKind | string,
+  getObjectShape: (schema) => getObjectShape(schema as z.ZodObject),
+  getTupleItems: (schema) => getTupleItems(schema),
+  getDiscriminatedOptions: (schema) => getDiscriminatedOptions(schema) as readonly z.ZodType[],
+  getDiscriminator: (schema) => getDiscriminator(schema),
+  getLiteralValues: (schema) => getLiteralValues(schema),
+  isPreprocessNode: (schema) => isPreprocessNode(schema),
+  isCoercePrimitive: (schema) => isCoercePrimitive(schema),
+  containsAsyncRefine: (schema) => containsAsyncRefine(schema),
+  containsAsyncTransform: (schema) => containsAsyncTransform(schema),
+  hasContainerOrRootRefine: (schema) => hasContainerOrRootRefine(schema),
+}
+
+/**
+ * Build the v4 `AbstractSchemaServices` instance. The services are
+ * stateless — every method receives the schema it acts on plus the
+ * factory-supplied `formKey` / `maxRecursionDepth`. The function is
+ * generic in `Form` / `GetValueFormType` so the typed methods
+ * (`runStrictGetDefaults` / `makeSubSchema`) propagate the form
+ * shape correctly.
+ */
+function buildV4Services<
+  Form extends GenericForm,
+  GetValueFormType extends GenericForm,
+>(): AbstractSchemaServices<z.ZodType, Form, GetValueFormType> {
+  return {
+    fingerprint: (schema) => fingerprintZodSchema(schema),
+    getNestedSchemasAtPath: (schema, path, maxRecursionDepth) =>
+      getNestedZodSchemasAtPath(schema as z.ZodObject, path, maxRecursionDepth),
+    // v4 doesn't pre-strip before slim-kind queries — the path walker
+    // already peels every transparent wrapper inline.
+    getNestedSchemasForSlimQuery: (schema, path, maxRecursionDepth) =>
+      getNestedZodSchemasAtPath(schema as z.ZodObject, path, maxRecursionDepth),
+    slimPrimitivesOf: (schema, maxRecursionDepth) => slimPrimitivesOf(schema, maxRecursionDepth),
+    deriveDefault: (schema, useDefault, maxRecursionDepth) =>
+      deriveDefault(schema, useDefault, maxRecursionDepth),
+    runStrictGetDefaults: (schema, config, fk, maxRecursionDepth) =>
+      runStrictGetDefaultsV4<Form>(schema as FormSchemaAlias<Form>, config, fk, maxRecursionDepth),
+    unwrapStructuralWrappers: (schema) => unwrapStructuralWrappers(schema),
+    unwrapToDiscriminatedUnion: (schema) => unwrapToDiscriminatedUnion(schema),
+    peelAllWrappers: (schema) => peelAllWrappers(schema),
+    isLeafRequired: (schema) => isLeafRequired(schema),
+    resolveFieldMetaAtPath: (schema, path, maxRecursionDepth) =>
+      resolveFieldMetaAtPath(schema, path, maxRecursionDepth),
+    issuesToValidationErrors: (issues, fk) =>
+      zodIssuesToValidationErrors(issues as z.core.$ZodIssue[], fk),
+    safeParseSync: (schema, data) => {
+      const result = schema.safeParse(data) as z.ZodSafeParseResult<unknown>
+      return result.success
+        ? { success: true, data: result.data }
+        : { success: false, issues: result.error.issues }
+    },
+    safeParseAsync: async (schema, data) => {
+      const result = (await schema.safeParseAsync(data)) as z.ZodSafeParseResult<unknown>
+      return result.success
+        ? { success: true, data: result.data }
+        : { success: false, issues: result.error.issues }
+    },
+    makeSubSchema: (schema, fk, maxRecursionDepth) =>
+      buildSubSchemaStubV4<GetValueFormType>(schema, fk, maxRecursionDepth),
+  }
+}
+
+// `runStrictGetDefaultsV4` infers its target shape from a single schema
+// argument; this alias lets the service signature compose without the
+// adapter having to repeat the ZodObject constraint inline.
+type FormSchemaAlias<Form> = z.ZodType & { _output: Form }
+
+/**
+ * v4's construction-time `getDefaultValues` flow. Wraps the slim
+ * default-value derivation (`getDefaultValuesFromZodSchema`) with a
+ * strict-mode parse that surfaces refinement errors at construction,
+ * with two pre-flight gates:
+ *
+ *   1. Async transforms (`z.preprocess(async fn, T)`) cannot be
+ *      stripped — the transform's output shape is load-bearing for
+ *      the inner schema's input. Skip the strict pass; the post-mount
+ *      async pass picks up verdicts via `safeParseAsync`.
+ *
+ *   2. Async refines CAN be stripped (the predicate is detachable
+ *      from the schema's shape). Strip them up front so the sync
+ *      parse runs cleanly; sync-refinement seeds on supplied defaults
+ *      still surface.
+ *
+ * Lax mode short-circuits: the validate-then-fix loop inside the slim
+ * derivation has done everything it can; partial-valid state ships
+ * over a mount-time exception.
+ */
+function runStrictGetDefaultsV4<Form>(
+  rootSchema: z.ZodType & { _output: Form },
+  config: GetDefaultValuesConfig<Form>,
+  formKey: FormKey,
+  maxRecursionDepth: number
+): DefaultValuesResponse<Form> {
+  const { data } = getDefaultValuesFromZodSchema<Form>({
+    schema: rootSchema as unknown as z.ZodObject,
+    useDefaultSchemaValues: config.useDefaultSchemaValues,
+    constraints: config.constraints,
+    maxRecursionDepth,
+  })
+
+  if (config.strict === false) {
+    // Lax mode: see docblock — partial-valid initial state preferred
+    // to a mount-time exception.
+    return { data, errors: undefined, success: true, formKey }
+  }
+
+  if (containsAsyncTransform(rootSchema)) {
+    return { data, errors: undefined, success: true, formKey }
+  }
+
+  const parseTarget = containsAsyncRefine(rootSchema) ? stripAsyncChecks(rootSchema) : rootSchema
+  try {
+    const strictResult = parseTarget.safeParse(data) as z.ZodSafeParseResult<Form>
+    if (strictResult.success) {
+      // Storage holds the pre-transform `z.input` view, so we return
+      // the original `data` (already filled by
+      // `getDefaultValuesFromZodSchema`) rather than `strictResult.data`
+      // (the post-transform `z.output`). For schemas without
+      // `.transform()` the two coincide; for schemas with one the
+      // storage stays the honest input view that `form.values` reflects.
+      return { data, errors: undefined, success: true, formKey }
+    }
+    return {
+      data,
+      errors: zodIssuesToValidationErrors(strictResult.error.issues, formKey),
+      success: false,
+      formKey,
+    }
+  } catch {
+    // Defensive floor: the strip walker covers every ZodKind, but a
+    // future Zod construct or a user-defined sync refine that itself
+    // throws would land here. Mount cleanly; the post-mount async
+    // pass is the source of truth for any verdict this code path
+    // can't surface.
+    return { data, errors: undefined, success: true, formKey }
+  }
+}
+
+/**
+ * Build the 5-method sub-schema stub that v4 returns from
+ * `getSchemasAtPath`. Mirrors the shape consumers expect
+ * (`fingerprint`, `needsAsyncValidation`, `getDefaultValues`,
+ * `getSchemasAtPath: () => []`, `validateAtPath`) without re-walking
+ * through the full factory — sub-schemas in the runtime are only
+ * queried for `needsAsyncValidation`, so the stub is observationally
+ * interchangeable with the recursive shape v3 returns.
+ */
+function buildSubSchemaStubV4<GetValueFormType extends GenericForm>(
+  schema: z.ZodType,
+  formKey: FormKey,
+  maxRecursionDepth: number
+): AbstractSchema<unknown, GetValueFormType> {
+  return {
+    fingerprint: () => fingerprintZodSchema(schema),
+    needsAsyncValidation: () => containsAsyncRefine(schema),
+    getDefaultValues: () => ({
+      data: deriveDefault(schema, true, maxRecursionDepth) as unknown,
+      errors: undefined,
+      success: true,
+      formKey,
+    }),
+    getSchemasAtPath: () => [],
+    validateAtPath: async (data: unknown) => {
+      // safeParseAsync accepts both sync and async refinements — sync
+      // check perf is a microtask slower than safeParse but we trade
+      // that for the ability to express .refine(async).
+      const result = await schema.safeParseAsync(data)
+      if (result.success) {
+        return {
+          data: result.data as GetValueFormType,
+          errors: undefined,
+          success: true,
+          formKey,
+        }
       }
       return {
-        discriminatorKey: discKey,
-        getVariantDefault(value: unknown): unknown {
-          for (const opt of options) {
-            const shape = getObjectShape(opt)
-            const litSchema = shape[discKey]
-            if (litSchema === undefined) continue
-            if (kindOf(litSchema) !== 'literal') continue
-            const literalValues = getLiteralValues(litSchema)
-            if (literalValues.includes(value)) return deriveDefault(opt, true, maxRecursionDepth)
-          }
-          return undefined
-        },
-        isVariantSelected(value: unknown): boolean {
-          return literalSet.has(value)
-        },
+        data: undefined,
+        errors: zodIssuesToValidationErrors(result.error.issues, formKey),
+        success: false,
+        formKey,
       }
-    }
-
-    return {
-      fingerprint: () => fingerprintZodSchema(rootSchema),
-
-      needsAsyncValidation(): boolean {
-        asyncValidationFlag ??=
-          containsAsyncRefine(rootSchema) || containsAsyncTransform(rootSchema)
-        return asyncValidationFlag
-      },
-
-      hasContainerOrRootRefine(): boolean {
-        containerRefineFlag ??= hasContainerOrRootRefine(rootSchema)
-        return containerRefineFlag
-      },
-
-      getDefaultValues(
-        config
-      ): ReturnType<AbstractSchema<Form, GetValueFormType>['getDefaultValues']> {
-        const { data } = getDefaultValuesFromZodSchema<Form>({
-          schema: rootSchema,
-          useDefaultSchemaValues: config.useDefaultSchemaValues,
-          constraints: config.constraints,
-          maxRecursionDepth,
-        })
-
-        if (config.strict !== false) {
-          // Strict mode: run the full schema (not the slim one) so
-          // refinement-level errors surface at construction.
-          //
-          // Two pre-flight checks before the sync `safeParse`:
-          //
-          // 1. Async transforms (`z.preprocess(async fn, T)`) cannot be
-          //    stripped — the transform's output shape is load-bearing
-          //    for the inner schema's input. A sync `safeParse` invokes
-          //    the async fn synchronously, gets a Promise back, and if
-          //    the fn rejects the rejection leaks as an Unhandled
-          //    Rejection. Skip the strict pass entirely; the post-mount
-          //    async validation seed picks up verdicts via
-          //    `safeParseAsync`.
-          //
-          // 2. Async refines can be stripped (the predicate is detachable
-          //    from the schema's shape), and stripping them BEFORE the
-          //    first `safeParse` is what keeps the parse sync. Without
-          //    the pre-strip, the sync parser invokes the async predicate
-          //    synchronously, gets a Promise back, and leaks the
-          //    rejection the same way. Stripping up front lets the
-          //    sync-refinement errors on supplied defaults still seed at
-          //    construction; async-only verdicts stay deferred to the
-          //    post-mount one-shot async pass.
-          if (containsAsyncTransform(rootSchema)) {
-            return { data, errors: undefined, success: true, formKey }
-          }
-          const parseTarget = containsAsyncRefine(rootSchema)
-            ? stripAsyncChecks(rootSchema)
-            : rootSchema
-          try {
-            const strictResult = parseTarget.safeParse(
-              data
-            ) as z.ZodSafeParseResult<GetValueFormType>
-            if (strictResult.success) {
-              // Storage holds the pre-transform `z.input` view, so we
-              // return the original `data` (already filled by
-              // `getDefaultValuesFromZodSchema`) rather than
-              // `strictResult.data` (the post-transform `z.output`).
-              // For schemas without `.transform()` the two coincide;
-              // for schemas with one the storage stays the honest input
-              // view that `form.values` reflects.
-              return { data, errors: undefined, success: true, formKey }
-            }
-            return {
-              data,
-              errors: zodIssuesToValidationErrors(strictResult.error.issues, formKey),
-              success: false,
-              formKey,
-            }
-          } catch {
-            // Defensive floor: the strip walker covers every ZodKind,
-            // but a future Zod construct or a user-defined sync
-            // refine that itself throws would land here. Mount
-            // cleanly; the post-mount async pass is the source of
-            // truth for any verdict this code path can't surface.
-            return { data, errors: undefined, success: true, formKey }
-          }
-        }
-
-        // Lax mode: the validate-then-fix loop has done everything it can;
-        // a partially-valid initial state is preferable to a mount-time
-        // exception. Matches v3's lax semantics.
-        return { data, errors: undefined, success: true, formKey }
-      },
-
-      getDefaultAtPath(path) {
-        // For empty path, the "default at root" is the schema's full
-        // default — return the deriveDefault of the root, not the slim-
-        // schema validate-then-fix loop (that's getDefaultValues' job).
-        if (path.length === 0) return deriveDefault(rootSchema, true, maxRecursionDepth)
-        const [first] = getNestedZodSchemasAtPath(rootSchema, path, maxRecursionDepth)
-        if (first === undefined) return undefined
-        // STRUCTURAL default: peel `.optional()` / `.nullable()` so the
-        // result is the inner shape's default (`''` for an optional
-        // string, `{ name: '' }` for an optional object). This is what
-        // the runtime structural-completeness invariant needs: when a
-        // consumer writes a partial object at an optional path, the lib
-        // fills missing keys from the inner shape's structural defaults.
-        // `.default(x)` is NOT peeled — the explicit default is the
-        // canonical "fresh" value at that path. ZodReadonly / ZodCatch /
-        // ZodPipe are handled inside `deriveDefault` itself.
-        // First candidate matches validateAtPath's first-success semantic
-        // and getDefaultValuesFromZodSchema's line-256 first-candidate
-        // behavior.
-        return deriveDefault(unwrapStructuralWrappers(first), true, maxRecursionDepth)
-      },
-
-      getEmptyValueAtPath(path) {
-        // `clear`'s underlying value lookup. Same path-resolution flow
-        // as `getDefaultAtPath` (root for empty path, first candidate
-        // for unions), but `useDefault=false` so `.default(x)` /
-        // `.prefault(x)` / `.catch(x)` wrappers are skipped — the
-        // walker yields the inner-schema's empty/falsy concrete
-        // instead. Structural wrappers (`.optional()` / `.nullable()`)
-        // are NOT peeled: clearing an `.optional()` slot is
-        // legitimately `undefined`, clearing a `.nullable()` slot is
-        // `null` — that's the user's "this slot is empty" signal at
-        // those wrapper types.
-        if (path.length === 0) return deriveDefault(rootSchema, false, maxRecursionDepth)
-        const [first] = getNestedZodSchemasAtPath(rootSchema, path, maxRecursionDepth)
-        if (first === undefined) return undefined
-        return deriveDefault(first, false, maxRecursionDepth)
-      },
-
-      arrayShapeAtPath(path) {
-        if (path.length === 0) return undefined
-        const [first] = getNestedZodSchemasAtPath(rootSchema, path, maxRecursionDepth)
-        if (first === undefined) return undefined
-        const peeled = peelAllWrappers(first)
-        const kind = kindOf(peeled)
-        if (kind === 'tuple') return getTupleItems(peeled).length
-        if (kind === 'array') return null
-        return undefined
-      },
-
-      getSchemasAtPath(path) {
-        const resolved = getNestedZodSchemasAtPath(rootSchema, path, maxRecursionDepth)
-        return resolved.map(
-          (schema) =>
-            ({
-              fingerprint: () => fingerprintZodSchema(schema),
-              needsAsyncValidation: () => containsAsyncRefine(schema),
-              getDefaultValues: () => ({
-                data: deriveDefault(schema, true, maxRecursionDepth),
-                errors: undefined,
-                success: true,
-                formKey,
-              }),
-              getSchemasAtPath: () => [],
-              validateAtPath: async (data: unknown) => {
-                // safeParseAsync accepts both sync and async refinements —
-                // sync check perf is a microtask slower than safeParse but
-                // we trade that for the ability to express .refine(async).
-                const result = await schema.safeParseAsync(data)
-                if (result.success) {
-                  return { data: result.data, errors: undefined, success: true, formKey }
-                }
-                return {
-                  data: undefined,
-                  errors: zodIssuesToValidationErrors(result.error.issues, formKey),
-                  success: false,
-                  formKey,
-                }
-              },
-            }) as unknown as ReturnType<
-              AbstractSchema<Form, GetValueFormType>['getSchemasAtPath']
-            >[number]
-        )
-      },
-
-      getSlimPrimitiveTypesAtPath(path): Set<SlimPrimitiveKind> {
-        // Resolve every leaf candidate at the path (unions return
-        // multiple) and union their slim-primitive sets. Empty path
-        // is the root form: always an object.
-        if (path.length === 0) return new Set(['object'])
-        const resolved = getNestedZodSchemasAtPath(rootSchema, path, maxRecursionDepth)
-        // Path doesn't resolve in the schema → no kinds accepted.
-        // The gate's membership check rejects every kind against an
-        // empty set, blocking writes to typo / unknown paths.
-        if (resolved.length === 0) return new Set()
-        const out = new Set<SlimPrimitiveKind>()
-        for (const candidate of resolved) {
-          for (const k of slimPrimitivesOf(candidate, maxRecursionDepth)) out.add(k)
-        }
-        return out
-      },
-
-      isLeafAtPath(path): boolean {
-        const cacheKey = canonicalizePath(path).key
-        const cached = leafCache.get(cacheKey)
-        if (cached !== undefined) return cached
-        const prim = this.getSlimPrimitiveTypesAtPath(path)
-        // Empty set → path doesn't exist in schema → descend
-        // permissively (treat as container so schema-named reserved keys
-        // at depth 2+ don't shadow). Any container kind in the set →
-        // descend. Otherwise every kind is a primitive → leaf.
-        const isLeaf =
-          prim.size > 0 &&
-          !prim.has('object') &&
-          !prim.has('array') &&
-          !prim.has('map') &&
-          !prim.has('set')
-        leafCache.set(cacheKey, isLeaf)
-        return isLeaf
-      },
-
-      isPreprocessOrCoerceLeaf(path): boolean {
-        // Walks prefixes of `path` looking for either shape Zod v4 uses
-        // for schema-side input normalizers:
-        //   - `z.preprocess(fn, inner)` desugars to `ZodPipe<ZodTransform, inner>`.
-        //   - `z.coerce.X()` is a primitive schema (ZodString / ZodNumber /
-        //     etc.) with `def.coerce === true` (NOT a pipe).
-        // Returns true at such a node OR anywhere underneath it; the
-        // slim-primitive gate uses this to accept raw consumer writes
-        // verbatim throughout that subtree.
-        const cacheKey = canonicalizePath(path).key
-        const cached = preprocessOrCoerceCache.get(cacheKey)
-        if (cached !== undefined) return cached
-        let hit = false
-        for (let i = 0; i <= path.length && !hit; i++) {
-          const prefix = path.slice(0, i)
-          const candidates: z.ZodType[] =
-            prefix.length === 0
-              ? [rootSchema]
-              : getNestedZodSchemasAtPath(rootSchema, prefix, maxRecursionDepth)
-          for (const candidate of candidates) {
-            if (isCoercePrimitive(candidate)) {
-              hit = true
-              break
-            }
-            if (kindOf(candidate) !== 'pipe') continue
-            const pipeIn = unwrapPipeIn(candidate)
-            if (pipeIn !== undefined && kindOf(pipeIn) === 'transform') {
-              hit = true
-              break
-            }
-          }
-        }
-        preprocessOrCoerceCache.set(cacheKey, hit)
-        return hit
-      },
-
-      isRequiredAtPath(path): boolean {
-        // Root form is always "required" in the structural sense — it's
-        // the object we're parsing. Submit/validate's required-empty
-        // check never sees the root path in `blankPaths`
-        // (the set tracks primitive leaves), so the value is academic.
-        if (path.length === 0) return true
-        const resolved = getNestedZodSchemasAtPath(rootSchema, path, maxRecursionDepth)
-        if (resolved.length === 0) return false
-        // Every candidate must be required for the path overall to be
-        // required — matches the union "any-branch-permissive" rule
-        // when the path traverses a union.
-        return resolved.every((candidate) => isLeafRequired(candidate))
-      },
-
-      getFieldMetaAtPath(path): ResolvedFieldMeta {
-        return resolveFieldMetaAtPath(rootSchema, path, maxRecursionDepth)
-      },
-
-      getUnionDiscriminatorAtPath(path): UnionDiscriminatorContext | undefined {
-        // Resolve every candidate at `path`; pick the unique one that
-        // is (or wraps) a discriminated union. Wrappers
-        // (`.optional()` / `.default(...)` / etc.) are peeled by
-        // `unwrapToDiscriminatedUnion`. Ambiguous resolutions (two
-        // distinct DUs both reachable) bail — the runtime then falls
-        // back to a plain write.
-        const cacheKey = canonicalizePath(path).key
-        if (discriminatorCache.has(cacheKey)) {
-          return discriminatorCache.get(cacheKey)
-        }
-        const result = computeDiscriminator(path)
-        discriminatorCache.set(cacheKey, result)
-        return result
-      },
-
-      validateAtPath(
-        data,
-        path,
-        options
-      ): ReturnType<AbstractSchema<Form, GetValueFormType>['validateAtPath']> {
-        // Sync attempt: when `options.sync === true`, try `safeParse`
-        // (synchronous). It throws on async refines / pipes /
-        // transforms; we catch and fall through to `safeParseAsync`.
-        // Without the flag the adapter goes straight to async — the
-        // historical contract every non-reshape callsite expects.
-        const trySync = options?.sync === true
-        if (trySync) {
-          try {
-            return runSync()
-          } catch {
-            // Async-only schema. Fall through to the async path.
-          }
-        }
-        return runAsync()
-
-        function runSync(): ValidationResponse<GetValueFormType> {
-          if (path === undefined) {
-            const result = rootSchema.safeParse(data) as z.ZodSafeParseResult<GetValueFormType>
-            return result.success
-              ? { data: result.data, errors: undefined, success: true, formKey }
-              : {
-                  data: undefined,
-                  errors: zodIssuesToValidationErrors(result.error.issues, formKey),
-                  success: false,
-                  formKey,
-                }
-          }
-          const resolved = getNestedZodSchemasAtPath(rootSchema, path, maxRecursionDepth)
-          if (resolved.length === 0) return pathNotFound(path)
-          const aggregated: ValidationError[] = []
-          for (const candidate of resolved) {
-            const result = candidate.safeParse(data)
-            if (result.success) {
-              return {
-                data: result.data as GetValueFormType,
-                errors: undefined,
-                success: true,
-                formKey,
-              }
-            }
-            aggregated.push(...zodIssuesToValidationErrors(result.error.issues, formKey))
-          }
-          return { data: undefined, errors: aggregated, success: false, formKey }
-        }
-
-        async function runAsync(): Promise<ValidationResponse<GetValueFormType>> {
-          if (path === undefined) {
-            let result: z.ZodSafeParseResult<GetValueFormType>
-            try {
-              result = (await rootSchema.safeParseAsync(
-                data
-              )) as z.ZodSafeParseResult<GetValueFormType>
-            } catch (err) {
-              return validatorThrewResponse(err, [])
-            }
-            return result.success
-              ? { data: result.data, errors: undefined, success: true, formKey }
-              : {
-                  data: undefined,
-                  errors: zodIssuesToValidationErrors(result.error.issues, formKey),
-                  success: false,
-                  formKey,
-                }
-          }
-          const resolved = getNestedZodSchemasAtPath(rootSchema, path, maxRecursionDepth)
-          if (resolved.length === 0) return pathNotFound(path)
-          // Sequential await — parallel parses would run every
-          // branch's async side effects on a value only one branch
-          // should see.
-          const aggregated: ValidationError[] = []
-          for (const candidate of resolved) {
-            let result: z.ZodSafeParseResult<unknown>
-            try {
-              result = await candidate.safeParseAsync(data)
-            } catch (err) {
-              return validatorThrewResponse(err, path)
-            }
-            if (result.success) {
-              return {
-                data: result.data as GetValueFormType,
-                errors: undefined,
-                success: true,
-                formKey,
-              }
-            }
-            aggregated.push(...zodIssuesToValidationErrors(result.error.issues, formKey))
-          }
-          return { data: undefined, errors: aggregated, success: false, formKey }
-        }
-
-        // User code inside `z.preprocess` / `.refine` / `.transform`
-        // can throw (sync) or reject (async). Zod v4 does NOT wrap
-        // these into issues; they propagate out of `safeParse` /
-        // `safeParseAsync`. Without this catch the throw would bubble
-        // through `validateAtPath` into the runtime's submit / change-
-        // mode pipelines as either a `submitError` (for handleSubmit)
-        // or an unhandled rejection (for scheduleFieldValidation), and
-        // the consumer would never see a path-scoped error message.
-        // Surface as a `ValidationError` at the field path so the
-        // form's normal error pipeline handles it.
-        function validatorThrewResponse(
-          err: unknown,
-          errPath: Path
-        ): ValidationResponse<GetValueFormType> {
-          const message =
-            err instanceof Error ? err.message : typeof err === 'string' ? err : 'Validator threw'
-          return {
-            data: undefined,
-            errors: [
-              {
-                message,
-                path: [...errPath],
-                formKey,
-                code: AttaformErrorCode.ValidatorThrew,
-              },
-            ],
-            success: false,
-            formKey,
-          }
-        }
-
-        function pathNotFound(p: Path): ValidationResponse<GetValueFormType> {
-          return {
-            data: undefined,
-            errors: [
-              {
-                message: `Path '${p.join(PATH_SEPARATOR)}' did not resolve to any schema`,
-                path: [...p],
-                formKey,
-                code: AttaformErrorCode.PathNotFound,
-              },
-            ],
-            success: false,
-            formKey,
-          }
-        }
-      },
-    }
-  }
+    },
+  } as unknown as AbstractSchema<unknown, GetValueFormType>
 }
 
 // Per-rootSchema cache of path → payload maps. Build is a single

--- a/src/runtime/adapters/zod-v4/introspect.ts
+++ b/src/runtime/adapters/zod-v4/introspect.ts
@@ -384,12 +384,96 @@ export function assertZodVersion(schema: unknown): void {
 }
 
 /**
+ * Generalized depth-first walk over Zod v4's schema tree. The visitor
+ * decides per-node whether the predicate fires; this walker handles
+ * recursion through every descendable `def.*` child (innerType, element,
+ * pipe in/out, intersection sides, record key/value, object shape, DU
+ * entries, union options, tuple items, lazy getter).
+ *
+ * First `visit(node) === true` short-circuits the whole walk. The
+ * shared `WeakSet<object>` guards against cycles (lazy schemas whose
+ * resolver returns the SAME instance on repeat calls). The lazy
+ * resolver invocation is wrapped in try/catch because some
+ * recursively-defined schemas throw before their inner is constructed
+ * — treated as no-match for that branch and walk continues.
+ *
+ * Three top-level predicates (`containsAsyncRefine`,
+ * `containsAsyncTransform`, `hasContainerOrRootRefine`) all express
+ * "walk the tree, short-circuit on first hit" — the walker hosts that
+ * shape once, the predicates contribute only the per-node test.
+ */
+export function walkSchemaTree(
+  schema: z.ZodType,
+  visit: (node: z.ZodType) => boolean,
+  seen?: WeakSet<object>
+): boolean {
+  const visited = seen ?? new WeakSet<object>()
+  // Defensive guard: sub-adapters cast through `as` and a malformed leaf
+  // could land here as a non-object. The TS signature claims object, but
+  // runtime safety beats the conditional-narrowing lint complaint.
+  const candidate = schema as unknown
+  if (typeof candidate !== 'object' || candidate === null) return false
+  if (visited.has(candidate)) return false
+  visited.add(candidate)
+
+  if (visit(schema)) return true
+
+  const def = readDef(schema)
+  if (def === undefined) return false
+
+  if (def.innerType !== undefined && walkSchemaTree(def.innerType as z.ZodType, visit, visited)) {
+    return true
+  }
+  if (def.element !== undefined && walkSchemaTree(def.element as z.ZodType, visit, visited)) {
+    return true
+  }
+  if (def.in !== undefined && walkSchemaTree(def.in as z.ZodType, visit, visited)) return true
+  if (def.out !== undefined && walkSchemaTree(def.out as z.ZodType, visit, visited)) return true
+  if (def.left !== undefined && walkSchemaTree(def.left as z.ZodType, visit, visited)) return true
+  if (def.right !== undefined && walkSchemaTree(def.right as z.ZodType, visit, visited)) return true
+  if (def.keyType !== undefined && walkSchemaTree(def.keyType as z.ZodType, visit, visited)) {
+    return true
+  }
+  if (def.valueType !== undefined && walkSchemaTree(def.valueType as z.ZodType, visit, visited)) {
+    return true
+  }
+  if (def.shape !== undefined) {
+    for (const sub of Object.values(def.shape)) {
+      if (walkSchemaTree(sub as z.ZodType, visit, visited)) return true
+    }
+  }
+  if (def.entries !== undefined) {
+    for (const sub of Object.values(def.entries)) {
+      if (walkSchemaTree(sub as z.ZodType, visit, visited)) return true
+    }
+  }
+  if (def.options !== undefined) {
+    for (const sub of def.options) {
+      if (walkSchemaTree(sub as z.ZodType, visit, visited)) return true
+    }
+  }
+  if (def.items !== undefined) {
+    for (const sub of def.items) {
+      if (walkSchemaTree(sub as z.ZodType, visit, visited)) return true
+    }
+  }
+  if (typeof def.getter === 'function') {
+    try {
+      const inner = def.getter() as z.ZodType
+      if (walkSchemaTree(inner, visit, visited)) return true
+    } catch {
+      // Lazy schemas may throw on resolution before their referenced
+      // schema is constructed; treat as no match and continue.
+    }
+  }
+
+  return false
+}
+
+/**
  * True iff any refinement check on the schema (or any descendant
- * subschema) is async. Detection: walks the tree once, peeling
- * wrappers (optional/nullable/default/readonly/catch/pipe), descending
- * into containers (object props, array element, tuple items, union
- * options, intersection sides, lazy getter, record key/value), and
- * inspecting each `def.checks[].def.fn` for
+ * subschema) is async. Detection: walks the tree once via
+ * `walkSchemaTree`, inspecting each `def.checks[].def.fn` for
  * `constructor.name === 'AsyncFunction'`. Direct `async (v) => …`
  * refinements are caught; sync functions that happen to return a
  * Promise (rare; we'd recommend marking them `async`) are NOT.
@@ -402,78 +486,16 @@ export function assertZodVersion(schema: unknown): void {
  * precise) and cost only one extra microtask of validation work.
  */
 export function containsAsyncRefine(schema: z.ZodType, seen?: WeakSet<object>): boolean {
-  const visited = seen ?? new WeakSet<object>()
-  // Defensive guard: sub-adapters cast through `as` and a malformed leaf
-  // could land here as a non-object. The TS signature claims object, but
-  // runtime safety beats the conditional-narrowing lint complaint.
-  const candidate = schema as unknown
-  if (typeof candidate !== 'object' || candidate === null) return false
-  if (visited.has(candidate)) return false
-  visited.add(candidate)
-
-  const checks = getChecks(schema)
-  for (const check of checks) {
-    if (isAsyncCheck(check)) return true
-  }
-
-  const def = readDef(schema)
-  if (def === undefined) return false
-
-  if (def.innerType !== undefined && containsAsyncRefine(def.innerType as z.ZodType, visited)) {
-    return true
-  }
-  if (def.element !== undefined && containsAsyncRefine(def.element as z.ZodType, visited)) {
-    return true
-  }
-  if (def.in !== undefined && containsAsyncRefine(def.in as z.ZodType, visited)) {
-    return true
-  }
-  if (def.out !== undefined && containsAsyncRefine(def.out as z.ZodType, visited)) {
-    return true
-  }
-  if (def.left !== undefined && containsAsyncRefine(def.left as z.ZodType, visited)) {
-    return true
-  }
-  if (def.right !== undefined && containsAsyncRefine(def.right as z.ZodType, visited)) {
-    return true
-  }
-  if (def.keyType !== undefined && containsAsyncRefine(def.keyType as z.ZodType, visited)) {
-    return true
-  }
-  if (def.valueType !== undefined && containsAsyncRefine(def.valueType as z.ZodType, visited)) {
-    return true
-  }
-  if (def.shape !== undefined) {
-    for (const sub of Object.values(def.shape)) {
-      if (containsAsyncRefine(sub as z.ZodType, visited)) return true
-    }
-  }
-  if (def.entries !== undefined) {
-    for (const sub of Object.values(def.entries)) {
-      if (containsAsyncRefine(sub as z.ZodType, visited)) return true
-    }
-  }
-  if (def.options !== undefined) {
-    for (const sub of def.options) {
-      if (containsAsyncRefine(sub as z.ZodType, visited)) return true
-    }
-  }
-  if (def.items !== undefined) {
-    for (const sub of def.items) {
-      if (containsAsyncRefine(sub as z.ZodType, visited)) return true
-    }
-  }
-  if (typeof def.getter === 'function') {
-    try {
-      const inner = def.getter() as z.ZodType
-      if (containsAsyncRefine(inner, visited)) return true
-    } catch {
-      // Lazy schemas may throw on resolution before their referenced
-      // schema is constructed; treat as no async refine and move on.
-    }
-  }
-
-  return false
+  return walkSchemaTree(
+    schema,
+    (node) => {
+      for (const check of getChecks(node)) {
+        if (isAsyncCheck(check)) return true
+      }
+      return false
+    },
+    seen
+  )
 }
 
 /**
@@ -494,101 +516,31 @@ export function containsAsyncRefine(schema: z.ZodType, seen?: WeakSet<object>): 
  *
  * Bias conservative: a missed wrapper variant or an exotic `def`
  * shape we don't yet recognise returns false ONLY for that node,
- * but the recursive descent continues, so a container refine
+ * but `walkSchemaTree`'s descent continues, so a container refine
  * nested inside still triggers `true`. Unknown wrappers we forget
  * to peel only lose the perf win, never correctness.
  */
 export function hasContainerOrRootRefine(schema: z.ZodType, seen?: WeakSet<object>): boolean {
-  const visited = seen ?? new WeakSet<object>()
-  const candidate = schema as unknown
-  if (typeof candidate !== 'object' || candidate === null) return false
-  if (visited.has(candidate)) return false
-  visited.add(candidate)
-
-  const def = readDef(schema)
-  if (def === undefined) return false
-
-  // A node is a "container" iff it owns descendable structure. Refines
-  // / checks on such a node fire only when the container is the parse
-  // scope — a leaf-scoped subtree pass beneath it never re-runs them.
-  const isContainer =
-    def.shape !== undefined ||
-    def.entries !== undefined ||
-    def.element !== undefined ||
-    def.options !== undefined ||
-    def.items !== undefined ||
-    def.keyType !== undefined ||
-    def.valueType !== undefined ||
-    def.left !== undefined ||
-    def.right !== undefined
-
-  if (isContainer) {
-    const checks = getChecks(schema)
-    if (checks.length > 0) return true
-  }
-
-  if (
-    def.innerType !== undefined &&
-    hasContainerOrRootRefine(def.innerType as z.ZodType, visited)
-  ) {
-    return true
-  }
-  if (def.element !== undefined && hasContainerOrRootRefine(def.element as z.ZodType, visited)) {
-    return true
-  }
-  if (def.in !== undefined && hasContainerOrRootRefine(def.in as z.ZodType, visited)) {
-    return true
-  }
-  if (def.out !== undefined && hasContainerOrRootRefine(def.out as z.ZodType, visited)) {
-    return true
-  }
-  if (def.left !== undefined && hasContainerOrRootRefine(def.left as z.ZodType, visited)) {
-    return true
-  }
-  if (def.right !== undefined && hasContainerOrRootRefine(def.right as z.ZodType, visited)) {
-    return true
-  }
-  if (def.keyType !== undefined && hasContainerOrRootRefine(def.keyType as z.ZodType, visited)) {
-    return true
-  }
-  if (
-    def.valueType !== undefined &&
-    hasContainerOrRootRefine(def.valueType as z.ZodType, visited)
-  ) {
-    return true
-  }
-  if (def.shape !== undefined) {
-    for (const sub of Object.values(def.shape)) {
-      if (hasContainerOrRootRefine(sub as z.ZodType, visited)) return true
-    }
-  }
-  if (def.entries !== undefined) {
-    for (const sub of Object.values(def.entries)) {
-      if (hasContainerOrRootRefine(sub as z.ZodType, visited)) return true
-    }
-  }
-  if (def.options !== undefined) {
-    for (const sub of def.options) {
-      if (hasContainerOrRootRefine(sub as z.ZodType, visited)) return true
-    }
-  }
-  if (def.items !== undefined) {
-    for (const sub of def.items) {
-      if (hasContainerOrRootRefine(sub as z.ZodType, visited)) return true
-    }
-  }
-  if (typeof def.getter === 'function') {
-    try {
-      const inner = def.getter() as z.ZodType
-      if (hasContainerOrRootRefine(inner, visited)) return true
-    } catch {
-      // Lazy schemas may throw before their inner is constructed;
-      // treat as no detection and let the caller's conservative
-      // default apply.
-    }
-  }
-
-  return false
+  return walkSchemaTree(
+    schema,
+    (node) => {
+      const def = readDef(node)
+      if (def === undefined) return false
+      const isContainer =
+        def.shape !== undefined ||
+        def.entries !== undefined ||
+        def.element !== undefined ||
+        def.options !== undefined ||
+        def.items !== undefined ||
+        def.keyType !== undefined ||
+        def.valueType !== undefined ||
+        def.left !== undefined ||
+        def.right !== undefined
+      if (!isContainer) return false
+      return getChecks(node).length > 0
+    },
+    seen
+  )
 }
 
 /**
@@ -610,76 +562,17 @@ export function hasContainerOrRootRefine(schema: z.ZodType, seen?: WeakSet<objec
  * to the post-mount `safeParseAsync` pass.
  */
 export function containsAsyncTransform(schema: z.ZodType, seen?: WeakSet<object>): boolean {
-  const visited = seen ?? new WeakSet<object>()
-  const candidate = schema as unknown
-  if (typeof candidate !== 'object' || candidate === null) return false
-  if (visited.has(candidate)) return false
-  visited.add(candidate)
-
-  const def = readDef(schema)
-  if (def === undefined) return false
-
-  if (
-    typeof def.transform === 'function' &&
-    (def.transform as { constructor: { name: string } }).constructor.name === 'AsyncFunction'
-  ) {
-    return true
-  }
-
-  if (def.innerType !== undefined && containsAsyncTransform(def.innerType as z.ZodType, visited)) {
-    return true
-  }
-  if (def.element !== undefined && containsAsyncTransform(def.element as z.ZodType, visited)) {
-    return true
-  }
-  if (def.in !== undefined && containsAsyncTransform(def.in as z.ZodType, visited)) {
-    return true
-  }
-  if (def.out !== undefined && containsAsyncTransform(def.out as z.ZodType, visited)) {
-    return true
-  }
-  if (def.left !== undefined && containsAsyncTransform(def.left as z.ZodType, visited)) {
-    return true
-  }
-  if (def.right !== undefined && containsAsyncTransform(def.right as z.ZodType, visited)) {
-    return true
-  }
-  if (def.keyType !== undefined && containsAsyncTransform(def.keyType as z.ZodType, visited)) {
-    return true
-  }
-  if (def.valueType !== undefined && containsAsyncTransform(def.valueType as z.ZodType, visited)) {
-    return true
-  }
-  if (def.shape !== undefined) {
-    for (const sub of Object.values(def.shape)) {
-      if (containsAsyncTransform(sub as z.ZodType, visited)) return true
-    }
-  }
-  if (def.entries !== undefined) {
-    for (const sub of Object.values(def.entries)) {
-      if (containsAsyncTransform(sub as z.ZodType, visited)) return true
-    }
-  }
-  if (def.options !== undefined) {
-    for (const sub of def.options) {
-      if (containsAsyncTransform(sub as z.ZodType, visited)) return true
-    }
-  }
-  if (def.items !== undefined) {
-    for (const sub of def.items) {
-      if (containsAsyncTransform(sub as z.ZodType, visited)) return true
-    }
-  }
-  if (typeof def.getter === 'function') {
-    try {
-      const inner = def.getter() as z.ZodType
-      if (containsAsyncTransform(inner, visited)) return true
-    } catch {
-      // Lazy schemas may throw on resolution; treat as no async transform.
-    }
-  }
-
-  return false
+  return walkSchemaTree(
+    schema,
+    (node) => {
+      const def = readDef(node)
+      if (def === undefined) return false
+      const fn = def.transform
+      if (typeof fn !== 'function') return false
+      return (fn as { constructor: { name: string } }).constructor.name === 'AsyncFunction'
+    },
+    seen
+  )
 }
 
 interface ZodCheckInternals {

--- a/src/runtime/adapters/zod-v4/introspect.ts
+++ b/src/runtime/adapters/zod-v4/introspect.ts
@@ -273,6 +273,18 @@ export function isCoercePrimitive(schema: z.ZodType): boolean {
   return readDef(schema)?.coerce === true
 }
 
+/**
+ * Detect `z.preprocess(fn, inner)` — v4 desugars this to a pipe whose
+ * `def.in` is a `ZodTransform`. The factory's `isPreprocessOrCoerceLeaf`
+ * consults this alongside `isCoercePrimitive` to gate raw consumer
+ * writes verbatim through the wrapped subtree.
+ */
+export function isPreprocessNode(schema: z.ZodType): boolean {
+  if (kindOf(schema) !== 'pipe') return false
+  const pipeIn = unwrapPipeIn(schema)
+  return pipeIn !== undefined && kindOf(pipeIn) === 'transform'
+}
+
 /** Output side of a pipe — the inner schema in `z.preprocess(fn, inner)`. */
 export function unwrapPipeOut(schema: z.ZodType): z.ZodType | undefined {
   const def = readDef(schema)

--- a/src/runtime/adapters/zod-v4/slim-primitives.ts
+++ b/src/runtime/adapters/zod-v4/slim-primitives.ts
@@ -11,6 +11,7 @@
  */
 import type { z } from 'zod'
 import type { SlimPrimitiveKind } from '../../types/types-api'
+import { slimKindOf } from '../../core/slim-primitive-gate'
 import {
   getEnumValues,
   getIntersectionLeft,
@@ -138,7 +139,7 @@ function walk(
     case 'literal': {
       const values = getLiteralValues(schema)
       const out = new Set<SlimPrimitiveKind>()
-      for (const v of values) out.add(slimKindOfRaw(v))
+      for (const v of values) out.add(slimKindOf(v))
       return out.size === 0 ? PERMISSIVE : out
     }
     case 'object':
@@ -232,33 +233,5 @@ function walk(
       return PERMISSIVE
     default:
       return PERMISSIVE
-  }
-}
-
-function slimKindOfRaw(value: unknown): SlimPrimitiveKind {
-  if (value === null) return 'null'
-  if (value === undefined) return 'undefined'
-  if (Array.isArray(value)) return 'array'
-  if (value instanceof Date) return 'date'
-  const t = typeof value
-  switch (t) {
-    case 'string':
-      return 'string'
-    case 'number':
-      return 'number'
-    case 'boolean':
-      return 'boolean'
-    case 'bigint':
-      return 'bigint'
-    case 'symbol':
-      return 'symbol'
-    case 'undefined':
-      return 'undefined'
-    case 'object':
-      return 'object'
-    case 'function':
-      return 'function'
-    default:
-      return 'object'
   }
 }

--- a/src/runtime/core/abstract-schema-factory.ts
+++ b/src/runtime/core/abstract-schema-factory.ts
@@ -214,13 +214,16 @@ export interface AbstractSchemaServices<Schema, Form, GetValueFormType> {
    */
   getNestedSchemasAtPath(schema: Schema, path: Path, maxRecursionDepth: number): Schema[]
   /**
-   * v3 strips refinements / defaults before walking for slim-kind
-   * queries (`getSlimPrimitiveTypesAtPath`); v4 walks the original
-   * schema. Both eventually feed `slimPrimitivesOf` per candidate;
-   * this service exists so each adapter controls its own pre-walk
-   * normalisation.
+   * "Slim-mode" path walk — the variant `getSlimPrimitiveTypesAtPath`
+   * and `getSchemasAtPath` consume. v3 strips refinements / defaults /
+   * optional / nullable / effects off the root before walking, so the
+   * yielded candidates reflect the slim shape (matches what the slim-
+   * primitive gate sees and what consumers expect when introspecting
+   * sub-schemas). v4 walks the original schema and aliases this to
+   * `getNestedSchemasAtPath` — its path walker already inlines the
+   * wrapper peeling.
    */
-  getNestedSchemasForSlimQuery(schema: Schema, path: Path, maxRecursionDepth: number): Schema[]
+  getNestedSchemasInSlimMode(schema: Schema, path: Path, maxRecursionDepth: number): Schema[]
   /** Returns the slim-primitive accept-set of a single sub-schema. */
   slimPrimitivesOf(schema: Schema, maxRecursionDepth: number): Set<SlimPrimitiveKind>
   /**
@@ -467,7 +470,13 @@ export function createAbstractSchema<Schema, Form, GetValueFormType>(
     },
 
     getSchemasAtPath(path) {
-      const resolved = services.getNestedSchemasAtPath(rootSchema, path, maxRecursionDepth)
+      // Slim-mode walk: v3 strips refinements / defaults / wrappers off
+      // the root so the yielded sub-schemas reflect the slim shape (the
+      // shape the slim-primitive gate consults). v4 aliases the slim
+      // and unstripped walks to the same call. The factory uses one
+      // hook for both `getSlimPrimitiveTypesAtPath` and
+      // `getSchemasAtPath` — same v3 strip semantic, same v4 alias.
+      const resolved = services.getNestedSchemasInSlimMode(rootSchema, path, maxRecursionDepth)
       // Empty list is a valid result for paths the schema doesn't
       // declare — callers (getValue / register / custom introspection)
       // treat `[]` as "no sub-schema here". No warning needed.
@@ -478,7 +487,7 @@ export function createAbstractSchema<Schema, Form, GetValueFormType>(
     getSlimPrimitiveTypesAtPath(path): Set<SlimPrimitiveKind> {
       // Empty path is the root form: always an object.
       if (path.length === 0) return new Set<SlimPrimitiveKind>(['object'])
-      const resolved = services.getNestedSchemasForSlimQuery(rootSchema, path, maxRecursionDepth)
+      const resolved = services.getNestedSchemasInSlimMode(rootSchema, path, maxRecursionDepth)
       // Path doesn't resolve in the schema → no kinds accepted. The
       // gate's membership check rejects every kind against an empty
       // set, blocking writes to typo / unknown paths.

--- a/src/runtime/core/abstract-schema-factory.ts
+++ b/src/runtime/core/abstract-schema-factory.ts
@@ -1,0 +1,719 @@
+/**
+ * `createAbstractSchema` — the schema-agnostic factory that hosts every
+ * `AbstractSchema` method whose implementation is identical-modulo-
+ * introspector between the v3 and v4 adapters.
+ *
+ * Each adapter wires through two small contracts:
+ *
+ *   - `SchemaIntrospector<Schema>` — pure, side-effect-free accessors
+ *     that read schema shape. The factory branches on `kindOf`, walks
+ *     discriminated-union literals via `getLiteralValues` /
+ *     `getDiscriminatedOptions`, detects coerce / preprocess nodes,
+ *     and consults the three async / container-refine flags.
+ *
+ *   - `AbstractSchemaServices<Schema, Form, GetValueFormType>` — the
+ *     adapter-specific delegates the factory calls for everything that
+ *     genuinely diverges per Zod version: fingerprinting, path-walking
+ *     (the path walker itself has v3 / v4 quirks), default-value
+ *     derivation, the strict-mode `getDefaultValues` flow,
+ *     wrapper-peeling that's tied to the per-version wrapper set,
+ *     field-meta resolution, and the per-version `safeParse`
+ *     boundary.
+ *
+ * The two-interface split keeps the introspector reusable by any other
+ * walker (fingerprint, slim-primitives, default-values) without dragging
+ * in the side-effectful services. Services consume the introspector as
+ * they wish; the factory consumes both.
+ *
+ * Behavior-neutral by design: the goal is one set of definitions for
+ * the 13 structurally-parallel methods, with no observable change at
+ * either adapter's `AbstractSchema` surface. Per-adapter caches keep
+ * the same lifetime (one per `useForm()` call); `getSchemasAtPath`
+ * preserves each adapter's prior sub-schema shape via the
+ * `makeSubSchema` service (v3 recurses; v4 builds the 5-method stub).
+ */
+import type {
+  AbstractSchema,
+  DefaultValuesResponse,
+  FormKey,
+  GetDefaultValuesConfig,
+  ResolvedFieldMeta,
+  SlimPrimitiveKind,
+  UnionDiscriminatorContext,
+  ValidationError,
+  ValidationResponse,
+  ValidateOptions,
+} from '../types/types-api'
+import type { SchemaFactoryOptions } from './get-computed-schema'
+import { AttaformErrorCode } from './error-codes'
+import { canonicalizePath, type Path, type PathKey } from './paths'
+
+const PATH_SEPARATOR = '.'
+
+/**
+ * Stable shape-discriminant the factory branches on. Adapters return
+ * the union of v3 + v4 kinds plus `'unknown'` for anything they don't
+ * recognise — the factory only inspects a small subset
+ * (`'tuple'` / `'array'` for `arrayShapeAtPath`,
+ * `'literal'` for the discriminated-union walk), so adapters can return
+ * extra version-specific kinds (`'effects'` / `'pipeline'` / `'branded'`
+ * / `'native-enum'` on v3) without confusing the factory.
+ */
+export type SharedZodKind =
+  | 'string'
+  | 'number'
+  | 'boolean'
+  | 'bigint'
+  | 'date'
+  | 'null'
+  | 'undefined'
+  | 'literal'
+  | 'enum'
+  | 'native-enum'
+  | 'object'
+  | 'array'
+  | 'tuple'
+  | 'set'
+  | 'record'
+  | 'map'
+  | 'union'
+  | 'discriminated-union'
+  | 'intersection'
+  | 'optional'
+  | 'nullable'
+  | 'default'
+  | 'catch'
+  | 'readonly'
+  | 'branded'
+  | 'effects'
+  | 'pipeline'
+  | 'lazy'
+  | 'pipe'
+  | 'transform'
+  | 'preprocess'
+  | 'any'
+  | 'unknown'
+  | 'never'
+  | 'nan'
+  | 'void'
+  | 'file'
+  | 'function'
+  | 'symbol'
+  | 'promise'
+  | 'custom'
+  | 'template-literal'
+
+/**
+ * Pure schema-shape accessors. The factory consults these to branch on
+ * structural facts about a schema node. Every member is side-effect-
+ * free and idempotent.
+ *
+ * `kindOf` returns the discriminant; the structural accessors
+ * (`getObjectShape`, `getTupleItems`, `getDiscriminatedOptions`,
+ * `getLiteralValues`) read a single field of the node's def shape.
+ * The three boolean predicates summarise tree-walking detections each
+ * adapter already exposes; both adapters memoise them at the
+ * AbstractSchema level so calling per construction is cheap.
+ */
+export interface SchemaIntrospector<Schema> {
+  /** Discriminant on schema shape. Adapters may return extra kinds. */
+  kindOf(schema: Schema): SharedZodKind | string
+  /**
+   * Returns the property-to-sub-schema map of a `ZodObject`. Empty
+   * record for non-objects.
+   */
+  getObjectShape(schema: Schema): Record<string, Schema>
+  /** Returns the position-typed items of a `ZodTuple`. Empty for non-tuples. */
+  getTupleItems(schema: Schema): readonly Schema[]
+  /**
+   * Returns the option objects of a `ZodDiscriminatedUnion` — each one
+   * is itself a `ZodObject` whose `getObjectShape` includes the
+   * discriminator key as a `ZodLiteral`.
+   */
+  getDiscriminatedOptions(schema: Schema): readonly Schema[]
+  /** Returns the discriminator key of a `ZodDiscriminatedUnion`. */
+  getDiscriminator(schema: Schema): string | undefined
+  /**
+   * Returns the literal values a `ZodLiteral` admits. Multi-value
+   * literals (`z.literal(['a', 'b'])`) return both; single-value return
+   * the one. Empty for non-literals.
+   */
+  getLiteralValues(schema: Schema): readonly unknown[]
+  /**
+   * True iff the node is a preprocess-style schema-side normalizer:
+   * `z.preprocess(fn, inner)` in either version. v3's `ZodEffects`
+   * with `effect.type === 'preprocess'` and v4's `ZodPipe<ZodTransform,
+   * inner>` both collapse here. Coerce primitives go through
+   * `isCoercePrimitive` instead — they're not pipes in v4 and not
+   * effects in v3, but both adapters detect them off the same flag.
+   */
+  isPreprocessNode(schema: Schema): boolean
+  /**
+   * True iff the schema is a `z.coerce.X()` primitive. Both adapter
+   * versions store the coerce intent as a flag on the wrapped
+   * primitive's def (not as a wrapper), so detection is uniform.
+   */
+  isCoercePrimitive(schema: Schema): boolean
+  /**
+   * True iff the schema tree contains a refine whose predicate can run
+   * asynchronously. v3 is conservative (every `.refine` flagged because
+   * the inner sync wrapper hides the user fn); v4 is exact (inspects
+   * `def.checks[].def.fn.constructor.name`). Either way the runtime
+   * uses this to decide whether a construction-time async pass is
+   * needed.
+   */
+  containsAsyncRefine(schema: Schema): boolean
+  /**
+   * True iff the schema tree contains a `.transform(asyncFn)` /
+   * `z.preprocess(asyncFn, …)`. Statically detectable in both adapters
+   * via the user fn's `constructor.name === 'AsyncFunction'`. Disjoint
+   * from `containsAsyncRefine` — refines and transforms live in
+   * different slots.
+   */
+  containsAsyncTransform(schema: Schema): boolean
+  /**
+   * True iff any refine fires at a container node (object / array /
+   * tuple / union / discriminated-union / intersection / record / set)
+   * or the root. False means every refine is leaf-local, so per-keystroke
+   * subtree validation catches the same verdicts as a whole-form pass.
+   */
+  hasContainerOrRootRefine(schema: Schema): boolean
+}
+
+/**
+ * Adapter-specific delegates the factory calls for operations that
+ * genuinely differ per Zod version (path walking, default-value
+ * derivation, wrapper-peeling, error normalization, sub-schema
+ * construction). Each service is a thin wrapper around per-adapter
+ * helpers; the factory composes them.
+ *
+ * `safeParseSync` / `safeParseAsync` abstract the per-version
+ * `safeParse` / `safeParseAsync` calls so the factory can stay
+ * version-agnostic. Both return a uniform success-discriminant shape;
+ * `safeParseSync` is allowed to throw when the schema is async-only
+ * (the factory catches and falls back to the async path).
+ *
+ * `makeSubSchema` is the per-adapter sub-schema constructor for
+ * `getSchemasAtPath`. v3 recurses through the full adapter factory
+ * (sub-schemas expose the entire `AbstractSchema` surface). v4 builds
+ * a 5-method stub (fingerprint / needsAsyncValidation /
+ * getDefaultValues / getSchemasAtPath / validateAtPath) because none
+ * of its consumers reach for the wider surface and the stub keeps
+ * sub-walker allocation cheap. The factory preserves each adapter's
+ * prior behavior by routing through this service rather than hard-
+ * coding one strategy.
+ */
+export interface AbstractSchemaServices<Schema, Form, GetValueFormType> {
+  /** Returns the deterministic structural fingerprint of the schema. */
+  fingerprint(schema: Schema): string
+  /**
+   * Returns every sub-schema reachable at the given path. Multiple
+   * results indicate a union / discriminated-union split; empty
+   * indicates the path doesn't resolve. Adapters cap descent through
+   * `z.lazy(...)` via `maxRecursionDepth`.
+   */
+  getNestedSchemasAtPath(schema: Schema, path: Path, maxRecursionDepth: number): Schema[]
+  /**
+   * v3 strips refinements / defaults before walking for slim-kind
+   * queries (`getSlimPrimitiveTypesAtPath`); v4 walks the original
+   * schema. Both eventually feed `slimPrimitivesOf` per candidate;
+   * this service exists so each adapter controls its own pre-walk
+   * normalisation.
+   */
+  getNestedSchemasForSlimQuery(schema: Schema, path: Path, maxRecursionDepth: number): Schema[]
+  /** Returns the slim-primitive accept-set of a single sub-schema. */
+  slimPrimitivesOf(schema: Schema, maxRecursionDepth: number): Set<SlimPrimitiveKind>
+  /**
+   * Returns the schema's prescribed default at the given root. The
+   * runtime calls this in `getDefaultAtPath` (`useDefault=true` — honor
+   * `.default(x)`) and `getEmptyValueAtPath` (`useDefault=false` —
+   * yield the inner-schema's falsy concrete). v3 and v4 each implement
+   * their own walker; the factory only consumes the result.
+   */
+  deriveDefault(
+    schema: Schema,
+    useDefault: boolean,
+    maxRecursionDepth: number,
+    formKey: FormKey
+  ): unknown
+  /**
+   * Adapter-owned construction-time default-values flow. v3 runs a
+   * validate-then-fix loop against a slim schema with strict-mode
+   * refine seeding; v4 runs a strict-pass-or-lax-success against the
+   * derived data. Both honour `config.strict ?? true` and
+   * `config.constraints`.
+   */
+  runStrictGetDefaults(
+    schema: Schema,
+    config: GetDefaultValuesConfig<Form>,
+    formKey: FormKey,
+    maxRecursionDepth: number
+  ): DefaultValuesResponse<Form>
+  /**
+   * Peels `.optional()` / `.nullable()` only when the inner is
+   * structurally fillable (object / array / tuple / record /
+   * union / intersection or a chain of peelable wrappers that resolve
+   * to one of those). Used by `getDefaultAtPath` so partial writes
+   * through optional sub-schemas fill from the inner shape's defaults.
+   * `.default(x)` is preserved at every layer.
+   */
+  unwrapStructuralWrappers(schema: Schema): Schema
+  /**
+   * Peels every transparent wrapper (optional / nullable / default /
+   * readonly / catch / pipe / lazy / branded / effects) and descends
+   * intersection sides looking for a single discriminated union.
+   * Returns the matching DU or `undefined` when no DU is found or
+   * when ambiguity bails (two different DUs both reachable).
+   */
+  unwrapToDiscriminatedUnion(schema: Schema): Schema | undefined
+  /**
+   * Peels every transparent wrapper off a schema — for `arrayShapeAtPath`
+   * the goal is the structural kind regardless of default-value
+   * semantics, so `.default(x)` / `.catch(x)` are peeled here whereas
+   * `unwrapStructuralWrappers` preserves them.
+   */
+  peelAllWrappers(schema: Schema): Schema
+  /**
+   * Returns `true` iff the leaf schema is "required" at the
+   * union-aware sense documented on `AbstractSchema.isRequiredAtPath`:
+   * `.optional()` / `.nullable()` / `.default()` / `.catch()` at any
+   * wrapper layer make the leaf permissive; union requires every
+   * branch; intersection requires either side.
+   */
+  isLeafRequired(schema: Schema): boolean
+  /** Returns the resolved field-meta payload for the schema at `path`. */
+  resolveFieldMetaAtPath(schema: Schema, path: Path, maxRecursionDepth: number): ResolvedFieldMeta
+  /**
+   * Normalise schema-library issues into the runtime's
+   * `ValidationError[]` shape. v3 and v4 have slightly different
+   * `ZodIssue` payloads; each adapter knows how to map its own.
+   */
+  issuesToValidationErrors(issues: readonly unknown[], formKey: FormKey): ValidationError[]
+  /**
+   * Run a sync `safeParse` against the schema. Returns a tagged result
+   * the factory aggregates into a `ValidationResponse`. MAY throw when
+   * the schema contains async-only refines / transforms (the factory
+   * catches and falls back to the async path).
+   */
+  safeParseSync(
+    schema: Schema,
+    data: unknown
+  ): { success: true; data: unknown } | { success: false; issues: readonly unknown[] }
+  /** Async sister of `safeParseSync`. MUST NOT throw (catch user-fn rejections). */
+  safeParseAsync(
+    schema: Schema,
+    data: unknown
+  ): Promise<{ success: true; data: unknown } | { success: false; issues: readonly unknown[] }>
+  /**
+   * Per-adapter sub-schema constructor for `getSchemasAtPath`. v3
+   * recurses through the full factory (sub-schemas carry the entire
+   * `AbstractSchema` surface). v4 returns a 5-method stub. The factory
+   * delegates here to preserve each adapter's prior shape; consumers
+   * across the runtime only reach for `needsAsyncValidation()` on
+   * sub-schemas, so both shapes are observationally interchangeable.
+   */
+  makeSubSchema(
+    schema: Schema,
+    formKey: FormKey,
+    maxRecursionDepth: number
+  ): AbstractSchema<unknown, GetValueFormType>
+}
+
+/**
+ * Build a runtime `AbstractSchema` for `rootSchema` by composing the
+ * shared uniform-method implementations with the per-adapter introspector
+ * + services. Each adapter calls this once per `useForm({ schema })` —
+ * the returned object plus its three caches (`leafCache`,
+ * `preprocessOrCoerceCache`, `discriminatorCache`) plus the two memoised
+ * lazy flags live for the form's lifetime.
+ */
+export function createAbstractSchema<Schema, Form, GetValueFormType>(
+  rootSchema: Schema,
+  intro: SchemaIntrospector<Schema>,
+  services: AbstractSchemaServices<Schema, Form, GetValueFormType>,
+  formKey: FormKey,
+  options: SchemaFactoryOptions
+): AbstractSchema<Form, GetValueFormType> {
+  const maxRecursionDepth = options.maxRecursionDepth
+
+  // Per-adapter caches. Lifetime = one `createAbstractSchema` call (one
+  // per `useForm()`). These memoise the schema walks that the proxy
+  // traps + reactive computeds hit on every read so the schema doesn't
+  // get re-walked per keystroke / per field-state get.
+  const leafCache = new Map<PathKey, boolean>()
+  const preprocessOrCoerceCache = new Map<PathKey, boolean>()
+  const discriminatorCache = new Map<PathKey, UnionDiscriminatorContext | undefined>()
+  // Memoised one-shot tree walks. `needsAsyncValidation` is queried at
+  // construction by the store (drives the construction-time async seed);
+  // `hasContainerOrRootRefine` is queried per keystroke (drives the
+  // subtree-vs-whole-form scope cut).
+  let asyncValidationFlag: boolean | null = null
+  let containerRefineFlag: boolean | null = null
+
+  function computeDiscriminator(path: Path): UnionDiscriminatorContext | undefined {
+    const candidates =
+      path.length === 0
+        ? [rootSchema]
+        : services.getNestedSchemasAtPath(rootSchema, path, maxRecursionDepth)
+    // `unwrapToDiscriminatedUnion` peels every transparent wrapper
+    // (Optional / Nullable / Default / Readonly / Catch / Effects /
+    // Pipeline / Branded) and descends Intersection sides looking for a
+    // single discriminated union. Ambiguous resolutions (two distinct
+    // DUs both reachable across candidates) bail — the runtime then
+    // falls back to a plain write.
+    let matchedUnion: Schema | undefined
+    for (const candidate of candidates) {
+      const du = services.unwrapToDiscriminatedUnion(candidate)
+      if (du === undefined) continue
+      if (matchedUnion !== undefined && matchedUnion !== du) return undefined
+      matchedUnion = du
+    }
+    if (matchedUnion === undefined) return undefined
+    const discKey = intro.getDiscriminator(matchedUnion)
+    if (discKey === undefined) return undefined
+    const unionOptions = intro.getDiscriminatedOptions(matchedUnion)
+    const literalSet = new Set<unknown>()
+    for (const opt of unionOptions) {
+      const shape = intro.getObjectShape(opt)
+      const litSchema = shape[discKey]
+      if (litSchema === undefined) continue
+      if (intro.kindOf(litSchema) !== 'literal') continue
+      // Multi-value literals (`z.literal(['a','b'])`) register every
+      // member as a selectable variant.
+      for (const v of intro.getLiteralValues(litSchema)) literalSet.add(v)
+    }
+    return {
+      discriminatorKey: discKey,
+      getVariantDefault(value: unknown): unknown {
+        for (const opt of unionOptions) {
+          const shape = intro.getObjectShape(opt)
+          const litSchema = shape[discKey]
+          if (litSchema === undefined) continue
+          if (intro.kindOf(litSchema) !== 'literal') continue
+          const literalValues = intro.getLiteralValues(litSchema)
+          if (literalValues.includes(value)) {
+            return services.deriveDefault(opt, true, maxRecursionDepth, formKey)
+          }
+        }
+        return undefined
+      },
+      isVariantSelected(value: unknown): boolean {
+        return literalSet.has(value)
+      },
+    }
+  }
+
+  const abstractSchema: AbstractSchema<Form, GetValueFormType> = {
+    fingerprint: () => services.fingerprint(rootSchema),
+
+    needsAsyncValidation(): boolean {
+      asyncValidationFlag ??=
+        intro.containsAsyncRefine(rootSchema) || intro.containsAsyncTransform(rootSchema)
+      return asyncValidationFlag
+    },
+
+    hasContainerOrRootRefine(): boolean {
+      containerRefineFlag ??= intro.hasContainerOrRootRefine(rootSchema)
+      return containerRefineFlag
+    },
+
+    getDefaultValues(config: GetDefaultValuesConfig<Form>): DefaultValuesResponse<Form> {
+      return services.runStrictGetDefaults(rootSchema, config, formKey, maxRecursionDepth)
+    },
+
+    getDefaultAtPath(path) {
+      // Empty path → root default. Reuses the same generator used at
+      // form construction so refines / wrappers behave consistently.
+      if (path.length === 0) {
+        return services.deriveDefault(rootSchema, true, maxRecursionDepth, formKey)
+      }
+      const [first] = services.getNestedSchemasAtPath(rootSchema, path, maxRecursionDepth)
+      if (first === undefined) return undefined
+      // STRUCTURAL default: peel `.optional()` / `.nullable()` so partial
+      // object writes through optional sub-schemas (`{ profile:
+      // z.object({...}).optional() }`) get the inner shape's defaults
+      // filled in. `.default(x)` is preserved so deriveDefault returns
+      // the explicit default. First candidate matches
+      // `validateAtPath`'s first-success semantic.
+      const peeled = services.unwrapStructuralWrappers(first)
+      return services.deriveDefault(peeled, true, maxRecursionDepth, formKey)
+    },
+
+    getEmptyValueAtPath(path) {
+      // `clear`'s underlying value lookup. Same path-resolution flow as
+      // `getDefaultAtPath` but with `useDefault=false` so `.default(x)`
+      // / `.catch(x)` wrappers are skipped — the walker yields the
+      // inner-schema's empty concrete instead. Structural wrappers
+      // (`.optional()` / `.nullable()`) are NOT peeled: clearing an
+      // `.optional()` slot is legitimately `undefined`, clearing a
+      // `.nullable()` slot is `null`.
+      if (path.length === 0) {
+        return services.deriveDefault(rootSchema, false, maxRecursionDepth, formKey)
+      }
+      const [first] = services.getNestedSchemasAtPath(rootSchema, path, maxRecursionDepth)
+      if (first === undefined) return undefined
+      return services.deriveDefault(first, false, maxRecursionDepth, formKey)
+    },
+
+    arrayShapeAtPath(path) {
+      if (path.length === 0) return undefined
+      const [first] = services.getNestedSchemasAtPath(rootSchema, path, maxRecursionDepth)
+      if (first === undefined) return undefined
+      const peeled = services.peelAllWrappers(first)
+      const kind = intro.kindOf(peeled)
+      if (kind === 'tuple') return intro.getTupleItems(peeled).length
+      if (kind === 'array') return null
+      return undefined
+    },
+
+    getSchemasAtPath(path) {
+      const resolved = services.getNestedSchemasAtPath(rootSchema, path, maxRecursionDepth)
+      // Empty list is a valid result for paths the schema doesn't
+      // declare — callers (getValue / register / custom introspection)
+      // treat `[]` as "no sub-schema here". No warning needed.
+      if (resolved.length === 0) return []
+      return resolved.map((sub) => services.makeSubSchema(sub, formKey, maxRecursionDepth))
+    },
+
+    getSlimPrimitiveTypesAtPath(path): Set<SlimPrimitiveKind> {
+      // Empty path is the root form: always an object.
+      if (path.length === 0) return new Set<SlimPrimitiveKind>(['object'])
+      const resolved = services.getNestedSchemasForSlimQuery(rootSchema, path, maxRecursionDepth)
+      // Path doesn't resolve in the schema → no kinds accepted. The
+      // gate's membership check rejects every kind against an empty
+      // set, blocking writes to typo / unknown paths.
+      if (resolved.length === 0) return new Set<SlimPrimitiveKind>()
+      const out = new Set<SlimPrimitiveKind>()
+      for (const candidate of resolved) {
+        for (const k of services.slimPrimitivesOf(candidate, maxRecursionDepth)) {
+          out.add(k)
+        }
+      }
+      return out
+    },
+
+    isLeafAtPath(path): boolean {
+      const cacheKey = canonicalizePath(path).key
+      const cached = leafCache.get(cacheKey)
+      if (cached !== undefined) return cached
+      const prim = this.getSlimPrimitiveTypesAtPath(path)
+      // Empty set → path doesn't exist in schema → descend permissively
+      // (treat as container so schema-named reserved keys at depth 2+
+      // don't shadow). Any container kind in the set → descend.
+      // Otherwise every kind is a primitive → leaf.
+      const isLeaf =
+        prim.size > 0 &&
+        !prim.has('object') &&
+        !prim.has('array') &&
+        !prim.has('map') &&
+        !prim.has('set')
+      leafCache.set(cacheKey, isLeaf)
+      return isLeaf
+    },
+
+    isPreprocessOrCoerceLeaf(path): boolean {
+      // Walks prefixes of `path` looking for either shape adapters
+      // use for schema-side input normalizers (`z.preprocess(...)` or
+      // `z.coerce.X()`). Returns true at such a node OR anywhere
+      // underneath it; the slim-primitive gate uses this to accept
+      // raw consumer writes verbatim throughout that subtree.
+      const cacheKey = canonicalizePath(path).key
+      const cached = preprocessOrCoerceCache.get(cacheKey)
+      if (cached !== undefined) return cached
+      let hit = false
+      for (let i = 0; i <= path.length && !hit; i++) {
+        const prefix = path.slice(0, i)
+        const candidates: Schema[] =
+          prefix.length === 0
+            ? [rootSchema]
+            : services.getNestedSchemasAtPath(rootSchema, prefix, maxRecursionDepth)
+        for (const candidate of candidates) {
+          if (intro.isCoercePrimitive(candidate) || intro.isPreprocessNode(candidate)) {
+            hit = true
+            break
+          }
+        }
+      }
+      preprocessOrCoerceCache.set(cacheKey, hit)
+      return hit
+    },
+
+    isRequiredAtPath(path): boolean {
+      // Root form is structurally required (it's the parsed object).
+      // The required-empty check tracks primitive leaves only, so this
+      // branch is academic for the call sites that matter.
+      if (path.length === 0) return true
+      const resolved = services.getNestedSchemasAtPath(rootSchema, path, maxRecursionDepth)
+      if (resolved.length === 0) return false
+      // Every candidate must be required for the path overall to be
+      // required — matches the union "any-branch-permissive" rule
+      // when the path traverses a union.
+      return resolved.every((candidate) => services.isLeafRequired(candidate))
+    },
+
+    getFieldMetaAtPath(path): ResolvedFieldMeta {
+      return services.resolveFieldMetaAtPath(rootSchema, path, maxRecursionDepth)
+    },
+
+    getUnionDiscriminatorAtPath(path): UnionDiscriminatorContext | undefined {
+      const cacheKey = canonicalizePath(path).key
+      if (discriminatorCache.has(cacheKey)) {
+        return discriminatorCache.get(cacheKey)
+      }
+      const result = computeDiscriminator(path)
+      discriminatorCache.set(cacheKey, result)
+      return result
+    },
+
+    validateAtPath(
+      data: unknown,
+      path: Path | undefined,
+      validateOptions?: ValidateOptions
+    ): ReturnType<AbstractSchema<Form, GetValueFormType>['validateAtPath']> {
+      // Sync attempt: when `options.sync === true`, try the sync parse.
+      // It throws on async refines / pipes / transforms; we catch and
+      // fall through to the async path. Without the flag the adapter
+      // goes straight to async — the historical contract every non-
+      // reshape callsite expects.
+      const trySync = validateOptions?.sync === true
+      if (trySync) {
+        try {
+          return runSync()
+        } catch {
+          // Async-only schema. Fall through to the async path.
+        }
+      }
+      return runAsync()
+
+      function runSync(): ValidationResponse<GetValueFormType> {
+        if (path === undefined) {
+          const result = services.safeParseSync(rootSchema, data)
+          return result.success
+            ? {
+                data: result.data as GetValueFormType,
+                errors: undefined,
+                success: true,
+                formKey,
+              }
+            : {
+                data: undefined,
+                errors: services.issuesToValidationErrors(result.issues, formKey),
+                success: false,
+                formKey,
+              }
+        }
+        const resolved = services.getNestedSchemasAtPath(rootSchema, path, maxRecursionDepth)
+        if (resolved.length === 0) return pathNotFound(path)
+        const aggregated: ValidationError[] = []
+        for (const candidate of resolved) {
+          const result = services.safeParseSync(candidate, data)
+          if (result.success) {
+            return {
+              data: result.data as GetValueFormType,
+              errors: undefined,
+              success: true,
+              formKey,
+            }
+          }
+          aggregated.push(...services.issuesToValidationErrors(result.issues, formKey))
+        }
+        return { data: undefined, errors: aggregated, success: false, formKey }
+      }
+
+      async function runAsync(): Promise<ValidationResponse<GetValueFormType>> {
+        if (path === undefined) {
+          let result: Awaited<ReturnType<typeof services.safeParseAsync>>
+          try {
+            result = await services.safeParseAsync(rootSchema, data)
+          } catch (err) {
+            return validatorThrewResponse(err, [])
+          }
+          return result.success
+            ? {
+                data: result.data as GetValueFormType,
+                errors: undefined,
+                success: true,
+                formKey,
+              }
+            : {
+                data: undefined,
+                errors: services.issuesToValidationErrors(result.issues, formKey),
+                success: false,
+                formKey,
+              }
+        }
+        const resolved = services.getNestedSchemasAtPath(rootSchema, path, maxRecursionDepth)
+        if (resolved.length === 0) return pathNotFound(path)
+        // Sequential await — parallelising would run every branch's
+        // async side effects on a value only one branch should see.
+        const aggregated: ValidationError[] = []
+        for (const candidate of resolved) {
+          let result: Awaited<ReturnType<typeof services.safeParseAsync>>
+          try {
+            result = await services.safeParseAsync(candidate, data)
+          } catch (err) {
+            return validatorThrewResponse(err, path)
+          }
+          if (result.success) {
+            return {
+              data: result.data as GetValueFormType,
+              errors: undefined,
+              success: true,
+              formKey,
+            }
+          }
+          aggregated.push(...services.issuesToValidationErrors(result.issues, formKey))
+        }
+        return { data: undefined, errors: aggregated, success: false, formKey }
+      }
+
+      // User code inside `z.preprocess` / `.refine` / `.transform` can
+      // throw (sync) or reject (async). Zod does NOT wrap these into
+      // issues; they propagate out of `safeParse` / `safeParseAsync`.
+      // Without this catch the throw bubbles through `validateAtPath`
+      // into the runtime's submit / change-mode pipelines as either a
+      // `submitError` (handleSubmit) or an unhandled rejection
+      // (scheduleFieldValidation), and the consumer would never see a
+      // path-scoped error message. Surface as a `ValidationError` at
+      // the field path so the form's normal error pipeline handles it.
+      function validatorThrewResponse(
+        err: unknown,
+        errPath: Path
+      ): ValidationResponse<GetValueFormType> {
+        const message =
+          err instanceof Error ? err.message : typeof err === 'string' ? err : 'Validator threw'
+        return {
+          data: undefined,
+          errors: [
+            {
+              message,
+              path: [...errPath],
+              formKey,
+              code: AttaformErrorCode.ValidatorThrew,
+            },
+          ],
+          success: false,
+          formKey,
+        }
+      }
+
+      function pathNotFound(p: Path): ValidationResponse<GetValueFormType> {
+        return {
+          data: undefined,
+          errors: [
+            {
+              message: `Path '${p.join(PATH_SEPARATOR)}' did not resolve to any schema`,
+              path: [...p],
+              formKey,
+              code: AttaformErrorCode.PathNotFound,
+            },
+          ],
+          success: false,
+          formKey,
+        }
+      }
+    },
+  }
+
+  return abstractSchema
+}

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -160,7 +160,16 @@ export type ValidateOptions = {
   sync?: boolean
 }
 
-type GetDefaultValuesConfig<Form> = {
+/**
+ * Configuration passed to `AbstractSchema.getDefaultValues`. Adapters
+ * receive `useDefaultSchemaValues` (honor `.default(x)` wrappers vs.
+ * empty/falsy fallbacks), an optional `strict` mode (refinement
+ * preservation), and an optional `constraints` overlay merged into the
+ * derived defaults so the runtime can stamp user-supplied defaults at
+ * construction. Exported so adapter authors can co-implement the
+ * service contract.
+ */
+export type GetDefaultValuesConfig<Form> = {
   useDefaultSchemaValues: boolean
   /**
    * Whether to keep schema refinements when deriving slim defaults.

--- a/test/adapters/zod-v4/introspect.test.ts
+++ b/test/adapters/zod-v4/introspect.test.ts
@@ -2,13 +2,19 @@ import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
 import {
   assertZodVersion,
+  containsAsyncRefine,
+  containsAsyncTransform,
   getArrayElement,
+  getChecks,
   getDefaultValue,
   getEnumValues,
   getLiteralValues,
   getObjectShape,
   getTupleItems,
   getUnionOptions,
+  hasChecks,
+  hasContainerOrRootRefine,
+  isAsyncCheck,
   kindOf,
   unwrapInner,
 } from '../../../src/runtime/adapters/zod-v4/introspect'
@@ -94,6 +100,231 @@ describe('accessors', () => {
   it('getDefaultValue returns the configured default', () => {
     expect(getDefaultValue(z.string().default('hi'))).toBe('hi')
     expect(getDefaultValue(z.number().default(42))).toBe(42)
+  })
+})
+
+describe('checks payload', () => {
+  it('hasChecks / getChecks reflect the schema refinement list', () => {
+    expect(hasChecks(z.string())).toBe(false)
+    expect(hasChecks(z.string().min(3))).toBe(true)
+    expect(getChecks(z.string().min(3))).toHaveLength(1)
+    expect(getChecks(z.string())).toHaveLength(0)
+  })
+})
+
+describe('isAsyncCheck', () => {
+  it('flags an async refine check and clears a sync one', () => {
+    // v4 stores refines in `def.checks[].def.fn`; isAsyncCheck reads
+    // the fn's `constructor.name` exactly like the v3 introspect's
+    // ZodEffects walker.
+    const asyncChecks = getChecks(z.string().refine(async () => Promise.resolve(true)))
+    const syncChecks = getChecks(z.string().refine(() => true))
+    expect(asyncChecks).toHaveLength(1)
+    expect(syncChecks).toHaveLength(1)
+    expect(isAsyncCheck(asyncChecks[0])).toBe(true)
+    expect(isAsyncCheck(syncChecks[0])).toBe(false)
+  })
+
+  it('returns false for non-check inputs', () => {
+    expect(isAsyncCheck(null)).toBe(false)
+    expect(isAsyncCheck({})).toBe(false)
+    expect(isAsyncCheck({ _def: { fn: 'not a function' } })).toBe(false)
+  })
+})
+
+describe('hasContainerOrRootRefine', () => {
+  it('returns false for a flat schema with only leaf refines', () => {
+    const schema = z.object({
+      name: z.string().refine((v) => v.length > 0, 'name-invalid'),
+      age: z.number().refine((v) => v >= 0, 'age-invalid'),
+    })
+    expect(hasContainerOrRootRefine(schema)).toBe(false)
+  })
+
+  it('returns true when the root carries a refine', () => {
+    const schema = z
+      .object({ name: z.string(), other: z.string() })
+      .refine(() => true, 'root-invariant')
+    expect(hasContainerOrRootRefine(schema)).toBe(true)
+  })
+
+  it('returns true when a nested container carries a refine', () => {
+    const schema = z.object({
+      profile: z.object({ first: z.string() }).refine(() => true, 'profile-invariant'),
+    })
+    expect(hasContainerOrRootRefine(schema)).toBe(true)
+  })
+
+  it('returns true for a refine through optional/nullable to a container', () => {
+    const schema = z.object({
+      payment: z
+        .object({ card: z.string() })
+        .refine(() => true, 'card-invariant')
+        .optional(),
+    })
+    expect(hasContainerOrRootRefine(schema)).toBe(true)
+  })
+
+  it('returns true for a refine on a union / discriminated-union container', () => {
+    const u = z.union([z.string(), z.number()]).refine(() => true, 'either')
+    const du = z
+      .discriminatedUnion('kind', [
+        z.object({ kind: z.literal('a'), v: z.string() }),
+        z.object({ kind: z.literal('b'), v: z.number() }),
+      ])
+      .refine(() => true, 'cross-cut')
+    expect(hasContainerOrRootRefine(u)).toBe(true)
+    expect(hasContainerOrRootRefine(du)).toBe(true)
+  })
+
+  it('returns true for a refine on intersection / record / set', () => {
+    const intersect = z
+      .intersection(z.object({ a: z.string() }), z.object({ b: z.string() }))
+      .refine(() => true)
+    const rec = z.record(z.string(), z.number()).refine(() => true)
+    const set = z.set(z.string()).refine(() => true)
+    expect(hasContainerOrRootRefine(intersect)).toBe(true)
+    expect(hasContainerOrRootRefine(rec)).toBe(true)
+    expect(hasContainerOrRootRefine(set)).toBe(true)
+  })
+
+  it('returns true for a refine on an array container', () => {
+    const schema = z.object({
+      tags: z.array(z.string()).refine((arr) => arr.length > 0, 'non-empty'),
+    })
+    expect(hasContainerOrRootRefine(schema)).toBe(true)
+  })
+
+  it('handles cycles without recursing forever', () => {
+    type N = { name: string; child?: N }
+    const node: z.ZodType<N> = z.lazy(() =>
+      z.object({ name: z.string(), child: z.lazy(() => node).optional() })
+    )
+    // The lazy resolver builds new instances per call; this only proves
+    // the walker terminates rather than diverging. False is correct here:
+    // no refines anywhere.
+    expect(hasContainerOrRootRefine(node)).toBe(false)
+  })
+})
+
+describe('containsAsyncRefine', () => {
+  it('flags an async leaf refine at the root', () => {
+    expect(containsAsyncRefine(z.string().refine(async () => Promise.resolve(true)))).toBe(true)
+  })
+
+  it('clears a sync-only schema (v4 reads checks exactly)', () => {
+    // v4 is more precise than v3 — sync refines do NOT trip the flag
+    // because `isAsyncCheck` reads the user fn's constructor.name.
+    expect(containsAsyncRefine(z.string().refine(() => true))).toBe(false)
+    expect(containsAsyncRefine(z.string())).toBe(false)
+    expect(containsAsyncRefine(z.object({ name: z.string(), age: z.number() }))).toBe(false)
+  })
+
+  it('flags an async refine nested under containers and wrappers', () => {
+    const nested = z.object({
+      profile: z
+        .object({
+          tags: z.array(
+            z
+              .string()
+              .refine(async () => Promise.resolve(true))
+              .optional()
+          ),
+        })
+        .nullable(),
+    })
+    expect(containsAsyncRefine(nested)).toBe(true)
+  })
+
+  it('does not flag a bare async transform (that’s the transform walker’s domain)', () => {
+    expect(
+      containsAsyncRefine(z.object({ x: z.string().transform(async (v) => Promise.resolve(v)) }))
+    ).toBe(false)
+  })
+
+  it('flags through pipe / intersection / discriminated-union / record / set', () => {
+    const pipe = z.pipe(
+      z.string(),
+      z.string().refine(async () => Promise.resolve(true))
+    )
+    const intersect = z.intersection(
+      z.object({ a: z.string() }),
+      z.object({ b: z.string().refine(async () => Promise.resolve(true)) })
+    )
+    const du = z.discriminatedUnion('kind', [
+      z.object({ kind: z.literal('a'), v: z.string() }),
+      z.object({ kind: z.literal('b'), v: z.string().refine(async () => Promise.resolve(true)) }),
+    ])
+    const rec = z.record(
+      z.string(),
+      z.string().refine(async () => Promise.resolve(true))
+    )
+    const set = z.set(z.string().refine(async () => Promise.resolve(true)))
+    expect(containsAsyncRefine(pipe)).toBe(true)
+    expect(containsAsyncRefine(intersect)).toBe(true)
+    expect(containsAsyncRefine(du)).toBe(true)
+    expect(containsAsyncRefine(rec)).toBe(true)
+    expect(containsAsyncRefine(set)).toBe(true)
+  })
+
+  it('flags through a lazy recursive schema (one hop)', () => {
+    type N = { name: string; child?: N }
+    const node: z.ZodType<N> = z.lazy(() =>
+      z.object({
+        name: z.string().refine(async () => Promise.resolve(true)),
+        child: z.lazy(() => node).optional(),
+      })
+    )
+    expect(containsAsyncRefine(node)).toBe(true)
+  })
+})
+
+describe('containsAsyncTransform', () => {
+  it('flags an async transform / preprocess at the root', () => {
+    expect(containsAsyncTransform(z.string().transform(async (v) => Promise.resolve(v)))).toBe(true)
+    expect(containsAsyncTransform(z.preprocess(async (v) => Promise.resolve(v), z.string()))).toBe(
+      true
+    )
+  })
+
+  it('does not flag sync transforms / preprocess', () => {
+    expect(containsAsyncTransform(z.string().transform((v) => v))).toBe(false)
+    expect(containsAsyncTransform(z.preprocess((v) => v, z.string()))).toBe(false)
+  })
+
+  it('does not flag refines (sync or async) — the refine walker’s domain', () => {
+    expect(containsAsyncTransform(z.string().refine(async () => Promise.resolve(true)))).toBe(false)
+    expect(containsAsyncTransform(z.string().refine(() => true))).toBe(false)
+  })
+
+  it('flags an async transform nested under union options', () => {
+    const schema = z.object({
+      payload: z.union([z.string(), z.string().transform(async (v) => Promise.resolve(`${v}!`))]),
+    })
+    expect(containsAsyncTransform(schema)).toBe(true)
+  })
+
+  it('flags through intersection / record / set / lazy', () => {
+    const intersect = z.intersection(
+      z.object({ a: z.string() }),
+      z.object({ b: z.string().transform(async (v) => Promise.resolve(v)) })
+    )
+    const rec = z.record(
+      z.string(),
+      z.string().transform(async (v) => Promise.resolve(v))
+    )
+    const set = z.set(z.string().transform(async (v) => Promise.resolve(v)))
+    type N = { v: string; child?: N }
+    const node: z.ZodType<N> = z.lazy(() =>
+      z.object({
+        v: z.string().transform(async (v) => Promise.resolve(v)),
+        child: z.lazy(() => node).optional(),
+      })
+    )
+    expect(containsAsyncTransform(intersect)).toBe(true)
+    expect(containsAsyncTransform(rec)).toBe(true)
+    expect(containsAsyncTransform(set)).toBe(true)
+    expect(containsAsyncTransform(node)).toBe(true)
   })
 })
 

--- a/test/adapters/zod-v4/introspect.test.ts
+++ b/test/adapters/zod-v4/introspect.test.ts
@@ -196,7 +196,7 @@ describe('hasContainerOrRootRefine', () => {
   })
 
   it('handles cycles without recursing forever', () => {
-    type N = { name: string; child?: N }
+    type N = { name: string; child?: N | undefined }
     const node: z.ZodType<N> = z.lazy(() =>
       z.object({ name: z.string(), child: z.lazy(() => node).optional() })
     )
@@ -268,7 +268,7 @@ describe('containsAsyncRefine', () => {
   })
 
   it('flags through a lazy recursive schema (one hop)', () => {
-    type N = { name: string; child?: N }
+    type N = { name: string; child?: N | undefined }
     const node: z.ZodType<N> = z.lazy(() =>
       z.object({
         name: z.string().refine(async () => Promise.resolve(true)),
@@ -314,7 +314,7 @@ describe('containsAsyncTransform', () => {
       z.string().transform(async (v) => Promise.resolve(v))
     )
     const set = z.set(z.string().transform(async (v) => Promise.resolve(v)))
-    type N = { v: string; child?: N }
+    type N = { v: string; child?: N | undefined }
     const node: z.ZodType<N> = z.lazy(() =>
       z.object({
         v: z.string().transform(async (v) => Promise.resolve(v)),


### PR DESCRIPTION
## Phase 12 — adapter dedup factory (part 1 of 2)

The big dedup payoff from `AUDIT-FINDINGS.md`'s Phase 12, landed in two stages. This PR is **part 1**: the `createAbstractSchema` factory (D1) plus the two warm-up dedups (D6 + B3). Part 2 — the inner walker / generateValue / strip dedup (D2-D5) — lands as a follow-up on a stacked branch so this PR reads as one coherent factory introduction.

## Design — surfaced + signed off before coding

Per [[feedback_iterative_collab]] + [[feedback_reference_before_api_change]], the factory shape was surfaced via `AskUserQuestion` before any code landed. **Option chosen: Two interfaces — Introspector + Services (Recommended).**

```ts
createAbstractSchema(
  rootSchema,
  intro: SchemaIntrospector<Schema>,           // pure schema-shape accessors
  services: AbstractSchemaServices<Schema, Form, Get>,  // per-adapter delegates
  formKey, options,
)
```

The split keeps the introspector reusable by any other walker (fingerprint, slim-primitives, defaults) without dragging in side-effectful services. Services consume the introspector as they wish; the factory consumes both.

## Series (7 commits)

| # | SHA | Summary | LOC |
|---|---|---|---|
| 1 | `9f880e7` | test(zod-v4): pin walker behavior before the walkSchemaTree dedup | +231 |
| 2 | `0f01d6e` | refactor(zod-v4): walkSchemaTree(visit) hosts the 3 walker predicates (D6) | -107 |
| 3 | `df3b501` | refactor(adapters): drop slimKindOfRaw twins; route through core/slim-primitive-gate (B3) | -54 |
| 4 | `691b760` | feat(core): introduce the schema-introspector + factory scaffold (D1) | +728 |
| 5 | `347f8b4` | refactor(core): rename slim-query hook so getSchemasAtPath rides it too (D1) | +10 |
| 6 | `10b40e6` | refactor(zod-v4): wire adapter through createAbstractSchema (D1 cutover) | -286 |
| 7 | `e7a789f` | refactor(zod-v3): wire adapter through createAbstractSchema (D1 cutover) | -313 |

**Net:** the two adapter files (zod-v3/index.ts + zod-v4/adapter.ts) shrink by ~600 LOC; `core/abstract-schema-factory.ts` holds the new ~750 LOC of shared infrastructure. Per-adapter cost drops to a thin wiring layer (introspector + services + a few extracted helpers).

## API & behavior-change ledger

Per the working agreement: **every public-API or observable-behavior delta is enumerated.**

- **None in this PR.** The factory is behavior-neutral by design — every caller-visible method on `AbstractSchema` keeps its prior signature and its prior verdicts. Per-adapter caches keep per-form lifetime; lazy memos keep one-shot semantics; `getSchemasAtPath` preserves each adapter's prior sub-schema shape (v3 recurses, v4 returns the 5-method stub) via the `makeSubSchema` service.
- New internal-only types exported: `SchemaIntrospector<Schema>`, `AbstractSchemaServices<Schema, Form, Get>`, `SharedZodKind`, plus the `createAbstractSchema` factory function. All in `src/runtime/core/abstract-schema-factory.ts`; no public re-export.
- New introspector-contract predicates added to each adapter's introspect.ts: `isPreprocessNode(schema)` (v4 + v3). Internal-use only; not re-exported.
- Type-only re-export of `GetDefaultValuesConfig` from `types-api` so adapter services can co-implement `runStrictGetDefaults`. No observable behavior change.

## Coverage adds

- `test/adapters/zod-v4/introspect.test.ts` — **+24 expectTypeOf-style cases** on the v4 walker family (`containsAsyncRefine`, `containsAsyncTransform`, `hasContainerOrRootRefine`, plus `isAsyncCheck` / `hasChecks` / `getChecks`). v3's `introspect.test.ts` had full walker coverage; v4's didn't. Lands ahead of the D6 dedup so the unified walker is gated by the same cases the per-function descent already passed.

## Preserved invariants

- All caches (`leafCache`, `preprocessOrCoerceCache`, `discriminatorCache`) hosted by the factory, lifetime = one `createAbstractSchema` call (one per `useForm()`).
- Two lazy memos (`asyncValidationFlag`, `containerRefineFlag`) preserve one-shot tree-walk semantics.
- v3's strict-mode `getDefaultValues` flow (including the async-detect re-parse + the validate-then-fix loop with slim-primitive refinement-vs-structural classifier) preserved verbatim in `runStrictGetDefaultsV3` — closure references rebound as parameters.
- v4's strict-mode flow preserved in `runStrictGetDefaultsV4`.
- v3's slim-mode walk (strip-then-walk) preserved in `getNestedSchemasInSlimModeV3` — used by both `getSlimPrimitiveTypesAtPath` and `getSchemasAtPath` callsites.

## Full gate ✓

| | |
|---|---|
| Lint | ✓ (eslint + prettier) |
| Typecheck | ✓ (tsc + vue-tsc) |
| check:site | ✓ |
| Tests | **3494 / 3494** across 283 files |
| Coverage | 91.88% lines (88.66% statements, 81.56% branches, 89.14% functions) |
| Bench | ✓ within 3× floor — `keystroke 500-leaf` 10.49× faster than baseline |
| Size | All within budget: `index.mjs` 46.76/48 kB · `zod.mjs` 61.15/63 · `zod-v4.mjs` 53.92/54 · `zod-v3.mjs` 55.19/56 · `transforms.mjs` 3.28/6 |

Sizes are roughly neutral (factory adds ~+1 kB to index.mjs while shrinking the per-adapter bundles by similar). The audit's hope of an `index.mjs` shrink doesn't materialise here — that's expected, since the factory's introspector + services indirection adds a few hundred bytes of plumbing per adapter. Maintainability + architectural-clarity win is the real deliverable.

## What's deferred to part 2

Phase 12 also includes **ADAPT-D2–D5** — unifying the inner walker / generateValue / strip twins (v3 `getDefaultValuesFromZodSchema` ≡ v4 `deriveDefault`; v3 `slimPrimitivesV3` ≡ v4 `slimPrimitivesOf`; v3 `stripAsyncChecks` ≡ v4 `stripAsyncChecks`; v3 `walkSegments` ≡ v4 `walkSegments`). Each twin is a few hundred lines of structurally-parallel code that would benefit from a shared core walker driven by the same introspector. That work is independent of the factory landing — it's a separate design surface (which accessors the inner walkers need on the introspector; how much of the per-version edge cases is genuinely irreducible).

Lands as a follow-up PR stacked on this branch (or after merge) so each PR reads as one coherent dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)