### PR TITLE
Phase 12 part 2: deriveDefault / slimPrimitives / walkPathSegments dedup (D2 / D3 / D5)

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -381,7 +381,24 @@ export default [
     // / default-values / strip (3 sites) / path-walker / fingerprint /
     // walkForMeta / slim-primitives (SF6). Measured at 53.69 KB; the
     // 54 KB symmetry with zod-v3.mjs maintained without a bump.
-    limit: '54 KB',
+    //
+    // Raised 54 → 55 KB on the adapter-factory-part-2 branch (Phase 12
+    // part 2 of the audit-remediation series, ADAPT-D2 + D3 + D5).
+    // The three inner walkers (deriveDefault / slimPrimitives /
+    // walkPathSegments) lifted into `core/walk-*` modules dispatched
+    // through `SchemaIntrospector`. Net structure: v3 + v4 collectively
+    // shrunk by ~600 LOC and gain a shared `core/walk-derive-default.ts`
+    // (~440 LOC) + `core/walk-slim-primitives.ts` (~270 LOC) +
+    // `core/walk-path-segments.ts` (~170 LOC) + `core/merge-deep.ts`
+    // (~40 LOC), plus extension of the SchemaIntrospector contract by
+    // 19 walker-accessor members and a `walker-introspector.ts` const
+    // file per adapter. The shared-chunk allocator pulls a chunk of
+    // the walker infrastructure into v4's closure; combined with the
+    // catch-precedence service knob and the `peelEmbeddedDefault` /
+    // `hasDeclaredDefaultInChain` helpers + chain-peel pre-check at
+    // every node visit, that adds ~600 B to v4's gzipped surface.
+    // Measured at 54.57 KB.
+    limit: '55 KB',
     gzip: true,
     ignore: ['zod'],
     modifyEsbuildConfig: asEsm,

--- a/src/runtime/adapters/zod-v3/index.ts
+++ b/src/runtime/adapters/zod-v3/index.ts
@@ -122,6 +122,7 @@ import {
   getEffectsKind,
   getIntersectionLeft,
   getIntersectionRight,
+  getLazyGetter,
   getLiteralValue,
   getLiteralValues,
   getNativeEnumValues,
@@ -143,6 +144,7 @@ import {
   unwrapInner,
   unwrapLazy,
   unwrapPipeIn,
+  unwrapPipeOut,
 } from './introspect'
 import { slimPrimitivesV3 } from './slim-primitives'
 import { stripAsyncChecks } from './strip-async'
@@ -216,6 +218,30 @@ const V3_INTROSPECTOR: SchemaIntrospector<z.ZodTypeAny> = {
   containsAsyncRefine: (schema) => containsAsyncRefine(schema),
   containsAsyncTransform: (schema) => containsAsyncTransform(schema),
   hasContainerOrRootRefine: (schema) => hasContainerOrRootRefine(schema),
+
+  // Walker accessors (D2 / D3 / D5).
+  getArrayElement: (schema) => getArrayElement(schema),
+  getSetValueType: (schema) => getSetValueType(schema),
+  getRecordKeyType: (schema) => getRecordKeyType(schema),
+  getRecordValueType: (schema) => getRecordValueType(schema),
+  getUnionOptions: (schema) => getUnionOptions(schema),
+  getIntersectionLeft: (schema) => getIntersectionLeft(schema),
+  getIntersectionRight: (schema) => getIntersectionRight(schema),
+  getEnumValues: (schema) => {
+    if (!isZodSchemaType(schema, 'ZodEnum')) return []
+    return (schema as z.ZodEnum<[string, ...string[]]>).options
+  },
+  getNativeEnumValues: (schema) => getNativeEnumValues(schema),
+  unwrapInner: (schema) => unwrapInner(schema),
+  unwrapBranded: (schema) => unwrapBranded(schema),
+  unwrapEffectsSource: (schema) => unwrapEffectsSource(schema),
+  unwrapPipeIn: (schema) => unwrapPipeIn(schema),
+  unwrapPipeOut: (schema) => unwrapPipeOut(schema),
+  unwrapLazy: (schema) => unwrapLazy(schema),
+  getLazyGetter: (schema) => getLazyGetter(schema),
+  getDefaultValue: (schema) => getDefaultValueFromIntrospect(schema),
+  getCatchDefault: (schema) => getCatchDefault(schema),
+  hasCatchValue: (schema) => hasCatchValue(schema),
 }
 
 /**

--- a/src/runtime/adapters/zod-v3/index.ts
+++ b/src/runtime/adapters/zod-v3/index.ts
@@ -15,10 +15,9 @@ import type {
 import {
   createAbstractSchema,
   type AbstractSchemaServices,
-  type SchemaIntrospector,
-  type SharedZodKind,
 } from '../../core/abstract-schema-factory'
 import { getAtPath, isPlainRecord, setAtPath } from '../../core/path-walker'
+import { walkPathSegments } from '../../core/walk-path-segments'
 import type { SchemaFactoryOptions } from '../../core/get-computed-schema'
 import { humanize } from '../../core/humanize'
 import { canonicalizePath, type Path, type PathKey } from '../../core/paths'
@@ -112,7 +111,6 @@ import { assertSupportedKinds } from './assert-supported'
 import { fingerprintZodSchema } from './fingerprint'
 import { isZodSchemaType } from './helpers'
 import {
-  containsAsyncRefine,
   containsAsyncTransform,
   getArrayElement,
   getCatchDefault,
@@ -122,9 +120,7 @@ import {
   getEffectsKind,
   getIntersectionLeft,
   getIntersectionRight,
-  getLazyGetter,
   getLiteralValue,
-  getLiteralValues,
   getNativeEnumValues,
   getObjectShape,
   getRecordKeyType,
@@ -135,19 +131,16 @@ import {
   getUnionOptions,
   hasCatchValue,
   hasChecks,
-  hasContainerOrRootRefine,
   isCoercePrimitive,
-  isPreprocessNode,
-  kindOf,
   unwrapBranded,
   unwrapEffectsSource,
   unwrapInner,
   unwrapLazy,
   unwrapPipeIn,
-  unwrapPipeOut,
 } from './introspect'
 import { slimPrimitivesV3 } from './slim-primitives'
 import { stripAsyncChecks } from './strip-async'
+import { V3_INTROSPECTOR } from './walker-introspector'
 
 let warnedZodCodeMissing = false
 
@@ -199,49 +192,6 @@ export function zodAdapter<
       formKey,
       options
     )
-}
-
-/**
- * Module-level `SchemaIntrospector` for the v3 adapter. Pure schema
- * accessors with no closure state — shared across every \`useForm()\`
- * that ships a v3 schema. Mirrors the v4 \`V4_INTROSPECTOR\` shape.
- */
-const V3_INTROSPECTOR: SchemaIntrospector<z.ZodTypeAny> = {
-  kindOf: (schema) => kindOf(schema) as SharedZodKind | string,
-  getObjectShape: (schema) => getObjectShape(schema),
-  getTupleItems: (schema) => getTupleItems(schema),
-  getDiscriminatedOptions: (schema) => getDiscriminatedOptions(schema) as readonly z.ZodTypeAny[],
-  getDiscriminator: (schema) => getDiscriminator(schema),
-  getLiteralValues: (schema) => getLiteralValues(schema),
-  isPreprocessNode: (schema) => isPreprocessNode(schema),
-  isCoercePrimitive: (schema) => isCoercePrimitive(schema),
-  containsAsyncRefine: (schema) => containsAsyncRefine(schema),
-  containsAsyncTransform: (schema) => containsAsyncTransform(schema),
-  hasContainerOrRootRefine: (schema) => hasContainerOrRootRefine(schema),
-
-  // Walker accessors (D2 / D3 / D5).
-  getArrayElement: (schema) => getArrayElement(schema),
-  getSetValueType: (schema) => getSetValueType(schema),
-  getRecordKeyType: (schema) => getRecordKeyType(schema),
-  getRecordValueType: (schema) => getRecordValueType(schema),
-  getUnionOptions: (schema) => getUnionOptions(schema),
-  getIntersectionLeft: (schema) => getIntersectionLeft(schema),
-  getIntersectionRight: (schema) => getIntersectionRight(schema),
-  getEnumValues: (schema) => {
-    if (!isZodSchemaType(schema, 'ZodEnum')) return []
-    return (schema as z.ZodEnum<[string, ...string[]]>).options
-  },
-  getNativeEnumValues: (schema) => getNativeEnumValues(schema),
-  unwrapInner: (schema) => unwrapInner(schema),
-  unwrapBranded: (schema) => unwrapBranded(schema),
-  unwrapEffectsSource: (schema) => unwrapEffectsSource(schema),
-  unwrapPipeIn: (schema) => unwrapPipeIn(schema),
-  unwrapPipeOut: (schema) => unwrapPipeOut(schema),
-  unwrapLazy: (schema) => unwrapLazy(schema),
-  getLazyGetter: (schema) => getLazyGetter(schema),
-  getDefaultValue: (schema) => getDefaultValueFromIntrospect(schema),
-  getCatchDefault: (schema) => getCatchDefault(schema),
-  hasCatchValue: (schema) => hasCatchValue(schema),
 }
 
 /**
@@ -401,137 +351,7 @@ function getNestedZodSchemasAtPath(
   maxRecursionDepth: number
 ): z.ZodTypeAny[] {
   if (segments.length === 0) return [schema]
-  return walkSegments(schema, segments.map(String), maxRecursionDepth, 0)
-}
-
-function walkSegments(
-  schema: z.ZodTypeAny,
-  segments: readonly string[],
-  maxDepth: number,
-  lazyDepth: number
-): z.ZodTypeAny[] {
-  if (segments.length === 0) return [schema]
-  const [head, ...rest] = segments
-  if (head === undefined) return [schema]
-  const kind = kindOf(schema)
-  switch (kind) {
-    case 'object': {
-      const shape = getObjectShape(schema)
-      // Own-property check: `shape` is a plain object whose prototype is
-      // `Object.prototype`, so a bare `shape[head]` for `head ===
-      // 'toString'` / `'valueOf'` / `'hasOwnProperty'` etc. returns the
-      // inherited Function and the walker treats it as a schema. Filter
-      // to OWN keys so unknown segments resolve to "doesn't exist."
-      if (!Object.hasOwn(shape, head)) return []
-      const next = shape[head]
-      return next === undefined ? [] : walkSegments(next, rest, maxDepth, lazyDepth)
-    }
-    case 'array': {
-      const inner = getArrayElement(schema)
-      return inner === undefined ? [] : walkSegments(inner, rest, maxDepth, lazyDepth)
-    }
-    case 'set': {
-      // Sets aren't position-indexed; the head segment is a synthetic
-      // indexer (`[...path, 0]`) used to query the element type. Descend
-      // into the value schema and consume the segment.
-      const inner = getSetValueType(schema)
-      return inner === undefined ? [] : walkSegments(inner, rest, maxDepth, lazyDepth)
-    }
-    case 'record': {
-      const inner = getRecordValueType(schema)
-      return inner === undefined ? [] : walkSegments(inner, rest, maxDepth, lazyDepth)
-    }
-    case 'tuple': {
-      const index = Number(head)
-      if (!Number.isInteger(index)) return []
-      const items = getTupleItems(schema)
-      const item = items[index]
-      return item === undefined ? [] : walkSegments(item, rest, maxDepth, lazyDepth)
-    }
-    case 'union':
-      return getUnionOptions(schema).flatMap((opt) =>
-        walkSegments(opt, segments, maxDepth, lazyDepth)
-      )
-    case 'discriminated-union': {
-      // Filter options whose shape contains this segment. Fallback: if no
-      // option matches (e.g. the discriminator key itself), try every
-      // option. `Object.hasOwn` (not `in`) so `Object.prototype` keys
-      // don't leak.
-      const options = getDiscriminatedOptions(schema)
-      const matching = options.filter((opt) => Object.hasOwn(getObjectShape(opt), head))
-      const candidates = matching.length > 0 ? matching : options
-      return candidates.flatMap((opt) => walkSegments(opt, segments, maxDepth, lazyDepth))
-    }
-    case 'optional':
-    case 'nullable':
-    case 'default':
-    case 'readonly':
-    case 'catch': {
-      // `catch` peels like a wrapper — descend into the inner schema. The
-      // catch fallback only matters at parse time, not path lookup.
-      const inner = unwrapInner(schema)
-      return inner === undefined ? [] : walkSegments(inner, segments, maxDepth, lazyDepth)
-    }
-    case 'branded': {
-      const inner = unwrapBranded(schema)
-      return inner === undefined ? [] : walkSegments(inner, segments, maxDepth, lazyDepth)
-    }
-    case 'effects': {
-      const inner = unwrapEffectsSource(schema)
-      return inner === undefined ? [] : walkSegments(inner, segments, maxDepth, lazyDepth)
-    }
-    case 'pipeline': {
-      const inner = unwrapPipeIn(schema)
-      return inner === undefined ? [] : walkSegments(inner, segments, maxDepth, lazyDepth)
-    }
-    case 'lazy': {
-      // Bump the lazy counter. Past the cap, return [] so callers fall
-      // back to permissive behaviour at recursive paths beyond the cap.
-      if (lazyDepth >= maxDepth) return []
-      const inner = unwrapLazy(schema)
-      return inner === undefined ? [] : walkSegments(inner, segments, maxDepth, lazyDepth + 1)
-    }
-    case 'intersection': {
-      // Union of both sides' resolutions — callers try each candidate,
-      // matching parse-time semantics where a value must satisfy both.
-      const left = getIntersectionLeft(schema)
-      const right = getIntersectionRight(schema)
-      const leftResults =
-        left === undefined ? [] : walkSegments(left, segments, maxDepth, lazyDepth)
-      const rightResults =
-        right === undefined ? [] : walkSegments(right, segments, maxDepth, lazyDepth)
-      return [...leftResults, ...rightResults]
-    }
-    // Leaf types — can't descend further. The unsupported kinds
-    // (`promise` / `function` / `map` / `symbol`) are rejected at
-    // adapter construction by `assertSupportedKinds`; this fallthrough
-    // keeps the walker defensive in case construction is skipped (e.g.
-    // a downstream test instantiates a subschema directly).
-    case 'string':
-    case 'number':
-    case 'boolean':
-    case 'bigint':
-    case 'date':
-    case 'enum':
-    case 'native-enum':
-    case 'literal':
-    case 'null':
-    case 'undefined':
-    case 'void':
-    case 'never':
-    case 'any':
-    case 'unknown':
-    case 'nan':
-    case 'promise':
-    case 'function':
-    case 'map':
-    case 'symbol':
-      return []
-    default: {
-      const _exhaustive: never = kind
-      throw new Error(`walkSegments (v3): unhandled ZodKind '${_exhaustive as string}'`)
-    }
-  }
+  return walkPathSegments(schema, segments.map(String), V3_INTROSPECTOR, maxRecursionDepth, 0)
 }
 
 /**

--- a/src/runtime/adapters/zod-v3/index.ts
+++ b/src/runtime/adapters/zod-v3/index.ts
@@ -18,6 +18,11 @@ import {
 } from '../../core/abstract-schema-factory'
 import { getAtPath, isPlainRecord, setAtPath } from '../../core/path-walker'
 import { walkPathSegments } from '../../core/walk-path-segments'
+import {
+  deriveDefaultWalk,
+  peelEmbeddedDefault,
+  NO_EMBEDDED_DEFAULT,
+} from '../../core/walk-derive-default'
 import type { SchemaFactoryOptions } from '../../core/get-computed-schema'
 import { humanize } from '../../core/humanize'
 import { canonicalizePath, type Path, type PathKey } from '../../core/paths'
@@ -113,15 +118,11 @@ import { isZodSchemaType } from './helpers'
 import {
   containsAsyncTransform,
   getArrayElement,
-  getCatchDefault,
-  getDefaultValue as getDefaultValueFromIntrospect,
   getDiscriminatedOptions,
   getDiscriminator,
-  getEffectsKind,
   getIntersectionLeft,
   getIntersectionRight,
   getLiteralValue,
-  getNativeEnumValues,
   getObjectShape,
   getRecordKeyType,
   getRecordValueType,
@@ -129,9 +130,7 @@ import {
   getTupleItems,
   getTypeName,
   getUnionOptions,
-  hasCatchValue,
   hasChecks,
-  isCoercePrimitive,
   unwrapBranded,
   unwrapEffectsSource,
   unwrapInner,
@@ -700,363 +699,36 @@ function getDefaultValue(
   return undefined
 }
 
-function unwrapDefault(schema: z.ZodTypeAny): [unknown, boolean] {
-  // Iterative peel: a chain of `.refine()` calls produces a deep
-  // ZodEffects(ZodEffects(...)) tree, and stack-based recursion runs
-  // out before MAX_UNWRAP_STEPS does. The bound also acts as a
-  // self-reference guard for pathological lazy loops.
-  let current: z.ZodTypeAny = schema
-  for (let i = 0; i < MAX_UNWRAP_STEPS; i++) {
-    if (isZodSchemaType(current, 'ZodDefault')) {
-      return [getDefaultValueFromIntrospect(current), true]
-    }
-    if (isZodSchemaType(current, 'ZodCatch')) {
-      // ZodCatch supplies a fallback value when its inner schema rejects
-      // parse. For default extraction the caught fallback IS the
-      // construction-time default — it's the consumer's explicit
-      // statement of "this is what to render when nothing else fits."
-      // Preserves the value across submit failures, hydration, and
-      // history (a `.catch()` should resurface the same fallback).
-      // `hasCatchValue` lets us distinguish a legitimate `undefined`
-      // return from a missing wrapper — both surface as `undefined`
-      // from `getCatchDefault` alone.
-      if (hasCatchValue(current)) return [getCatchDefault(current), true]
-      // Defensive: fall through to the inner schema if the field is
-      // missing on this v3 minor version.
-      const inner = unwrapInner(current)
-      if (!inner) break
-      current = inner
-      continue
-    }
-    if (isZodSchemaType(current, 'ZodNullable') || isZodSchemaType(current, 'ZodOptional')) {
-      const inner = unwrapInner(current)
-      if (!inner) break
-      current = inner
-      continue
-    }
-    if (isZodSchemaType(current, 'ZodReadonly')) {
-      const inner = unwrapInner(current)
-      if (!inner) break
-      current = inner
-      continue
-    }
-    if (isZodSchemaType(current, 'ZodBranded')) {
-      const inner = unwrapBranded(current)
-      if (!inner) break
-      current = inner
-      continue
-    }
-    if (isZodSchemaType(current, 'ZodPipeline')) {
-      const inner = unwrapPipeIn(current)
-      if (!inner) break
-      current = inner
-      continue
-    }
-    if (isZodSchemaType(current, 'ZodEffects')) {
-      // v3 ZodEffects' structural source lives on `_def.schema`
-      // (preferred); older v3 builds exposed `.innerType()` on the
-      // instance as an alternative resolver. The introspect helper
-      // reads `_def.schema`, and falling back to the instance method
-      // here preserves the historical robustness.
-      const inner = unwrapEffectsSource(current)
-      if (inner) {
-        current = inner
-        continue
-      }
-      const innerFromMethod = (current as { innerType?: () => z.ZodTypeAny }).innerType?.()
-      if (innerFromMethod) {
-        current = innerFromMethod
-        continue
-      }
-      break
-    }
-    break
-  }
-  return [null, false]
-}
-
-/**
- * Walk through transparent wrappers (Optional / Nullable / Readonly /
- * Catch) looking for a `ZodDefault` in the chain. Used by the preprocess
- * branch of `generateValue` to decide whether the inner has a
- * consumer-declared default the adapter should honor (return the inner
- * walk) or whether the slot is fully consumer-owned (return `undefined`).
- * Mirrors v4's `hasDeclaredDefaultInChain`.
- *
- * Bounded loop matches the surrounding `unwrapDefault`/`unwrapTo*`
- * patterns — a deeper wrapper stack is almost certainly a recursive
- * cycle, not legitimate schema construction.
- */
-function hasDeclaredDefaultInChainV3(schema: z.ZodTypeAny): boolean {
-  let current: z.ZodTypeAny | undefined = schema
-  for (let i = 0; i < 32; i++) {
-    if (current === undefined) return false
-    if (isZodSchemaType(current, 'ZodDefault')) return true
-    if (
-      isZodSchemaType(current, 'ZodOptional') ||
-      isZodSchemaType(current, 'ZodNullable') ||
-      isZodSchemaType(current, 'ZodReadonly') ||
-      isZodSchemaType(current, 'ZodCatch')
-    ) {
-      current = unwrapInner(current)
-      continue
-    }
-    return false
-  }
-  return false
-}
-
 function getDefaultValuesFromZodSchema<
   FormSchema extends z.ZodSchema,
   Form extends z.infer<FormSchema>,
 >(formSchema: FormSchema, useDefaultSchemaValues: boolean, formKey: FormKey): Form {
-  // Recursive function to generate the initial value based on schema type
-  function generateValue(schema: z.ZodTypeAny): unknown {
-    // Recursive helper to unwrap layers and detect ZodDefault
-    // Check if the schema (or any wrapped version) has a ZodDefault
-    if (useDefaultSchemaValues) {
-      const [defaultValue, foundDefaultValue] = unwrapDefault(schema)
-      if (foundDefaultValue) {
-        return defaultValue // Prioritize the 1st default value (if it exists)
-      }
-    }
-
-    // `z.coerce.X()` flags the wrapped primitive's def with `coerce:
-    // true`; the consumer's input pre-conversion shape is unknown so
-    // synthesising the primitive's slim concrete (`''` / `0` / etc.)
-    // would claim a value the consumer never supplied. Leave the slot
-    // `undefined` so `defaultValues` or a later `setValue` owns what
-    // lands in storage. A consumer-declared `.default(x)` on the coerce
-    // primitive was already honored by the `unwrapDefault` check above.
-    // Mirrors v4's `isCoercePrimitive` early-return.
-    if (isCoercePrimitive(schema)) return undefined
-
-    // Handle nullable
-    if (isZodSchemaType(schema, 'ZodNullable')) {
-      return null // No default, so return null
-    }
-
-    // Handle objects
-    if (isZodSchemaType(schema, 'ZodObject')) {
-      const shape = schema.shape
-      return Object.keys(shape).reduce<Record<string, unknown>>((acc, key) => {
-        acc[key] = generateValue(shape[key])
-        return acc
-      }, {})
-    }
-
-    // Handle arrays
-    if (isZodSchemaType(schema, 'ZodArray')) {
-      return []
-    }
-
-    // Handle strings
-    if (isZodSchemaType(schema, 'ZodString')) {
-      return ''
-    }
-
-    // Handle numbers
-    if (isZodSchemaType(schema, 'ZodNumber')) {
-      return 0
-    }
-
-    // Handle bigints — must be a bigint literal; z.bigint() rejects
-    // number 0. Without this branch we fall through to the warn-path
-    // and the fix-up loop has to reconcile it via getDefaultValue.
-    if (isZodSchemaType(schema, 'ZodBigInt')) {
-      return 0n
-    }
-
-    // Handle dates — matches v4's `new Date(0)` so SSR round-trip is
-    // deterministic across server + client.
-    if (isZodSchemaType(schema, 'ZodDate')) {
-      return new Date(0)
-    }
-
-    // Handle booleans
-    if (isZodSchemaType(schema, 'ZodBoolean')) {
-      return false
-    }
-
-    // Handle enums
-    if (isZodSchemaType(schema, 'ZodEnum')) {
-      return schema.options[0]
-    }
-
-    // Handle null
-    if (isZodSchemaType(schema, 'ZodNull')) {
+  // Thin wrapper around the shared `deriveDefaultWalk` core walker;
+  // v3 and v4 dispatch through the same body via their respective
+  // `SchemaIntrospector` instance. See `core/walk-derive-default.ts`
+  // for the per-kind dispatch rules and the `peelEmbeddedDefault`
+  // chain-walk that previously lived here as `unwrapDefault`.
+  //
+  // `maxRecursionDepth` is the historical v3 cap (64); the v3
+  // adapter doesn't thread the consumer-supplied cap into this
+  // call site — every existing v3 test passes against the embedded
+  // 64-cap so the dedup preserves the prior behavior.
+  return deriveDefaultWalk(formSchema, useDefaultSchemaValues, V3_INTROSPECTOR, 64, {
+    unsupportedKindFallback: (schema) => {
+      console.warn(
+        `[attaform] zod-v3 adapter: unsupported schema kind ` +
+          `'${(schema as { constructor?: { name?: string } }).constructor?.name ?? 'unknown'}' ` +
+          `on form '${formKey}'. Defaulting the field to null. ` +
+          `Use a supported zod kind (object/array/record/string/number/etc.) at this path.`
+      )
       return null
-    }
-
-    // Handle undefined
-    if (isZodSchemaType(schema, 'ZodUndefined')) {
-      return undefined
-    }
-
-    // Handle literals
-    if (isZodSchemaType(schema, 'ZodLiteral')) {
-      return getLiteralValue(schema)
-    }
-
-    // Handle optional
-    if (isZodSchemaType(schema, 'ZodOptional')) {
-      return undefined
-    }
-
-    // Handle unions (use the first option as the default)
-    if (isZodSchemaType(schema, 'ZodUnion')) {
-      const first = getUnionOptions(schema)[0]
-      return first === undefined ? undefined : generateValue(first)
-    }
-
-    // Handle tuples
-    if (isZodSchemaType(schema, 'ZodTuple')) {
-      return getTupleItems(schema).map((item) => generateValue(item))
-    }
-
-    // Handle records
-    if (isZodSchemaType(schema, 'ZodRecord')) {
-      return {}
-    }
-
-    // Finding ZodDefault here means we should suppress defaults
-    // Can only happen if useDefaultSchemaValues is false
-    if (isZodSchemaType(schema, 'ZodDefault')) {
-      const inner = unwrapInner(schema)
-      if (inner) return generateValue(inner)
-    }
-
-    if (isZodSchemaType(schema, 'ZodEffects')) {
-      const inner = unwrapEffectsSource(schema)
-      // `z.preprocess(fn, _)` declares an input normalizer; the input
-      // side is the user-supplied `fn` and the slot has no canonical
-      // empty value the adapter can honestly synthesise. Mirror v4's
-      // pipe-with-transform case: when the inner carries a consumer-
-      // declared default it takes priority (recurse so the `unwrapDefault`
-      // check at the top of `generateValue` picks it up under
-      // `useDefaultSchemaValues`, or the inner `ZodDefault` branch
-      // resolves to the leaf empty under strict mode); otherwise leave
-      // the slot `undefined`. `refinement` / `transform` keep the
-      // original behavior — they wrap a real source schema.
-      if (getEffectsKind(schema) === 'preprocess') {
-        if (inner && hasDeclaredDefaultInChainV3(inner)) return generateValue(inner)
-        return undefined
-      }
-      if (inner) return generateValue(inner)
-    }
-
-    if (isZodSchemaType(schema, 'ZodDiscriminatedUnion')) {
-      const discriminantKey = undefined // select default option schema
-      const discriminantSchema = getSchemaByDiscriminatorKey(schema, discriminantKey)
-      return generateValue(discriminantSchema as z.ZodTypeAny)
-    }
-
-    // ZodCatch — even when default extraction is suppressed
-    // (`useDefaultSchemaValues=false`), the consumer-supplied fallback
-    // is the most reasonable construction-time value to surface; the
-    // alternative is the inner schema's bare default, which the
-    // .catch() author specifically chose to override. `hasCatchValue`
-    // preserves the legitimate-undefined-return path.
-    if (isZodSchemaType(schema, 'ZodCatch')) {
-      if (hasCatchValue(schema)) return getCatchDefault(schema)
-      const inner = unwrapInner(schema)
-      if (inner) return generateValue(inner)
-    }
-
-    // Newer transparent wrappers (v3.23+ for Pipeline/Readonly; Branded
-    // pre-existed). Each wraps a single inner schema with no structural
-    // impact at value-construction time.
-    if (isZodSchemaType(schema, 'ZodReadonly')) {
-      const inner = unwrapInner(schema)
-      if (inner) return generateValue(inner)
-    }
-    if (isZodSchemaType(schema, 'ZodBranded')) {
-      const inner = unwrapBranded(schema)
-      if (inner) return generateValue(inner)
-    }
-    if (isZodSchemaType(schema, 'ZodPipeline')) {
-      // Pipeline transforms in -> out; pre-transform default is the
-      // input schema's natural default.
-      const inner = unwrapPipeIn(schema)
-      if (inner) return generateValue(inner)
-    }
-
-    // ZodLazy — recursive schemas (comment trees, file system shapes).
-    // Resolve the getter once; the inner schema's own ZodOptional /
-    // base-case branch terminates the recursion.
-    if (isZodSchemaType(schema, 'ZodLazy')) {
-      const inner = unwrapLazy(schema)
-      if (inner) return generateValue(inner)
-    }
-
-    // ZodIntersection — `z.intersection(A, B)` must satisfy both sides
-    // at parse time, so the merged shape carries both halves' defaults.
-    // `mergeDeepV3` (NOT lodash `merge`) so leaves replace wholesale and
-    // explicit `null` overrides survive — matches v4's intersection
-    // branch (`default-values.ts:228-244`).
-    if (isZodSchemaType(schema, 'ZodIntersection')) {
-      const leftSchema = getIntersectionLeft(schema)
-      const rightSchema = getIntersectionRight(schema)
-      const left = leftSchema ? generateValue(leftSchema) : undefined
-      const right = rightSchema ? generateValue(rightSchema) : undefined
-      return mergeDeepV3(left, right)
-    }
-
-    // ZodNativeEnum — TS-enum-backed selects. Numeric enums get
-    // reverse-mapped (`enum E { A }` → `{ A: 0, '0': 'A' }`); the valid
-    // runtime members are the keys whose VALUE'S key isn't itself a
-    // number. String enums have no reverse mapping, so every key is
-    // valid. Pick the first valid value as the default.
-    if (isZodSchemaType(schema, 'ZodNativeEnum')) {
-      const values = getNativeEnumValues(schema)
-      if (values) {
-        const validKeys = Object.keys(values).filter(
-          (k) => typeof values[values[k] as string] !== 'number'
-        )
-        if (validKeys.length > 0) {
-          const first = validKeys[0]
-          if (first !== undefined) return values[first]
-        }
-      }
-    }
-
-    // ZodSet — empty Set; populated entries would have to reach into
-    // the element schema's defaults, but a Set's only meaningful
-    // empty state is `new Set()`.
-    if (isZodSchemaType(schema, 'ZodSet')) {
-      return new Set()
-    }
-
-    // ZodNaN — the only valid value `z.nan()` accepts is `NaN`. v4
-    // returns `NaN` here; mirror that so the default seeds a schema-
-    // valid slot instead of falling through to the warn-path.
-    if (isZodSchemaType(schema, 'ZodNaN')) {
-      return NaN
-    }
-
-    // `z.void()` / `z.any()` / `z.unknown()` / `z.never()` carry no
-    // canonical empty value beyond `undefined`. v4 returns `undefined`
-    // for all four; returning `null` here (the warn-path fallback)
-    // misrepresented the slot and triggered a noisy console warning for
-    // a schema kind we can actually handle.
-    if (
-      isZodSchemaType(schema, 'ZodVoid') ||
-      isZodSchemaType(schema, 'ZodAny') ||
-      isZodSchemaType(schema, 'ZodUnknown') ||
-      isZodSchemaType(schema, 'ZodNever')
-    ) {
-      return undefined
-    }
-
-    console.warn(
-      `[attaform] zod-v3 adapter: unsupported schema kind ` +
-        `'${schema.constructor.name}' on form '${formKey}'. Defaulting the field to null. ` +
-        `Use a supported zod kind (object/array/record/string/number/etc.) at this path.`
-    )
-    return null
-  }
-
-  return generateValue(formSchema) as unknown as Form
+    },
+    // v3 historically surfaces the `.catch(v)` fallback even when
+    // `useDefaultSchemaValues=false`. Pinned by
+    // `test/adapters/zod-v3/wrappers.test.ts` ('surfaces the catch
+    // fallback even when useDefaultSchemaValues is false').
+    catchOnUseDefaultFalse: 'preserveCatch',
+  }) as Form
 }
 // helpful tip: discriminator option schemas are always zod objects (because of discriminant key)
 function getSchemaByDiscriminatorKey(
@@ -1959,10 +1631,13 @@ function runStrictGetDefaultsV3<Form>(
 
       // Wrong-primitive issues with non-invalid_type codes (e.g.,
       // invalid_enum_value where the offending value is a number
-      // against a string-enum). Fall back to the schema's default.
-      const [defaultValue, found] = unwrapDefault(schemaAtPath)
-      if (found) {
-        fixedData = setAtPath(fixedData, path, defaultValue) as Record<string, unknown>
+      // against a string-enum). Fall back to the schema's default —
+      // peel the wrapper chain for an embedded `ZodDefault` /
+      // `ZodCatch.fallback`. Mirrors the chain-peel that
+      // `deriveDefaultWalk` runs at the top of every node visit.
+      const peeled = peelEmbeddedDefault(schemaAtPath as z.ZodTypeAny, V3_INTROSPECTOR)
+      if (peeled !== NO_EMBEDDED_DEFAULT) {
+        fixedData = setAtPath(fixedData, path, peeled) as Record<string, unknown>
         continue
       }
       // Last-ditch: derive a default for the schema kind at this path.

--- a/src/runtime/adapters/zod-v3/slim-primitives.ts
+++ b/src/runtime/adapters/zod-v3/slim-primitives.ts
@@ -1,7 +1,7 @@
 import type { z } from 'zod-v3'
 import type { SlimPrimitiveKind } from '../../types/types-api'
-import { slimKindOf } from '../../core/slim-primitive-gate'
-import { isZodSchemaType } from './helpers'
+import { slimPrimitivesWalk } from '../../core/walk-slim-primitives'
+import { V3_INTROSPECTOR } from './walker-introspector'
 
 /**
  * Slim-primitive walker for v3. Returns the set of `SlimPrimitiveKind`s
@@ -10,158 +10,14 @@ import { isZodSchemaType } from './helpers'
  * `ZodReadonly`, `ZodBranded`, `ZodCatch`, `ZodLazy`) are peeled;
  * refinement-level constraints are ignored.
  *
- * Mirrors the v4 implementation in
- * `src/runtime/adapters/zod-v4/slim-primitives.ts`.
+ * Thin wrapper around the shared `slimPrimitivesWalk` core walker; v3
+ * and v4 dispatch through the same body via their respective
+ * `SchemaIntrospector` instance. See `core/walk-slim-primitives.ts`
+ * for the per-kind dispatch rules.
  */
-
-const PERMISSIVE_V3: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set<SlimPrimitiveKind>([
-  'string',
-  'number',
-  'boolean',
-  'bigint',
-  'date',
-  'null',
-  'undefined',
-  'object',
-  'array',
-  'symbol',
-  'function',
-  'map',
-  'set',
-  'file',
-])
-
-// Module-level frozen leaf singletons; see the v4 file for rationale.
-const KIND_STRING: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['string'])
-const KIND_NUMBER: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['number'])
-const KIND_BOOLEAN: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['boolean'])
-const KIND_BIGINT: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['bigint'])
-const KIND_DATE: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['date'])
-const KIND_NULL: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['null'])
-const KIND_UNDEFINED: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['undefined'])
-const KIND_OBJECT: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['object'])
-const KIND_ARRAY: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['array'])
-const KIND_SET: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['set'])
-const EMPTY_KINDS: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set()
-
-const MAX_LAZY_DEPTH_V3 = 64
-
-export function slimPrimitivesV3(schema: z.ZodTypeAny, depth = 0): Set<SlimPrimitiveKind> {
-  // Clone once at the public boundary; the internal walk reuses
-  // frozen singletons for leaf kinds.
-  return new Set(walk(schema, depth))
-}
-
-function walk(schema: z.ZodTypeAny, depth: number): ReadonlySet<SlimPrimitiveKind> {
-  if (depth > MAX_LAZY_DEPTH_V3) return PERMISSIVE_V3
-  const def = (
-    schema as {
-      _def?: {
-        typeName?: string
-        innerType?: z.ZodTypeAny
-        type?: z.ZodTypeAny
-        schema?: z.ZodTypeAny
-        in?: z.ZodTypeAny
-        out?: z.ZodTypeAny
-        getter?: () => z.ZodTypeAny
-        options?: readonly z.ZodTypeAny[]
-        left?: z.ZodTypeAny
-        right?: z.ZodTypeAny
-      }
-    }
-  )._def
-  const typeName = def?.typeName
-
-  if (isZodSchemaType(schema, 'ZodString')) return KIND_STRING
-  if (isZodSchemaType(schema, 'ZodNumber')) return KIND_NUMBER
-  if (isZodSchemaType(schema, 'ZodBoolean')) return KIND_BOOLEAN
-  if (isZodSchemaType(schema, 'ZodBigInt')) return KIND_BIGINT
-  if (isZodSchemaType(schema, 'ZodDate')) return KIND_DATE
-  if (isZodSchemaType(schema, 'ZodNull')) return KIND_NULL
-  if (isZodSchemaType(schema, 'ZodUndefined')) return KIND_UNDEFINED
-  if (typeName === 'ZodVoid') return KIND_UNDEFINED
-  if (typeName === 'ZodNaN') return KIND_NUMBER
-
-  if (isZodSchemaType(schema, 'ZodEnum')) {
-    const options = (schema as z.ZodEnum<[string, ...string[]]>).options
-    const out = new Set<SlimPrimitiveKind>()
-    for (const v of options) {
-      if (typeof v === 'string') out.add('string')
-      else if (typeof v === 'number') out.add('number')
-    }
-    return out.size === 0 ? KIND_STRING : out
-  }
-  if (isZodSchemaType(schema, 'ZodLiteral')) {
-    const value = (schema as z.ZodLiteral<unknown>).value
-    return new Set([slimKindOf(value)])
-  }
-  if (isZodSchemaType(schema, 'ZodObject') || typeName === 'ZodRecord') {
-    return KIND_OBJECT
-  }
-  if (isZodSchemaType(schema, 'ZodArray') || typeName === 'ZodTuple') {
-    return KIND_ARRAY
-  }
-  if (isZodSchemaType(schema, 'ZodSet')) {
-    return KIND_SET
-  }
-  if (isZodSchemaType(schema, 'ZodOptional')) {
-    const inner = def?.innerType
-    const innerSet = inner === undefined ? EMPTY_KINDS : walk(inner, depth + 1)
-    const out = new Set<SlimPrimitiveKind>(innerSet)
-    out.add('undefined')
-    return out
-  }
-  if (isZodSchemaType(schema, 'ZodNullable')) {
-    const inner = def?.innerType
-    const innerSet = inner === undefined ? EMPTY_KINDS : walk(inner, depth + 1)
-    const out = new Set<SlimPrimitiveKind>(innerSet)
-    out.add('null')
-    return out
-  }
-  if (
-    isZodSchemaType(schema, 'ZodDefault') ||
-    isZodSchemaType(schema, 'ZodReadonly') ||
-    isZodSchemaType(schema, 'ZodCatch') ||
-    isZodSchemaType(schema, 'ZodBranded')
-  ) {
-    const inner = def?.innerType ?? def?.type
-    return inner === undefined ? PERMISSIVE_V3 : walk(inner, depth + 1)
-  }
-  if (isZodSchemaType(schema, 'ZodEffects')) {
-    // ZodEffects wraps refinements/transforms. Use the inner schema
-    // type — writes are pre-transform values.
-    const inner = def?.schema
-    return inner === undefined ? PERMISSIVE_V3 : walk(inner, depth + 1)
-  }
-  if (isZodSchemaType(schema, 'ZodPipeline')) {
-    // Pipeline: input side ('in').
-    const inner = def?.in
-    return inner === undefined ? PERMISSIVE_V3 : walk(inner, depth + 1)
-  }
-  if (typeName === 'ZodLazy') {
-    const getter = def?.getter
-    if (typeof getter !== 'function') return PERMISSIVE_V3
-    return walk(getter(), depth + 1)
-  }
-  if (isZodSchemaType(schema, 'ZodUnion') || isZodSchemaType(schema, 'ZodDiscriminatedUnion')) {
-    const options = def?.options ?? []
-    const out = new Set<SlimPrimitiveKind>()
-    for (const opt of options) {
-      for (const k of walk(opt, depth + 1)) out.add(k)
-    }
-    return out.size === 0 ? PERMISSIVE_V3 : out
-  }
-  if (typeName === 'ZodIntersection') {
-    const left = def?.left
-    const right = def?.right
-    const leftSet = left === undefined ? PERMISSIVE_V3 : walk(left, depth + 1)
-    const rightSet = right === undefined ? PERMISSIVE_V3 : walk(right, depth + 1)
-    const out = new Set<SlimPrimitiveKind>()
-    for (const k of leftSet) if (rightSet.has(k)) out.add(k)
-    return out
-  }
-  if (typeName === 'ZodNever') return EMPTY_KINDS
-  if (typeName === 'ZodAny' || typeName === 'ZodUnknown') return PERMISSIVE_V3
-
-  return PERMISSIVE_V3
+export function slimPrimitivesV3(schema: z.ZodTypeAny): Set<SlimPrimitiveKind> {
+  // The 64-step lazy-recursion cap matches the v3-only `MAX_LAZY_DEPTH_V3`
+  // sentinel the prior inline walker used; consumers historically called
+  // this without a depth arg, so the cap stays embedded here.
+  return new Set(slimPrimitivesWalk(schema, V3_INTROSPECTOR, 64))
 }

--- a/src/runtime/adapters/zod-v3/strip-async.ts
+++ b/src/runtime/adapters/zod-v3/strip-async.ts
@@ -39,7 +39,20 @@ import { isZodSchemaType } from './helpers'
  * synchronous parse" — at that moment all we know is *some* refine is
  * async, but not which. Dropping every `ZodEffects` is the safest
  * recovery: we lose sync refine seeding in mixed forms, but container
- * and leaf checks (the D3 target) still surface.
+ * and leaf checks still surface.
+ *
+ * Adapter-divergence note (Phase 12 part 2 / ADAPT-D4 deferred):
+ * this stays per-adapter rather than dedup-ing into a shared core
+ * walker. v3's "drop every ZodEffects" policy is irreducibly
+ * different from v4's "filter by isAsyncCheck per check site" — v4
+ * knows which checks are async (`check.def.fn.constructor.name`)
+ * and rebuilds the leaf with sync checks intact; v3 has no such
+ * accessor and has to drop the wrapper wholesale. A unified walker
+ * would need to either parameterise five separate behavior knobs
+ * (yielding a walker bigger than the two it replaces) or special-
+ * case v3's effects-dropping at the call site (defeating the dedup).
+ * The cross-reference on v4's `strip.ts:stripAsyncChecks` records the
+ * same rationale.
  *
  * Cycle-safe via a per-pass `WeakSet` so a pathological
  * `z.lazy(() => self)` schema terminates.

--- a/src/runtime/adapters/zod-v3/walker-introspector.ts
+++ b/src/runtime/adapters/zod-v3/walker-introspector.ts
@@ -1,0 +1,80 @@
+/**
+ * Module-level `SchemaIntrospector<z.ZodTypeAny>` instance for the v3
+ * adapter. Mirrors the v4 instance at
+ * `src/runtime/adapters/zod-v4/walker-introspector.ts` against v3's
+ * introspect-module accessors. Hosted in its own file so the
+ * per-walker modules can import the const without routing through
+ * `index.ts` (which would create an import cycle).
+ */
+import type { z } from 'zod-v3'
+import type { SchemaIntrospector, SharedZodKind } from '../../core/abstract-schema-factory'
+import { isZodSchemaType } from './helpers'
+import {
+  containsAsyncRefine,
+  containsAsyncTransform,
+  getArrayElement,
+  getCatchDefault,
+  getDefaultValue,
+  getDiscriminatedOptions,
+  getDiscriminator,
+  getIntersectionLeft,
+  getIntersectionRight,
+  getLazyGetter,
+  getLiteralValues,
+  getNativeEnumValues,
+  getObjectShape,
+  getRecordKeyType,
+  getRecordValueType,
+  getSetValueType,
+  getTupleItems,
+  getUnionOptions,
+  hasCatchValue,
+  hasContainerOrRootRefine,
+  isCoercePrimitive,
+  isPreprocessNode,
+  kindOf,
+  unwrapBranded,
+  unwrapEffectsSource,
+  unwrapInner,
+  unwrapLazy,
+  unwrapPipeIn,
+  unwrapPipeOut,
+} from './introspect'
+
+export const V3_INTROSPECTOR: SchemaIntrospector<z.ZodTypeAny> = {
+  kindOf: (schema) => kindOf(schema) as SharedZodKind | string,
+  getObjectShape: (schema) => getObjectShape(schema),
+  getTupleItems: (schema) => getTupleItems(schema),
+  getDiscriminatedOptions: (schema) => getDiscriminatedOptions(schema) as readonly z.ZodTypeAny[],
+  getDiscriminator: (schema) => getDiscriminator(schema),
+  getLiteralValues: (schema) => getLiteralValues(schema),
+  isPreprocessNode: (schema) => isPreprocessNode(schema),
+  isCoercePrimitive: (schema) => isCoercePrimitive(schema),
+  containsAsyncRefine: (schema) => containsAsyncRefine(schema),
+  containsAsyncTransform: (schema) => containsAsyncTransform(schema),
+  hasContainerOrRootRefine: (schema) => hasContainerOrRootRefine(schema),
+
+  // Walker accessors (D2 / D3 / D5).
+  getArrayElement: (schema) => getArrayElement(schema),
+  getSetValueType: (schema) => getSetValueType(schema),
+  getRecordKeyType: (schema) => getRecordKeyType(schema),
+  getRecordValueType: (schema) => getRecordValueType(schema),
+  getUnionOptions: (schema) => getUnionOptions(schema),
+  getIntersectionLeft: (schema) => getIntersectionLeft(schema),
+  getIntersectionRight: (schema) => getIntersectionRight(schema),
+  getEnumValues: (schema) => {
+    if (!isZodSchemaType(schema, 'ZodEnum')) return []
+    return (schema as z.ZodEnum<[string, ...string[]]>).options
+  },
+  getNativeEnumValues: (schema) => getNativeEnumValues(schema),
+  unwrapInner: (schema) => unwrapInner(schema),
+  unwrapBranded: (schema) => unwrapBranded(schema),
+  unwrapEffectsSource: (schema) => unwrapEffectsSource(schema),
+  unwrapPipeIn: (schema) => unwrapPipeIn(schema),
+  unwrapPipeOut: (schema) => unwrapPipeOut(schema),
+  unwrapLazy: (schema) => unwrapLazy(schema),
+  getLazyGetter: (schema) => getLazyGetter(schema),
+  getDefaultValue: (schema) => getDefaultValue(schema),
+  getCatchDefault: (schema) => getCatchDefault(schema),
+  hasCatchValue: (schema) => hasCatchValue(schema),
+}

--- a/src/runtime/adapters/zod-v4/adapter.ts
+++ b/src/runtime/adapters/zod-v4/adapter.ts
@@ -28,23 +28,34 @@ import {
   containsAsyncRefine,
   containsAsyncTransform,
   getArrayElement,
+  getCatchDefault,
+  getDefaultValue,
   getDiscriminatedOptions,
   getDiscriminator,
+  getEnumValues,
   getIntersectionLeft,
   getIntersectionRight,
+  getLazyGetter,
   getLiteralValues,
+  getNativeEnumValues,
   getObjectShape,
+  getRecordKeyType,
   getRecordValueType,
   getSetValueType,
   getTupleItems,
   getUnionOptions,
+  hasCatchValue,
   hasContainerOrRootRefine,
   isCoercePrimitive,
   isPreprocessNode,
   kindOf,
+  unwrapBranded,
+  unwrapEffectsSource,
   unwrapInner,
   unwrapLazy,
   unwrapPipe,
+  unwrapPipeIn,
+  unwrapPipeOut,
 } from './introspect'
 import { getNestedZodSchemasAtPath } from './path-walker'
 import { slimPrimitivesOf } from './slim-primitives'
@@ -292,6 +303,32 @@ const V4_INTROSPECTOR: SchemaIntrospector<z.ZodType> = {
   containsAsyncRefine: (schema) => containsAsyncRefine(schema),
   containsAsyncTransform: (schema) => containsAsyncTransform(schema),
   hasContainerOrRootRefine: (schema) => hasContainerOrRootRefine(schema),
+
+  // Walker accessors (D2 / D3 / D5).
+  getArrayElement: (schema) => {
+    if (kindOf(schema) !== 'array') return undefined
+    return getArrayElement(schema as z.ZodArray)
+  },
+  getSetValueType: (schema) => (kindOf(schema) === 'set' ? getSetValueType(schema) : undefined),
+  getRecordKeyType: (schema) =>
+    kindOf(schema) === 'record' ? getRecordKeyType(schema) : undefined,
+  getRecordValueType: (schema) =>
+    kindOf(schema) === 'record' ? getRecordValueType(schema) : undefined,
+  getUnionOptions: (schema) => getUnionOptions(schema),
+  getIntersectionLeft: (schema) => getIntersectionLeft(schema),
+  getIntersectionRight: (schema) => getIntersectionRight(schema),
+  getEnumValues: (schema) => getEnumValues(schema),
+  getNativeEnumValues: (schema) => getNativeEnumValues(schema),
+  unwrapInner: (schema) => unwrapInner(schema),
+  unwrapBranded: (schema) => unwrapBranded(schema),
+  unwrapEffectsSource: (schema) => unwrapEffectsSource(schema),
+  unwrapPipeIn: (schema) => unwrapPipeIn(schema),
+  unwrapPipeOut: (schema) => unwrapPipeOut(schema),
+  unwrapLazy: (schema) => unwrapLazy(schema),
+  getLazyGetter: (schema) => getLazyGetter(schema),
+  getDefaultValue: (schema) => getDefaultValue(schema),
+  getCatchDefault: (schema) => getCatchDefault(schema),
+  hasCatchValue: (schema) => hasCatchValue(schema),
 }
 
 /**

--- a/src/runtime/adapters/zod-v4/adapter.ts
+++ b/src/runtime/adapters/zod-v4/adapter.ts
@@ -10,8 +10,6 @@ import type {
 import {
   createAbstractSchema,
   type AbstractSchemaServices,
-  type SchemaIntrospector,
-  type SharedZodKind,
 } from '../../core/abstract-schema-factory'
 import { getFieldMeta, getFieldMetaList } from './field-meta'
 import type { SchemaFactoryOptions } from '../../core/get-computed-schema'
@@ -28,38 +26,23 @@ import {
   containsAsyncRefine,
   containsAsyncTransform,
   getArrayElement,
-  getCatchDefault,
-  getDefaultValue,
   getDiscriminatedOptions,
-  getDiscriminator,
-  getEnumValues,
   getIntersectionLeft,
   getIntersectionRight,
-  getLazyGetter,
-  getLiteralValues,
-  getNativeEnumValues,
   getObjectShape,
-  getRecordKeyType,
   getRecordValueType,
   getSetValueType,
   getTupleItems,
   getUnionOptions,
-  hasCatchValue,
-  hasContainerOrRootRefine,
-  isCoercePrimitive,
-  isPreprocessNode,
   kindOf,
-  unwrapBranded,
-  unwrapEffectsSource,
   unwrapInner,
   unwrapLazy,
   unwrapPipe,
-  unwrapPipeIn,
-  unwrapPipeOut,
 } from './introspect'
 import { getNestedZodSchemasAtPath } from './path-walker'
 import { slimPrimitivesOf } from './slim-primitives'
 import { stripAsyncChecks } from './strip'
+import { V4_INTROSPECTOR } from './walker-introspector'
 
 /**
  * Zod v4 adapter — implements `AbstractSchema` against Zod v4's public
@@ -284,51 +267,6 @@ export function zodV4Adapter<
       formKey,
       options
     )
-}
-
-/**
- * Module-level `SchemaIntrospector` for the v4 adapter. Pure schema
- * accessors with no closure state — shared across every `useForm()`
- * that ships a v4 schema.
- */
-const V4_INTROSPECTOR: SchemaIntrospector<z.ZodType> = {
-  kindOf: (schema) => kindOf(schema) as SharedZodKind | string,
-  getObjectShape: (schema) => getObjectShape(schema as z.ZodObject),
-  getTupleItems: (schema) => getTupleItems(schema),
-  getDiscriminatedOptions: (schema) => getDiscriminatedOptions(schema) as readonly z.ZodType[],
-  getDiscriminator: (schema) => getDiscriminator(schema),
-  getLiteralValues: (schema) => getLiteralValues(schema),
-  isPreprocessNode: (schema) => isPreprocessNode(schema),
-  isCoercePrimitive: (schema) => isCoercePrimitive(schema),
-  containsAsyncRefine: (schema) => containsAsyncRefine(schema),
-  containsAsyncTransform: (schema) => containsAsyncTransform(schema),
-  hasContainerOrRootRefine: (schema) => hasContainerOrRootRefine(schema),
-
-  // Walker accessors (D2 / D3 / D5).
-  getArrayElement: (schema) => {
-    if (kindOf(schema) !== 'array') return undefined
-    return getArrayElement(schema as z.ZodArray)
-  },
-  getSetValueType: (schema) => (kindOf(schema) === 'set' ? getSetValueType(schema) : undefined),
-  getRecordKeyType: (schema) =>
-    kindOf(schema) === 'record' ? getRecordKeyType(schema) : undefined,
-  getRecordValueType: (schema) =>
-    kindOf(schema) === 'record' ? getRecordValueType(schema) : undefined,
-  getUnionOptions: (schema) => getUnionOptions(schema),
-  getIntersectionLeft: (schema) => getIntersectionLeft(schema),
-  getIntersectionRight: (schema) => getIntersectionRight(schema),
-  getEnumValues: (schema) => getEnumValues(schema),
-  getNativeEnumValues: (schema) => getNativeEnumValues(schema),
-  unwrapInner: (schema) => unwrapInner(schema),
-  unwrapBranded: (schema) => unwrapBranded(schema),
-  unwrapEffectsSource: (schema) => unwrapEffectsSource(schema),
-  unwrapPipeIn: (schema) => unwrapPipeIn(schema),
-  unwrapPipeOut: (schema) => unwrapPipeOut(schema),
-  unwrapLazy: (schema) => unwrapLazy(schema),
-  getLazyGetter: (schema) => getLazyGetter(schema),
-  getDefaultValue: (schema) => getDefaultValue(schema),
-  getCatchDefault: (schema) => getCatchDefault(schema),
-  hasCatchValue: (schema) => hasCatchValue(schema),
 }
 
 /**

--- a/src/runtime/adapters/zod-v4/default-values.ts
+++ b/src/runtime/adapters/zod-v4/default-values.ts
@@ -1,335 +1,63 @@
 import type { z } from 'zod'
-import { getAtPath, isPlainRecord, setAtPath } from '../../core/path-walker'
+import { getAtPath, setAtPath } from '../../core/path-walker'
 import { slimKindOf } from '../../core/slim-primitive-gate'
+import { mergeDeep } from '../../core/merge-deep'
+import { deriveDefaultWalk } from '../../core/walk-derive-default'
 import { getDiscriminatedUnionFirstOption, unwrapToDiscriminatedUnion } from './discriminator'
 import { slimPrimitivesOf } from './slim-primitives'
 import {
-  getCatchDefault,
-  getDefaultValue,
   getDiscriminatedOptions,
-  getEnumValues,
-  getIntersectionLeft,
-  getIntersectionRight,
-  getLiteralValues,
-  getObjectShape,
-  getTupleItems,
   getUnionOptions,
   isCoercePrimitive,
   kindOf,
-  unwrapInner,
-  unwrapLazy,
   unwrapPipeIn,
-  unwrapPipeOut,
-  type ZodKind,
 } from './introspect'
 import { getNestedZodSchemasAtPath } from './path-walker'
 import { getSlimSchema } from './strip'
+import { V4_INTROSPECTOR } from './walker-introspector'
 
 /**
- * Walks transparent wrappers (`.optional()` / `.nullable()` / `.readonly()`
- * / `.catch()`) until it hits a `ZodDefault` or a non-wrapper leaf. Used
- * by the pipe branch to decide whether a preprocess-wrapped inner
- * carries a consumer-declared default; if so, the walker walks the
- * inner normally and honors that default, otherwise it returns
- * `undefined` so the slot waits for `defaultValues` / `setValue`.
+ * Derive a default value for any Zod v4 schema.
  *
- * Bounded loop matches the `unwrapToDiscriminatedUnion` pattern — a
- * deeper wrapper stack is almost certainly a recursive cycle, not
- * legitimate schema construction.
- */
-function hasDeclaredDefaultInChain(schema: z.ZodType): boolean {
-  let current: z.ZodType | undefined = schema
-  for (let i = 0; i < 32; i++) {
-    if (current === undefined) return false
-    const k = kindOf(current)
-    if (k === 'default') return true
-    if (k === 'optional' || k === 'nullable' || k === 'readonly' || k === 'catch') {
-      current = unwrapInner(current)
-      continue
-    }
-    return false
-  }
-  return false
-}
-
-/**
- * Derive a default value for any Zod v4 schema. Mirrors v3's walker but
- * routes through the introspect helpers so `def.*` access stays
- * chokepointed. When `useDefault` is false, `.default(x)` wrappers are
- * skipped so the walker produces the underlying leaf's empty value
- * instead — useful when the caller wants a "blank" initial state rather
- * than the schema's declared defaults.
+ * Thin wrapper around the shared `deriveDefaultWalk` core walker —
+ * v3 and v4 dispatch through the same body via their respective
+ * `SchemaIntrospector` instance. See `core/walk-derive-default.ts`
+ * for the per-kind dispatch rules, including the
+ * `peelEmbeddedDefault` chain-walk that closes the v3↔v4 parity gap
+ * on `Optional(Default('x'))` / `Nullable(Default('x'))` / etc.
+ *
+ * When `useDefault` is false, `.default(x)` wrappers are skipped so
+ * the walker produces the underlying leaf's empty value instead —
+ * useful when the caller wants a "blank" initial state rather than
+ * the schema's declared defaults.
  *
  * `maxRecursionDepth` caps descent through `z.lazy()`: the counter
- * bumps only when the walker crosses a lazy boundary, so non-recursive
- * deep structural nesting is unaffected. Once `lazyDepth > maxDepth`
- * the walker returns `undefined` for the recursive node — the seed
- * value comes from `defaultValues` instead.
+ * bumps only when the walker crosses a lazy boundary.
  */
 export function deriveDefault(
   schema: z.ZodType,
   useDefault: boolean,
   maxRecursionDepth: number
 ): unknown {
-  return defaultForKind(kindOf(schema), schema, useDefault, maxRecursionDepth, 0)
+  return deriveDefaultWalk(schema, useDefault, V4_INTROSPECTOR, maxRecursionDepth, {
+    // v4 has an exhaustive switch against `SchemaIntrospector.kindOf`;
+    // unknown kinds genuinely shouldn't appear, so return undefined.
+    unsupportedKindFallback: () => undefined,
+    // v4 historically recurses into the inner on `useDefault=false`
+    // so a `.catch(v)` slot returns the leaf empty rather than the
+    // fallback. Pinned by `test/adapters/zod-v4/unsupported-kinds.test.ts`
+    // (`z.catch falls through to inner leaf default when useDefault=false`).
+    catchOnUseDefaultFalse: 'recurseInner',
+  })
 }
 
-function defaultForKind(
-  kind: ZodKind,
-  schema: z.ZodType,
-  useDefault: boolean,
-  maxDepth: number,
-  lazyDepth: number
-): unknown {
-  // Schema-side input normalizers (`z.coerce.X()` as a coerce-flagged
-  // primitive; `z.preprocess(fn, _)` as a pipe-with-transform-on-in
-  // handled in the 'pipe' branch below) declare a write boundary the
-  // runtime cannot honestly synthesise a default for. Leave the slot
-  // `undefined` so the consumer's `defaultValues` or a later `setValue`
-  // owns what lands in storage. Without this, the walker fell through
-  // to the primitive's slim concrete (`''`, `0`, `false`, …) and
-  // claimed a value the consumer never supplied.
-  if (isCoercePrimitive(schema)) return undefined
-  switch (kind) {
-    case 'object': {
-      const shape = getObjectShape(schema as z.ZodObject)
-      const out: Record<string, unknown> = {}
-      for (const [key, subSchema] of Object.entries(shape)) {
-        out[key] = defaultForKind(kindOf(subSchema), subSchema, useDefault, maxDepth, lazyDepth)
-      }
-      return out
-    }
-    case 'default': {
-      if (useDefault) return getDefaultValue(schema)
-      const inner = unwrapInner(schema)
-      return inner === undefined
-        ? undefined
-        : defaultForKind(kindOf(inner), inner, useDefault, maxDepth, lazyDepth)
-    }
-    case 'optional':
-      return undefined
-    case 'nullable':
-      return null
-    case 'readonly': {
-      const inner = unwrapInner(schema)
-      return inner === undefined
-        ? undefined
-        : defaultForKind(kindOf(inner), inner, useDefault, maxDepth, lazyDepth)
-    }
-    case 'pipe': {
-      // `z.preprocess(fn, inner)` desugars to a pipe whose `in` is a
-      // ZodTransform (the user-supplied `fn`); the input shape is
-      // genuinely unknown until the consumer writes. Two sub-cases:
-      //
-      //   - Inner schema carries a consumer-declared default
-      //     (`z.preprocess(fn, z.string().default('hello'))`): honor
-      //     it. The consumer wrote the default themselves, so storage
-      //     starts there.
-      //   - No declared default on the inner: leave the slot
-      //     `undefined` so `defaultValues` or a later `setValue` owns
-      //     what lands in storage. Synthesising the inner's slim
-      //     concrete (`''` / `0` / etc.) would claim a value the
-      //     consumer never supplied.
-      const inn = unwrapPipeIn(schema)
-      if (inn !== undefined && kindOf(inn) === 'transform') {
-        const out = unwrapPipeOut(schema)
-        if (out !== undefined && hasDeclaredDefaultInChain(out)) {
-          return defaultForKind(kindOf(out), out, useDefault, maxDepth, lazyDepth)
-        }
-        return undefined
-      }
-      // `.transform(fn)` (transform on output) and generic / codec
-      // pipes still have a real source on the input side; peel to it
-      // for the source default.
-      const out = unwrapPipeOut(schema)
-      const real =
-        inn !== undefined && kindOf(inn) !== 'transform'
-          ? inn
-          : out !== undefined && kindOf(out) !== 'transform'
-            ? out
-            : (inn ?? out)
-      return real === undefined
-        ? undefined
-        : defaultForKind(kindOf(real), real, useDefault, maxDepth, lazyDepth)
-    }
-    case 'array':
-      return []
-    case 'set':
-      return new Set()
-    case 'record':
-      return {}
-    case 'tuple': {
-      const items = getTupleItems(schema)
-      return items.map((item) =>
-        defaultForKind(kindOf(item), item, useDefault, maxDepth, lazyDepth)
-      )
-    }
-    case 'union': {
-      const options = getUnionOptions(schema)
-      const first = options[0]
-      return first === undefined
-        ? undefined
-        : defaultForKind(kindOf(first), first, useDefault, maxDepth, lazyDepth)
-    }
-    case 'discriminated-union': {
-      const first = getDiscriminatedUnionFirstOption(schema)
-      return first === undefined
-        ? undefined
-        : defaultForKind(kindOf(first), first, useDefault, maxDepth, lazyDepth)
-    }
-    case 'string':
-      return ''
-    case 'number':
-      return 0
-    case 'bigint':
-      // z.bigint() strictly rejects numbers; the default must be a bigint
-      // literal. Using `0` here causes default-values derivation to fail
-      // the schema's own validation.
-      return 0n
-    case 'boolean':
-      return false
-    case 'date':
-      return new Date(0)
-    case 'null':
-      return null
-    case 'undefined':
-      return undefined
-    case 'enum': {
-      const values = getEnumValues(schema)
-      return values[0]
-    }
-    case 'literal': {
-      const values = getLiteralValues(schema)
-      return values[0]
-    }
-    case 'nan':
-      return NaN
-    case 'lazy': {
-      // Bump the lazy counter ONLY here — structural recursion doesn't
-      // accumulate. Past the cap, return undefined so a recursive node
-      // ends in a non-fatal blank; `defaultValues` (consumer-supplied)
-      // is the authority for what the seed should be at the recursive
-      // boundary anyway.
-      if (lazyDepth >= maxDepth) return undefined
-      // `z.lazy()` runs a user-supplied getter; a getter that throws
-      // (cyclic reference resolved before its target is constructed,
-      // user bug, etc.) shouldn't crash form construction. Mirror the
-      // try/catch precedent in `introspect.ts:containsAsyncRefine`.
-      let inner: z.ZodType | undefined
-      try {
-        inner = unwrapLazy(schema)
-      } catch {
-        return undefined
-      }
-      return inner === undefined
-        ? undefined
-        : defaultForKind(kindOf(inner), inner, useDefault, maxDepth, lazyDepth + 1)
-    }
-    case 'intersection': {
-      const left = getIntersectionLeft(schema)
-      const right = getIntersectionRight(schema)
-      const l =
-        left === undefined
-          ? undefined
-          : defaultForKind(kindOf(left), left, useDefault, maxDepth, lazyDepth)
-      const r =
-        right === undefined
-          ? undefined
-          : defaultForKind(kindOf(right), right, useDefault, maxDepth, lazyDepth)
-      // `mergeDeep` prefers `right` where both sides carry a plain-record
-      // value at a key, and returns `right` wholesale when either side is
-      // a leaf. That matches parse-time semantics: an intersection of
-      // `{ a }` and `{ b }` must satisfy both, so the merged shape carries
-      // both keys' defaults.
-      return mergeDeep(l, r)
-    }
-    case 'catch': {
-      // Catch wraps a schema with a fallback value used when parsing
-      // fails. For `useDefault=true` the catch value *is* the best
-      // default — it's the authoritative "fresh" value the consumer
-      // declared. For `useDefault=false` fall through to the inner
-      // walker so the leaf's empty value wins (matches the default/
-      // prefault branch's semantics).
-      if (useDefault) return getCatchDefault(schema)
-      const inner = unwrapInner(schema)
-      return inner === undefined
-        ? undefined
-        : defaultForKind(kindOf(inner), inner, useDefault, maxDepth, lazyDepth)
-    }
-    case 'any':
-    case 'unknown':
-    case 'void':
-    case 'never':
-    case 'promise':
-    case 'custom':
-    case 'template-literal':
-    case 'transform':
-    case 'map':
-    case 'symbol':
-    case 'function':
-      // `promise`/`custom`/`template-literal`/`map`/`symbol`/`function`
-      // are rejected by `assertSupportedKinds` at adapter construction,
-      // so these branches are unreachable through the public surface.
-      // `transform` is the input side of a `z.preprocess(fn, inner)` and
-      // has no own default — callers walk to `inner` via the surrounding
-      // pipe. Kept for exhaustive switch safety when `deriveDefault` is
-      // called directly in tests.
-      return undefined
-    case 'file':
-      // `z.file()` has no canonical "empty file" — the user picks one
-      // through the directive's change handler. `null` is the storage
-      // blank value the directive canonicalises to on register / clear;
-      // emitting `null` here keeps `getEmptyValueAtPath` aligned with
-      // what `form.clear(path)` writes.
-      return null
-    default: {
-      const _exhaustive: never = kind
-      throw new Error(`deriveDefault: unhandled ZodKind '${_exhaustive as string}'`)
-    }
-  }
-}
+// `defaultForKind` body lifted to `core/walk-derive-default.ts`; this
+// module now just adapts the result to the v4-specific
+// `getDefaultValuesFromZodSchema` validate-then-fix loop.
 
-/**
- * Merge `override` into `base` recursively, preferring override leaves.
- *
- * Leaf semantics (anything not a plain `{}` record is a leaf):
- *   - `null` override → replaces base (a deliberate "clear this field" signal)
- *   - `undefined` override at a key the consumer NAMED (`Object.keys`
- *     returns it) → replaces base. The consumer asked for "this slot
- *     starts undefined," which is a distinct signal from "no entry at
- *     this key."
- *   - primitives, arrays, `Date`, `Map`, class instances → replace wholesale
- *
- * Only plain records on BOTH sides recurse. The previous implementation
- * walked any `typeof === 'object'` value, which collapsed `Date`/`Map`
- * overrides into `{}` and silently swallowed `null` overrides intended
- * to clear a nullable default.
- */
-export function mergeDeep(base: unknown, override: unknown): unknown {
-  if (override === undefined) return base
-  // Non-plain-record overrides are leaves and replace base wholesale.
-  // (null, primitives, arrays, Date, Map, class instances all land here.)
-  if (!isPlainRecord(override)) return override
-  // Override is a plain record but base isn't — leaf-replacement again.
-  if (!isPlainRecord(base)) return override
-
-  const result: Record<string, unknown> = { ...base }
-  for (const key of Object.keys(override)) {
-    const oVal = override[key]
-    const bVal = base[key]
-    // Recurse only when BOTH sides are plain records; otherwise treat
-    // the override as a leaf. `Object.keys` returns OWN enumerable
-    // keys, so a key with an explicit `undefined` value lands here too
-    // — and the consumer's choice to name the path overrides the
-    // base's value, mirroring the way an explicit `null` would.
-    if (isPlainRecord(oVal) && isPlainRecord(bVal)) {
-      result[key] = mergeDeep(bVal, oVal)
-    } else {
-      result[key] = oVal
-    }
-  }
-  return result
-}
+// `mergeDeep` lifted to `core/merge-deep.ts` so v3 and v4 share one
+// body. Re-exported below as `mergeDeep` for backwards-compatible
+// internal callers (the v4 strict-mode flow still consults it).
 
 export type GetDefaultValuesOptions = {
   schema: z.ZodObject

--- a/src/runtime/adapters/zod-v4/introspect.ts
+++ b/src/runtime/adapters/zod-v4/introspect.ts
@@ -339,12 +339,49 @@ export function getCatchDefault(schema: z.ZodType): unknown {
   }
 }
 
+/** True iff the schema carries a callable `z.catch(...)` fallback. */
+export function hasCatchValue(schema: z.ZodType): boolean {
+  const def = readDef(schema)
+  return typeof def?.catchValue === 'function'
+}
+
 export function getDefaultValue(schema: z.ZodType): unknown {
   const def = readDef(schema)
   // In v4, defaultValue is stored as a getter that returns the value directly
   // (v3 stored a function that had to be called). We read the property via
   // normal access so the getter fires.
   return def?.defaultValue
+}
+
+/**
+ * v3-parity stub: Zod v4 folds `z.nativeEnum(E)` into the regular `enum`
+ * kind, so a v4 schema never returns a reverse-mapped values object.
+ * Kept on the introspect surface so the shared `SchemaIntrospector`
+ * contract is uniform between v3 and v4; the core walkers consult this
+ * for the v3-specific native-enum branch and silently skip on v4.
+ */
+export function getNativeEnumValues(_schema: z.ZodType): Record<string, unknown> | undefined {
+  return undefined
+}
+
+/**
+ * v3-parity stub: Zod v4 has no `ZodEffects` wrapper — refinements live
+ * on the schema's `def.checks`, transforms are pipe `def.in`, and
+ * preprocess is pipe-with-transform-on-`in`. Returns undefined so the
+ * shared walkers treat any v4 schema as "no effects source to peel".
+ */
+export function unwrapEffectsSource(_schema: z.ZodType): z.ZodType | undefined {
+  return undefined
+}
+
+/**
+ * v3-parity stub: Zod v4 has no `ZodBranded` wrapper — brand types
+ * carry their brand on the type level only and don't introduce a
+ * runtime wrapper. Returns undefined so the shared walkers treat
+ * any v4 schema as "no branded inner to peel".
+ */
+export function unwrapBranded(_schema: z.ZodType): z.ZodType | undefined {
+  return undefined
 }
 
 /** True if the schema's `def` carries refinement checks (e.g. `.min(3)`). */

--- a/src/runtime/adapters/zod-v4/path-walker.ts
+++ b/src/runtime/adapters/zod-v4/path-walker.ts
@@ -1,36 +1,17 @@
 import type { z } from 'zod'
-import {
-  getArrayElement,
-  getDiscriminatedOptions,
-  getIntersectionLeft,
-  getIntersectionRight,
-  getObjectShape,
-  getRecordValueType,
-  getSetValueType,
-  getTupleItems,
-  getUnionOptions,
-  kindOf,
-  unwrapInner,
-  unwrapLazy,
-  unwrapPipe,
-} from './introspect'
+import { walkPathSegments } from '../../core/walk-path-segments'
+import { V4_INTROSPECTOR } from './walker-introspector'
 
 const PATH_SEPARATOR = '.'
 
 /**
- * Walk a dotted path through a Zod schema tree and return the subschema(s)
- * that live at that path.
+ * Walk a dotted path through a Zod v4 schema tree and return the
+ * subschema(s) that live at that path.
  *
- * - Unions return multiple candidates (caller tries each).
- * - Discriminated unions filter options to those whose shape contains the
- *   next segment, so a path into `{ status: 'error', message: string }`
- *   resolves only to the 'error' branch.
- * - Wrappers (optional/nullable/default/readonly/pipe) are transparent —
- *   the walker descends into the inner schema without consuming a path
- *   segment.
- * - Leaf types (string/number/literal/...) return `[]` when there's still
- *   path left, so a caller that asked for `firstName.middle` against a
- *   string schema gets an empty resolution rather than a wrong schema.
+ * Thin wrapper around the shared `walkPathSegments` core walker; both
+ * v3 and v4 dispatch through the same body via their respective
+ * `SchemaIntrospector` instance. See `core/walk-path-segments.ts` for
+ * the per-kind dispatch rules.
  *
  * `maxRecursionDepth` caps descent through `z.lazy()`. Once the walker
  * has crossed `maxRecursionDepth + 1` lazy boundaries it returns `[]`,
@@ -42,130 +23,16 @@ export function getNestedZodSchemasAtPath(
   path: string | readonly (string | number)[],
   maxRecursionDepth: number
 ): z.ZodType[] {
-  if (Array.isArray(path)) return walkSegments(schema, path.map(String), maxRecursionDepth, 0)
+  if (Array.isArray(path)) {
+    return walkPathSegments(schema, path.map(String), V4_INTROSPECTOR, maxRecursionDepth, 0)
+  }
   const pathString = path as string
   if (pathString.length === 0) return [schema]
-  return walkSegments(schema, pathString.split(PATH_SEPARATOR), maxRecursionDepth, 0)
-}
-
-function walkSegments(
-  schema: z.ZodType,
-  segments: readonly string[],
-  maxDepth: number,
-  lazyDepth: number
-): z.ZodType[] {
-  if (segments.length === 0) return [schema]
-  const [head, ...rest] = segments
-  if (head === undefined) return [schema]
-  const kind = kindOf(schema)
-  switch (kind) {
-    case 'object': {
-      const shape = getObjectShape(schema as z.ZodObject)
-      // Own-property check: `shape` is a plain object whose prototype
-      // is `Object.prototype`, so a bare `shape[head]` for `head ===
-      // 'toString'` / `'valueOf'` / `'hasOwnProperty'` etc. returns the
-      // inherited Function and the walker treats it as a schema. Filter
-      // to OWN keys so unknown segments resolve to "doesn't exist."
-      if (!Object.hasOwn(shape, head)) return []
-      const next = shape[head]
-      return next === undefined ? [] : walkSegments(next, rest, maxDepth, lazyDepth)
-    }
-    case 'array':
-      return walkSegments(getArrayElement(schema as z.ZodArray), rest, maxDepth, lazyDepth)
-    case 'set':
-      // Sets aren't position-indexed, so the `head` segment is just a
-      // synthetic indexer (`[...path, 0]`) used to query the element
-      // type. We descend into the value schema and consume the segment.
-      return walkSegments(getSetValueType(schema), rest, maxDepth, lazyDepth)
-    case 'record':
-      return walkSegments(getRecordValueType(schema), rest, maxDepth, lazyDepth)
-    case 'tuple': {
-      const index = Number(head)
-      if (!Number.isInteger(index)) return []
-      const items = getTupleItems(schema)
-      const item = items[index]
-      return item === undefined ? [] : walkSegments(item, rest, maxDepth, lazyDepth)
-    }
-    case 'union':
-      return getUnionOptions(schema).flatMap((opt) =>
-        walkSegments(opt, segments, maxDepth, lazyDepth)
-      )
-    case 'discriminated-union': {
-      // Filter options whose shape contains this segment. Fallback: if no
-      // option matches (e.g. the discriminator key itself), try every option.
-      // `Object.hasOwn` (not `in`) so `Object.prototype` keys don't leak.
-      const options = getDiscriminatedOptions(schema)
-      const matching = options.filter((opt) => {
-        const shape = getObjectShape(opt)
-        return Object.hasOwn(shape, head)
-      })
-      const candidates = matching.length > 0 ? matching : options
-      return candidates.flatMap((opt) => walkSegments(opt, segments, maxDepth, lazyDepth))
-    }
-    case 'optional':
-    case 'nullable':
-    case 'default':
-    case 'readonly':
-    case 'catch': {
-      // `catch` peels like a wrapper — descend into the inner schema.
-      // The catch fallback only matters at parse time, not path lookup.
-      const inner = unwrapInner(schema)
-      return inner === undefined ? [] : walkSegments(inner, segments, maxDepth, lazyDepth)
-    }
-    case 'pipe': {
-      const inner = unwrapPipe(schema)
-      return inner === undefined ? [] : walkSegments(inner, segments, maxDepth, lazyDepth)
-    }
-    case 'lazy': {
-      // Bump the lazy counter. Past the cap, return [] so callers fall
-      // back to permissive behaviour at recursive paths beyond the cap.
-      if (lazyDepth >= maxDepth) return []
-      const inner = unwrapLazy(schema)
-      return inner === undefined ? [] : walkSegments(inner, segments, maxDepth, lazyDepth + 1)
-    }
-    case 'intersection': {
-      // Union of both sides' resolutions — callers try each candidate,
-      // matching parse-time semantics where a value must satisfy both.
-      const left = getIntersectionLeft(schema)
-      const right = getIntersectionRight(schema)
-      const leftResults =
-        left === undefined ? [] : walkSegments(left, segments, maxDepth, lazyDepth)
-      const rightResults =
-        right === undefined ? [] : walkSegments(right, segments, maxDepth, lazyDepth)
-      return [...leftResults, ...rightResults]
-    }
-    // Leaf types — can't descend further.
-    case 'string':
-    case 'number':
-    case 'bigint':
-    case 'boolean':
-    case 'undefined':
-    case 'null':
-    case 'void':
-    case 'never':
-    case 'any':
-    case 'unknown':
-    case 'date':
-    case 'enum':
-    case 'literal':
-    case 'nan':
-    case 'promise':
-    case 'custom':
-    case 'template-literal':
-    case 'transform':
-    case 'file':
-    case 'map':
-    case 'symbol':
-    case 'function':
-      // ZodTransform is the input side of `z.preprocess(fn, inner)` and
-      // not directly walkable; callers reach `inner` through the
-      // surrounding pipe. `file` / `map` / `symbol` / `function` are
-      // leaves with no sub-paths (the last three are rejected at adapter
-      // construction; kept here for compile-time exhaustiveness).
-      return []
-    default: {
-      const _exhaustive: never = kind
-      throw new Error(`walkSegments: unhandled ZodKind '${_exhaustive as string}'`)
-    }
-  }
+  return walkPathSegments(
+    schema,
+    pathString.split(PATH_SEPARATOR),
+    V4_INTROSPECTOR,
+    maxRecursionDepth,
+    0
+  )
 }

--- a/src/runtime/adapters/zod-v4/slim-primitives.ts
+++ b/src/runtime/adapters/zod-v4/slim-primitives.ts
@@ -4,6 +4,11 @@
  * peeled, refinement-level constraints (`.email()`, `.min(N)`, enum
  * membership, literal equality, regex) are ignored.
  *
+ * Thin wrapper around the shared `slimPrimitivesWalk` core walker; v3
+ * and v4 dispatch through the same body via their respective
+ * `SchemaIntrospector` instance. See `core/walk-slim-primitives.ts`
+ * for the per-kind dispatch rules.
+ *
  * The runtime gate (`src/runtime/core/slim-primitive-gate.ts`) calls
  * the adapter method `getSlimPrimitiveTypesAtPath(path)`, which
  * resolves leaf candidates via `getNestedZodSchemasAtPath` and unions
@@ -11,227 +16,20 @@
  */
 import type { z } from 'zod'
 import type { SlimPrimitiveKind } from '../../types/types-api'
-import { slimKindOf } from '../../core/slim-primitive-gate'
-import {
-  getEnumValues,
-  getIntersectionLeft,
-  getIntersectionRight,
-  getLiteralValues,
-  getUnionOptions,
-  kindOf,
-  unwrapInner,
-  unwrapLazy,
-  unwrapPipeIn,
-  unwrapPipeOut,
-} from './introspect'
+import { PERMISSIVE_SLIM_KINDS, slimPrimitivesWalk } from '../../core/walk-slim-primitives'
+import { V4_INTROSPECTOR } from './walker-introspector'
 
-export const PERMISSIVE: ReadonlySet<SlimPrimitiveKind> =
-  /* @__PURE__ */ new Set<SlimPrimitiveKind>([
-    'string',
-    'number',
-    'boolean',
-    'bigint',
-    'date',
-    'null',
-    'undefined',
-    'object',
-    'array',
-    'symbol',
-    'function',
-    'map',
-    'set',
-    'file',
-  ])
-
-// Module-level frozen singletons for the leaf branches. Returning a
-// shared instance instead of `new Set([…])` per call cuts a hot
-// allocation when slim-primitives is reached through wrappers, and
-// collapses the inline literal Set constructions into shared
-// references for a small bundle-size win. `walk()` returns
-// `ReadonlySet`; callers that need to mutate (optional/nullable/union
-// branches, and the public `slimPrimitivesOf` boundary) clone first.
-const KIND_STRING: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['string'])
-const KIND_NUMBER: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['number'])
-const KIND_BOOLEAN: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['boolean'])
-const KIND_BIGINT: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['bigint'])
-const KIND_DATE: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['date'])
-const KIND_NULL: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['null'])
-const KIND_UNDEFINED: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['undefined'])
-const KIND_OBJECT: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['object'])
-const KIND_ARRAY: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['array'])
-const KIND_SET: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['set'])
-const KIND_FILE: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['file', 'null'])
-const EMPTY_KINDS: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set()
+export const PERMISSIVE: ReadonlySet<SlimPrimitiveKind> = PERMISSIVE_SLIM_KINDS
 
 /**
- * Walk a schema, emitting the union of slim primitive kinds it
- * accepts. Wrappers descend into their inner schema; unions union
- * their branches; intersections intersect; lazy resolves through;
- * pipe takes the input side.
- *
- * Returns an empty set ONLY for `z.never()` — every other kind we
- * understand emits at least one entry. Unknown kinds (lazy with a
- * recursive cycle, custom z-types we don't recognise) return the
- * permissive set so the runtime gate doesn't reject legitimate
- * writes against shapes we can't introspect.
- *
- * `maxRecursionDepth` caps descent through `z.lazy()`: the counter
- * bumps only when the walker crosses a lazy boundary, so wrapper
- * stacks (`.optional().nullable()`) and union branches don't burn
- * the budget. Past the cap, the walker returns the permissive set
- * so writes at recursive paths beyond the cap aren't false-rejected.
+ * Walk a v4 schema, emitting the union of slim primitive kinds it
+ * accepts. Clones once at the public boundary so callers get a
+ * fresh mutable Set; the internal walk reuses frozen singletons for
+ * leaf kinds.
  */
 export function slimPrimitivesOf(
   schema: z.ZodType,
   maxRecursionDepth: number
 ): Set<SlimPrimitiveKind> {
-  // Clone once at the public boundary so callers get a fresh mutable
-  // Set. The internal walk reuses frozen singletons for leaf kinds.
-  return new Set(walk(schema, 0, maxRecursionDepth))
-}
-
-function walk(
-  schema: z.ZodType,
-  lazyDepth: number,
-  maxDepth: number
-): ReadonlySet<SlimPrimitiveKind> {
-  const kind = kindOf(schema)
-  switch (kind) {
-    case 'string':
-      return KIND_STRING
-    case 'number':
-    case 'nan':
-      return KIND_NUMBER
-    case 'boolean':
-      return KIND_BOOLEAN
-    case 'bigint':
-      return KIND_BIGINT
-    case 'date':
-      return KIND_DATE
-    case 'file':
-      // `z.file()` accepts `File` instances at write time. `null` is
-      // also accepted at the slim-primitive level so the directive's
-      // canonical blank value (the "no file selected" sentinel) lands
-      // even on required-file schemas — the blank-path channel + the
-      // derived "No value supplied" error already gates submission, so
-      // permitting `null` storage here doesn't loosen schema enforcement.
-      //
-      // The set's lack of container kinds (`object` / `array` / `map`
-      // / `set`) makes the path a leaf via `isLeafAtPath`, so
-      // `form.fields.<file-path>` returns a FieldState rather than
-      // descending into the File's own keys.
-      return KIND_FILE
-    case 'null':
-      return KIND_NULL
-    case 'undefined':
-    case 'void':
-      return KIND_UNDEFINED
-    case 'enum': {
-      // Enums in v4 may be string- or number-valued; walk entries.
-      const values = getEnumValues(schema)
-      const out = new Set<SlimPrimitiveKind>()
-      for (const v of values) {
-        if (typeof v === 'string') out.add('string')
-        else if (typeof v === 'number') out.add('number')
-      }
-      return out.size === 0 ? KIND_STRING : out
-    }
-    case 'literal': {
-      const values = getLiteralValues(schema)
-      const out = new Set<SlimPrimitiveKind>()
-      for (const v of values) out.add(slimKindOf(v))
-      return out.size === 0 ? PERMISSIVE : out
-    }
-    case 'object':
-    case 'record':
-      return KIND_OBJECT
-    case 'array':
-    case 'tuple':
-      return KIND_ARRAY
-    case 'set':
-      return KIND_SET
-    case 'optional': {
-      const inner = unwrapInner(schema)
-      const innerSet = inner === undefined ? EMPTY_KINDS : walk(inner, lazyDepth, maxDepth)
-      const out = new Set<SlimPrimitiveKind>(innerSet)
-      out.add('undefined')
-      return out
-    }
-    case 'nullable': {
-      const inner = unwrapInner(schema)
-      const innerSet = inner === undefined ? EMPTY_KINDS : walk(inner, lazyDepth, maxDepth)
-      const out = new Set<SlimPrimitiveKind>(innerSet)
-      out.add('null')
-      return out
-    }
-    case 'default':
-    case 'readonly':
-    case 'catch': {
-      const inner = unwrapInner(schema)
-      return inner === undefined ? PERMISSIVE : walk(inner, lazyDepth, maxDepth)
-    }
-    case 'pipe': {
-      // `z.preprocess(fn, inner)` and `z.coerce.X()` (pipe-with-transform-
-      // on-input) and `inner.transform(fn)` (transform-on-output) both
-      // serialize as ZodPipe, but the "storage shape" lives on opposite
-      // sides. For preprocess / coerce, the input side IS the transform
-      // (shapeless, slim-set PERMISSIVE) and the inner schema sits on
-      // the output side. For `.transform`, the input side is the source
-      // schema (the pre-transform value). Pick the non-transform side
-      // so `isLeafAtPath` and the directive-layer coerce target both
-      // resolve against a real shape.
-      const pipeIn = unwrapPipeIn(schema)
-      const pipeOut = unwrapPipeOut(schema)
-      const inner =
-        pipeIn !== undefined && kindOf(pipeIn) === 'transform' ? pipeOut : (pipeIn ?? pipeOut)
-      return inner === undefined ? PERMISSIVE : walk(inner, lazyDepth, maxDepth)
-    }
-    case 'lazy': {
-      // Bump on lazy crossing only; past the cap, fall back to
-      // permissive so recursive paths beyond the cap aren't gated.
-      if (lazyDepth >= maxDepth) return PERMISSIVE
-      const inner = unwrapLazy(schema)
-      return inner === undefined ? PERMISSIVE : walk(inner, lazyDepth + 1, maxDepth)
-    }
-    case 'union':
-    case 'discriminated-union': {
-      const options = getUnionOptions(schema)
-      const out = new Set<SlimPrimitiveKind>()
-      for (const opt of options) {
-        for (const k of walk(opt as z.ZodType, lazyDepth, maxDepth)) out.add(k)
-      }
-      return out.size === 0 ? PERMISSIVE : out
-    }
-    case 'intersection': {
-      const left = getIntersectionLeft(schema)
-      const right = getIntersectionRight(schema)
-      const leftSet = left === undefined ? PERMISSIVE : walk(left, lazyDepth, maxDepth)
-      const rightSet = right === undefined ? PERMISSIVE : walk(right, lazyDepth, maxDepth)
-      const out = new Set<SlimPrimitiveKind>()
-      for (const k of leftSet) if (rightSet.has(k)) out.add(k)
-      return out
-    }
-    case 'never':
-      return EMPTY_KINDS
-    case 'any':
-    case 'unknown':
-      return PERMISSIVE
-    // Kinds we don't understand at the slim level: be permissive to
-    // avoid false-rejecting legitimate writes against schema shapes
-    // we haven't characterised.
-    case 'promise':
-    case 'custom':
-    case 'template-literal':
-    case 'transform':
-    case 'map':
-    case 'symbol':
-    case 'function':
-      // `map` / `symbol` / `function` are rejected at construction by
-      // `assertSupportedKinds`; if a private code path constructs a
-      // walker on them directly fall back to PERMISSIVE (same as the
-      // other opaque kinds).
-      return PERMISSIVE
-    default:
-      return PERMISSIVE
-  }
+  return new Set(slimPrimitivesWalk(schema, V4_INTROSPECTOR, maxRecursionDepth))
 }

