### PR TITLE
Phase 14: wizard decouple + dedup (COMP-W1-W5)

### DIFF
--- a/src/runtime/composables/use-wizard.ts
+++ b/src/runtime/composables/use-wizard.ts
@@ -410,10 +410,22 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
     return -1
   })
 
+  // `currentStep` and `activeForm` resolve through the same
+  // `activeIndex`-aware lookup so they can never disagree on which
+  // step the wizard is on. A function slot that previously
+  // resolved to the active form and now returns `undefined` drops
+  // the matching index to `-1`; both reads then fall back to the
+  // first compiled step uniformly (W-BRITTLE-1). Pre-fix
+  // `currentStep` trusted `activeKey` verbatim and could return the
+  // dropped form's key while `activeForm` fell back to the first
+  // compiled step.
   const currentStep = computed<FormKey | undefined>(() => {
-    const key = activeKey.value
-    if (key !== '') return key
-    const first = compiledSteps.value[0]
+    const list = compiledSteps.value
+    const idx = activeIndex.value
+    if (idx >= 0 && idx < list.length) {
+      return (list[idx] as CompiledStep).key
+    }
+    const first = list[0]
     return first === undefined ? undefined : first.key
   })
 

--- a/src/runtime/composables/use-wizard.ts
+++ b/src/runtime/composables/use-wizard.ts
@@ -434,38 +434,105 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
     return out
   })
 
-  const allValues = computed<Readonly<Record<FormKey, unknown>>>(() => {
-    const out: Record<FormKey, unknown> = {}
-    for (const step of compiledSteps.value) {
-      const source = step.form as unknown as StatusSourceForm
-      out[step.key] = source.values
-    }
-    return out
-  })
+  // Per-key memoization for `allValues` / `allErrors`. One field edit
+  // on form A only invalidates form A's slot; templates reading
+  // `wizard.allErrors.formB` stay cached. Mirrors `statusCache` below
+  // — the audit's COMP-W2 finding flagged the whole-record
+  // re-evaluation each per-step computed used to do.
+  const valuesCache = new Map<FormKey, ComputedRef<unknown>>()
+  function valuesFor(form: AnyForm): ComputedRef<unknown> {
+    const cached = valuesCache.get(form.key)
+    if (cached !== undefined) return cached
+    const source = form as unknown as StatusSourceForm
+    const computedValues = computed(() => source.values)
+    valuesCache.set(form.key, computedValues)
+    return computedValues
+  }
 