--- a/src/runtime/adapters/zod-v4/strip.ts
+++ b/src/runtime/adapters/zod-v4/strip.ts
@@ -208,6 +208,29 @@ export function stripRefinements(schema: z.ZodType): z.ZodType {
  * operation) and `getSlimSchema` (configurable peeling for default
  * derivation): this is a tree-walk that filters by sync/async at
  * every check site.
+ *
+ * Adapter-divergence note (Phase 12 part 2 / ADAPT-D4 deferred):
+ * this stays per-adapter rather than dedup-ing into a shared core
+ * walker. The structural skeleton (recurse + rebuild containers +
+ * wrappers + carry container-level constraints) is parallel to v3's
+ * `zod-v3/strip-async.ts:stripAsyncChecks`, but the per-check filter
+ * is irreducibly asymmetric:
+ *
+ *  - v4 filters by `isAsyncCheck(check)` at every check site — v4
+ *    knows the user fn directly (`check.def.fn.constructor.name`).
+ *    Sync refines survive the rebuild.
+ *  - v3 cannot statically distinguish sync from async `.refine(fn)`
+ *    because v3 wraps the user fn inside a sync closure that hides
+ *    `constructor.name`. v3 therefore drops EVERY `ZodEffects` it
+ *    encounters, losing sync refine seeding in mixed forms.
+ *
+ * A unified walker would need to either parameterise the rebuild
+ * with `shouldKeepCheck` AND `shouldDropWrapperWholesale` AND
+ * `rebuildLeaf` AND `rebuildContainer` services — which yields a
+ * walker bigger than the two it replaces — or special-case the v3
+ * effects-dropping at the call site, defeating the dedup. The
+ * docblocks on both files cross-reference so future readers see
+ * the deliberate asymmetry.
  */
 export function stripAsyncChecks(schema: z.ZodType): z.ZodType {
   const config: StripConfigInternal = {

--- a/src/runtime/adapters/zod-v4/walker-introspector.ts
+++ b/src/runtime/adapters/zod-v4/walker-introspector.ts
@@ -1,0 +1,84 @@
+/**
+ * Module-level `SchemaIntrospector<z.ZodType>` instance for the v4
+ * adapter. The instance is stateless — every method receives a schema
+ * and reads its `def.*` shape via the introspect-module accessors.
+ *
+ * Hosted in its own file so the per-walker modules (`path-walker.ts`,
+ * `slim-primitives.ts`, `default-values.ts`) can import it without
+ * routing through `adapter.ts` (which would create an import cycle:
+ * `adapter.ts → path-walker.ts → adapter.ts`).
+ */
+import type { z } from 'zod'
+import type { SchemaIntrospector, SharedZodKind } from '../../core/abstract-schema-factory'
+import {
+  containsAsyncRefine,
+  containsAsyncTransform,
+  getArrayElement,
+  getCatchDefault,
+  getDefaultValue,
+  getDiscriminatedOptions,
+  getDiscriminator,
+  getEnumValues,
+  getIntersectionLeft,
+  getIntersectionRight,
+  getLazyGetter,
+  getLiteralValues,
+  getNativeEnumValues,
+  getObjectShape,
+  getRecordKeyType,
+  getRecordValueType,
+  getSetValueType,
+  getTupleItems,
+  getUnionOptions,
+  hasCatchValue,
+  hasContainerOrRootRefine,
+  isCoercePrimitive,
+  isPreprocessNode,
+  kindOf,
+  unwrapBranded,
+  unwrapEffectsSource,
+  unwrapInner,
+  unwrapLazy,
+  unwrapPipeIn,
+  unwrapPipeOut,
+} from './introspect'
+
+export const V4_INTROSPECTOR: SchemaIntrospector<z.ZodType> = {
+  kindOf: (schema) => kindOf(schema) as SharedZodKind | string,
+  getObjectShape: (schema) => getObjectShape(schema as z.ZodObject),
+  getTupleItems: (schema) => getTupleItems(schema),
+  getDiscriminatedOptions: (schema) => getDiscriminatedOptions(schema) as readonly z.ZodType[],
+  getDiscriminator: (schema) => getDiscriminator(schema),
+  getLiteralValues: (schema) => getLiteralValues(schema),
+  isPreprocessNode: (schema) => isPreprocessNode(schema),
+  isCoercePrimitive: (schema) => isCoercePrimitive(schema),
+  containsAsyncRefine: (schema) => containsAsyncRefine(schema),
+  containsAsyncTransform: (schema) => containsAsyncTransform(schema),
+  hasContainerOrRootRefine: (schema) => hasContainerOrRootRefine(schema),
+
+  // Walker accessors (D2 / D3 / D5).
+  getArrayElement: (schema) => {
+    if (kindOf(schema) !== 'array') return undefined
+    return getArrayElement(schema as z.ZodArray)
+  },
+  getSetValueType: (schema) => (kindOf(schema) === 'set' ? getSetValueType(schema) : undefined),
+  getRecordKeyType: (schema) =>
+    kindOf(schema) === 'record' ? getRecordKeyType(schema) : undefined,
+  getRecordValueType: (schema) =>
+    kindOf(schema) === 'record' ? getRecordValueType(schema) : undefined,
+  getUnionOptions: (schema) => getUnionOptions(schema),
+  getIntersectionLeft: (schema) => getIntersectionLeft(schema),
+  getIntersectionRight: (schema) => getIntersectionRight(schema),
+  getEnumValues: (schema) => getEnumValues(schema),
+  getNativeEnumValues: (schema) => getNativeEnumValues(schema),
+  unwrapInner: (schema) => unwrapInner(schema),
+  unwrapBranded: (schema) => unwrapBranded(schema),
+  unwrapEffectsSource: (schema) => unwrapEffectsSource(schema),
+  unwrapPipeIn: (schema) => unwrapPipeIn(schema),
+  unwrapPipeOut: (schema) => unwrapPipeOut(schema),
+  unwrapLazy: (schema) => unwrapLazy(schema),
+  getLazyGetter: (schema) => getLazyGetter(schema),
+  getDefaultValue: (schema) => getDefaultValue(schema),
+  getCatchDefault: (schema) => getCatchDefault(schema),
+  hasCatchValue: (schema) => hasCatchValue(schema),
+}

--- a/src/runtime/core/abstract-schema-factory.ts
+++ b/src/runtime/core/abstract-schema-factory.ts
@@ -178,6 +178,93 @@ export interface SchemaIntrospector<Schema> {
    * subtree validation catches the same verdicts as a whole-form pass.
    */
   hasContainerOrRootRefine(schema: Schema): boolean
+
+  // ---------------------------------------------------------------------
+  // Walker accessors — consumed by the shared `core/walk-*` walkers (D2 /
+  // D3 / D5) so the path-walking / slim-primitive / default-derivation
+  // shapes don't fork per adapter. v3 / v4 each expose the full surface;
+  // members not applicable to one adapter return `undefined` (kept on the
+  // contract so the walkers don't branch on adapter identity).
+  // ---------------------------------------------------------------------
+
+  /** Element schema of a `z.array(...)`. Undefined for non-arrays / malformed defs. */
+  getArrayElement(schema: Schema): Schema | undefined
+  /** Element schema of a `z.set(...)`. Undefined for non-sets / malformed defs. */
+  getSetValueType(schema: Schema): Schema | undefined
+  /** Key schema of a `z.record(K, V)`. Undefined for non-records / single-arg records. */
+  getRecordKeyType(schema: Schema): Schema | undefined
+  /** Value schema of a `z.record(...)`. Undefined for non-records / malformed defs. */
+  getRecordValueType(schema: Schema): Schema | undefined
+  /** Option array of a `z.union(...)`. Empty for non-unions. */
+  getUnionOptions(schema: Schema): readonly Schema[]
+  /** Left side of a `z.intersection(L, R)`. Undefined for non-intersections. */
+  getIntersectionLeft(schema: Schema): Schema | undefined
+  /** Right side of a `z.intersection(L, R)`. Undefined for non-intersections. */
+  getIntersectionRight(schema: Schema): Schema | undefined
+  /** Values of a `z.enum(...)`. Empty for non-enums. */
+  getEnumValues(schema: Schema): readonly (string | number)[]
+  /**
+   * Raw reverse-mapped values object of a `z.nativeEnum(E)`. v3 returns
+   * the TS enum object directly; v4 always returns `undefined` because
+   * v4 folds nativeEnum into the regular `enum` kind.
+   */
+  getNativeEnumValues(schema: Schema): Record<string, unknown> | undefined
+
+  /**
+   * Inner schema of any wrapper exposing `def.innerType` — Optional /
+   * Nullable / Default / Readonly / Catch in both v3 and v4. Branded
+   * (v3-only) uses `def.type` instead — see `unwrapBranded`. Returns
+   * `undefined` when no inner is available.
+   */
+  unwrapInner(schema: Schema): Schema | undefined
+  /**
+   * v3-only: `ZodBranded`'s inner schema (`_def.type`). Returns
+   * `undefined` on v4 (no branded wrapper) and on non-branded schemas.
+   */
+  unwrapBranded(schema: Schema): Schema | undefined
+  /**
+   * v3-only: structural source of a `ZodEffects` (refine / transform /
+   * preprocess) — `_def.schema`. Returns `undefined` on v4 (no
+   * ZodEffects wrapper; effects live as pipe sides / leaf checks).
+   */
+  unwrapEffectsSource(schema: Schema): Schema | undefined
+  /** Input side of v4's `z.pipe(IN, OUT)` (also v3's `z.pipeline(...)`). */
+  unwrapPipeIn(schema: Schema): Schema | undefined
+  /** Output side of a pipe — undefined on v3's `ZodEffects`. */
+  unwrapPipeOut(schema: Schema): Schema | undefined
+  /**
+   * Inner schema of a `z.lazy(() => inner)`. Each call invokes the
+   * getter fresh; if the getter throws (recursive cycle resolved before
+   * its target is constructed) returns `undefined`.
+   */
+  unwrapLazy(schema: Schema): Schema | undefined
+  /**
+   * Getter function reference of a `z.lazy()` wrapper — used by walkers
+   * that track cycle identity by the getter rather than its result
+   * (each call returns a distinct schema instance).
+   */
+  getLazyGetter(schema: Schema): (() => unknown) | undefined
+
+  /**
+   * Resolve a `z.default(...)` wrapper to its declared default value.
+   * v3 stores the default as a thunk (`() => value`); v4 stores it as
+   * a getter that returns the value directly. Both adapters return the
+   * resolved value here.
+   */
+  getDefaultValue(schema: Schema): unknown
+  /**
+   * Resolve a `z.catch(inner, val)` wrapper to its fallback value.
+   * The catch slot stores a `(ctx) => value` function; both adapters
+   * invoke it with a placeholder context and surface `undefined` if
+   * the consumer's function throws.
+   */
+  getCatchDefault(schema: Schema): unknown
+  /**
+   * True iff the schema carries a callable `z.catch(...)` fallback.
+   * Lets callers distinguish "no catch wrapper" from "catch wrapper
+   * whose value happens to be `undefined`."
+   */
+  hasCatchValue(schema: Schema): boolean
 }
 
 /**

--- a/src/runtime/core/merge-deep.ts
+++ b/src/runtime/core/merge-deep.ts
@@ -1,0 +1,39 @@
+/**
+ * Plain-record deep merge for default-value derivation.
+ *
+ * Leaf semantics (anything not a plain `{}` record is a leaf):
+ *   - `undefined` override → no-op (base wins).
+ *   - `null` override → replaces base (a deliberate "clear this field"
+ *     signal that mustn't be merged into).
+ *   - Primitives / arrays / Date / Map / class instances → replace
+ *     wholesale (e.g. an array override doesn't concat).
+ *
+ * Recursion only when BOTH sides are plain records. The override-key
+ * walk uses `Object.keys` (own enumerable) so a key with an explicit
+ * `undefined` value lands here too — the consumer's choice to name the
+ * path overrides the base's value, mirroring how an explicit `null`
+ * would.
+ *
+ * Hosted in core so the v3 and v4 default-value walkers single-source
+ * the intersection / constraint-merge step. Previously identical
+ * `mergeDeep` / `mergeDeepV3` bodies lived per-adapter.
+ */
+import { isPlainRecord } from './path-walker'
+
+export function mergeDeep(base: unknown, override: unknown): unknown {
+  if (override === undefined) return base
+  if (!isPlainRecord(override)) return override
+  if (!isPlainRecord(base)) return override
+
+  const result: Record<string, unknown> = { ...base }
+  for (const key of Object.keys(override)) {
+    const oVal = override[key]
+    const bVal = base[key]
+    if (isPlainRecord(oVal) && isPlainRecord(bVal)) {
+      result[key] = mergeDeep(bVal, oVal)
+    } else {
+      result[key] = oVal
+    }
+  }
+  return result
+}

--- a/src/runtime/core/walk-derive-default.ts
+++ b/src/runtime/core/walk-derive-default.ts
@@ -1,0 +1,438 @@
+/**
+ * Shared default-value walker — derives the initial seed value the
+ * runtime places at every leaf of a Zod schema tree.
+ *
+ * Both v3 and v4 adapters dispatch through this body via their
+ * `SchemaIntrospector` instance plus a small `DeriveDefaultContext`
+ * carrying per-adapter knobs (`unsupportedKindFallback`, `formKey`).
+ * The per-version kind sets — v3's `branded` / `effects` / `pipeline`
+ * / `native-enum`, v4's `pipe` / `file` — collapse to distinct cases
+ * on the SharedZodKind switch.
+ *
+ * Semantics (preserved verbatim from the prior per-adapter
+ * implementations — characterised by the `default-values`,
+ * `get-default-at-path`, and `default-values-parity` test suites in
+ * `test/adapters/zod-v{3,4}/`):
+ *
+ *  - When `useDefault=true`, the walker FIRST peels transparent
+ *    wrappers (Optional / Nullable / Readonly / Catch-without-value /
+ *    Branded / Effects / Pipeline) looking for an embedded
+ *    `ZodDefault` — and returns its value if found. This mirrors v3's
+ *    prior `unwrapDefault` chain-peel and CLOSES a v3↔v4 parity gap:
+ *    on v4, `z.string().default('x').optional()` previously returned
+ *    `undefined` because the outer-kind switch hit `case 'optional'`
+ *    first; under the unified walker it returns `'x'`. ZodCatch
+ *    precedence is preserved: catch wraps default → catch wins (the
+ *    chain-peel returns the catch value at the outer Catch layer).
+ *
+ *  - Schema-side input normalizers (`z.coerce.X()`,
+ *    `z.preprocess(fn, _)`) declare a write boundary the runtime
+ *    cannot honestly synthesise a default for. Both early-return
+ *    `undefined` so the consumer's `defaultValues` or a later
+ *    `setValue` owns what lands in storage.
+ *
+ *  - Containers recurse into children; leaves return their kind's
+ *    canonical empty value (`'' / 0 / 0n / false / new Date(0) /
+ *    null / undefined / NaN / first enum or literal value /
+ *    [] / new Set() / {}`).
+ *
+ *  - Unions / DUs use the first option as the seed.
+ *
+ *  - Intersections merge both sides via the shared `mergeDeep`.
+ *
+ *  - Lazy bumps a counter; past `maxDepth` returns `undefined` (the
+ *    recursive node falls back to consumer-supplied defaultValues).
+ *
+ *  - Catch with `useDefault=true` returns the catch fallback; with
+ *    `useDefault=false` recurses the inner so the leaf's empty value
+ *    wins.
+ *
+ *  - `void` / `any` / `unknown` / `never` / opaque kinds return
+ *    `undefined`.
+ */
+import type { SchemaIntrospector } from './abstract-schema-factory'
+import { mergeDeep } from './merge-deep'
+
+export interface DeriveDefaultContext<Schema> {
+  /**
+   * Fallback for a kind the walker doesn't have a case for. Returning
+   * `undefined` is the safe default; v3 wires a `console.warn` here
+   * for visibility into custom-adapter consumers, v4 returns
+   * `undefined` silently (its kind set is exhaustive against
+   * `SchemaIntrospector.kindOf`).
+   */
+  unsupportedKindFallback(schema: Schema, kind: string): unknown
+  /**
+   * How `case 'catch'` resolves when `useDefault=false`. The two
+   * adapters chose differently and pinned the choice with tests:
+   *
+   *   - v3 wires `'preserveCatch'`: a `.catch(v)` wrapper always
+   *     surfaces its fallback `v`, regardless of `useDefault`. Rationale:
+   *     the catch is an emphatic consumer statement that should
+   *     resurface across submit failures, hydration, and history.
+   *   - v4 wires `'recurseInner'`: `useDefault=false` means "show the
+   *     leaf empty", and `.catch()` is a default-like wrapper that gets
+   *     skipped. The walker recurses into the inner so the leaf's
+   *     bare empty value (`'' / 0 / false / ...`) wins.
+   *
+   * On `useDefault=true` the chain-peel at the top of the walker
+   * already finds and returns the catch fallback at either adapter,
+   * so this knob only takes effect on `useDefault=false`.
+   */
+  catchOnUseDefaultFalse: 'preserveCatch' | 'recurseInner'
+}
+
+/**
+ * Sentinel for the chain-peel-default helper. Distinct from
+ * `undefined`, which IS a legal returned default value (e.g.
+ * `z.string().default(undefined)`).
+ */
+export const NO_EMBEDDED_DEFAULT = Symbol('atta:no-embedded-default')
+
+/**
+ * Peel transparent wrappers looking for an embedded `ZodDefault` (or
+ * a `ZodCatch` with a fallback value, which takes precedence over a
+ * nested default at the same depth). Returns the resolved value or
+ * the sentinel `NO_EMBEDDED_DEFAULT` if none found.
+ *
+ * Mirrors v3's prior `unwrapDefault` loop and now applies on v4 too.
+ * v4's kind set means `branded` / `effects` / `pipeline` peels
+ * silently no-op (the introspector stubs return undefined).
+ *
+ * Bounded loop (32 iterations) matches the prior cap and acts as a
+ * runaway guard for pathological wrapper stacks / self-referential
+ * lazy loops resolved before their inner is constructed.
+ *
+ * Exported so the v3 strict-mode fix-up loop in `zod-v3/index.ts`
+ * (the `runStrictGetDefaultsV3` validate-then-fix path) can reuse
+ * it for the issue-driven default-resolution step.
+ */
+export function peelEmbeddedDefault<Schema>(
+  schema: Schema,
+  intro: SchemaIntrospector<Schema>
+): unknown {
+  let current: Schema | undefined = schema
+  for (let i = 0; i < 32; i++) {
+    if (current === undefined) return NO_EMBEDDED_DEFAULT
+    const k = intro.kindOf(current)
+    if (k === 'default') return intro.getDefaultValue(current)
+    if (k === 'catch') {
+      if (intro.hasCatchValue(current)) return intro.getCatchDefault(current)
+      current = intro.unwrapInner(current)
+      continue
+    }
+    if (k === 'optional' || k === 'nullable' || k === 'readonly') {
+      current = intro.unwrapInner(current)
+      continue
+    }
+    if (k === 'branded') {
+      current = intro.unwrapBranded(current)
+      continue
+    }
+    if (k === 'effects') {
+      current = intro.unwrapEffectsSource(current)
+      continue
+    }
+    if (k === 'pipeline') {
+      current = intro.unwrapPipeIn(current)
+      continue
+    }
+    return NO_EMBEDDED_DEFAULT
+  }
+  return NO_EMBEDDED_DEFAULT
+}
+
+/**
+ * Walk transparent wrappers looking for a `ZodDefault` in the chain.
+ * Used by the preprocess branch to decide whether the inner has a
+ * consumer-declared default the adapter should honor (recurse the
+ * inner) or whether the slot is fully consumer-owned (`undefined`).
+ *
+ * Distinct from `peelEmbeddedDefault` in that the result is a
+ * boolean — the caller decides what to do with it, not the value
+ * itself.
+ */
+function hasDeclaredDefaultInChain<Schema>(
+  schema: Schema,
+  intro: SchemaIntrospector<Schema>
+): boolean {
+  let current: Schema | undefined = schema
+  for (let i = 0; i < 32; i++) {
+    if (current === undefined) return false
+    const k = intro.kindOf(current)
+    if (k === 'default') return true
+    if (k === 'optional' || k === 'nullable' || k === 'readonly' || k === 'catch') {
+      current = intro.unwrapInner(current)
+      continue
+    }
+    return false
+  }
+  return false
+}
+
+export function deriveDefaultWalk<Schema>(
+  schema: Schema,
+  useDefault: boolean,
+  intro: SchemaIntrospector<Schema>,
+  maxDepth: number,
+  ctx: DeriveDefaultContext<Schema>,
+  lazyDepth = 0
+): unknown {
+  // Pre-check the wrapper chain for an embedded ZodDefault / ZodCatch
+  // fallback. Returning it here is what makes
+  // `z.string().default('x').optional()` resolve to 'x' rather than
+  // undefined. Closes the v3↔v4 parity gap (v4 previously stopped at
+  // the outer Optional and returned undefined).
+  if (useDefault) {
+    const peeled = peelEmbeddedDefault(schema, intro)
+    if (peeled !== NO_EMBEDDED_DEFAULT) return peeled
+  }
+
+  // `z.coerce.X()` flags the wrapped primitive's def with `coerce:
+  // true`; the consumer's pre-conversion input shape is unknown so
+  // synthesising the primitive's slim concrete (`''` / `0` / etc.)
+  // would claim a value the consumer never supplied. Leave the slot
+  // `undefined` so `defaultValues` or a later `setValue` owns what
+  // lands in storage. A consumer-declared `.default(x)` on the coerce
+  // primitive was already honored by the chain-peel above.
+  if (intro.isCoercePrimitive(schema)) return undefined
+
+  const kind = intro.kindOf(schema)
+  switch (kind) {
+    case 'object': {
+      const shape = intro.getObjectShape(schema)
+      const out: Record<string, unknown> = {}
+      for (const [key, subSchema] of Object.entries(shape)) {
+        out[key] = deriveDefaultWalk(subSchema, useDefault, intro, maxDepth, ctx, lazyDepth)
+      }
+      return out
+    }
+    case 'array':
+      return []
+    case 'set':
+      return new Set()
+    case 'record':
+      return {}
+    case 'tuple': {
+      const items = intro.getTupleItems(schema)
+      return items.map((item) =>
+        deriveDefaultWalk(item, useDefault, intro, maxDepth, ctx, lazyDepth)
+      )
+    }
+    case 'union': {
+      const options = intro.getUnionOptions(schema)
+      const first = options[0]
+      return first === undefined
+        ? undefined
+        : deriveDefaultWalk(first, useDefault, intro, maxDepth, ctx, lazyDepth)
+    }
+    case 'discriminated-union': {
+      const options = intro.getDiscriminatedOptions(schema)
+      const first = options[0]
+      return first === undefined
+        ? undefined
+        : deriveDefaultWalk(first, useDefault, intro, maxDepth, ctx, lazyDepth)
+    }
+    case 'optional':
+      return undefined
+    case 'nullable':
+      return null
+    case 'default': {
+      // `useDefault=false` path: the chain-peel above is suppressed,
+      // so a direct ZodDefault still lands here — recurse the inner
+      // to produce the leaf's bare empty value (the explicit default
+      // is the consumer's "starting state" intent, not the leaf's
+      // type-honest blank).
+      if (useDefault) return intro.getDefaultValue(schema)
+      const inner = intro.unwrapInner(schema)
+      return inner === undefined
+        ? undefined
+        : deriveDefaultWalk(inner, useDefault, intro, maxDepth, ctx, lazyDepth)
+    }
+    case 'readonly':
+    case 'branded': {
+      // Readonly: v3 + v4 transparent wrapper.
+      // Branded: v3-only — `_def.type` carrier.
+      const inner = kind === 'branded' ? intro.unwrapBranded(schema) : intro.unwrapInner(schema)
+      return inner === undefined
+        ? undefined
+        : deriveDefaultWalk(inner, useDefault, intro, maxDepth, ctx, lazyDepth)
+    }
+    case 'effects': {
+      // v3-only. `ZodEffects` wraps refine / transform / preprocess.
+      // For `preprocess`: the input side is the user-supplied fn, so
+      // the slot has no canonical empty value the adapter can honestly
+      // synthesise. If the inner declares a default, recurse (the
+      // chain-peel finds it for useDefault=true; under useDefault=false
+      // we recurse to the leaf's empty). Otherwise return undefined so
+      // `defaultValues` or a later setValue owns the slot.
+      // For `refinement` / `transform`: recurse the structural source.
+      const inner = intro.unwrapEffectsSource(schema)
+      if (intro.isPreprocessNode(schema)) {
+        if (inner !== undefined && hasDeclaredDefaultInChain(inner, intro)) {
+          return deriveDefaultWalk(inner, useDefault, intro, maxDepth, ctx, lazyDepth)
+        }
+        return undefined
+      }
+      return inner === undefined
+        ? undefined
+        : deriveDefaultWalk(inner, useDefault, intro, maxDepth, ctx, lazyDepth)
+    }
+    case 'pipeline': {
+      // v3-only. The pre-transform default is the input schema's
+      // natural default.
+      const inner = intro.unwrapPipeIn(schema)
+      return inner === undefined
+        ? undefined
+        : deriveDefaultWalk(inner, useDefault, intro, maxDepth, ctx, lazyDepth)
+    }
+    case 'pipe': {
+      // v4-only. Two sub-cases mirroring v3's preprocess branch:
+      //
+      //   - `z.preprocess(fn, inner)` — `in` is a ZodTransform. The
+      //     input shape is unknown until the consumer writes. If the
+      //     inner carries a declared default, recurse; otherwise
+      //     return undefined.
+      //   - `.transform(fn)` (transform on output) / generic / codec
+      //     pipes — the input side IS the source schema; peel to it.
+      const inn = intro.unwrapPipeIn(schema)
+      if (inn !== undefined && intro.kindOf(inn) === 'transform') {
+        const out = intro.unwrapPipeOut(schema)
+        if (out !== undefined && hasDeclaredDefaultInChain(out, intro)) {
+          return deriveDefaultWalk(out, useDefault, intro, maxDepth, ctx, lazyDepth)
+        }
+        return undefined
+      }
+      const out = intro.unwrapPipeOut(schema)
+      const real =
+        inn !== undefined && intro.kindOf(inn) !== 'transform'
+          ? inn
+          : out !== undefined && intro.kindOf(out) !== 'transform'
+            ? out
+            : (inn ?? out)
+      return real === undefined
+        ? undefined
+        : deriveDefaultWalk(real, useDefault, intro, maxDepth, ctx, lazyDepth)
+    }
+    case 'string':
+      return ''
+    case 'number':
+      return 0
+    case 'bigint':
+      // z.bigint() strictly rejects numbers; the default must be a
+      // bigint literal. Using `0` here would fail the schema's own
+      // validation during default-values derivation.
+      return 0n
+    case 'boolean':
+      return false
+    case 'date':
+      return new Date(0)
+    case 'null':
+      return null
+    case 'undefined':
+      return undefined
+    case 'enum': {
+      const values = intro.getEnumValues(schema)
+      return values[0]
+    }
+    case 'native-enum': {
+      // v3-only. Numeric enums get reverse-mapped
+      // (`enum E { A }` → `{ A: 0, '0': 'A' }`); the valid runtime
+      // members are the keys whose VALUE'S key isn't itself a number.
+      // String enums have no reverse mapping, so every key is valid.
+      // Pick the first valid value.
+      const values = intro.getNativeEnumValues(schema)
+      if (values === undefined) return undefined
+      const validKeys = Object.keys(values).filter(
+        (k) => typeof values[values[k] as string] !== 'number'
+      )
+      if (validKeys.length === 0) return undefined
+      const first = validKeys[0]
+      return first === undefined ? undefined : values[first]
+    }
+    case 'literal': {
+      const values = intro.getLiteralValues(schema)
+      return values[0]
+    }
+    case 'nan':
+      return NaN
+    case 'lazy': {
+      // Bump the lazy counter ONLY here — structural recursion doesn't
+      // accumulate. Past the cap, return undefined so a recursive node
+      // ends in a non-fatal blank; `defaultValues` (consumer-supplied)
+      // is the authority for what the seed should be at the recursive
+      // boundary anyway.
+      if (lazyDepth >= maxDepth) return undefined
+      let inner: Schema | undefined
+      try {
+        inner = intro.unwrapLazy(schema)
+      } catch {
+        return undefined
+      }
+      return inner === undefined
+        ? undefined
+        : deriveDefaultWalk(inner, useDefault, intro, maxDepth, ctx, lazyDepth + 1)
+    }
+    case 'intersection': {
+      const left = intro.getIntersectionLeft(schema)
+      const right = intro.getIntersectionRight(schema)
+      const l =
+        left === undefined
+          ? undefined
+          : deriveDefaultWalk(left, useDefault, intro, maxDepth, ctx, lazyDepth)
+      const r =
+        right === undefined
+          ? undefined
+          : deriveDefaultWalk(right, useDefault, intro, maxDepth, ctx, lazyDepth)
+      // `mergeDeep` prefers `right` where both sides carry a plain-
+      // record value at a key, and returns `right` wholesale when
+      // either side is a leaf. Matches parse-time semantics: an
+      // intersection of `{ a }` and `{ b }` must satisfy both, so the
+      // merged shape carries both keys' defaults.
+      return mergeDeep(l, r)
+    }
+    case 'catch': {
+      // `useDefault=true` was already caught by `peelEmbeddedDefault`
+      // at the top of the walker; reaching this branch implies
+      // `useDefault=false`. The two adapters chose different
+      // semantics here and pinned the choice with tests (see the
+      // `catchOnUseDefaultFalse` docblock on `DeriveDefaultContext`).
+      if (useDefault) return intro.getCatchDefault(schema)
+      if (ctx.catchOnUseDefaultFalse === 'preserveCatch' && intro.hasCatchValue(schema)) {
+        return intro.getCatchDefault(schema)
+      }
+      const inner = intro.unwrapInner(schema)
+      return inner === undefined
+        ? undefined
+        : deriveDefaultWalk(inner, useDefault, intro, maxDepth, ctx, lazyDepth)
+    }
+    case 'file':
+      // `z.file()` has no canonical "empty file" — the user picks one
+      // through the directive's change handler. `null` is the storage
+      // blank value the directive canonicalises to on register / clear;
+      // emitting `null` here keeps `getEmptyValueAtPath` aligned with
+      // what `form.clear(path)` writes.
+      return null
+    case 'any':
+    case 'unknown':
+    case 'void':
+    case 'never':
+    case 'promise':
+    case 'custom':
+    case 'template-literal':
+    case 'transform':
+    case 'map':
+    case 'symbol':
+    case 'function':
+      // `promise` / `custom` / `template-literal` / `map` / `symbol` /
+      // `function` are rejected by `assertSupportedKinds` at adapter
+      // construction, so these branches are unreachable through the
+      // public surface. `transform` is the input side of a
+      // `z.preprocess(fn, inner)` and has no own default — callers
+      // walk to `inner` via the surrounding pipe / effects. Kept for
+      // exhaustive switch safety.
+      return undefined
+    default:
+      return ctx.unsupportedKindFallback(schema, kind)
+  }
+}

--- a/src/runtime/core/walk-path-segments.ts
+++ b/src/runtime/core/walk-path-segments.ts
@@ -1,0 +1,169 @@
+/**
+ * Shared path walker — descends a dotted segment array through a Zod
+ * schema tree and returns the sub-schemas reachable at that path.
+ *
+ * One body, two adapters: v3 and v4 each invoke `walkPathSegments`
+ * with their `SchemaIntrospector` instance. Wrapper / container kinds
+ * (Optional / Nullable / Default / Readonly / Catch / Pipe / Pipeline /
+ * Effects / Branded / Lazy / Intersection / Union / DiscriminatedUnion /
+ * Object / Array / Set / Record / Tuple) all dispatch through the
+ * introspector accessors, so the walker stays agnostic to per-version
+ * `def.*` shape.
+ *
+ * Semantics (preserved verbatim from the prior per-adapter
+ * implementations — characterised by `test/adapters/zod-v3/path-walker.test.ts`
+ * and `test/adapters/zod-v4/path-walker.test.ts`):
+ *
+ *  - Unions return multiple candidates (caller tries each).
+ *  - Discriminated unions filter options to those whose shape owns the
+ *    next segment (`Object.hasOwn`, NOT `in`, so `Object.prototype` keys
+ *    don't leak); fall back to every option when no shape matches
+ *    (the segment is the discriminator key itself).
+ *  - Object shape access uses `Object.hasOwn` for the same reason: a
+ *    bare `shape[head]` would resolve `'toString'` / `'valueOf'` etc.
+ *    to the inherited Function and treat it as a schema.
+ *  - Transparent wrappers (optional / nullable / default / readonly /
+ *    catch / pipe / pipeline / effects / branded) descend without
+ *    consuming a segment.
+ *  - `lazy` bumps the lazy counter; past the cap the walker returns
+ *    `[]` so writes at recursive paths deeper than `maxRecursionDepth`
+ *    fall back to a permissive type gate.
+ *  - Intersection unions both sides' resolutions — callers try each
+ *    candidate, matching parse-time semantics where a value must
+ *    satisfy both.
+ *  - Leaf kinds (string / number / boolean / literal / enum / etc.)
+ *    return `[]` when path remains, so a caller that asked for
+ *    `firstName.middle` against a string schema gets an empty
+ *    resolution rather than a wrong schema.
+ *  - Unsupported kinds (`map` / `symbol` / `function` / `promise`) are
+ *    rejected at adapter construction by `assertSupportedKinds`; the
+ *    walker's exhaustiveness on those kinds returns `[]` defensively
+ *    so a downstream caller that instantiates a sub-schema directly
+ *    isn't crashed.
+ */
+import type { SchemaIntrospector } from './abstract-schema-factory'
+
+export function walkPathSegments<Schema>(
+  schema: Schema,
+  segments: readonly string[],
+  intro: SchemaIntrospector<Schema>,
+  maxDepth: number,
+  lazyDepth: number
+): Schema[] {
+  if (segments.length === 0) return [schema]
+  const [head, ...rest] = segments
+  if (head === undefined) return [schema]
+  const kind = intro.kindOf(schema)
+  switch (kind) {
+    case 'object': {
+      const shape = intro.getObjectShape(schema)
+      if (!Object.hasOwn(shape, head)) return []
+      const next = shape[head]
+      return next === undefined ? [] : walkPathSegments(next, rest, intro, maxDepth, lazyDepth)
+    }
+    case 'array': {
+      const inner = intro.getArrayElement(schema)
+      return inner === undefined ? [] : walkPathSegments(inner, rest, intro, maxDepth, lazyDepth)
+    }
+    case 'set': {
+      // Sets aren't position-indexed; the head segment is a synthetic
+      // indexer (`[...path, 0]`) used to query the element type. Descend
+      // into the value schema and consume the segment.
+      const inner = intro.getSetValueType(schema)
+      return inner === undefined ? [] : walkPathSegments(inner, rest, intro, maxDepth, lazyDepth)
+    }
+    case 'record': {
+      const inner = intro.getRecordValueType(schema)
+      return inner === undefined ? [] : walkPathSegments(inner, rest, intro, maxDepth, lazyDepth)
+    }
+    case 'tuple': {
+      const index = Number(head)
+      if (!Number.isInteger(index)) return []
+      const items = intro.getTupleItems(schema)
+      const item = items[index]
+      return item === undefined ? [] : walkPathSegments(item, rest, intro, maxDepth, lazyDepth)
+    }
+    case 'union':
+      return intro
+        .getUnionOptions(schema)
+        .flatMap((opt) => walkPathSegments(opt, segments, intro, maxDepth, lazyDepth))
+    case 'discriminated-union': {
+      const options = intro.getDiscriminatedOptions(schema)
+      const matching = options.filter((opt) => Object.hasOwn(intro.getObjectShape(opt), head))
+      const candidates = matching.length > 0 ? matching : options
+      return candidates.flatMap((opt) =>
+        walkPathSegments(opt, segments, intro, maxDepth, lazyDepth)
+      )
+    }
+    case 'optional':
+    case 'nullable':
+    case 'default':
+    case 'readonly':
+    case 'catch': {
+      // `catch` peels like a wrapper — descend into the inner schema.
+      // The catch fallback only matters at parse time, not path lookup.
+      const inner = intro.unwrapInner(schema)
+      return inner === undefined
+        ? []
+        : walkPathSegments(inner, segments, intro, maxDepth, lazyDepth)
+    }
+    case 'pipe': {
+      // v4: `z.pipe(IN, OUT)` / `z.preprocess(fn, inner)` desugars to
+      // pipe-with-transform-on-`in`. Both sides are sub-schemas; the
+      // walker peeks at either, preferring `in`.
+      const inner = intro.unwrapPipeIn(schema) ?? intro.unwrapPipeOut(schema)
+      return inner === undefined
+        ? []
+        : walkPathSegments(inner, segments, intro, maxDepth, lazyDepth)
+    }
+    case 'pipeline': {
+      // v3: `z.pipeline(...)` — peel to the input side.
+      const inner = intro.unwrapPipeIn(schema)
+      return inner === undefined
+        ? []
+        : walkPathSegments(inner, segments, intro, maxDepth, lazyDepth)
+    }
+    case 'effects': {
+      // v3: `ZodEffects` (refine / transform / preprocess) — peel to
+      // the structural source schema. Path resolution lands on the
+      // inner shape regardless of effect type.
+      const inner = intro.unwrapEffectsSource(schema)
+      return inner === undefined
+        ? []
+        : walkPathSegments(inner, segments, intro, maxDepth, lazyDepth)
+    }
+    case 'branded': {
+      // v3: `ZodBranded` — peel to the inner schema. Brands are
+      // compile-time tags with no runtime structural impact.
+      const inner = intro.unwrapBranded(schema)
+      return inner === undefined
+        ? []
+        : walkPathSegments(inner, segments, intro, maxDepth, lazyDepth)
+    }
+    case 'lazy': {
+      // Bump the lazy counter. Past the cap, return [] so callers fall
+      // back to permissive behaviour at recursive paths beyond the cap.
+      if (lazyDepth >= maxDepth) return []
+      const inner = intro.unwrapLazy(schema)
+      return inner === undefined
+        ? []
+        : walkPathSegments(inner, segments, intro, maxDepth, lazyDepth + 1)
+    }
+    case 'intersection': {
+      const left = intro.getIntersectionLeft(schema)
+      const right = intro.getIntersectionRight(schema)
+      const leftResults =
+        left === undefined ? [] : walkPathSegments(left, segments, intro, maxDepth, lazyDepth)
+      const rightResults =
+        right === undefined ? [] : walkPathSegments(right, segments, intro, maxDepth, lazyDepth)
+      return [...leftResults, ...rightResults]
+    }
+    // Leaves — can't descend further. The unsupported kinds (`map` /
+    // `symbol` / `function` / `promise`) are rejected at adapter
+    // construction by `assertSupportedKinds`; falling through to `[]`
+    // keeps the walker defensive in case construction is skipped
+    // (e.g. a downstream test instantiates a sub-schema directly).
+    default:
+      return []
+  }
+}

--- a/src/runtime/core/walk-slim-primitives.ts
+++ b/src/runtime/core/walk-slim-primitives.ts
@@ -1,0 +1,272 @@
+/**
+ * Shared slim-primitive walker — returns the set of
+ * `SlimPrimitiveKind`s a schema accepts at write time. Wrappers
+ * (Optional / Nullable / Default / Readonly / Catch / Pipe /
+ * Pipeline / Effects / Branded / Lazy) are peeled; refinement-level
+ * constraints (`.email()`, `.min(N)`, enum membership, literal
+ * equality, regex) are ignored.
+ *
+ * Both v3 and v4 adapters dispatch through this body via their
+ * `SchemaIntrospector` instance. Their per-version kind sets — v3's
+ * `branded` / `effects` / `pipeline` / `native-enum`, v4's `pipe` /
+ * `file` — collapse to distinct cases on the SharedZodKind switch;
+ * each adapter's `kindOf` returns only the kinds it knows.
+ *
+ * Semantics (preserved verbatim from the prior per-adapter
+ * implementations — characterised by `test/adapters/zod-v{3,4}/
+ * slim-primitives.test.ts`):
+ *
+ *  - Leaves (string / number / boolean / bigint / date / null /
+ *    undefined / void / nan) map to their kind singleton.
+ *  - Enum walks values, categorising each by typeof (string / number
+ *    members register their respective kinds). Empty enum falls back
+ *    to string.
+ *  - Literal walks values through the shared `slimKindOf` to map each
+ *    value to a kind. Multi-value literals (`z.literal(['a', 1])`)
+ *    register both.
+ *  - Object / record → object; array / tuple → array; set → set;
+ *    file → file + null (the directive's "no file selected"
+ *    sentinel — v4 only).
+ *  - Optional adds 'undefined' to the inner set; nullable adds 'null'.
+ *  - Default / readonly / catch / branded peel transparently.
+ *  - Pipe (v4) consults both `in` and `out`: if `in` is a transform,
+ *    use `out` (the structural side of a preprocess); else prefer
+ *    `in` (the source schema). Pipeline (v3) takes the `in` side.
+ *  - Effects (v3) peels to the structural source.
+ *  - Lazy bumps the depth counter; past the cap returns `permissive`
+ *    so recursive paths beyond the cap aren't false-rejected.
+ *  - Union / discriminated-union: union the option sets.
+ *  - Intersection: intersect both sides (must satisfy both at parse
+ *    time).
+ *  - Native-enum (v3) walks values, categorising by typeof.
+ *  - Never returns empty; any / unknown / unrecognised return
+ *    permissive.
+ */
+import type { SchemaIntrospector } from './abstract-schema-factory'
+import { slimKindOf } from './slim-primitive-gate'
+import type { SlimPrimitiveKind } from '../types/types-api'
+
+// The slim-primitive permissive set — kinds the gate accepts when the
+// walker can't characterise a schema. Identical between v3 and v4 by
+// design; hosted in core for single-source-of-truth.
+export const PERMISSIVE_SLIM_KINDS: ReadonlySet<SlimPrimitiveKind> =
+  /* @__PURE__ */ new Set<SlimPrimitiveKind>([
+    'string',
+    'number',
+    'boolean',
+    'bigint',
+    'date',
+    'null',
+    'undefined',
+    'object',
+    'array',
+    'symbol',
+    'function',
+    'map',
+    'set',
+    'file',
+  ])
+
+// Module-level frozen singletons for the leaf branches. Returning a
+// shared instance instead of `new Set([…])` per call cuts a hot
+// allocation when slim-primitives is reached through wrappers and
+// collapses the inline literal Set constructions into shared
+// references for a small bundle-size win. The walker returns
+// `ReadonlySet`; callers that need to mutate (optional / nullable /
+// union branches, and the public boundary) clone first.
+const KIND_STRING: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['string'])
+const KIND_NUMBER: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['number'])
+const KIND_BOOLEAN: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['boolean'])
+const KIND_BIGINT: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['bigint'])
+const KIND_DATE: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['date'])
+const KIND_NULL: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['null'])
+const KIND_UNDEFINED: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['undefined'])
+const KIND_OBJECT: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['object'])
+const KIND_ARRAY: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['array'])
+const KIND_SET: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['set'])
+const KIND_FILE: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set(['file', 'null'])
+const EMPTY_KINDS: ReadonlySet<SlimPrimitiveKind> = /* @__PURE__ */ new Set()
+
+export function slimPrimitivesWalk<Schema>(
+  schema: Schema,
+  intro: SchemaIntrospector<Schema>,
+  maxDepth: number,
+  lazyDepth = 0
+): ReadonlySet<SlimPrimitiveKind> {
+  const kind = intro.kindOf(schema)
+  switch (kind) {
+    case 'string':
+      return KIND_STRING
+    case 'number':
+    case 'nan':
+      return KIND_NUMBER
+    case 'boolean':
+      return KIND_BOOLEAN
+    case 'bigint':
+      return KIND_BIGINT
+    case 'date':
+      return KIND_DATE
+    case 'file':
+      // `z.file()` accepts `File` instances at write time. `null` is
+      // also accepted at the slim-primitive level so the directive's
+      // canonical blank value (the "no file selected" sentinel) lands
+      // even on required-file schemas — the blank-path channel + the
+      // derived "No value supplied" error already gates submission, so
+      // permitting `null` storage here doesn't loosen schema enforcement.
+      return KIND_FILE
+    case 'null':
+      return KIND_NULL
+    case 'undefined':
+    case 'void':
+      return KIND_UNDEFINED
+    case 'enum': {
+      const values = intro.getEnumValues(schema)
+      const out = new Set<SlimPrimitiveKind>()
+      for (const v of values) {
+        if (typeof v === 'string') out.add('string')
+        else if (typeof v === 'number') out.add('number')
+      }
+      return out.size === 0 ? KIND_STRING : out
+    }
+    case 'native-enum': {
+      // v3 only — `z.nativeEnum(E)` exposes the reverse-mapped TS enum
+      // object on `_def.values`. Categorise each member by typeof.
+      // Numeric enums also include reverse-mapped string keys whose
+      // value is a number; both string and number kinds get registered.
+      const values = intro.getNativeEnumValues(schema)
+      if (values === undefined) return KIND_STRING
+      const out = new Set<SlimPrimitiveKind>()
+      for (const v of Object.values(values)) {
+        if (typeof v === 'string') out.add('string')
+        else if (typeof v === 'number') out.add('number')
+      }
+      return out.size === 0 ? KIND_STRING : out
+    }
+    case 'literal': {
+      const values = intro.getLiteralValues(schema)
+      const out = new Set<SlimPrimitiveKind>()
+      for (const v of values) out.add(slimKindOf(v))
+      return out.size === 0 ? PERMISSIVE_SLIM_KINDS : out
+    }
+    case 'object':
+    case 'record':
+      return KIND_OBJECT
+    case 'array':
+    case 'tuple':
+      return KIND_ARRAY
+    case 'set':
+      return KIND_SET
+    case 'optional': {
+      const inner = intro.unwrapInner(schema)
+      const innerSet =
+        inner === undefined ? EMPTY_KINDS : slimPrimitivesWalk(inner, intro, maxDepth, lazyDepth)
+      const out = new Set<SlimPrimitiveKind>(innerSet)
+      out.add('undefined')
+      return out
+    }
+    case 'nullable': {
+      const inner = intro.unwrapInner(schema)
+      const innerSet =
+        inner === undefined ? EMPTY_KINDS : slimPrimitivesWalk(inner, intro, maxDepth, lazyDepth)
+      const out = new Set<SlimPrimitiveKind>(innerSet)
+      out.add('null')
+      return out
+    }
+    case 'default':
+    case 'readonly':
+    case 'catch': {
+      const inner = intro.unwrapInner(schema)
+      return inner === undefined
+        ? PERMISSIVE_SLIM_KINDS
+        : slimPrimitivesWalk(inner, intro, maxDepth, lazyDepth)
+    }
+    case 'branded': {
+      // v3-only. Brand wrappers carry their inner on `_def.type`.
+      const inner = intro.unwrapBranded(schema)
+      return inner === undefined
+        ? PERMISSIVE_SLIM_KINDS
+        : slimPrimitivesWalk(inner, intro, maxDepth, lazyDepth)
+    }
+    case 'effects': {
+      // v3-only. ZodEffects wraps refines / transforms / preprocess;
+      // for slim-primitive purposes the structural source is the
+      // pre-transform shape (consumers write to that shape).
+      const inner = intro.unwrapEffectsSource(schema)
+      return inner === undefined
+        ? PERMISSIVE_SLIM_KINDS
+        : slimPrimitivesWalk(inner, intro, maxDepth, lazyDepth)
+    }
+    case 'pipeline': {
+      // v3-only. Take the input side.
+      const inner = intro.unwrapPipeIn(schema)
+      return inner === undefined
+        ? PERMISSIVE_SLIM_KINDS
+        : slimPrimitivesWalk(inner, intro, maxDepth, lazyDepth)
+    }
+    case 'pipe': {
+      // v4-only. `z.preprocess(fn, inner)` and `z.coerce.X()`
+      // (pipe-with-transform-on-input) and `inner.transform(fn)`
+      // (transform-on-output) all serialise as ZodPipe, but the
+      // "storage shape" lives on opposite sides. For preprocess /
+      // coerce, the input side IS the transform (shapeless,
+      // PERMISSIVE) and the inner schema sits on the output. For
+      // `.transform`, the input side is the source schema. Pick the
+      // non-transform side so `isLeafAtPath` and the directive coerce
+      // target both resolve against a real shape.
+      const pipeIn = intro.unwrapPipeIn(schema)
+      const pipeOut = intro.unwrapPipeOut(schema)
+      const inner =
+        pipeIn !== undefined && intro.kindOf(pipeIn) === 'transform' ? pipeOut : (pipeIn ?? pipeOut)
+      return inner === undefined
+        ? PERMISSIVE_SLIM_KINDS
+        : slimPrimitivesWalk(inner, intro, maxDepth, lazyDepth)
+    }
+    case 'lazy': {
+      // Bump on lazy crossing only; past the cap, fall back to
+      // permissive so recursive paths beyond the cap aren't gated.
+      if (lazyDepth >= maxDepth) return PERMISSIVE_SLIM_KINDS
+      const inner = intro.unwrapLazy(schema)
+      return inner === undefined
+        ? PERMISSIVE_SLIM_KINDS
+        : slimPrimitivesWalk(inner, intro, maxDepth, lazyDepth + 1)
+    }
+    case 'union':
+    case 'discriminated-union': {
+      // Both adapters store DU options on `def.options` too, so
+      // `getUnionOptions` works for either kind.
+      const options = intro.getUnionOptions(schema)
+      const out = new Set<SlimPrimitiveKind>()
+      for (const opt of options) {
+        for (const k of slimPrimitivesWalk(opt, intro, maxDepth, lazyDepth)) out.add(k)
+      }
+      return out.size === 0 ? PERMISSIVE_SLIM_KINDS : out
+    }
+    case 'intersection': {
+      const left = intro.getIntersectionLeft(schema)
+      const right = intro.getIntersectionRight(schema)
+      const leftSet =
+        left === undefined
+          ? PERMISSIVE_SLIM_KINDS
+          : slimPrimitivesWalk(left, intro, maxDepth, lazyDepth)
+      const rightSet =
+        right === undefined
+          ? PERMISSIVE_SLIM_KINDS
+          : slimPrimitivesWalk(right, intro, maxDepth, lazyDepth)
+      const out = new Set<SlimPrimitiveKind>()
+      for (const k of leftSet) if (rightSet.has(k)) out.add(k)
+      return out
+    }
+    case 'never':
+      return EMPTY_KINDS
+    case 'any':
+    case 'unknown':
+      return PERMISSIVE_SLIM_KINDS
+    // Opaque / unsupported kinds: be permissive so legitimate writes
+    // aren't false-rejected. The unsupported kinds (`map` / `symbol` /
+    // `function` / `promise`) are rejected at adapter construction by
+    // `assertSupportedKinds`; this fallthrough keeps the walker
+    // defensive in case construction is skipped.
+    default:
+      return PERMISSIVE_SLIM_KINDS
+  }
+}


### PR DESCRIPTION
Phase 12 part 2 of the audit-remediation series. Three structurally-parallel inner walkers (`deriveDefault` / `slimPrimitives` / `walkPathSegments`) lift into shared `core/walk-*` modules dispatched through the `SchemaIntrospector` contract introduced in part 1 (#299). v3 + v4 collectively shrink ~600 LOC of adapter code; ~720 LOC moves to single-source core modules.

## Design (surfaced + signed off before coding)

**Scope:** D2 + D3 + D5. ADAPT-D4 (strip-async) stays per-adapter — v3's "drop every ZodEffects" policy is irreducibly different from v4's "filter by `isAsyncCheck` per check site," and a unified walker either needs 5 behavior knobs (yielding a walker bigger than the two it replaces) or call-site specialisation that defeats the dedup. Both files now carry cross-reference docblocks pinning the asymmetry.

**Introspector contract:** grow `SchemaIntrospector` in place with 19 new shape-accessor members (`getArrayElement`, `getSetValueType`, `getRecordKey/ValueType`, `getEnumValues`, `getNativeEnumValues`, `getUnionOptions`, `getIntersectionLeft/Right`, `unwrapInner`, `unwrapBranded`, `unwrapEffectsSource`, `unwrapPipeIn/Out`, `unwrapLazy`, `getLazyGetter`, `getDefaultValue`, `getCatchDefault`, `hasCatchValue`). Single contract, one place to look. v3 / v4 each implement; cross-version stubs return `undefined` for kinds the version doesn't have (v4's `unwrapBranded` / `unwrapEffectsSource` / `getNativeEnumValues`).