-  const allErrors = computed<Readonly<Record<FormKey, readonly AggregateError[]>>>(() => {
-    const out: Record<FormKey, readonly AggregateError[]> = {}
-    for (const step of compiledSteps.value) {
-      const source = step.form as unknown as StatusSourceForm
-      const list: AggregateError[] = []
-      const store = registry.forms.get(step.key)
+  const errorsCache = new Map<FormKey, ComputedRef<readonly AggregateError[]>>()
+  function errorsFor(form: AnyForm): ComputedRef<readonly AggregateError[]> {
+    const cached = errorsCache.get(form.key)
+    if (cached !== undefined) return cached
+    const source = form as unknown as StatusSourceForm
+    const computedErrors = computed<readonly AggregateError[]>(() => {
+      const store = registry.forms.get(form.key)
       const resolved = store?.defaultsResolved.value === true
-      if (resolved) {
-        const errors = source.meta?.errors ?? []
-        for (const err of errors) {
-          const entry: { -readonly [P in keyof AggregateError]: AggregateError[P] } = {
-            formKey: step.key,
-            path: err.path,
-            message: err.message,
-          }
-          if (err.code !== undefined) entry.code = err.code
-          list.push(entry)
+      if (!resolved) return []
+      const errors = source.meta?.errors ?? []
+      const list: AggregateError[] = []
+      for (const err of errors) {
+        const entry: { -readonly [P in keyof AggregateError]: AggregateError[P] } = {
+          formKey: form.key,
+          path: err.path,
+          message: err.message,
         }
+        if (err.code !== undefined) entry.code = err.code
+        list.push(entry)
       }
-      out[step.key] = list
-    }
-    return out
-  })
+      return list
+    })
+    errorsCache.set(form.key, computedErrors)
+    return computedErrors
+  }
+
+  // Identity-stable Proxy surfaces backed by the per-key caches.
+  // `get` and `getOwnPropertyDescriptor` delegate to the per-key
+  // ComputedRef, so reads track only the form they target; `ownKeys`
+  // and `has` use `formsRecord` so iteration order matches the
+  // compiled step list.
+  const allValues = new Proxy({} as Record<FormKey, unknown>, {
+    get(_, key: string | symbol): unknown {
+      if (typeof key !== 'string') return undefined
+      const form = formsRecord.value[key]
+      if (form === undefined) return undefined
+      return valuesFor(form).value
+    },
+    has(_, key: string | symbol): boolean {
+      if (typeof key !== 'string') return false
+      return formsRecord.value[key] !== undefined
+    },
+    ownKeys(): ArrayLike<string | symbol> {
+      return Object.keys(formsRecord.value)
+    },
+    getOwnPropertyDescriptor(_, key: string | symbol): PropertyDescriptor | undefined {
+      if (typeof key !== 'string') return undefined
+      const form = formsRecord.value[key]
+      if (form === undefined) return undefined
+      return {
+        configurable: true,
+        enumerable: true,
+        writable: false,
+        value: valuesFor(form).value,
+      }
+    },
+  }) as Readonly<Record<FormKey, unknown>>
+
+  const allErrors = new Proxy({} as Record<FormKey, readonly AggregateError[]>, {
+    get(_, key: string | symbol): readonly AggregateError[] | undefined {
+      if (typeof key !== 'string') return undefined
+      const form = formsRecord.value[key]
+      if (form === undefined) return undefined
+      return errorsFor(form).value
+    },
+    has(_, key: string | symbol): boolean {
+      if (typeof key !== 'string') return false
+      return formsRecord.value[key] !== undefined
+    },
+    ownKeys(): ArrayLike<string | symbol> {
+      return Object.keys(formsRecord.value)
+    },
+    getOwnPropertyDescriptor(_, key: string | symbol): PropertyDescriptor | undefined {
+      if (typeof key !== 'string') return undefined
+      const form = formsRecord.value[key]
+      if (form === undefined) return undefined
+      return {
+        configurable: true,
+        enumerable: true,
+        writable: false,
+        value: errorsFor(form).value,
+      }
+    },
+  }) as Readonly<Record<FormKey, readonly AggregateError[]>>
 
   // --- Statuses proxy + seed --------------------------------------------
 
@@ -1159,12 +1226,8 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
       return count.value
     },
     statuses,
-    get allValues(): Readonly<Record<FormKey, unknown>> {
-      return allValues.value
-    },
-    get allErrors(): Readonly<Record<FormKey, readonly AggregateError[]>> {
-      return allErrors.value
-    },
+    allValues,
+    allErrors,
     get progress(): number {
       return progress.value
     },

--- a/src/runtime/composables/use-wizard.ts
+++ b/src/runtime/composables/use-wizard.ts
@@ -279,10 +279,20 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
       return { configurable: true, enumerable: true, writable: false, value: form }
     },
   })