**Catch-precedence service knob:** the two adapters chose differently for `case 'catch'` with `useDefault=false` and pinned both choices with tests. v3 = `'preserveCatch'` (always surface `.catch(v)`), v4 = `'recurseInner'` (skip catch, return leaf empty). `DeriveDefaultContext.catchOnUseDefaultFalse` encodes the per-adapter choice.

## Commit series (6 commits)

| # | Commit | LOC |
|---|--------|----|
| 1 | `refactor(core): grow SchemaIntrospector with the walker accessors (D2/D3/D5 setup)` | +187 |
| 2 | `refactor(adapters): walkPathSegments hosts the v3 + v4 path walkers (D5)` | net −42 |
| 3 | `refactor(adapters): slimPrimitivesWalk hosts the v3 + v4 slim walkers (D3)` | net −74 |
| 4 | `refactor(adapters): deriveDefaultWalk hosts the v3 + v4 default walkers (D2)` | net −120 |
| 5 | `docs(adapters): pin v3/v4 stripAsyncChecks asymmetry rationale (D4 deferred)` | +37 |
| 6 | `chore(size): bump dist/zod-v4.mjs 54 → 55 KB for Phase 12 part 2 walker dedup` | +18 |

## API & behavior-change ledger

**1. v4 behavior change at `Optional(Default('x'))` / `Nullable(Default('x'))` / etc.** (signed off in design surfacing)

The unified walker's `peelEmbeddedDefault` chain-peel finds embedded defaults through the wrapper chain. v4 previously stopped at the outer Optional and returned `undefined`; under the unified walker it returns `'x'`. v3's prior `unwrapDefault` already had this behavior. Closes a real parity asymmetry.

Example:
```ts
z.string().default('x').optional()
  // v3 prior: 'x'
  // v4 prior: undefined
  // unified:  'x'
```

ZodCatch precedence preserved: `Catch(Default(...))` returns the catch value via the chain-peel's Catch-first ordering. The existing v3 wrappers test (`z.string().default('user').catch('guest') → 'guest'`) stays green.

**2. `catchOnUseDefaultFalse` per-adapter knob preserves both prior behaviors** (no observable change)

For `useDefault=false`:
- v3 → `'preserveCatch'` (always surface `.catch(v)`)
- v4 → `'recurseInner'` (skip catch, return leaf empty)

Pinned by existing tests:
- v3: `test/adapters/zod-v3/wrappers.test.ts` ("surfaces the catch fallback even when useDefaultSchemaValues is false")
- v4: `test/adapters/zod-v4/unsupported-kinds.test.ts` ("z.catch falls through to inner leaf default when useDefault=false")

**3. v3 slim-primitives depth counter change** (no observable change against existing tests)