-  const slotCtx = computed<WizardCtx>(() => ({
+  // Shared slot-resolution context. Built as a plain object with
+  // `currentKey` exposed as a getter so the `activeKey` dep is
+  // established only when a slot body actually reads `ctx.currentKey`
+  // — every navigation writes `activeKey`, so reading it eagerly
+  // (e.g. via a wrapping `computed`) would thread the dep through
+  // every bare function slot and re-fire the entire compile pass on
+  // each `next` / `back` / `goTo`. The getter form lets `lazy()` and
+  // bare function slots opt into the active-step dep individually.
+  const slotCtx: WizardCtx = {
     forms: slotForms,
-    currentKey: activeKey.value === '' ? undefined : activeKey.value,
-  }))
+    get currentKey() {
+      return activeKey.value === '' ? undefined : activeKey.value
+    },
+  }
 
   /**
    * Resolve a single raw slot to a participating form, or `undefined`
@@ -331,19 +341,10 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
   // subscribes to `lazyEpoch` so `reset()` can invalidate every cache
   // in one move, and to whatever reactive reads its own resolver makes
   // (Vue's standard dep tracking). The closure over `idx` and `marker`
-  // pins this computed to a specific slot in `rawSteps`.
-  //
-  // The ctx object is built inline with `currentKey` as a getter so
-  // the resolver only establishes an `activeKey` dep when it actually
-  // reads `ctx.currentKey` — reading the wizard's wider `slotCtx`
-  // computed would thread activeKey through every lazy slot's deps
-  // and re-fire on navigation regardless of the resolver's intent.
-  const lazyCtx: WizardCtx = {
-    forms: slotForms,
-    get currentKey() {
-      return activeKey.value === '' ? undefined : activeKey.value
-    },
-  }
+  // pins this computed to a specific slot in `rawSteps`. Lazy slots
+  // and bare function slots share `slotCtx` — the same getter-style
+  // object — so the `activeKey` dep is opt-in per resolver body for
+  // both slot kinds.
   for (let i = 0; i < rawSteps.length; i++) {
     const slot = rawSteps[i]
     if (isLazyMarker(slot)) {
@@ -353,7 +354,7 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
         idx,
         computed(() => {
           void lazyEpoch.value
-          return marker.resolve(lazyCtx)
+          return marker.resolve(slotCtx)
         })
       )
     }
@@ -361,14 +362,17 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
 
   // The compiled step list. Function slots re-evaluate on every read
   // of their reactive deps; lazy slots run through their own memoized
-  // computed; string slots cache their noop forms.
+  // computed; string slots cache their noop forms. The compile pass
+  // itself has no `activeKey` dep — each function-slot body
+  // contributes its own deps through `slotCtx.currentKey`'s getter,
+  // so navigation only re-fires the slots that actually look at the
+  // active step.
   const compiledSteps = computed<readonly CompiledStep[]>(() => {
-    const ctx = slotCtx.value
     const out: CompiledStep[] = []
     const seen = new Set<FormKey>()
     for (let i = 0; i < rawSteps.length; i++) {
       const slot = rawSteps[i] as StepSlot
-      const form = resolveSlot(slot, i, ctx)
+      const form = resolveSlot(slot, i, slotCtx)
       if (form === undefined) continue
       if (seen.has(form.key)) {
         if (__DEV__) {

--- a/src/runtime/composables/use-wizard.ts
+++ b/src/runtime/composables/use-wizard.ts
@@ -434,6 +434,42 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
     return out
   })
 
+  // "Form ready?" gate — `true` once a participating form's defaults
+  // have applied (sync defaults at construction, or async factory
+  // settle complete). Reads through the registry's per-store flag,
+  // not through the public `form.ready` getter, because the latter
+  // would activate dormant lazy factories the wizard hasn't asked
+  // for. Hoisted so `errorsFor` and `statusFor` share one definition
+  // of the gate (W-DUP-2 dedup).
+  function isFormReady(key: FormKey): boolean {
+    const store = registry.forms.get(key)
+    return store?.defaultsResolved.value === true
+  }
+
+  // Lift a per-form error into the wizard's aggregate shape. `err`
+  // may arrive without `formKey` (e.g. entries from `form.meta.errors`,
+  // which are pre-scoped to the form) or with it (`ValidationError`
+  // entries from `processOne`'s result). Centralising the lift dedups
+  // the construction shared by `allErrors` and `collectErrors`
+  // (W-DUP-1).
+  function toAggregateError(
+    err: {
+      readonly path: ReadonlyArray<string | number>
+      readonly message: string
+      readonly code?: string
+      readonly formKey?: FormKey
+    },
+    fallbackKey: FormKey
+  ): AggregateError {
+    const entry: { -readonly [P in keyof AggregateError]: AggregateError[P] } = {
+      formKey: err.formKey ?? fallbackKey,
+      path: err.path,
+      message: err.message,
+    }
+    if (err.code !== undefined) entry.code = err.code
+    return entry
+  }
+
   // Per-key memoization for `allValues` / `allErrors`. One field edit
   // on form A only invalidates form A's slot; templates reading
   // `wizard.allErrors.formB` stay cached. Mirrors `statusCache` below
@@ -455,20 +491,10 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
     if (cached !== undefined) return cached
     const source = form as unknown as StatusSourceForm
     const computedErrors = computed<readonly AggregateError[]>(() => {
-      const store = registry.forms.get(form.key)
-      const resolved = store?.defaultsResolved.value === true
-      if (!resolved) return []
+      if (!isFormReady(form.key)) return []
       const errors = source.meta?.errors ?? []
       const list: AggregateError[] = []
-      for (const err of errors) {
-        const entry: { -readonly [P in keyof AggregateError]: AggregateError[P] } = {
-          formKey: form.key,
-          path: err.path,
-          message: err.message,
-        }
-        if (err.code !== undefined) entry.code = err.code
-        list.push(entry)
-      }
+      for (const err of errors) list.push(toAggregateError(err, form.key))
       return list
     })
     errorsCache.set(form.key, computedErrors)
@@ -564,9 +590,7 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
     if (cached !== undefined) return cached
     const source = form as unknown as StatusSourceForm
     const computedStatus = computed<FormStatus>(() => {
-      const store = registry.forms.get(form.key)
-      const resolved = store?.defaultsResolved.value === true
-      if (resolved) {
+      if (isFormReady(form.key)) {
         const meta = source.meta
         if (meta !== undefined && meta !== null) {
           return {
@@ -1027,15 +1051,7 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
     for (const step of compiledSteps.value) {
       const processed = results.get(step.key)
       if (processed === undefined || processed.success === true) continue
-      for (const err of processed.errors) {
-        const entry: { -readonly [P in keyof AggregateError]: AggregateError[P] } = {
-          formKey: err.formKey,
-          path: err.path,
-          message: err.message,
-        }
-        if (err.code !== undefined) entry.code = err.code
-        out.push(entry)
-      }
+      for (const err of processed.errors) out.push(toAggregateError(err, step.key))
     }
     return out
   }

--- a/src/runtime/composables/use-wizard.ts
+++ b/src/runtime/composables/use-wizard.ts
@@ -48,7 +48,8 @@ import type {
   WizardRestoreState,
   WizardSubmitContext,
 } from '../types/types-wizard'
-import type { FormKey, OnInvalidSubmitPolicy, ValidationResponse } from '../types/types-api'
+import type { FormKey, UseFormReturnType, ValidationResponse } from '../types/types-api'
+import type { GenericForm } from '../types/types-core'
 
 /** Default URL search param when the consumer doesn't supply a custom
  *  `restore` / `persist` pair. */
@@ -74,30 +75,38 @@ const NOOP_VALID_STATUS: FormStatus = {
   errorCount: 0,
 }
 
-/** Subset of the form's surface the wizard reads for status + values. */
-type StatusSourceForm = {
-  readonly meta: {
-    readonly valid: boolean
-    readonly dirty: boolean
-    readonly submitted: boolean
-    readonly errorCount: number
-    readonly errors: ReadonlyArray<{
-      readonly path: ReadonlyArray<string | number>
-      readonly message: string
-      readonly code?: string
-    }>
-    readonly updatedAt: string | null
-  }
-  readonly values: unknown
-}
+/**
+ * Subset of the form's surface the wizard reads for status + values.
+ * Picked off the public `UseFormReturnType` so additions on the form
+ * side don't drift this slice (and so a removal/rename trips the type
+ * checker instead of leaking silently through a hand-redeclared shape).
+ */
+type StatusSourceForm = Pick<UseFormReturnType<GenericForm>, 'meta' | 'values'>
 
-/** Subset of the form's surface the wizard's submission walk exercises. */
-type SubmissionSourceForm = StatusSourceForm & {
-  activate(): Promise<void>
-  process(): Promise<ValidationResponse<unknown>>
-  applyInvalidSubmitPolicy(policy?: OnInvalidSubmitPolicy): void
-  reset(): void
-  readonly hydrateError: { readonly message: string } | null | undefined
+/**
+ * Subset of the form's surface the wizard's submission walk exercises.
+ * Picked off `UseFormReturnType` for the same drift-detection reason as
+ * `StatusSourceForm`.
+ */
+type SubmissionSourceForm = Pick<
+  UseFormReturnType<GenericForm>,
+  'meta' | 'values' | 'activate' | 'process' | 'applyInvalidSubmitPolicy' | 'reset' | 'hydrateError'
+>
+
+/**
+ * Internal helpers that center the `AnyForm → UseFormReturnType` cast.
+ * The wizard's slot surface is intentionally narrow (`AnyForm` —
+ * `{ readonly key: FormKey }`) to avoid forcing contravariant
+ * unification across participating forms; at runtime every form is
+ * the full `UseFormReturnType`. These helpers do the one-way coercion
+ * in a single place per surface so call sites read as a typed access
+ * instead of a `as unknown as` chain (W-COUPLE-1).
+ */
+function asStatusSource(form: AnyForm): StatusSourceForm {
+  return form as unknown as StatusSourceForm
+}
+function asSubmissionSource(form: AnyForm): SubmissionSourceForm {
+  return form as unknown as SubmissionSourceForm
 }
 
 /**
@@ -479,7 +488,7 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
   function valuesFor(form: AnyForm): ComputedRef<unknown> {
     const cached = valuesCache.get(form.key)
     if (cached !== undefined) return cached
-    const source = form as unknown as StatusSourceForm
+    const source = asStatusSource(form)
     const computedValues = computed(() => source.values)
     valuesCache.set(form.key, computedValues)
     return computedValues
@@ -489,7 +498,7 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
   function errorsFor(form: AnyForm): ComputedRef<readonly AggregateError[]> {
     const cached = errorsCache.get(form.key)
     if (cached !== undefined) return cached
-    const source = form as unknown as StatusSourceForm
+    const source = asStatusSource(form)
     const computedErrors = computed<readonly AggregateError[]>(() => {
       if (!isFormReady(form.key)) return []
       const errors = source.meta?.errors ?? []
@@ -588,7 +597,7 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
   function statusFor(form: AnyForm): ComputedRef<FormStatus> {
     const cached = statusCache.get(form.key)
     if (cached !== undefined) return cached
-    const source = form as unknown as StatusSourceForm
+    const source = asStatusSource(form)
     const computedStatus = computed<FormStatus>(() => {
       if (isFormReady(form.key)) {
         const meta = source.meta
@@ -821,7 +830,7 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
   // client-side contract.
   if (!registry.ssr) {
     for (const step of compiledSteps.value) {
-      const source = step.form as unknown as SubmissionSourceForm
+      const source = asSubmissionSource(step.form)
       if (typeof source.activate === 'function') void source.activate()
     }
   }
@@ -900,7 +909,7 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
   // --- Navigation internals --------------------------------------------
 
   function activateForm(form: AnyForm): void {
-    const source = form as unknown as SubmissionSourceForm
+    const source = asSubmissionSource(form)
     if (typeof source.activate === 'function') {
       void source.activate()
     }
@@ -1016,7 +1025,7 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
   }
 
   async function processOne(form: AnyForm): Promise<ValidationResponse<unknown>> {
-    const full = form as unknown as SubmissionSourceForm
+    const full = asSubmissionSource(form)
     let activationFailure: string | undefined
     try {
       if (typeof full.activate === 'function') await full.activate()
@@ -1122,8 +1131,7 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
             if (processed !== undefined && processed.success === true) {
               valuesMap[step.key] = processed.data
             } else {
-              const source = step.form as unknown as StatusSourceForm
-              valuesMap[step.key] = source.values
+              valuesMap[step.key] = asStatusSource(step.form).values
             }
           }
           const ctx = buildSubmitContext(valuesMap, currentKey, final)
@@ -1146,14 +1154,12 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
             if (firstFailedKey !== undefined && isCompiledKey(firstFailedKey)) {
               moveTo(firstFailedKey)
               await nextTick()
-              const failedForm = formsRecord.value[firstFailedKey] as unknown as
-                | SubmissionSourceForm
-                | undefined
-              if (
-                failedForm !== undefined &&
-                typeof failedForm.applyInvalidSubmitPolicy === 'function'
-              ) {
-                failedForm.applyInvalidSubmitPolicy()
+              const failedForm = formsRecord.value[firstFailedKey]
+              if (failedForm !== undefined) {
+                const failedSource = asSubmissionSource(failedForm)
+                if (typeof failedSource.applyInvalidSubmitPolicy === 'function') {
+                  failedSource.applyInvalidSubmitPolicy()
+                }
               }
             }
           }
@@ -1176,7 +1182,7 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
     // reboot, not a soft rewind.
     lazyEpoch.value += 1
     for (const step of compiledSteps.value) {
-      const full = step.form as unknown as SubmissionSourceForm
+      const full = asSubmissionSource(step.form)
       if (typeof full.reset === 'function') full.reset()
     }
     const firstStep = compiledSteps.value[0]

--- a/test/composables/wizard-active-step-reconciliation.test.ts
+++ b/test/composables/wizard-active-step-reconciliation.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, nextTick, ref, type App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { useWizard } from '../../src/runtime/composables/use-wizard'
+import { createAttaform } from '../../src/runtime/core/plugin'
+
+/**
+ * COMP-W5 / W-BRITTLE-1: when the active step's slot becomes
+ * un-resolvable mid-flight (a function slot that previously returned
+ * a form now returns `undefined`), `wizard.currentStep` and
+ * `wizard.activeForm` must agree on the same step. Pre-fix they
+ * could disagree — `currentStep` trusted `activeKey` verbatim and
+ * returned the dropped form's key, while `activeForm` fell back to
+ * the first compiled step. The fix routes `currentStep` through
+ * the same `activeIndex`-aware fallback so both reads stay in
+ * lockstep.
+ */
+
+const schema = z.object({ email: z.string().optional() })
+
+function mountHarness<R>(setup: () => R): { app: App; result: R } {
+  const handle: { result?: R } = {}
+  const App = defineComponent({
+    setup() {
+      handle.result = setup()
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  app.config.warnHandler = () => {}
+  app.config.errorHandler = () => {}
+  app.mount(document.createElement('div'))
+  return { app, result: handle.result as R }
+}
+
+describe('useWizard — currentStep / activeForm reconciliation (W-BRITTLE-1)', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('agrees on the fallback step when the active slot drops mid-flight', async () => {
+    const showMiddle = ref(true)
+    const { app, result } = mountHarness(() => {
+      const entry = useForm({ schema, key: 'w-brittle-entry' })
+      const middle = useForm({ schema, key: 'w-brittle-middle' })
+      const final = useForm({ schema, key: 'w-brittle-final' })
+      return useWizard({
+        steps: [entry, () => (showMiddle.value ? middle : undefined), final],
+        restore: false,
+        persist: false,
+      })
+    })
+    apps.push(app)
+
+    // Baseline: all three steps compile, navigate to middle.
+    expect(result.steps.map((s) => s.key)).toEqual([
+      'w-brittle-entry',
+      'w-brittle-middle',
+      'w-brittle-final',
+    ])
+    await result.next()
+    expect(result.currentStep).toBe('w-brittle-middle')
+    expect(result.activeForm?.key).toBe('w-brittle-middle')
+
+    // Drop the middle slot while the wizard is sitting on it.
+    showMiddle.value = false
+    await nextTick()
+
+    // The compiled list contracts to [entry, final]. The active key
+    // ('w-brittle-middle') is no longer in the list, so both reads
+    // must agree on the fallback (the first compiled step).
+    expect(result.steps.map((s) => s.key)).toEqual(['w-brittle-entry', 'w-brittle-final'])
+    expect(result.activeForm?.key).toBe('w-brittle-entry')
+    // Pre-fix: returned 'w-brittle-middle' (stale activeKey).
+    // Post-fix: returns 'w-brittle-entry' (matches activeForm).
+    expect(result.currentStep).toBe(result.activeForm?.key)
+  })
+
+  it('keeps currentStep === activeForm.key on the happy path too', async () => {
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema, key: 'w-brittle-happy-a' })
+      const b = useForm({ schema, key: 'w-brittle-happy-b' })
+      return useWizard({ steps: [a, b], restore: false, persist: false })
+    })
+    apps.push(app)
+
+    expect(result.currentStep).toBe(result.activeForm?.key)
+    await result.next()
+    expect(result.currentStep).toBe(result.activeForm?.key)
+    result.back()
+    expect(result.currentStep).toBe(result.activeForm?.key)
+  })
+})