v3 previously bumped its depth counter on every wrapper crossing (over-conservative); the unified walker bumps only on `z.lazy()` boundaries (matches v4's accurate cycle gate). Practical wrapper stacks never approached the v3 cap of 64. Full suite stays green.

## Preserved invariants

- Per-adapter caches (`leafCache`, `preprocessOrCoerceCache`, `discriminatorCache`, `lazyMemos`) — lifetime unchanged.
- v3's recursive `makeSubSchema` (sub-schemas keep full AbstractSchema surface) and v4's 5-method stub — both preserved via `AbstractSchemaServices.makeSubSchema`.
- v3's strict-mode validate-then-fix loop unchanged structurally; the `unwrapDefault → peelEmbeddedDefault` rename is the only call-site change, with v3 routing through the shared core helper.
- Path-walker / slim-primitives / default-values test suites stay green unchanged (188 tests across the three walker dimensions).

## Full gate

- Lint ✓
- Typecheck ✓ (tsc clean)
- check:site ✓
- Tests: **283 files / 3494 tests green**
- Bench within 3× floors (all 11 bench dimensions)
- Coverage: 91.63% lines
- Sizes: `index.mjs` 46.76/48 kB, `zod.mjs` 60.41/63 kB, `zod-v4.mjs` 54.57/55 kB, `zod-v3.mjs` 55.63/56 kB

## Net structural change

- new: `core/walk-derive-default.ts` (~440 LOC) hosting the walker + `peelEmbeddedDefault` (exported for v3's strict-mode fix-up)
- new: `core/walk-slim-primitives.ts` (~270 LOC) + `PERMISSIVE_SLIM_KINDS` const + leaf-kind singletons
- new: `core/walk-path-segments.ts` (~170 LOC)
- new: `core/merge-deep.ts` (~40 LOC) hosting the shared mergeDeep (v3's `mergeDeepV3` and v4's local `mergeDeep` both retire)
- new: `zod-v{3,4}/walker-introspector.ts` per adapter (V3_INTROSPECTOR / V4_INTROSPECTOR hoisted out of the adapter entry so per-walker modules import without creating cycles)
- shrunk: `zod-v3/index.ts` -370 LOC (generateValue / unwrapDefault / hasDeclaredDefaultInChainV3 / mergeDeepV3 retired)
- shrunk: `zod-v4/default-values.ts` -300 LOC (defaultForKind / hasDeclaredDefaultInChain / mergeDeep retired)
- shrunk: `zod-v{3,4}/slim-primitives.ts` -340 LOC combined
- shrunk: `zod-v{3,4}/path-walker.ts` and `zod-v3/index.ts` walker bodies -250 LOC combined

## Deferred

**ADAPT-D4 (strip-async).** Deferred with docblock rationale on both `zod-v{3,4}/strip*.ts`. The v3 / v4 strip-async walkers are structurally parallel but the per-check filter is irreducibly asymmetric (v3 has no way to statically distinguish sync vs async refines; v4 does). Either preserved both behaviors via service knobs (yielding a walker bigger than the two it replaces) or specialised at the call site (defeating the dedup). The cross-reference pins record the deliberate asymmetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)