--- a/test/composables/wizard-bare-function-slot-resolver.test.ts
+++ b/test/composables/wizard-bare-function-slot-resolver.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, type App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { useWizard } from '../../src/runtime/composables/use-wizard'
+import { createAttaform } from '../../src/runtime/core/plugin'
+
+/**
+ * COMP-W1 + COMP-W4 invariant: a bare function slot whose body does
+ * not read `ctx.currentKey` must NOT re-fire on wizard navigation.
+ * Only the slot's own tracked reactive reads should invalidate its
+ * resolution.
+ *
+ * The audit pinned this as P1 perf because pre-fix every `next` /
+ * `back` / `goTo` writes `activeKey`, which invalidates the `slotCtx`
+ * computed (`use-wizard.ts:282`) and cascades into `compiledSteps` —
+ * re-running every bare function slot's resolver. A 50-step wizard
+ * with eager function slots therefore re-runs all 50 resolvers per
+ * navigation, even ones whose body is independent of the active step.
+ *
+ * The fix unifies bare function slots on the same getter-style ctx
+ * `lazy()` slots already receive (`use-wizard.ts:341` `lazyCtx`): the
+ * `currentKey` dep is only established when the slot body actually
+ * reads it.
+ */
+
+const schema = z.object({ email: z.string().optional() })
+
+function mountHarness<R>(setup: () => R): { app: App; result: R } {
+  const handle: { result?: R } = {}
+  const App = defineComponent({
+    setup() {
+      handle.result = setup()
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  app.config.warnHandler = () => {}
+  app.config.errorHandler = () => {}
+  app.mount(document.createElement('div'))
+  return { app, result: handle.result as R }
+}
+
+describe('useWizard — bare function slot resolver-call accounting (COMP-W1)', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('a bare function slot that does not read ctx.currentKey fires once and stays cached across navigation', async () => {
+    let resolverCalls = 0
+    const { app, result } = mountHarness(() => {
+      const entry = useForm({ schema, key: 'comp-w1-entry' })
+      const middle = useForm({ schema, key: 'comp-w1-middle' })
+      const final = useForm({ schema, key: 'comp-w1-final' })
+      return useWizard({
+        steps: [
+          entry,
+          // Bare function slot — no `lazy()` wrapper, no reactive
+          // reads inside the body. Should fire once on initial
+          // compile and never again, regardless of how many times
+          // the wizard navigates around it.
+          () => {
+            resolverCalls += 1
+            return middle
+          },
+          final,
+        ],
+        restore: false,
+        persist: false,
+      })
+    })
+    apps.push(app)
+
+    expect(resolverCalls).toBe(1)
+    expect(result.steps.map((s) => s.key)).toEqual([
+      'comp-w1-entry',
+      'comp-w1-middle',
+      'comp-w1-final',
+    ])
+
+    await result.next() // entry → middle
+    await result.next() // middle → final
+    result.back() //         final → middle
+    result.goTo('comp-w1-entry')
+
+    // Pre-fix: `compiledSteps` reads `slotCtx.value` which reads
+    // `activeKey.value`, so each navigation invalidates the
+    // compile-pass computed and the bare function slot re-fires.
+    // Pre-fix resolverCalls === 5 (1 setup + 4 navigations).
+    // Post-fix: the getter-style ctx never establishes the
+    // activeKey dep because the slot body never reads
+    // ctx.currentKey, so resolverCalls stays at 1.
+    expect(resolverCalls).toBe(1)
+  })
+
+  it('a bare function slot that reads ctx.currentKey re-fires on navigation as expected', async () => {
+    let resolverCalls = 0
+    let lastSeenCurrentKey: string | undefined
+    const { app, result } = mountHarness(() => {
+      const entry = useForm({ schema, key: 'comp-w1-rdk-entry' })
+      const middle = useForm({ schema, key: 'comp-w1-rdk-middle' })
+      const final = useForm({ schema, key: 'comp-w1-rdk-final' })
+      return useWizard({
+        steps: [
+          entry,
+          (ctx) => {
+            resolverCalls += 1
+            lastSeenCurrentKey = ctx.currentKey
+            return middle
+          },
+          final,
+        ],
+        restore: false,
+        persist: false,
+      })
+    })
+    apps.push(app)
+
+    // Sanity: the slot observed at least the initial compile.
+    const initialCalls = resolverCalls
+    expect(initialCalls).toBeGreaterThanOrEqual(1)
+    expect(lastSeenCurrentKey).toBe('comp-w1-rdk-entry')
+
+    await result.next() // → middle: ctx.currentKey changes, slot re-fires.
+    expect(resolverCalls).toBeGreaterThan(initialCalls)
+    expect(lastSeenCurrentKey).toBe('comp-w1-rdk-middle')
+  })
+})


### PR DESCRIPTION
## Phase 14 — Wizard decouple & dedup (`perf/wizard-decouple`)

Resolves audit findings **COMP-W1 / COMP-W2 / COMP-W3 / COMP-W4 / COMP-W5** in a focused 7-commit series on `src/runtime/composables/use-wizard.ts`. Two RED→GREEN characterization tests pin observable invariants; three internal refactors compress drift surface and dedup helpers.

## Why now

Phase 13 took the proxy layer + entry barrel; Phase 14 takes the wizard. The audit clustered five findings (`COMP-W1`–`W5`) on a single ~1290-LOC file with two recurring problems:

1. **Compile-pass coupled to navigation pointer** (W1/W4). `compiledSteps` read `slotCtx.value` (a `computed` that eagerly read `activeKey.value`), so every `next` / `back` / `goTo` invalidated the compile pass and re-ran every eager function-slot resolver. A 50-step wizard re-ran 50 resolvers per "Next."
2. **Whole-record aggregates** (W2). `allValues` / `allErrors` / the statuses snapshot each looped *all* steps + read every form's reactive meta, so one field edit re-evaluated the whole record.

The remaining findings ride along: helper dedup (W3), public type drift via hand-redeclared slices (W5 W-COUPLE-1), and a reconciliation gap between `currentStep` and `activeForm` when a function slot drops the active step mid-flight (W5 W-BRITTLE-1).

## Commit series (7 commits)

| # | Commit | LOC | Note |
|---|---|---|---|
| 1 | `test(wizard): pin bare-function-slot resolver-call accounting (COMP-W1)` | +130 | RED |
| 2 | `perf(wizard): decouple compiledSteps from activeKey (COMP-W1 + COMP-W4)` | +24/-20 | GREEN |
| 3 | `perf(wizard): per-key memoization for allValues / allErrors (COMP-W2)` | +97/-34 | |
| 4 | `refactor(wizard): extract toAggregateError + isFormReady (COMP-W3)` | +40/-24 | |
| 5 | `refactor(wizard): derive Status/SubmissionSourceForm from UseFormReturnType (COMP-W5 W-COUPLE-1)` | +47/-41 | |
| 6 | `test(wizard): pin currentStep / activeForm reconciliation gap (COMP-W5 W-BRITTLE-1)` | +96 | RED |
| 7 | `fix(wizard): reconcile currentStep with activeForm fallback (COMP-W5 W-BRITTLE-1)` | +15/-3 | GREEN |

Net: **+435 / −108** across 3 files (1 modified + 2 new tests). The growth is concentrated in the per-key memoization proxies and the four extracted helpers — the surrounding logic shrunk.

## What changed

### `compiledSteps` no longer reads `activeKey` (COMP-W1 + COMP-W4)
Deleted the `slotCtx = computed(() => ({ ..., currentKey: activeKey.value }))` shape; unified on the getter-style `slotCtx` that `lazy()` slots already used. The `activeKey` dep is now established **only** when a slot body actually reads `ctx.currentKey` — bare function slots that don't look at the active step stay cached across navigation; slots that do look at it still re-fire correctly. Sibling RED test confirms `resolverCalls === 1` through 4 navigations (was `≥ 5` on `main`); the second arm confirms `ctx.currentKey`-reading slots still re-fire as expected.

### Per-key memoization for `allValues` / `allErrors` (COMP-W2)
Added `valuesFor(form)` and `errorsFor(form)` per-key `ComputedRef` caches mirroring the existing `statusCache`. The aggregates are now identity-stable `Proxy` surfaces whose `get` / `getOwnPropertyDescriptor` delegate to the per-key computed, so one form's edit only invalidates that form's slot. Iteration order still matches the compiled step list via `formsRecord` in `ownKeys`. **Identity note:** the proxies are stable references where the previous `ComputedRef` returned a fresh record per evaluation — same pattern as `wizard.statuses`. Per-key reads, `JSON.stringify`, and `Object.entries` continue to track each form individually as before.

### Helpers extracted (COMP-W3)
- `toAggregateError(err, fallbackKey)` — centralizes the `AggregateError` construction shared by `allErrors` (errors from `form.meta.errors`, no per-entry `formKey`) and `collectErrors` (`ValidationError` entries that already carry `formKey`). Prefers `err.formKey` when present.
- `isFormReady(key)` — lifts the `registry.forms.get(key) + defaultsResolved.value === true` gate out of `statusFor` and `errorsFor`. Reads through the registry's per-store flag (not the public `form.ready` getter) so wizard introspection never activates a dormant lazy factory on its own.

### Typed source-form slices (COMP-W5 W-COUPLE-1)
Replaced the hand-redeclared `StatusSourceForm` / `SubmissionSourceForm` with `Pick<UseFormReturnType<GenericForm>, ...>` slices, so additions / renames on the form surface trip the type checker here instead of leaking through hand-spec drift. Centralized the `AnyForm → UseFormReturnType` coercion behind two helpers (`asStatusSource`, `asSubmissionSource`) — nine inline `as unknown as` casts replaced by one cast per helper.

### `currentStep` / `activeForm` reconciliation (COMP-W5 W-BRITTLE-1)
**⚠️ Observable behavior change.** Pre-fix, when a function slot stopped returning the form the wizard was sitting on, `currentStep` kept reporting the dropped form's key while `activeForm` independently fell back to the first compiled step. Routed `currentStep` through the same `activeIndex`-aware lookup `activeForm` uses, so both reads now agree on the same step (either the active index, or the first-step fallback when the active key is no longer compiled). Pinned with a RED→GREEN characterization test covering both the drop-mid-flight case and the happy path.

## API & behavior-change ledger

- **COMP-W5 W-BRITTLE-1** — `currentStep` returns the first compiled step's key (instead of the stale `activeKey`) when a function slot drops the active step mid-flight. This is the documented contract — `currentStep` is the active step's key, and the active step is whatever `activeForm` resolves to. Flagged per the plan's Phase 14 ledger.
- **COMP-W2 identity stability** — `wizard.allValues` / `wizard.allErrors` are now identity-stable `Proxy` references (was a `ComputedRef`'s value, fresh object per re-evaluation). Per-key reads, iteration, and `JSON.stringify` are unaffected; matches the existing `wizard.statuses` shape.

No other observable changes. The COMP-W1/W4/W3 commits and the COMP-W5 W-COUPLE-1 typed-slice refactor are behavior-neutral.

## Full gate

- `pnpm lint` ✓
- `pnpm typecheck` ✓
- `pnpm check:site` ✓
- `pnpm test` ✓ **3498/3498** (was 3494 — +4 from the two new RED→GREEN characterization tests)
- `pnpm check:size` ✓ all entries within budget:
  - `index.mjs` 46.83 / 48 kB
  - `zod.mjs` 60.45 / 63 kB
  - `zod-v4.mjs` 54.6 / 55 kB
  - `zod-v3.mjs` 55.65 / 56 kB
- `pnpm check:bench` ✓ all scenarios within 3× floors
- `pnpm check:coverage` ✓ Lines **91.75%** (unchanged from Phase 13 baseline)

## Net structural change

One file modified (`use-wizard.ts`, ~210 LOC net delta — extracted helpers + per-key cache + typed slices add weight; deleted `slotCtx` computed + inline duplicate constructions remove some). Two new characterization tests pinning the COMP-W1 resolver-call invariant and the COMP-W5 W-BRITTLE-1 reconciliation contract.

Phase 14 complete. Next phase: **Phase 15 (`refactor/transform-dedup`)** — DIR-F1/F2/F4/F5/F6/F8/F9/F10/F11 + the `test/vite/` transform-wiring coverage gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
