### PR TITLE
Phase 15: transform dedup + DIR-F4 SSR hydration fix (DIR-F1/F2/F4/F5/F6/F8/F9/F10/F11 + test/vite coverage gap)

### DIFF
--- a/src/runtime/composables/use-register.ts
+++ b/src/runtime/composables/use-register.ts
@@ -123,6 +123,17 @@ let warnedOutsideSetup = false
  * `bind` pass. The `has` / `ownKeys` traps cooperate with
  * `'innerRef' in rv` / `Object.keys(rv)` — including the
  * `isRegisterValue` type guard the directive uses.
+ *
+ * Perf trade-off (DIR-F11): every read traverses the `get` trap, so
+ * a tight hot loop reading `rv.innerRef.value` pays a per-read trap
+ * cost. The hybrid Proxy is what lets `useRegister` return a single
+ * value that's BOTH a `Ref<RegisterValue|undefined>` (for `v-register
+ * ="rv"`) AND a `RegisterValue`-shaped object (for script-setup
+ * `rv.path`). Replacing the proxy with an object built per
+ * `useRegister` would either lose the lazy `ref`-unwrap behaviour or
+ * recreate the union shape with per-property getters anyway — net
+ * trap cost would stay. The audit flagged this as minor; the DX win
+ * is the justification for keeping it.
  */
 function makeRegisterValueProxy<V>(
   capturedRegisterValue: Ref<RegisterValue<V> | undefined>

--- a/src/runtime/composables/use-register.ts
+++ b/src/runtime/composables/use-register.ts
@@ -209,7 +209,7 @@ export function useRegister<V = unknown>(): UseRegisterReturn<V> | undefined {
 
   const refreshAndStripBridgeAttrs = (): void => {
     const rawAttrs = instance.attrs as Record<string, unknown>
-    // Primary path: the compile-time `selectNodeTransform` injected a
+    // Primary path: the compile-time `componentBridgeTransform` injected a
     // `:registerValue` bridge prop on the host component, which Vue's
     // `initProps` lands in `instance.attrs.registerValue`. Capture
     // only when the key is present; the strip below removes it from
@@ -257,7 +257,7 @@ export function useRegister<V = unknown>(): UseRegisterReturn<V> | undefined {
   // server-side template read would otherwise misrender. Vue's
   // `setupComponent` runs `initProps` (which populates
   // `instance.attrs.registerValue` from the parent's `:registerValue`
-  // binding injected by `selectNodeTransform`) before `setup()` runs,
+  // binding injected by `componentBridgeTransform`) before `setup()` runs,
   // so the sync read sees the correct value on both server and client.
   // The `onBeforeMount` hook stays as defence in depth against any
   // re-population that could happen after setup (e.g. from a parent's

--- a/src/runtime/core/directive.ts
+++ b/src/runtime/core/directive.ts
@@ -28,6 +28,7 @@ import type { DirectiveBinding, DirectiveHook, ObjectDirective, VNode } from 'vu
 import { effectScope, isRef, nextTick, warn, watch } from 'vue'
 import { REGISTER_OWNER_MARKER } from '../composables/use-register'
 import { __DEV__ } from './dev'
+import { INTERACTIVE_TAG_NAMES } from './interactive-tags'
 import type {
   CustomDirectiveRegisterAssignerFn,
   DisplayState,
@@ -210,7 +211,7 @@ function isDefaultAssigner(fn: unknown): boolean {
  * the next input event fires, the user's assigner is in place.
  */
 function shouldBailListener(el: HTMLElement): boolean {
-  if (SUPPORTED_TAGS.has(el.tagName)) return false
+  if (INTERACTIVE_TAG_NAMES.has(el.tagName)) return false
   return isDefaultAssigner((el as unknown as { [k: symbol]: unknown })[assignKey])
 }
 
@@ -1418,7 +1419,6 @@ function getCheckboxValue(
 // reach the child instance via `binding.instance` — that's the
 // page/parent component, whose `subTree` is the outer element tree,
 // not the child component vnode directly).
-const SUPPORTED_TAGS = new Set(['INPUT', 'TEXTAREA', 'SELECT'])
 
 // One-shot dev-warn dedupe so a v-for over 100 unsupported elements
 // produces one warning, not 100. Keyed by element identity (WeakSet
@@ -1568,7 +1568,7 @@ const vRegisterDynamic: RegisterModelDynamicCustomDirective = {
     if (
       __DEV__ &&
       warnedUnsupportedElements !== null &&
-      !SUPPORTED_TAGS.has(el.tagName) &&
+      !INTERACTIVE_TAG_NAMES.has(el.tagName) &&
       !warnedUnsupportedElements.has(el)
     ) {
       void nextTick(() => {

--- a/src/runtime/core/interactive-tags.ts
+++ b/src/runtime/core/interactive-tags.ts
@@ -1,0 +1,21 @@
+/**
+ * Single source of truth for the set of HTML form-element tag names
+ * Attaform treats as "interactive value-bearing" — the elements whose
+ * default behaviour produces a model-relevant `change`/`input` event
+ * and whose `value` / `checked` / `selectedIndex` properties the
+ * v-register directive and `useRegister` composable own end-to-end.
+ *
+ * Both `directive.ts` (gate the unsupported-tag dev-warn + the
+ * static-fallback path) and `register-api.ts` (gate focus/blur
+ * listener attachment in the composable) read this same set. Pre-
+ * dedup each file declared its own copy in a different order, with
+ * nothing tying them together — the audit DIR-F2 flagged the silent-
+ * drift risk that comes with two parallel sets gating the same
+ * predicate.
+ *
+ * Tag names are uppercase to match `element.tagName` (the HTML spec
+ * uppercases element tag names on the DOM side regardless of the
+ * source's casing). Membership checks therefore work against the
+ * native `.tagName` property without case normalization.
+ */
+export const INTERACTIVE_TAG_NAMES: ReadonlySet<string> = new Set(['INPUT', 'SELECT', 'TEXTAREA'])

--- a/src/runtime/core/register-api.ts
+++ b/src/runtime/core/register-api.ts
@@ -14,6 +14,7 @@ import { captureUserCallSite } from './dev-stack-trace'
 import { AnonPersistError } from './errors'
 import { extractSchemaFields } from './extract-schema-fields'
 import { computeFieldIdentity } from './field-ids'
+import { INTERACTIVE_TAG_NAMES } from './interactive-tags'
 import { canonicalizePath, type Path, type PathKey } from './paths'
 import { PERSISTENCE_MODULE_KEY } from './persistence'
 import { buildCoerceFn, buildElementCoerceFn, resolveCoercionIndex } from './schema-coerce'
@@ -67,8 +68,6 @@ const EMPTY_TRANSFORMS: ReadonlyArray<RegisterTransform> = Object.freeze([])
  * - Cross-form isolation is by construction: every call to `buildRegister`
  *   closes over a FormStore<F> unique to one form.
  */
-
-const INTERACTIVE_TAG_NAMES = new Set(['INPUT', 'SELECT', 'TEXTAREA'])
 
 // `Symbol.for(...)` so duplicate copies of attaform agree on the
 // element-property key for stashed focus/blur handlers — see

--- a/src/runtime/lib/core/transforms/_shared-props.ts
+++ b/src/runtime/lib/core/transforms/_shared-props.ts
@@ -4,6 +4,7 @@ import type {
   DirectiveNode,
   ExpressionNode,
   RootNode,
+  SimpleExpressionNode,
   TemplateChildNode,
 } from '@vue/compiler-core'
 import { NodeTypes } from '@vue/compiler-core'
@@ -128,4 +129,42 @@ export function removePropsByName(
  */
 export function isExactKey(summarizedKey: string, name: string): boolean {
   return summarizedKey === name || summarizedKey === `"${name}"`
+}
+
+/**
+ * Flatten an ExpressionNode (`SimpleExpressionNode` |
+ * `CompoundExpressionNode`) back to its source-text string. Compound
+ * nodes carry a list of strings interleaved with nested expression
+ * nodes — concatenate the textual content to reconstruct the source.
+ *
+ * Single source of truth for the select transform's per-`<option>`
+ * processExpression input AND the v-register preamble transform's
+ * pre-wrap binding capture. Both call sites built equivalent inline
+ * helpers; the consolidation prevents drift in how a future Vue node-
+ * type addition gets handled.
+ *
+ * Children that aren't string / SIMPLE / COMPOUND (symbols from the
+ * codegen helper indices; node types added in a future Vue) are
+ * dropped silently — the serialized text is for downstream parsing,
+ * not faithful round-trip.
+ */
+export function flattenExpression(exp: ExpressionNode): string {
+  if (exp.type === NodeTypes.SIMPLE_EXPRESSION) return exp.content
+  let out = ''
+  for (const child of exp.children) {
+    if (typeof child === 'string') {
+      out += child
+      continue
+    }
+    if (typeof child === 'symbol') continue
+    const node = child as ExpressionNode | SimpleExpressionNode
+    if (node.type === NodeTypes.SIMPLE_EXPRESSION) {
+      out += node.content
+      continue
+    }
+    if (node.type === NodeTypes.COMPOUND_EXPRESSION) {
+      out += flattenExpression(node)
+    }
+  }
+  return out
 }

--- a/src/runtime/lib/core/transforms/_shared-props.ts
+++ b/src/runtime/lib/core/transforms/_shared-props.ts
@@ -1,0 +1,131 @@
+import type {
+  AttributeNode,
+  CompoundExpressionNode,
+  DirectiveNode,
+  ExpressionNode,
+  RootNode,
+  TemplateChildNode,
+} from '@vue/compiler-core'
+import { NodeTypes } from '@vue/compiler-core'
+
+/**
+ * Shared prop-summarization toolkit for the compile-time node
+ * transforms. `input-text-area-transform.ts` and `select-transform.ts`
+ * both summarize their host element's props into a uniform
+ * `{ key, value }` shape before deciding which directive to inject,
+ * which props to strip, and how to construct the synthesized binding.
+ * The summarization rules are byte-identical across both transforms;
+ * keeping two copies risked silent drift — particularly on key-shape
+ * decisions (`isExactKey`) and quoting (`renderAsStatic`).
+ *
+ * Consumers in the `transforms/` directory only — not exported from
+ * any package barrel. The underscore prefix mirrors the existing
+ * convention for transform-internal modules.
+ */
+
+/**
+ * Uniform summary of a Vue-compiler AST prop. `key` is the prop name
+ * (string for attributes, the rendered text of `arg` for directive
+ * binds); `value` is either a string (attribute literal, simple
+ * expression, or quoted static) or the children array of a
+ * `CompoundExpressionNode` (template literals, interpolated
+ * expressions, etc.).
+ */
+export type SummarizedProp = {
+  key: string
+  value: string | CompoundExpressionNode['children']
+}
+
+/**
+ * Summarize every prop on a Vue-compiler element node into the
+ * `SummarizedProp` shape. Returns an empty array for nodes that don't
+ * carry props (template / interpolation / comment).
+ */
+export function getSummarizedProps(node: RootNode | TemplateChildNode): SummarizedProp[] {
+  if (!('props' in node)) return []
+  const props = node.props
+
+  const summarizedProps = props.reduce<SummarizedProp[]>((acc, currProp) => {
+    if (currProp.type === NodeTypes.ATTRIBUTE) {
+      const key = currProp.name
+      const value = currProp.value?.content ?? ''
+      return [...acc, { key, value: renderAsStatic(value, true) }]
+    }
+
+    if (currProp.exp === undefined) return acc
+    const key = currProp.arg
+      ? getSummarizedPropValue(currProp.arg)
+      : renderAsStatic(currProp.name, true)
+    if (typeof key !== 'string') return acc // key must always be a string
+    const value = getSummarizedPropValue(currProp.exp)
+
+    return [...acc, { key, value }]
+  }, [])
+
+  return summarizedProps
+}
+
+/**
+ * Wrap a static value in double quotes so it serializes back to a
+ * JS string literal. Pass `isStatic: false` to return the raw text
+ * unchanged (already a dynamic-expression source string).
+ */
+export function renderAsStatic(val: string, isStatic: boolean): string {
+  return isStatic ? `"${val}"` : val
+}
+
+/**
+ * Resolve an ExpressionNode to its `SummarizedProp['value']` shape —
+ * either a quoted static literal (for simple static expressions) or
+ * the raw children array (for compound / interpolated expressions).
+ */
+export function getSummarizedPropValue(exp: ExpressionNode): SummarizedProp['value'] {
+  if (exp.type === NodeTypes.SIMPLE_EXPRESSION) {
+    return renderAsStatic(exp.content, exp.isStatic)
+  }
+
+  return exp.children
+}
+
+/**
+ * Mutate `props` in place to drop every entry whose name (or
+ * directive-arg content) matches any of `propNames`. Indices are
+ * collected high-to-low so the splice loop doesn't shift remaining
+ * entries mid-iteration.
+ */
+export function removePropsByName(
+  props: (AttributeNode | DirectiveNode)[],
+  propNames: string[]
+): void {
+  const removePropIndices: number[] = []
+  for (let index = 0; index < props.length; index++) {
+    const prop = props[index]
+    if (!prop) continue
+
+    if (
+      propNames.includes(prop.name) ||
+      ('arg' in prop && prop.arg && 'content' in prop.arg && propNames.includes(prop.arg.content))
+    ) {
+      removePropIndices.push(index) // store index to remove later, don't mutate variable while looping through it
+    }
+  }
+
+  for (const index of removePropIndices.sort((a, z) => z - a)) {
+    props.splice(index, 1) // index runs from high to low, so this works
+  }
+}
+
+/**
+ * Exact prop-name match. Pre-rewrite used .includes('register') /
+ * .includes('value') / .includes('type') which false-positived on
+ * any user prop whose name contained those substrings (e.g.
+ * `data-register-id`, `valueFoo`, `prototype`, `:registerField`).
+ *
+ * Summarized keys come in three shapes depending on prop type:
+ *   attribute       -> "name"          (from getSummarizedProps)
+ *   v-bind:name="x" -> "\"name\""      (quoted via renderAsStatic)
+ *   static v-prefix -> "\"name\""
+ */
+export function isExactKey(summarizedKey: string, name: string): boolean {
+  return summarizedKey === name || summarizedKey === `"${name}"`
+}

--- a/src/runtime/lib/core/transforms/component-bridge-transform.ts
+++ b/src/runtime/lib/core/transforms/component-bridge-transform.ts
@@ -201,16 +201,25 @@ function inferOptionValueFromChildren(node: TemplateChildNode | RootNode): strin
 }
 
 /**
- * Vue compiler node transform for `<select v-register>` and any
- * component that wraps a select. Injects the `:value` /
- * `:registerValue` bridge bindings the runtime directive needs to
- * pre-mark selected options at SSR time.
+ * Vue compiler node transform that bridges `v-register` into the
+ * downstream binding shapes its consumers expect:
  *
- * Wired automatically by `attaform/vite` and
- * `attaform/nuxt`. Use directly only when integrating with
- * a custom bundler.
+ *   - `<select v-register>` — injects `:value` (single-select) and
+ *     per-`<option>` `:selected` so the runtime directive can pre-mark
+ *     selected options at SSR time.
+ *   - `<MyComponent v-register>` and kebab-case custom-element hosts
+ *     — injects a `:registerValue` bridge prop so `useRegister` inside
+ *     the child sees the parent's RegisterValue (the binding the audit
+ *     called out as the transform's "fires on every component" path).
+ *
+ * Wired automatically by `attaform/vite` and `attaform/nuxt`. Use
+ * directly only when integrating with a custom bundler.
+ *
+ * Renamed from `selectNodeTransform` (DIR-F6): the original name read
+ * as a `<select>`-only transform, but the component-bridge path is
+ * load-bearing for every `useRegister` consumer.
  */
-export const selectNodeTransform: NodeTransform = (node, context) => {
+export const componentBridgeTransform: NodeTransform = (node, context) => {
   // Snapshot every prop array we're about to mutate so a throw
   // mid-traversal rewinds to the pre-transform state. Without this,
   // a partial transform leaves the template with some `<option
@@ -411,7 +420,7 @@ export const selectNodeTransform: NodeTransform = (node, context) => {
         outputExp = processExpression(simpleExpression, { ...context, prefixIdentifiers: false })
       } catch (err) {
         console.error(
-          '[attaform] select transform: processExpression failed; falling back to the unprocessed expression.',
+          '[attaform] component-bridge transform: processExpression failed; falling back to the unprocessed expression.',
           err
         )
         outputExp = simpleExpression
@@ -483,6 +492,6 @@ export const selectNodeTransform: NodeTransform = (node, context) => {
       target.splice(0, target.length, ...snapshot)
     }
 
-    console.error('[attaform] select transform failed, skipping:', err)
+    console.error('[attaform] component-bridge transform failed, skipping:', err)
   }
 }

--- a/src/runtime/lib/core/transforms/input-text-area-transform.ts
+++ b/src/runtime/lib/core/transforms/input-text-area-transform.ts
@@ -74,6 +74,24 @@ function generateEqualityExpression(
 }
 
 /**
+ * Parse a one-line JS string literal from `text`. Returns `null` for
+ * any non-literal source (dynamic expression, compound, mismatched
+ * quotes); on a match returns the quote character and the inner
+ * payload separately so callers can disambiguate template literals
+ * with interpolations from literal-static strings.
+ *
+ * Doesn't attempt to handle escaped quotes inside the literal — a
+ * value containing escaped quotes is vanishingly rare in the prop
+ * shapes the transforms inspect (HTML attribute values, type names).
+ * Callers that can't prove safety on `null` should bail conservatively.
+ */
+function parseStaticStringLiteral(text: string): { quote: string; inner: string } | null {
+  const literalMatch = /^(["'`])(.*)\1$/.exec(text.trim())
+  if (literalMatch === null) return null
+  return { quote: literalMatch[1] as string, inner: literalMatch[2] as string }
+}
+
+/**
  * Returns true iff the type prop's value is the static-attribute literal
  * matching one of `names` (case-insensitive). Used to detect static
  * `type="checkbox"` / `type="radio"` shapes where the `value` attribute
@@ -87,11 +105,9 @@ function generateEqualityExpression(
  */
 function isStaticTypeOneOf(value: SummarizedProp['value'], names: readonly string[]): boolean {
   if (Array.isArray(value)) return false
-  const trimmed = value.trim()
-  const literalMatch = /^(["'`])(.*)\1$/.exec(trimmed)
-  if (literalMatch === null) return false
-  const inner = (literalMatch[2] as string).toLowerCase()
-  return names.includes(inner)
+  const parsed = parseStaticStringLiteral(value)
+  if (parsed === null) return false
+  return names.includes(parsed.inner.toLowerCase())
 }
 
 /**
@@ -109,21 +125,14 @@ function isStaticTypeOneOf(value: SummarizedProp['value'], names: readonly strin
  */
 function couldResolveToFileType(value: SummarizedProp['value']): boolean {
   if (Array.isArray(value)) return true
-  const trimmed = value.trim()
-  // Match a one-line JS string literal: '...', "...", or `...`. Doesn't
-  // attempt to handle escaped quotes inside the literal — a `type` prop
-  // containing escaped quotes is vanishingly rare and falling through to
-  // "could be file" here is the safe direction anyway.
-  const literalMatch = /^(["'`])(.*)\1$/.exec(trimmed)
-  if (literalMatch === null) return true // dynamic expression — can't prove safe
-  const quote = literalMatch[1] as string
-  const inner = literalMatch[2] as string
+  const parsed = parseStaticStringLiteral(value)
+  if (parsed === null) return true // dynamic expression — can't prove safe
   // Template literals with interpolations resolve at runtime.
-  if (quote === '`' && inner.includes('${')) return true
+  if (parsed.quote === '`' && parsed.inner.includes('${')) return true
   // The HTML spec matches `type` ASCII case-insensitively, so
   // `<input type="FILE">` behaves identically to `<input type="file">`.
   // Compare lower-cased so we catch both.
-  return inner.toLowerCase() === 'file'
+  return parsed.inner.toLowerCase() === 'file'
 }
 
 /**

--- a/src/runtime/lib/core/transforms/input-text-area-transform.ts
+++ b/src/runtime/lib/core/transforms/input-text-area-transform.ts
@@ -1,56 +1,17 @@
 import type {
-  AttributeNode,
   CompoundExpressionNode,
   DirectiveNode,
-  ExpressionNode,
   NodeTransform,
   PlainElementNode,
-  RootNode,
   SourceLocation,
-  TemplateChildNode,
 } from '@vue/compiler-core'
 import { createCompoundExpression, NodeTypes } from '@vue/compiler-core'
-
-type SummarizedProp = {
-  key: string
-  value: string | CompoundExpressionNode['children']
-}
-
-function getSummarizedProps(node: RootNode | TemplateChildNode) {
-  if (!('props' in node)) return []
-  const props = node.props
-
-  const summarizedProps = props.reduce<SummarizedProp[]>((acc, currProp) => {
-    if (currProp.type === NodeTypes.ATTRIBUTE) {
-      const key = currProp.name
-      const value = currProp.value?.content ?? ''
-      return [...acc, { key, value: renderAsStatic(value, true) }]
-    }
-
-    if (currProp.exp === undefined) return acc
-    const key = currProp.arg
-      ? getSummarizedPropValue(currProp.arg)
-      : renderAsStatic(currProp.name, true)
-    if (typeof key !== 'string') return acc // key must always be a string
-    const value = getSummarizedPropValue(currProp.exp)
-
-    return [...acc, { key, value }]
-  }, [])
-
-  return summarizedProps
-}
-
-function renderAsStatic(val: string, isStatic: boolean) {
-  return isStatic ? `"${val}"` : val
-}
-
-function getSummarizedPropValue(exp: ExpressionNode): SummarizedProp['value'] {
-  if (exp.type === NodeTypes.SIMPLE_EXPRESSION) {
-    return renderAsStatic(exp.content, exp.isStatic)
-  }
-
-  return exp.children
-}
+import {
+  getSummarizedProps,
+  isExactKey,
+  removePropsByName,
+  type SummarizedProp,
+} from './_shared-props'
 
 function generateEqualityExpression(
   registerValue: SummarizedProp['value'],
@@ -110,36 +71,6 @@ function generateEqualityExpression(
     ...scalarTargetArr,
     ')))',
   ]
-}
-
-function removePropsByName(props: (AttributeNode | DirectiveNode)[], propNames: string[]) {
-  const removePropIndices: number[] = []
-  for (let index = 0; index < props.length; index++) {
-    const prop = props[index]
-    if (!prop) continue
-
-    if (
-      propNames.includes(prop.name) ||
-      ('arg' in prop && prop.arg && 'content' in prop.arg && propNames.includes(prop.arg.content))
-    ) {
-      removePropIndices.push(index) // store index to remove later, don't mutate variable while looping through it
-    }
-  }
-
-  for (const index of removePropIndices.sort((a, z) => z - a)) {
-    props.splice(index, 1) // index runs from high to low, so this works
-  }
-}
-
-// Exact prop-name match. Pre-rewrite used .includes('register') / .includes('value') /
-// .includes('type') which false-positived on any user prop whose name contained those
-// substrings (e.g. `data-register-id`, `valueFoo`, `prototype`, `:registerField`).
-function isExactKey(summarizedKey: string, name: string): boolean {
-  // Summarized keys come in three shapes depending on prop type:
-  //   attribute       -> "name"          (from getSummarizedProps)
-  //   v-bind:name="x" -> "\"name\""      (quoted via renderAsStatic)
-  //   static v-prefix -> "\"name\""
-  return summarizedKey === name || summarizedKey === `"${name}"`
 }
 
 /**

--- a/src/runtime/lib/core/transforms/input-text-area-transform.ts
+++ b/src/runtime/lib/core/transforms/input-text-area-transform.ts
@@ -64,7 +64,7 @@ function generateEqualityExpression(
   // Discriminator selection:
   //   - Array model     → membership of the option-value (e.g. value="apple")
   //   - Set model       → membership of the option-value
-  //   - Scalar model    → equality with the scalar-equality target
+  //   - Scalar model    → coerced String() equality with the scalar target
   //
   // The scalar target differs from the option-value for two checkbox
   // shapes that the directive's runtime `setChecked` already handles
@@ -75,6 +75,17 @@ function generateEqualityExpression(
   //
   // For radio inputs the model is always scalar and the discriminator
   // IS the option-value, so `optionValue === scalarTarget` there.
+  //
+  // The scalar branch routes both sides through `String(...)` to mirror
+  // the runtime `setChecked` path, which uses Vue's `looseEqual` —
+  // looseEqual coerces primitives via `String(...)` before comparing.
+  // Without the coerce, SSR on `<input type="radio" value="2">` bound
+  // to a `z.number()` model of `2` evaluated `2 === "2"` → `false` and
+  // emitted unchecked HTML, then the runtime's `looseEqual(2, applyCoerce("2"))`
+  // returned `true` on hydration and flipped to checked — a one-tick
+  // visible flicker (DIR-F4). The `typeof !== 'object'` guard preserves
+  // current behaviour for non-array / non-Set object models, which both
+  // ladders fall through this scalar branch with no realistic match.
   return [
     'Array.isArray((',
     ...registerValueArr,
@@ -91,11 +102,13 @@ function generateEqualityExpression(
     ')?.innerRef?.value?.has(',
     ...optionValueArr,
     ') : ',
-    '((',
+    '(typeof (',
     ...registerValueArr,
-    ')?.innerRef?.value === (',
+    ")?.innerRef?.value !== 'object' && String((",
+    ...registerValueArr,
+    ')?.innerRef?.value) === String((',
     ...scalarTargetArr,
-    '))',
+    ')))',
   ]
 }
 

--- a/src/runtime/lib/core/transforms/select-transform.ts
+++ b/src/runtime/lib/core/transforms/select-transform.ts
@@ -13,47 +13,12 @@ import {
   type SourceLocation,
   type TemplateChildNode,
 } from '@vue/compiler-core'
-
-type SummarizedProp = {
-  key: string
-  value: string | CompoundExpressionNode['children']
-}
-
-function getSummarizedProps(node: RootNode | TemplateChildNode) {
-  if (!('props' in node)) return []
-  const props = node.props
-
-  const summarizedProps = props.reduce<SummarizedProp[]>((acc, currProp) => {
-    if (currProp.type === NodeTypes.ATTRIBUTE) {
-      const key = currProp.name
-      const value = currProp.value?.content ?? ''
-      return [...acc, { key, value: renderAsStatic(value, true) }]
-    }
-
-    if (currProp.exp === undefined) return acc
-    const key = currProp.arg
-      ? getSummarizedPropValue(currProp.arg)
-      : renderAsStatic(currProp.name, true)
-    if (typeof key !== 'string') return acc // key must always be a string
-    const value = getSummarizedPropValue(currProp.exp)
-
-    return [...acc, { key, value }]
-  }, [])
-
-  return summarizedProps
-}
-
-function renderAsStatic(val: string, isStatic: boolean) {
-  return isStatic ? `"${val}"` : val
-}
-
-function getSummarizedPropValue(exp: ExpressionNode): SummarizedProp['value'] {
-  if (exp.type === NodeTypes.SIMPLE_EXPRESSION) {
-    return renderAsStatic(exp.content, exp.isStatic)
-  }
-
-  return exp.children
-}
+import {
+  getSummarizedProps,
+  isExactKey,
+  removePropsByName,
+  type SummarizedProp,
+} from './_shared-props'
 
 function generateEqualityExpression(
   selectValue: SummarizedProp['value'],
@@ -176,25 +141,6 @@ function extractMultipleFromSelectSummarizedProps(
   return typeof value === 'string' ? value.replace(/'|"/g, '') : (value ?? 'true')
 }
 
-function removePropsByName(props: (AttributeNode | DirectiveNode)[], propNames: string[]) {
-  const removePropIndices: number[] = []
-  for (let index = 0; index < props.length; index++) {
-    const prop = props[index]
-    if (!prop) continue
-
-    if (
-      propNames.includes(prop.name) ||
-      ('arg' in prop && prop.arg && 'content' in prop.arg && propNames.includes(prop.arg.content))
-    ) {
-      removePropIndices.push(index) // store index to remove later, don't mutate variable while looping through it
-    }
-  }
-
-  for (const index of removePropIndices.sort((a, z) => z - a)) {
-    props.splice(index, 1) // index runs from high to low, so this works
-  }
-}
-
 function flattenCompoundExpression(node: CompoundExpressionNode): string {
   let result = ''
 
@@ -211,12 +157,6 @@ function flattenCompoundExpression(node: CompoundExpressionNode): string {
   }
 
   return result
-}
-
-// Exact prop-name match. Pre-rewrite used .includes('register') / .includes('value')
-// which false-positived on user props with those substrings in their names.
-function isExactKey(summarizedKey: string, name: string): boolean {
-  return summarizedKey === name || summarizedKey === `"${name}"`
 }
 
 // Whitelist of node types that contain iterable child nodes. Used by

--- a/src/runtime/lib/core/transforms/select-transform.ts
+++ b/src/runtime/lib/core/transforms/select-transform.ts
@@ -24,81 +24,59 @@ function generateEqualityExpression(
   selectValue: SummarizedProp['value'],
   optionValue: SummarizedProp['value'],
   previousOptionExpressions: CompoundExpressionNode['children'][]
-) {
-  function getExpressionNodeChildren(
-    _selectValue: SummarizedProp['value'],
-    _optionValue: SummarizedProp['value'],
-    _previousOptionExpressions: CompoundExpressionNode['children'][]
-  ): CompoundExpressionNode['children'] {
-    const multipleExpression = _previousOptionExpressions?.[0] // this should always exist
-    if (multipleExpression === undefined) {
-      // this should NEVER happen
-      throw new Error(
-        'Programming error: `multiple` expression for `select` node not generated while transforming AST'
-      )
-    }
-
-    const optExpressions = _previousOptionExpressions.slice(1)
-
-    // for `multiple`="false", we ONLY execute latest expression if all past expressions were falsy
-    const noMultipleOptExpressions = optExpressions.reduce<CompoundExpressionNode['children']>(
-      (acc, curr, index) => {
-        if (index === 0) {
-          acc.push('(')
-        }
-
-        acc.push(...curr) // all expressions from last operation were grouped into an array
-        if (index < optExpressions.length - 1) {
-          acc.push(' || ')
-        }
-
-        if (index === optExpressions.length - 1) {
-          acc.push(')')
-        }
-
-        return acc
-      },
-      []
+): CompoundExpressionNode['children'] {
+  const multipleExpression = previousOptionExpressions?.[0] // this should always exist
+  if (multipleExpression === undefined) {
+    // this should NEVER happen
+    throw new Error(
+      'Programming error: `multiple` expression for `select` node not generated while transforming AST'
     )
+  }
 
-    const selectValueArr = Array.isArray(_selectValue) ? _selectValue : [_selectValue]
-    const optionValueArr = Array.isArray(_optionValue) ? _optionValue : [_optionValue]
+  const optExpressions = previousOptionExpressions.slice(1)
 
-    function getImplicitTrueMultipleExpression(expression: CompoundExpressionNode['children']) {
-      // Identify user passing in `multiple` as an implied truthy prop
-      if (expression.length === 1 && expression[0] === '') return [`true`]
-      return expression
-    }
+  // for `multiple`="false", we ONLY execute latest expression if all past expressions were falsy
+  const noMultipleOptExpressions = optExpressions.reduce<CompoundExpressionNode['children']>(
+    (acc, curr, index) => {
+      if (index === 0) {
+        acc.push('(')
+      }
 
-    // capture the current expression for the next round
-    _previousOptionExpressions.push(['(', ...selectValueArr, ') === (', ...optionValueArr, ')'])
-    // Single-select branch String-coerces both sides to mirror the
-    // runtime directive's `looseEqual`-style match — a typed-numeric
-    // model (`z.number()`) matches `<option value="1">` at SSR time.
-    // The `typeof !== 'object'` guard preserves the pre-existing
-    // "array model on a single-select doesn't match" behaviour: an
-    // array stringifies to its joined elements, which would otherwise
-    // false-positive against a single-element option.
-    // The multi-select branch keeps `innerRef.value` because Array
-    // / Set models need findIndex / membership iteration.
-    if (!noMultipleOptExpressions.length) {
-      return [
-        '(',
-        ...getImplicitTrueMultipleExpression(multipleExpression),
-        `) ? ((`,
-        ...selectValueArr,
-        `)?.innerRef?.value?.findIndex?.(el => el === (`,
-        ...optionValueArr,
-        `)) > -1) : (typeof (`,
-        ...selectValueArr,
-        `)?.innerRef?.value !== 'object' && String((`,
-        ...selectValueArr,
-        `)?.innerRef?.value) === String((`,
-        ...optionValueArr,
-        `)))`,
-      ]
-    }
+      acc.push(...curr) // all expressions from last operation were grouped into an array
+      if (index < optExpressions.length - 1) {
+        acc.push(' || ')
+      }
 
+      if (index === optExpressions.length - 1) {
+        acc.push(')')
+      }
+
+      return acc
+    },
+    []
+  )
+
+  const selectValueArr = Array.isArray(selectValue) ? selectValue : [selectValue]
+  const optionValueArr = Array.isArray(optionValue) ? optionValue : [optionValue]
+
+  function getImplicitTrueMultipleExpression(expression: CompoundExpressionNode['children']) {
+    // Identify user passing in `multiple` as an implied truthy prop
+    if (expression.length === 1 && expression[0] === '') return [`true`]
+    return expression
+  }
+
+  // capture the current expression for the next round
+  previousOptionExpressions.push(['(', ...selectValueArr, ') === (', ...optionValueArr, ')'])
+  // Single-select branch String-coerces both sides to mirror the
+  // runtime directive's `looseEqual`-style match — a typed-numeric
+  // model (`z.number()`) matches `<option value="1">` at SSR time.
+  // The `typeof !== 'object'` guard preserves the pre-existing
+  // "array model on a single-select doesn't match" behaviour: an
+  // array stringifies to its joined elements, which would otherwise
+  // false-positive against a single-element option.
+  // The multi-select branch keeps `innerRef.value` because Array
+  // / Set models need findIndex / membership iteration.
+  if (!noMultipleOptExpressions.length) {
     return [
       '(',
       ...getImplicitTrueMultipleExpression(multipleExpression),
@@ -106,19 +84,33 @@ function generateEqualityExpression(
       ...selectValueArr,
       `)?.innerRef?.value?.findIndex?.(el => el === (`,
       ...optionValueArr,
-      `)) > -1) : ((`,
-      ...noMultipleOptExpressions, // if true, we already found the relevant option
-      `) ? false : (typeof (`,
+      `)) > -1) : (typeof (`,
       ...selectValueArr,
       `)?.innerRef?.value !== 'object' && String((`,
       ...selectValueArr,
       `)?.innerRef?.value) === String((`,
       ...optionValueArr,
-      `))))`,
+      `)))`,
     ]
   }
 
-  return getExpressionNodeChildren(selectValue, optionValue, previousOptionExpressions)
+  return [
+    '(',
+    ...getImplicitTrueMultipleExpression(multipleExpression),
+    `) ? ((`,
+    ...selectValueArr,
+    `)?.innerRef?.value?.findIndex?.(el => el === (`,
+    ...optionValueArr,
+    `)) > -1) : ((`,
+    ...noMultipleOptExpressions, // if true, we already found the relevant option
+    `) ? false : (typeof (`,
+    ...selectValueArr,
+    `)?.innerRef?.value !== 'object' && String((`,
+    ...selectValueArr,
+    `)?.innerRef?.value) === String((`,
+    ...optionValueArr,
+    `))))`,
+  ]
 }
 
 function extractMultipleFromSelectSummarizedProps(

--- a/src/runtime/lib/core/transforms/select-transform.ts
+++ b/src/runtime/lib/core/transforms/select-transform.ts
@@ -14,6 +14,7 @@ import {
   type TemplateChildNode,
 } from '@vue/compiler-core'
 import {
+  flattenExpression,
   getSummarizedProps,
   isExactKey,
   removePropsByName,
@@ -131,24 +132,6 @@ function extractMultipleFromSelectSummarizedProps(
   // attempt to convert expression within string into boolean
   // if undefined, make value `true` because of `<input multiple />` usage
   return typeof value === 'string' ? value.replace(/'|"/g, '') : (value ?? 'true')
-}
-
-function flattenCompoundExpression(node: CompoundExpressionNode): string {
-  let result = ''
-
-  for (const child of node.children) {
-    if (typeof child === 'string') {
-      result += child
-    } else if (typeof child === 'symbol') {
-      continue
-    } else if (child.type === NodeTypes.SIMPLE_EXPRESSION) {
-      result += child.content
-    } else if (child.type === NodeTypes.COMPOUND_EXPRESSION) {
-      result += flattenCompoundExpression(child)
-    }
-  }
-
-  return result
 }
 
 // Whitelist of node types that contain iterable child nodes. Used by
@@ -415,10 +398,7 @@ export const selectNodeTransform: NodeTransform = (node, context) => {
         ')?.displayValue.value',
       ])
 
-      const simpleExpression = createSimpleExpression(
-        flattenCompoundExpression(initExpression),
-        false
-      )
+      const simpleExpression = createSimpleExpression(flattenExpression(initExpression), false)
       // `processExpression` can throw on malformed identifiers or
       // exotic expression shapes. Pre-fix, the throw bubbled to the
       // outer try/catch, which then ran the snapshot-restore path AND

--- a/src/runtime/lib/core/transforms/ssr-accessed-transform.ts
+++ b/src/runtime/lib/core/transforms/ssr-accessed-transform.ts
@@ -15,7 +15,7 @@
  * live in the implementation plan and in `docs/multistep/ssr.md`.
  */
 import { parse as parseSfc, babelParse } from '@vue/compiler-sfc'
-import type { RootNode, TemplateChildNode } from '@vue/compiler-core'
+import { NodeTypes, type RootNode, type TemplateChildNode } from '@vue/compiler-core'
 
 interface BabelNode {
   readonly type: string
@@ -228,11 +228,11 @@ function collectTemplateReferences(
     if ('children' in node && Array.isArray(node.children)) {
       for (const child of node.children as TemplateChildNode[]) visit(child)
     }
-    if (node.type === 5 /* INTERPOLATION */) {
+    if (node.type === NodeTypes.INTERPOLATION) {
       collectFromExpression(node.content, candidates, referenced)
-    } else if (node.type === 1 /* ELEMENT */ && Array.isArray(node.props)) {
+    } else if (node.type === NodeTypes.ELEMENT && Array.isArray(node.props)) {
       for (const prop of node.props) {
-        if (prop.type === 7 /* DIRECTIVE */) {
+        if (prop.type === NodeTypes.DIRECTIVE) {
           if (prop.exp !== undefined && prop.exp !== null) {
             collectFromExpression(prop.exp, candidates, referenced)
           }
@@ -261,13 +261,13 @@ function collectFromExpression(
   if (expr === null || expr === undefined) return
   if (typeof expr !== 'object') return
   const node = expr as ExpressionLike
-  if (node.type === 4 /* SIMPLE_EXPRESSION */ && typeof node.content === 'string') {
+  if (node.type === NodeTypes.SIMPLE_EXPRESSION && typeof node.content === 'string') {
     for (const name of candidates) {
       if (matchesIdentifier(node.content, name)) out.add(name)
     }
     return
   }
-  if (node.type === 8 /* COMPOUND_EXPRESSION */ && Array.isArray(node.children)) {
+  if (node.type === NodeTypes.COMPOUND_EXPRESSION && Array.isArray(node.children)) {
     for (const child of node.children) collectFromExpression(child, candidates, out)
   }
 }

--- a/src/runtime/lib/core/transforms/v-register-preamble-transform.ts
+++ b/src/runtime/lib/core/transforms/v-register-preamble-transform.ts
@@ -8,6 +8,7 @@ import {
   type RootNode,
   type SimpleExpressionNode,
 } from '@vue/compiler-core'
+import { flattenExpression } from './_shared-props'
 
 /**
  * `vRegisterPreambleTransform` — closes the render-order edge that
@@ -201,32 +202,6 @@ function hasVForDirective(node: ElementNode): boolean {
     if (prop.type === NodeTypes.DIRECTIVE && prop.name === 'for') return true
   }
   return false
-}
-
-/**
- * Flatten an ExpressionNode to its source text. The compiler-core AST
- * stores expressions either as a SimpleExpressionNode (one piece of
- * text) or a CompoundExpressionNode (a list of strings + nested
- * SimpleExpressionNodes interleaved, which is what `processExpression`
- * produces when prefixing identifiers). We can serialise either back
- * to source by concatenating the textual content.
- */
-function flattenExpression(exp: ExpressionNode): string {
-  if (exp.type === NodeTypes.SIMPLE_EXPRESSION) return exp.content
-  let out = ''
-  for (const child of exp.children) {
-    if (typeof child === 'string') {
-      out += child
-      continue
-    }
-    if (typeof child === 'symbol') continue
-    if ('content' in child) {
-      out += child.content
-      continue
-    }
-    out += flattenExpression(child as ExpressionNode)
-  }
-  return out
 }
 
 /**

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -11,7 +11,7 @@
  * transforms to Vue's template compiler manually:
  *
  *   import {
- *     selectNodeTransform,
+ *     componentBridgeTransform,
  *     inputTextAreaNodeTransform,
  *     vRegisterPreambleTransform,
  *     vRegisterHintTransform,
@@ -25,7 +25,7 @@
  * into the preamble's collected text.
  */
 
+export { componentBridgeTransform } from './runtime/lib/core/transforms/component-bridge-transform'
 export { inputTextAreaNodeTransform } from './runtime/lib/core/transforms/input-text-area-transform'
-export { selectNodeTransform } from './runtime/lib/core/transforms/select-transform'
 export { vRegisterHintTransform } from './runtime/lib/core/transforms/v-register-hint-transform'
 export { vRegisterPreambleTransform } from './runtime/lib/core/transforms/v-register-preamble-transform'

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -37,8 +37,8 @@ import { readFileSync } from 'node:fs'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { join } from 'node:path'
 import type { Plugin } from 'vite'
+import { componentBridgeTransform } from './runtime/lib/core/transforms/component-bridge-transform'
 import { inputTextAreaNodeTransform } from './runtime/lib/core/transforms/input-text-area-transform'
-import { selectNodeTransform } from './runtime/lib/core/transforms/select-transform'
 import { vRegisterHintTransform } from './runtime/lib/core/transforms/v-register-hint-transform'
 import { vRegisterPreambleTransform } from './runtime/lib/core/transforms/v-register-preamble-transform'
 import { transformSsrAccessed } from './runtime/lib/core/transforms/ssr-accessed-transform'
@@ -183,7 +183,7 @@ export function attaform(options: AttaformVitePluginOptions = {}): Plugin {
         // when injected at the root.
         api.options.template.compilerOptions.nodeTransforms = [
           ...existing,
-          selectNodeTransform,
+          componentBridgeTransform,
           inputTextAreaNodeTransform,
           vRegisterPreambleTransform,
           vRegisterHintTransform,

--- a/test/composables/spike-modifier-bugs.test.ts
+++ b/test/composables/spike-modifier-bugs.test.ts
@@ -7,7 +7,7 @@ import { z } from 'zod'
 import { useForm } from '../../src/zod'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import { inputTextAreaNodeTransform } from '../../src/runtime/lib/core/transforms/input-text-area-transform'
-import { selectNodeTransform } from '../../src/runtime/lib/core/transforms/select-transform'
+import { componentBridgeTransform } from '../../src/runtime/lib/core/transforms/component-bridge-transform'
 import { vRegisterHintTransform } from '../../src/runtime/lib/core/transforms/v-register-hint-transform'
 import { vRegisterPreambleTransform } from '../../src/runtime/lib/core/transforms/v-register-preamble-transform'
 import { waitUntil } from '../utils/form-harness'
@@ -44,7 +44,7 @@ function compileTemplateToRender(template: string): (...args: unknown[]) => unkn
     mode: 'function',
     prefixIdentifiers: false,
     nodeTransforms: [
-      selectNodeTransform,
+      componentBridgeTransform,
       inputTextAreaNodeTransform,
       vRegisterPreambleTransform,
       vRegisterHintTransform,

--- a/test/composables/use-register-no-transforms.test.ts
+++ b/test/composables/use-register-no-transforms.test.ts
@@ -19,7 +19,7 @@ import { waitUntil } from '../utils/form-harness'
  *     compiles SFCs with its own pipeline; attaform-vite isn't wired
  *     in, so `<MyWrapper v-register="form.register('email')" />`
  *     never gets the `:registerValue` bridge prop injected by
- *     `selectNodeTransform`. The child's useRegister() sees no bridge
+ *     `componentBridgeTransform`. The child's useRegister() sees no bridge
  *     attr and falls back to `undefined`, so the inner input never
  *     wires up — typing has no effect.
  *
@@ -46,7 +46,7 @@ const schema = z.object({ email: z.string(), name: z.string() })
 
 function compileTemplateWithoutTransforms(template: string): (...args: unknown[]) => unknown {
   // Crucially: no `nodeTransforms` array. This is what a stock Vue
-  // compile looks like — no `selectNodeTransform`, no
+  // compile looks like — no `componentBridgeTransform`, no
   // `inputTextAreaNodeTransform`, no `vRegisterPreambleTransform`, no
   // `vRegisterHintTransform`. Mirrors the @vue/repl playground's
   // compile path and the bare-bundler scenario.
@@ -66,7 +66,7 @@ describe('useRegister — works without attaform compile-time transforms', () =>
     document.body.innerHTML = ''
   })
 
-  it('captures the parent v-register binding without the selectNodeTransform bridge prop', async () => {
+  it('captures the parent v-register binding without the componentBridgeTransform bridge prop', async () => {
     const captured: { api?: UseFormReturn<typeof schema>; childRv?: unknown } = {}
 
     const Child = defineComponent({

--- a/test/composables/use-register-template.test.ts
+++ b/test/composables/use-register-template.test.ts
@@ -10,7 +10,7 @@ import { useRegister } from '../../src/runtime/composables/use-register'
 import { vRegister } from '../../src/runtime/core/directive'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import { inputTextAreaNodeTransform } from '../../src/runtime/lib/core/transforms/input-text-area-transform'
-import { selectNodeTransform } from '../../src/runtime/lib/core/transforms/select-transform'
+import { componentBridgeTransform } from '../../src/runtime/lib/core/transforms/component-bridge-transform'
 import { vRegisterHintTransform } from '../../src/runtime/lib/core/transforms/v-register-hint-transform'
 import { vRegisterPreambleTransform } from '../../src/runtime/lib/core/transforms/v-register-preamble-transform'
 import { waitUntil } from '../utils/form-harness'
@@ -27,7 +27,7 @@ import { waitUntil } from '../utils/form-harness'
  * v-register on a DOM input) works as one piece.
  *
  * The compiler stack mirrors `src/vite.ts`'s production order:
- *   1. selectNodeTransform — injects :value + :registerValue on
+ *   1. componentBridgeTransform — injects :value + :registerValue on
  *      <Component v-register> nodes; parent-side bridge
  *   2. inputTextAreaNodeTransform — text-input compile-time hooks
  *   3. vRegisterPreambleTransform — preamble for v-register
@@ -52,7 +52,7 @@ function compileTemplateToRender(template: string): (...args: unknown[]) => unkn
     mode: 'function',
     prefixIdentifiers: false,
     nodeTransforms: [
-      selectNodeTransform,
+      componentBridgeTransform,
       inputTextAreaNodeTransform,
       vRegisterPreambleTransform,
       vRegisterHintTransform,
@@ -92,7 +92,7 @@ describe('useRegister — template-compiled v-register reaches inner input', () 
     })
 
     // Parent SFC equivalent: <Child v-register="form.register('email')" />.
-    // The select-transform's component branch fires on `<Child>`,
+    // The component-bridge-transform's component branch fires on `<Child>`,
     // injects `:value` and `:registerValue` props. At runtime,
     // useRegister captures registerValue and strips both bridge keys
     // from instance.attrs (no DOM leak on the wrapper).

--- a/test/composables/use-register.test.ts
+++ b/test/composables/use-register.test.ts
@@ -739,7 +739,7 @@ describe('useRegister — strips bridge keys from attrs (no inheritAttrs needed)
   })
 
   /**
-   * The select-transform's component branch injects `:value` and
+   * The component-bridge-transform's component branch injects `:value` and
    * `:registerValue` on the parent's component vnode so `useRegister`
    * can read them. Those are non-prop attrs from the child's
    * perspective; without intervention they fall through to the

--- a/test/composables/v-register-component-runtime.test.ts
+++ b/test/composables/v-register-component-runtime.test.ts
@@ -42,7 +42,7 @@ type MountReturn = {
  *
  * The bridge props (`registerValue: rv` + `value: rv.innerRef.value`)
  * are passed alongside the directive — this mirrors the AST output of
- * `selectNodeTransform`'s component branch so the runtime test
+ * `componentBridgeTransform`'s component branch so the runtime test
  * exercises the same prop / attr surface a compiled template would
  * produce. Tests that don't read these props are unaffected.
  */

--- a/test/packaging/vite-plugin.test.ts
+++ b/test/packaging/vite-plugin.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { resolveConfig, type Plugin, type ResolvedConfig } from 'vite'
 import { attaform } from '../../src/vite'
 import { inputTextAreaNodeTransform } from '../../src/runtime/lib/core/transforms/input-text-area-transform'
-import { selectNodeTransform } from '../../src/runtime/lib/core/transforms/select-transform'
+import { componentBridgeTransform } from '../../src/runtime/lib/core/transforms/component-bridge-transform'
 
 /**
  * Integration coverage for `attaform/vite`. The plugin mutates
@@ -44,7 +44,7 @@ describe('attaform/vite — plugin registration', () => {
     // Reference identity — the plugin must register OUR transform functions,
     // not wrappers. This rules out a regression where a bundler (e.g.
     // unbuild) accidentally wraps the export.
-    expect(nodeTransforms).toContain(selectNodeTransform)
+    expect(nodeTransforms).toContain(componentBridgeTransform)
     expect(nodeTransforms).toContain(inputTextAreaNodeTransform)
   })
 
@@ -66,7 +66,7 @@ describe('attaform/vite — plugin registration', () => {
     const api = getVueApi(config)
     const nodeTransforms = api?.options?.template?.compilerOptions?.nodeTransforms ?? []
     expect(nodeTransforms).toContain(sentinel)
-    expect(nodeTransforms).toContain(selectNodeTransform)
+    expect(nodeTransforms).toContain(componentBridgeTransform)
     expect(nodeTransforms).toContain(inputTextAreaNodeTransform)
   })
 
@@ -83,7 +83,7 @@ describe('attaform/vite — plugin registration', () => {
     const config = await resolveWith([vue(), attaform(), attaform()])
     const api = getVueApi(config)
     const nodeTransforms = api?.options?.template?.compilerOptions?.nodeTransforms ?? []
-    const selectCount = nodeTransforms.filter((t) => t === selectNodeTransform).length
+    const selectCount = nodeTransforms.filter((t) => t === componentBridgeTransform).length
     const inputCount = nodeTransforms.filter((t) => t === inputTextAreaNodeTransform).length
     expect(selectCount).toBe(1)
     expect(inputCount).toBe(1)

--- a/test/ssr-bare-vue/use-register-ssr.test.ts
+++ b/test/ssr-bare-vue/use-register-ssr.test.ts
@@ -5,7 +5,7 @@ import * as Vue from 'vue'
 import { createSSRApp, defineComponent } from 'vue'
 import { useForm, useRegister } from '../../src'
 import { createAttaform } from '../../src/runtime/core/plugin'
-import { selectNodeTransform } from '../../src/runtime/lib/core/transforms/select-transform'
+import { componentBridgeTransform } from '../../src/runtime/lib/core/transforms/component-bridge-transform'
 import { vRegisterHintTransform } from '../../src/runtime/lib/core/transforms/v-register-hint-transform'
 import { vRegisterPreambleTransform } from '../../src/runtime/lib/core/transforms/v-register-preamble-transform'
 import { fakeSchema } from '../utils/fake-schema'
@@ -34,13 +34,13 @@ import { fakeSchema } from '../utils/fake-schema'
 type Form = { email: string; password: string; color: string }
 
 function compileWithTransforms(template: string): (this: unknown, ctx: unknown) => unknown {
-  // Full transform stack — `selectNodeTransform` is what injects
+  // Full transform stack — `componentBridgeTransform` is what injects
   // `:registerValue` on a `<MyChild v-register="...">` component vnode,
   // and that's the binding `useRegister` reads back via
   // `instance.attrs.registerValue`. Without it the parent's directive
   // never reaches the child as a prop.
   const result = baseCompile(template, {
-    nodeTransforms: [selectNodeTransform, vRegisterPreambleTransform, vRegisterHintTransform],
+    nodeTransforms: [componentBridgeTransform, vRegisterPreambleTransform, vRegisterHintTransform],
     mode: 'function',
     prefixIdentifiers: true,
     hoistStatic: false,

--- a/test/transforms/component-bridge-transform.test.ts
+++ b/test/transforms/component-bridge-transform.test.ts
@@ -1,6 +1,6 @@
 import { baseCompile } from '@vue/compiler-core'
 import { describe, expect, it } from 'vitest'
-import { selectNodeTransform } from '../../src/runtime/lib/core/transforms/select-transform'
+import { componentBridgeTransform } from '../../src/runtime/lib/core/transforms/component-bridge-transform'
 
 /**
  * Compile a template through @vue/compiler-core with the select
@@ -14,7 +14,7 @@ import { selectNodeTransform } from '../../src/runtime/lib/core/transforms/selec
 
 function compileWithTransform(template: string): string {
   const result = baseCompile(template, {
-    nodeTransforms: [selectNodeTransform],
+    nodeTransforms: [componentBridgeTransform],
     mode: 'module',
   })
   return result.code
@@ -29,7 +29,7 @@ function countSelectedBindings(code: string): number {
   return (code.match(/\bselected:/g) ?? []).length
 }
 
-describe('selectNodeTransform — `:value` injection on the select element', () => {
+describe('componentBridgeTransform — `:value` injection on the select element', () => {
   // Patching `select.value` on a `<select multiple>` runs the spec's
   // value-setter loop and DESELECTS every option whose value isn't
   // case-equal to the new string. Our `displayValue.value` for an
@@ -70,7 +70,7 @@ describe('selectNodeTransform — `:value` injection on the select element', () 
   })
 })
 
-describe('selectNodeTransform — option value fallback (D3)', () => {
+describe('componentBridgeTransform — option value fallback (D3)', () => {
   it('binds :selected on options that already have an explicit value=', () => {
     const code = compileWithTransform(
       `<select v-register="fruit"><option value="apple">Apple</option></select>`
@@ -138,7 +138,7 @@ describe('selectNodeTransform — option value fallback (D3)', () => {
   })
 })
 
-describe('selectNodeTransform — E1 source-location fidelity', () => {
+describe('componentBridgeTransform — E1 source-location fidelity', () => {
   it('preserves a non-zero source location on the injected :value binding', () => {
     // Pad the template so the <select> doesn't sit at line/column 0
     // — this lets us assert that the injected directive's loc matches
@@ -147,7 +147,7 @@ describe('selectNodeTransform — E1 source-location fidelity', () => {
     // baseCompile preserves AST node `loc` fields; we walk the AST and
     // confirm the `:value` directive on the select has the select's loc.
     const result = baseCompile(template, {
-      nodeTransforms: [selectNodeTransform],
+      nodeTransforms: [componentBridgeTransform],
       mode: 'module',
     })
     const root = result.ast as unknown as { children: { tag?: string; children?: unknown[] }[] }

--- a/test/transforms/equality-ladder-characterization.test.ts
+++ b/test/transforms/equality-ladder-characterization.test.ts
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+import { baseCompile, type NodeTransform } from '@vue/compiler-core'
+import { renderToString } from '@vue/server-renderer'
+import { describe, expect, it } from 'vitest'
+import * as Vue from 'vue'
+import { createSSRApp, defineComponent } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import { inputTextAreaNodeTransform } from '../../src/runtime/lib/core/transforms/input-text-area-transform'
+import { selectNodeTransform } from '../../src/runtime/lib/core/transforms/select-transform'
+
+/**
+ * DIR-F4 characterization. The Array→`.includes` / Set→`.has` / scalar→`===`
+ * decision ladder is encoded three times — once each in
+ * `input-text-area-transform.ts`, `select-transform.ts`, and at runtime in
+ * `directive.ts` (`setChecked` / `setSelected`). The two compile-time
+ * emitters diverge in their scalar branch:
+ *
+ *   - `input-text-area-transform`: strict `===` between `innerRef.value`
+ *     and the raw scalar target.
+ *   - `select-transform`:           coerced `String(...) === String(...)`.
+ *
+ * The runtime uses Vue's `looseEqual`, which routes primitives through
+ * `String(...)` (so it agrees with the select transform on a canonical
+ * `<option value="1">` × `z.number()` + model `1`, but disagrees with the
+ * input-text-area transform on the equivalent `<input type="radio" value="1">`
+ * × `z.number()` + model `1`).
+ *
+ * Pin both ladders at the source-string level AND at the SSR-output level
+ * so the divergence surfaces as a single failing assertion the moment
+ * either branch shifts. Updating the ladder in a future commit will need
+ * to touch these pins explicitly, which is the point — silent drift is
+ * what got us here.
+ */
+
+function compileInputTextArea(template: string): string {
+  const result = baseCompile(template, {
+    nodeTransforms: [inputTextAreaNodeTransform],
+    mode: 'module',
+  })
+  return result.code
+}
+
+function compileSelect(template: string): string {
+  const result = baseCompile(template, {
+    nodeTransforms: [selectNodeTransform],
+    mode: 'module',
+  })
+  return result.code
+}
+
+describe('DIR-F4 compile-time emitter ladders', () => {
+  it('input-text-area emits a strict `===` against the raw scalar target', () => {
+    const code = compileInputTextArea(
+      `<input type="radio" v-register="form.register('size')" value="2" />`
+    )
+    // The radio branch lands the option-value as `"2"` (the static
+    // attribute, rendered as a quoted JS string literal). The synthesized
+    // equality expression is strict `===` against that literal.
+    expect(code).toContain('innerRef?.value === ("2")')
+    // It does NOT route through String() for primitives — that's the
+    // crux of the divergence with the select transform below.
+    expect(code).not.toMatch(/String\(\([^)]*innerRef\?\.value\)\)\s*===\s*String/)
+  })
+
+  it('select emits a coerced `String(...) === String(...)` for the scalar branch', () => {
+    const code = compileSelect(
+      `<select v-register="form.register('age')"><option value="2">2</option></select>`
+    )
+    // Multi-select (`findIndex(el => el === optionValue)`) uses strict
+    // `===`; the single-select branch coerces via String() on both sides.
+    // This is the literal shape we depend on for SSR parity with the
+    // runtime's `looseEqual` — pinning here makes any silent flattening
+    // of this expression visible to review.
+    expect(code).toMatch(/String\(.+?\?\.innerRef\?\.value\)\s*===\s*String\(\("2"\)\)/)
+  })
+})
+
+/**
+ * The SSR pin the plan asks for: render the canonical
+ * `<select>` × `z.number()` × `<option value="1">` against a model of
+ * `1`, and assert SSR emits the `selected` attribute (matching what
+ * `setSelected` would do at CSR time).
+ *
+ * Add the symmetric radio case to surface the strict-vs-coerced
+ * divergence: same shape (`z.number()` + `value="2"` + model `2`), but
+ * the input-text-area transform's strict `===` against the raw `"2"`
+ * string literal evaluates to `false` at SSR. The runtime `setChecked`
+ * routes through `looseEqual(applyCoerce("2"), 2) === true`, so the
+ * DOM flips to checked on hydration. Visible flicker.
+ */
+function makeTemplateModule(template: string, nodeTransforms: NodeTransform[]): Vue.Component {
+  const result = baseCompile(template, {
+    nodeTransforms,
+    mode: 'function',
+    prefixIdentifiers: true,
+    hoistStatic: false,
+  })
+  const fn = new Function('Vue', `${result.code}\nreturn render`)
+  const render = fn(Vue) as (this: unknown, ctx: unknown) => unknown
+  return defineComponent({
+    setup() {
+      const form = useForm({
+        schema: z.object({ size: z.number(), age: z.number() }),
+        defaultValues: { size: 2, age: 1 },
+      })
+      return { form }
+    },
+    render,
+  })
+}
+
+async function ssr(template: string, nodeTransforms: NodeTransform[]): Promise<string> {
+  const Component = makeTemplateModule(template, nodeTransforms)
+  const app = createSSRApp(Component)
+  app.use(createAttaform())
+  return renderToString(app)
+}
+
+describe('DIR-F4 SSR-output verdict', () => {
+  it('select with z.number() × <option value="1"> emits SSR `selected` (matches setSelected verdict)', async () => {
+    const html = await ssr(
+      `<select v-register="form.register('age')"><option value="1">one</option><option value="2">two</option></select>`,
+      [selectNodeTransform]
+    )
+    // The single-select branch coerces via String(), so the SSR pass
+    // sees `"1" === "1"` and emits `selected` on the matching option.
+    // This is the canonical happy path; the runtime `setSelected` ends
+    // at the same verdict via `looseEqual(applyCoerce("1"), 1)`.
+    expect(html).toMatch(/<option[^>]*value="1"[^>]*selected/)
+    expect(html).not.toMatch(/<option[^>]*value="2"[^>]*selected/)
+  })
+
+  it('CHARACTERIZATION (current bug): radio with z.number() × value="2" DOES NOT emit SSR `checked` despite model === 2', async () => {
+    const html = await ssr(`<input type="radio" v-register="form.register('size')" value="2" />`, [
+      inputTextAreaNodeTransform,
+    ])
+    // PRE-FIX behaviour — the strict `===` against the string literal
+    // `"2"` evaluates to `false` at SSR even though the runtime's
+    // `looseEqual(applyCoerce("2"), 2)` returns `true`. The input
+    // therefore SSRs unchecked and flips to checked on hydration — a
+    // visible flicker.
+    //
+    // This assertion documents the current diverged behaviour. If a
+    // future fix unifies the input-text-area ladder with the select
+    // ladder (or with the runtime `looseEqual`), this test flips and
+    // the assertion below will need to update. That's the intended
+    // gate — the divergence is no longer silent.
+    expect(html).not.toMatch(/\bchecked\b/)
+  })
+})

--- a/test/transforms/equality-ladder-characterization.test.ts
+++ b/test/transforms/equality-ladder-characterization.test.ts
@@ -8,12 +8,12 @@ import { z } from 'zod'
 import { useForm } from '../../src/zod'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import { inputTextAreaNodeTransform } from '../../src/runtime/lib/core/transforms/input-text-area-transform'
-import { selectNodeTransform } from '../../src/runtime/lib/core/transforms/select-transform'
+import { componentBridgeTransform } from '../../src/runtime/lib/core/transforms/component-bridge-transform'
 
 /**
  * DIR-F4 characterization. The Array→`.includes` / Set→`.has` / scalar→
  * coerced `String() === String()` decision ladder is encoded three times
- * — once each in `input-text-area-transform.ts`, `select-transform.ts`,
+ * — once each in `input-text-area-transform.ts`, `component-bridge-transform.ts`,
  * and at runtime in `directive.ts` (`setChecked` / `setSelected`). Both
  * compile-time emitters now route primitives through `String(...)`
  * before comparing, mirroring the runtime `looseEqual` behaviour. Pre-
@@ -38,7 +38,7 @@ function compileInputTextArea(template: string): string {
 
 function compileSelect(template: string): string {
   const result = baseCompile(template, {
-    nodeTransforms: [selectNodeTransform],
+    nodeTransforms: [componentBridgeTransform],
     mode: 'module',
   })
   return result.code
@@ -114,7 +114,7 @@ describe('DIR-F4 SSR-output verdict', () => {
   it('select with z.number() × <option value="1"> emits SSR `selected` (matches setSelected verdict)', async () => {
     const html = await ssr(
       `<select v-register="form.register('age')"><option value="1">one</option><option value="2">two</option></select>`,
-      [selectNodeTransform]
+      [componentBridgeTransform]
     )
     // The single-select branch coerces via String(), so the SSR pass
     // sees `"1" === "1"` and emits `selected` on the matching option.

--- a/test/transforms/equality-ladder-characterization.test.ts
+++ b/test/transforms/equality-ladder-characterization.test.ts
@@ -11,27 +11,21 @@ import { inputTextAreaNodeTransform } from '../../src/runtime/lib/core/transform
 import { selectNodeTransform } from '../../src/runtime/lib/core/transforms/select-transform'
 
 /**
- * DIR-F4 characterization. The Array→`.includes` / Set→`.has` / scalar→`===`
- * decision ladder is encoded three times — once each in
- * `input-text-area-transform.ts`, `select-transform.ts`, and at runtime in
- * `directive.ts` (`setChecked` / `setSelected`). The two compile-time
- * emitters diverge in their scalar branch:
+ * DIR-F4 characterization. The Array→`.includes` / Set→`.has` / scalar→
+ * coerced `String() === String()` decision ladder is encoded three times
+ * — once each in `input-text-area-transform.ts`, `select-transform.ts`,
+ * and at runtime in `directive.ts` (`setChecked` / `setSelected`). Both
+ * compile-time emitters now route primitives through `String(...)`
+ * before comparing, mirroring the runtime `looseEqual` behaviour. Pre-
+ * fix the input-text-area scalar branch used strict `===`, so an SSR
+ * `<input type="radio" value="2">` × `z.number()` + model `2` rendered
+ * unchecked (`2 === "2"` → false) and then flipped to checked on
+ * hydration via `looseEqual` — a one-tick flicker.
  *
- *   - `input-text-area-transform`: strict `===` between `innerRef.value`
- *     and the raw scalar target.
- *   - `select-transform`:           coerced `String(...) === String(...)`.
- *
- * The runtime uses Vue's `looseEqual`, which routes primitives through
- * `String(...)` (so it agrees with the select transform on a canonical
- * `<option value="1">` × `z.number()` + model `1`, but disagrees with the
- * input-text-area transform on the equivalent `<input type="radio" value="1">`
- * × `z.number()` + model `1`).
- *
- * Pin both ladders at the source-string level AND at the SSR-output level
- * so the divergence surfaces as a single failing assertion the moment
- * either branch shifts. Updating the ladder in a future commit will need
- * to touch these pins explicitly, which is the point — silent drift is
- * what got us here.
+ * Pin both ladders at the source-string level AND at the SSR-output
+ * level so a future drift surfaces as a single failing assertion.
+ * Updating the ladder will need to touch these pins explicitly, which
+ * is the point — silent drift is what got us here in the first place.
  */
 
 function compileInputTextArea(template: string): string {
@@ -51,17 +45,18 @@ function compileSelect(template: string): string {
 }
 
 describe('DIR-F4 compile-time emitter ladders', () => {
-  it('input-text-area emits a strict `===` against the raw scalar target', () => {
+  it('input-text-area emits a coerced `String(...) === String(...)` for the scalar branch', () => {
     const code = compileInputTextArea(
       `<input type="radio" v-register="form.register('size')" value="2" />`
     )
     // The radio branch lands the option-value as `"2"` (the static
-    // attribute, rendered as a quoted JS string literal). The synthesized
-    // equality expression is strict `===` against that literal.
-    expect(code).toContain('innerRef?.value === ("2")')
-    // It does NOT route through String() for primitives — that's the
-    // crux of the divergence with the select transform below.
-    expect(code).not.toMatch(/String\(\([^)]*innerRef\?\.value\)\)\s*===\s*String/)
+    // attribute, rendered as a quoted JS string literal). Post-fix the
+    // synthesized equality expression routes both sides through String()
+    // to mirror the runtime `looseEqual` behaviour for primitives.
+    expect(code).toMatch(/String\(.+?\?\.innerRef\?\.value\)\s*===\s*String\(\("2"\)\)/)
+    // It does NOT use strict `===` on the raw scalar target anymore —
+    // that was the source of the SSR/CSR mismatch.
+    expect(code).not.toMatch(/innerRef\?\.value\s*===\s*\("2"\)/)
   })
 
   it('select emits a coerced `String(...) === String(...)` for the scalar branch', () => {
@@ -83,12 +78,9 @@ describe('DIR-F4 compile-time emitter ladders', () => {
  * `1`, and assert SSR emits the `selected` attribute (matching what
  * `setSelected` would do at CSR time).
  *
- * Add the symmetric radio case to surface the strict-vs-coerced
- * divergence: same shape (`z.number()` + `value="2"` + model `2`), but
- * the input-text-area transform's strict `===` against the raw `"2"`
- * string literal evaluates to `false` at SSR. The runtime `setChecked`
- * routes through `looseEqual(applyCoerce("2"), 2) === true`, so the
- * DOM flips to checked on hydration. Visible flicker.
+ * The symmetric radio case proves the post-fix parity: same shape
+ * (`z.number()` + `value="2"` + model `2`) and SSR now emits `checked`.
+ * Pre-fix this rendered unchecked and flipped to checked on hydration.
  */
 function makeTemplateModule(template: string, nodeTransforms: NodeTransform[]): Vue.Component {
   const result = baseCompile(template, {
@@ -132,21 +124,14 @@ describe('DIR-F4 SSR-output verdict', () => {
     expect(html).not.toMatch(/<option[^>]*value="2"[^>]*selected/)
   })
 
-  it('CHARACTERIZATION (current bug): radio with z.number() × value="2" DOES NOT emit SSR `checked` despite model === 2', async () => {
+  it('radio with z.number() × value="2" emits SSR `checked` when model === 2 (post-fix parity)', async () => {
     const html = await ssr(`<input type="radio" v-register="form.register('size')" value="2" />`, [
       inputTextAreaNodeTransform,
     ])
-    // PRE-FIX behaviour — the strict `===` against the string literal
-    // `"2"` evaluates to `false` at SSR even though the runtime's
-    // `looseEqual(applyCoerce("2"), 2)` returns `true`. The input
-    // therefore SSRs unchecked and flips to checked on hydration — a
-    // visible flicker.
-    //
-    // This assertion documents the current diverged behaviour. If a
-    // future fix unifies the input-text-area ladder with the select
-    // ladder (or with the runtime `looseEqual`), this test flips and
-    // the assertion below will need to update. That's the intended
-    // gate — the divergence is no longer silent.
-    expect(html).not.toMatch(/\bchecked\b/)
+    // Post-fix the scalar branch coerces via String(...), so the SSR
+    // pass evaluates `String(2) === String("2")` → true → emits
+    // `checked`. The runtime `setChecked` ends at the same verdict via
+    // `looseEqual(applyCoerce("2"), 2) === true`. No hydration flicker.
+    expect(html).toMatch(/\bchecked\b/)
   })
 })

--- a/test/transforms/input-text-area.test.ts
+++ b/test/transforms/input-text-area.test.ts
@@ -212,24 +212,28 @@ describe('inputTextAreaNodeTransform', () => {
         `<input type="checkbox" :true-value="'subscribe'" v-register="newsletter" />`
       )
       // The scalar leg should compare against 'subscribe', not ''.
-      // We assert the literal appears in an equality position
-      // immediately followed by `)` (the scalar branch's closing).
-      expect(code).toMatch(/===\s*\('subscribe'\)/)
+      // DIR-F4: the scalar branch routes both sides through `String(...)`
+      // before comparing — mirroring the runtime `looseEqual` so SSR and
+      // hydration agree on the rendered `checked` state.
+      expect(code).toMatch(/===\s*String\(\('subscribe'\)\)/)
     })
 
     it('uses literal `true` as the scalar equality target when no value / true-value', () => {
       const code = compileWithTransform(`<input type="checkbox" v-register="agreed" />`)
       // Boolean checkbox: the scalar branch must compare against
       // `true`, not `''` (which would always evaluate false against
-      // `false`/`true` model values).
-      expect(code).toMatch(/===\s*\(true\)/)
+      // `false`/`true` model values). DIR-F4 routes via String() to
+      // match runtime `looseEqual` semantics.
+      expect(code).toMatch(/===\s*String\(\(true\)\)/)
     })
 
     it('uses value= as the scalar equality target on radio', () => {
       // Radio model is always scalar; the option-value (`value=`)
       // IS the right discriminator there.
       const code = compileWithTransform(`<input type="radio" value="apple" v-register="fruit" />`)
-      expect(code).toMatch(/===\s*\("apple"\)/)
+      // DIR-F4 routes via String() so a typed-numeric / boolean radio
+      // model agrees with the runtime's `looseEqual` verdict at SSR.
+      expect(code).toMatch(/===\s*String\(\("apple"\)\)/)
     })
 
     it('checkbox group keeps option-value for the array/Set legs', () => {

--- a/test/transforms/v-register-component.test.ts
+++ b/test/transforms/v-register-component.test.ts
@@ -1,7 +1,7 @@
 import { baseCompile } from '@vue/compiler-core'
 import { describe, expect, it } from 'vitest'
 import { inputTextAreaNodeTransform } from '../../src/runtime/lib/core/transforms/input-text-area-transform'
-import { selectNodeTransform } from '../../src/runtime/lib/core/transforms/select-transform'
+import { componentBridgeTransform } from '../../src/runtime/lib/core/transforms/component-bridge-transform'
 import { vRegisterHintTransform } from '../../src/runtime/lib/core/transforms/v-register-hint-transform'
 import { vRegisterPreambleTransform } from '../../src/runtime/lib/core/transforms/v-register-preamble-transform'
 
@@ -17,7 +17,7 @@ import { vRegisterPreambleTransform } from '../../src/runtime/lib/core/transform
  * refactor might want to address.
  *
  * Production pipeline order (`src/vite.ts`):
- *   1. selectNodeTransform
+ *   1. componentBridgeTransform
  *   2. inputTextAreaNodeTransform
  *   3. vRegisterPreambleTransform
  *   4. vRegisterHintTransform
@@ -29,7 +29,7 @@ type NodeTransformList = NonNullable<CompilerOptions['nodeTransforms']>
 function compileFull(template: string): string {
   return baseCompile(template, {
     nodeTransforms: [
-      selectNodeTransform,
+      componentBridgeTransform,
       inputTextAreaNodeTransform,
       vRegisterPreambleTransform,
       vRegisterHintTransform,
@@ -110,7 +110,7 @@ describe('v-register on Vue components — AST behaviour', () => {
     it('emits no synthetic :value binding when only this transform runs', () => {
       // The transform's tag check is `node.tag === 'input' || 'textarea'`
       // — component tags are NEITHER. Result: this transform contributes
-      // nothing for a component. (selectNodeTransform DOES fire on
+      // nothing for a component. (componentBridgeTransform DOES fire on
       // components — see the next describe block.)
       const code = compileWith(`<MyInput v-register="form.register('email')" />`, [
         inputTextAreaNodeTransform,
@@ -130,7 +130,7 @@ describe('v-register on Vue components — AST behaviour', () => {
     })
   })
 
-  describe('selectNodeTransform — fires on EVERY component with v-register (surprising ⚠)', () => {
+  describe('componentBridgeTransform — fires on EVERY component with v-register (surprising ⚠)', () => {
     it('injects :value="reg.displayValue.value" + :registerValue="reg" as component props', () => {
       // The transform's branch `node.tagType === ElementTypes.COMPONENT`
       // makes ANY component with v-register a transform target — even
@@ -141,7 +141,7 @@ describe('v-register on Vue components — AST behaviour', () => {
       // <select> natively; the component branch reuses the prop-name
       // contract `<select>` doesn't know about.
       const code = compileWith(`<MyInput v-register="form.register('email')" />`, [
-        selectNodeTransform,
+        componentBridgeTransform,
       ])
       expect(code).toContain('displayValue')
       // Both keys appear in the generated component-prop object.
@@ -162,7 +162,7 @@ describe('v-register on Vue components — AST behaviour', () => {
            <option value="admin">Admin</option>
            <option value="user">User</option>
          </MyCustomSelect>`,
-        [selectNodeTransform]
+        [componentBridgeTransform]
       )
       // The component itself gets the value + registerValue prop pair.
       expect(code).toContain('displayValue')
@@ -180,7 +180,7 @@ describe('v-register on Vue components — AST behaviour', () => {
         `<select v-register="form.register('role')">
            <option value="admin">Admin</option>
          </select>`,
-        [selectNodeTransform]
+        [componentBridgeTransform]
       )
       expect(code).toContain('innerRef')
       expect(code).toMatch(/selected:\s*\(/)
@@ -188,15 +188,15 @@ describe('v-register on Vue components — AST behaviour', () => {
 
     it('does NOT fire on a component without v-register', () => {
       // Bound by the early-out `registerIndex < 0`.
-      const code = compileWith(`<MyInput :value="x" />`, [selectNodeTransform])
+      const code = compileWith(`<MyInput :value="x" />`, [componentBridgeTransform])
       expect(code).not.toContain('innerRef')
       expect(code).not.toContain('registerValue:')
     })
 
     it('PascalCase + self-closing PascalCase hit the component branch', () => {
-      const pascal = compileWith(`<MyInput v-register="reg" />`, [selectNodeTransform])
+      const pascal = compileWith(`<MyInput v-register="reg" />`, [componentBridgeTransform])
       const explicitClose = compileWith(`<MyInput v-register="reg"></MyInput>`, [
-        selectNodeTransform,
+        componentBridgeTransform,
       ])
       for (const code of [pascal, explicitClose]) {
         expect(code).toContain('displayValue')
@@ -216,7 +216,7 @@ describe('v-register on Vue components — AST behaviour', () => {
       // Components without a Vue component definition see them as DOM
       // attributes — the documented assignKey escape hatch covers
       // that case.
-      const code = compileWith(`<my-input v-register="reg" />`, [selectNodeTransform])
+      const code = compileWith(`<my-input v-register="reg" />`, [componentBridgeTransform])
       expect(code).toContain('displayValue')
       expect(code).toContain('registerValue:')
       expect(code).toContain('_directive_register')
@@ -230,7 +230,7 @@ describe('v-register on Vue components — AST behaviour', () => {
       // the explicit guard documents the conservative stance and
       // catches a hypothetical `<form-something v-register>` future
       // mistake.
-      const code = compileWith(`<form v-register="reg" />`, [selectNodeTransform])
+      const code = compileWith(`<form v-register="reg" />`, [componentBridgeTransform])
       expect(code).not.toContain('displayValue')
       expect(code).not.toContain('registerValue:')
     })
@@ -250,14 +250,14 @@ describe('v-register on Vue components — AST behaviour', () => {
       ).not.toThrow()
     })
 
-    it('combines select-transform component-prop injection + hint wrapper + preamble hoist', () => {
+    it('combines component-bridge-transform component-prop injection + hint wrapper + preamble hoist', () => {
       const code = compileFull(
         `<div>
            <pre>{{ form.fields.email }}</pre>
            <MyInput v-register="form.register('email')" />
          </div>`
       )
-      // selectNodeTransform contributed value: + registerValue:
+      // componentBridgeTransform contributed value: + registerValue:
       expect(code).toContain('displayValue')
       expect(code).toContain('registerValue:')
       // vRegisterHintTransform wrapped the directive expression.
@@ -277,7 +277,7 @@ describe('v-register on Vue components — AST behaviour', () => {
       // checkbox/radio equality branch of inputTextAreaNodeTransform's
       // ternary (the runtime takes the value branch for text inputs,
       // but Vue's static codegen emits both legs). Component takes the
-      // displayValue path through selectNodeTransform's component
+      // displayValue path through componentBridgeTransform's component
       // branch — no innerRef on that side.
       const innerRefHits = code.match(/innerRef/g)?.length ?? 0
       expect(innerRefHits).toBeGreaterThanOrEqual(1)
@@ -322,7 +322,7 @@ describe('v-register on Vue components — AST behaviour', () => {
       expect(hits).toBe(1)
     })
 
-    it('select-transform on a component IS idempotent under duplicate registration', () => {
+    it('component-bridge-transform on a component IS idempotent under duplicate registration', () => {
       // The component branch carries an already-applied marker so a
       // doubly-registered transform pipeline only injects the
       // `:value` + `:registerValue` props once. This protects against
@@ -330,8 +330,8 @@ describe('v-register on Vue components — AST behaviour', () => {
       // transform twice; without the marker, the duplicate output is
       // valid (last write wins) but bloats the generated render.
       const code = compileWith(`<MyInput v-register="reg" />`, [
-        selectNodeTransform,
-        selectNodeTransform,
+        componentBridgeTransform,
+        componentBridgeTransform,
       ])
       const valueHits = code.match(/value:\s*\(.*\)\?\.displayValue\.value/g)?.length ?? 0
       const regValueHits = code.match(/registerValue:/g)?.length ?? 0

--- a/test/vite/transform-wiring.test.ts
+++ b/test/vite/transform-wiring.test.ts
@@ -1,0 +1,189 @@
+import vue from '@vitejs/plugin-vue'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { resolveConfig, type Plugin, type ResolvedConfig } from 'vite'
+import { attaform } from '../../src/vite'
+import { inputTextAreaNodeTransform } from '../../src/runtime/lib/core/transforms/input-text-area-transform'
+import { selectNodeTransform } from '../../src/runtime/lib/core/transforms/select-transform'
+import { vRegisterHintTransform } from '../../src/runtime/lib/core/transforms/v-register-hint-transform'
+import { vRegisterPreambleTransform } from '../../src/runtime/lib/core/transforms/v-register-preamble-transform'
+
+/**
+ * Lock the load-bearing wiring contract for `attaform/vite`:
+ *
+ *   1. After `configResolved`, all four compile-time node transforms
+ *      land in `api.options.template.compilerOptions.nodeTransforms`.
+ *   2. The preamble transform comes BEFORE the hint transform
+ *      (`vite.ts:177-190`) — reversed order double-wraps every
+ *      v-register IIFE because the preamble's pre-order capture would
+ *      pick up an already-wrapped expression.
+ *   3. The push is idempotent. A second `configResolved` invocation
+ *      (a separate plugin instance, or any caller re-running the
+ *      pipeline) must not re-append the same transforms.
+ *   4. The `transform(code, id)` hook invokes `transformSsrAccessed`
+ *      for an SFC whose `<script setup>` binds `useForm` and whose
+ *      `<template>` references it — the only path that injects
+ *      `__ssrAccessed: true` into the call's options literal.
+ *
+ * No prior coverage existed for any of this — the resolve-alias suite
+ * (`resolve-alias.test.ts`) only exercises the build-time zod rewrite.
+ * Pinning these invariants now so every subsequent transform-layer
+ * dedup is guarded by behavior-locking tests rather than guesses.
+ */
+
+let zodV4Root: string
+
+function makeFixtureWithZod(name: string, zodVersion: string): string {
+  const root = mkdtempSync(join(tmpdir(), `attaform-vite-${name}-`))
+  writeFileSync(
+    join(root, 'package.json'),
+    JSON.stringify({ name: `${name}-fixture`, private: true }),
+    'utf8'
+  )
+  const zodDir = join(root, 'node_modules', 'zod')
+  mkdirSync(zodDir, { recursive: true })
+  writeFileSync(
+    join(zodDir, 'package.json'),
+    JSON.stringify({
+      name: 'zod',
+      version: zodVersion,
+      main: './index.js',
+      exports: { './package.json': './package.json', '.': './index.js' },
+    }),
+    'utf8'
+  )
+  writeFileSync(join(zodDir, 'index.js'), 'module.exports = {}\n', 'utf8')
+  return root
+}
+
+beforeAll(() => {
+  zodV4Root = makeFixtureWithZod('wiring-zod-v4', '4.3.0')
+})
+
+async function resolveWithRoot(plugins: Plugin[], root: string): Promise<ResolvedConfig> {
+  return resolveConfig({ plugins, configFile: false, root }, 'serve')
+}
+
+interface CompilerOptionsShape {
+  nodeTransforms?: unknown[]
+}
+interface VueApiShape {
+  options?: {
+    template?: {
+      compilerOptions?: CompilerOptionsShape
+    }
+  }
+}
+
+function readVueNodeTransforms(config: ResolvedConfig): unknown[] {
+  const vuePlugin = config.plugins.find((p) => p.name === 'vite:vue')
+  if (vuePlugin === undefined) throw new Error('vite:vue plugin not found in resolved config')
+  const api = (vuePlugin as unknown as { api?: VueApiShape }).api
+  const transforms = api?.options?.template?.compilerOptions?.nodeTransforms
+  if (transforms === undefined)
+    throw new Error('nodeTransforms not populated on @vitejs/plugin-vue')
+  return transforms
+}
+
+describe('attaform/vite — node-transform wiring', () => {
+  it('registers all four compile-time transforms on @vitejs/plugin-vue', async () => {
+    const config = await resolveWithRoot([vue(), attaform()], zodV4Root)
+    const transforms = readVueNodeTransforms(config)
+    expect(transforms).toContain(selectNodeTransform)
+    expect(transforms).toContain(inputTextAreaNodeTransform)
+    expect(transforms).toContain(vRegisterPreambleTransform)
+    expect(transforms).toContain(vRegisterHintTransform)
+  })
+
+  it('orders the preamble transform before the hint transform', async () => {
+    const config = await resolveWithRoot([vue(), attaform()], zodV4Root)
+    const transforms = readVueNodeTransforms(config)
+    const preambleIdx = transforms.indexOf(vRegisterPreambleTransform)
+    const hintIdx = transforms.indexOf(vRegisterHintTransform)
+    expect(preambleIdx).toBeGreaterThanOrEqual(0)
+    expect(hintIdx).toBeGreaterThanOrEqual(0)
+    // Reversing this order makes the preamble capture an already-wrapped
+    // IIFE expression and double-wrap every v-register binding at the
+    // template root.
+    expect(preambleIdx).toBeLessThan(hintIdx)
+  })
+
+  it('does not re-push when the same nodeTransforms array already carries the sentinel', async () => {
+    // Two plugin instances sharing the same vue() — exercises the
+    // `if (!existing.includes(...))` idempotency gate that protects
+    // against vite + nuxt + manual `plugins: [attaform()]` stacking.
+    const sharedVue = vue()
+    const config = await resolveWithRoot([sharedVue, attaform(), attaform()], zodV4Root)
+    const transforms = readVueNodeTransforms(config)
+    const occurrences = (target: unknown): number =>
+      transforms.reduce<number>((n, t) => (t === target ? n + 1 : n), 0)
+    expect(occurrences(selectNodeTransform)).toBe(1)
+    expect(occurrences(inputTextAreaNodeTransform)).toBe(1)
+    expect(occurrences(vRegisterPreambleTransform)).toBe(1)
+    expect(occurrences(vRegisterHintTransform)).toBe(1)
+  })
+
+  it('preserves user-supplied nodeTransforms already on @vitejs/plugin-vue', async () => {
+    // Custom transform users may have pre-registered via vue()'s own
+    // template.compilerOptions. We must extend, not replace.
+    const sentinel = () => {}
+    const customVue = vue({
+      template: { compilerOptions: { nodeTransforms: [sentinel] } },
+    })
+    const config = await resolveWithRoot([customVue, attaform()], zodV4Root)
+    const transforms = readVueNodeTransforms(config)
+    expect(transforms).toContain(sentinel)
+    expect(transforms).toContain(vRegisterPreambleTransform)
+    expect(transforms.indexOf(sentinel)).toBeLessThan(
+      transforms.indexOf(vRegisterPreambleTransform)
+    )
+  })
+})
+
+describe('attaform/vite — transform hook (SSR-accessed injection)', () => {
+  it('injects __ssrAccessed: true for a useForm binding referenced in the template', async () => {
+    const config = await resolveWithRoot([vue(), attaform()], zodV4Root)
+    const plugin = config.plugins.find((p) => p.name === 'attaform')
+    if (plugin === undefined) throw new Error('attaform plugin missing from resolved config')
+    const hook = plugin.transform
+    if (hook === undefined) throw new Error('attaform plugin exposes no transform hook')
+    const handler = typeof hook === 'function' ? hook : hook.handler
+
+    const sfc = `
+<script setup lang="ts">
+import { useForm } from 'attaform/zod'
+import { z } from 'zod'
+const form = useForm({ schema: z.object({ email: z.string() }) })
+</script>
+<template>
+  <input v-register="form.register('email')" />
+</template>
+`
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = (handler as any).call({}, sfc, '/abs/path/to/example.vue') as
+      | { code: string }
+      | null
+      | undefined
+    expect(result).not.toBeNull()
+    expect(result).not.toBeUndefined()
+    expect(result?.code).toContain('__ssrAccessed: true')
+  })
+
+  it('returns null for non-Vue ids (no .vue suffix)', async () => {
+    const config = await resolveWithRoot([vue(), attaform()], zodV4Root)
+    const plugin = config.plugins.find((p) => p.name === 'attaform')
+    if (plugin === undefined) throw new Error('attaform plugin missing from resolved config')
+    const hook = plugin.transform
+    if (hook === undefined) throw new Error('attaform plugin exposes no transform hook')
+    const handler = typeof hook === 'function' ? hook : hook.handler
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = (handler as any).call(
+      {},
+      "import { useForm } from 'attaform/zod'\nconst form = useForm()",
+      '/abs/path/to/example.ts'
+    )
+    expect(result).toBeNull()
+  })
+})

--- a/test/vite/transform-wiring.test.ts
+++ b/test/vite/transform-wiring.test.ts
@@ -6,7 +6,7 @@ import { beforeAll, describe, expect, it } from 'vitest'
 import { resolveConfig, type Plugin, type ResolvedConfig } from 'vite'
 import { attaform } from '../../src/vite'
 import { inputTextAreaNodeTransform } from '../../src/runtime/lib/core/transforms/input-text-area-transform'
-import { selectNodeTransform } from '../../src/runtime/lib/core/transforms/select-transform'
+import { componentBridgeTransform } from '../../src/runtime/lib/core/transforms/component-bridge-transform'
 import { vRegisterHintTransform } from '../../src/runtime/lib/core/transforms/v-register-hint-transform'
 import { vRegisterPreambleTransform } from '../../src/runtime/lib/core/transforms/v-register-preamble-transform'
 
@@ -91,7 +91,7 @@ describe('attaform/vite — node-transform wiring', () => {
   it('registers all four compile-time transforms on @vitejs/plugin-vue', async () => {
     const config = await resolveWithRoot([vue(), attaform()], zodV4Root)
     const transforms = readVueNodeTransforms(config)
-    expect(transforms).toContain(selectNodeTransform)
+    expect(transforms).toContain(componentBridgeTransform)
     expect(transforms).toContain(inputTextAreaNodeTransform)
     expect(transforms).toContain(vRegisterPreambleTransform)
     expect(transforms).toContain(vRegisterHintTransform)
@@ -119,7 +119,7 @@ describe('attaform/vite — node-transform wiring', () => {
     const transforms = readVueNodeTransforms(config)
     const occurrences = (target: unknown): number =>
       transforms.reduce<number>((n, t) => (t === target ? n + 1 : n), 0)
-    expect(occurrences(selectNodeTransform)).toBe(1)
+    expect(occurrences(componentBridgeTransform)).toBe(1)
     expect(occurrences(inputTextAreaNodeTransform)).toBe(1)
     expect(occurrences(vRegisterPreambleTransform)).toBe(1)
     expect(occurrences(vRegisterHintTransform)).toBe(1)


### PR DESCRIPTION
## Phase 15 — Transform dedup + SSR audit

`refactor/transform-dedup`. Closes audit IDs DIR-F1, DIR-F2, DIR-F4, DIR-F5, DIR-F6, DIR-F8, DIR-F9, DIR-F10, DIR-F11 + `test/vite/` coverage gap. Eleven focused commits.

### Series

1. `0df0f39` test(vite): close transform-wiring coverage gap
2. `a0265e1` test(transforms): characterize DIR-F4 SSR/CSR equality-ladder divergence — **RED** (pins the bug)
3. `d3b216c` fix(transforms): unify input-text-area scalar ladder with select / runtime (**DIR-F4**) — **GREEN**
4. `3aff56f` refactor(transforms): extract shared prop-summarization toolkit (DIR-F1)
5. `2144be4` refactor(core): single-source the interactive-tag set (DIR-F2)
6. `a8a09ea` refactor(transforms): extract `parseStaticStringLiteral` helper (DIR-F5)
7. `4dc0d92` refactor(transforms): swap raw NodeType ints for NodeTypes enum (DIR-F8)
8. `a82e93c` refactor(transforms): inline `getExpressionNodeChildren` wrapper (DIR-F9)
9. `2cf4cc2` refactor(transforms): consolidate near-dup flatten serializers (DIR-F10)
10. `fd2335d` refactor(transforms): rename `selectNodeTransform` → `componentBridgeTransform` (**DIR-F6**) — ⚠️ public-API rename
11. `b74da45` docs(use-register): pin DIR-F11 perf rationale on the hybrid Proxy

### API & behavior-change ledger

Two surfaces this phase:

- **DIR-F4 (observable hydration fix)** — the `input-text-area-transform` scalar branch now coerces via `String(model) === String(scalarTarget)` instead of strict `===`. Pre-fix, `<input type="radio" v-register="form.register('size')" value="2" />` bound to `z.number()` + model `2` rendered unchecked in SSR HTML (`2 === "2"` → false) and flipped to checked on hydration (`looseEqual(applyCoerce("2"), 2)` → true) — visible flicker. Post-fix both SSR and CSR agree on `checked`. Mirrors what `componentBridgeTransform` (née `selectNodeTransform`) and runtime `setChecked`/`setSelected` already did. Sign-off: confirmed.

- **DIR-F6 (public-API rename)** — `attaform/transforms` no longer exports `selectNodeTransform`; the export is now `componentBridgeTransform`. File renamed `select-transform.ts` → `component-bridge-transform.ts`. The transform's responsibilities (per-`<option>` `:selected` injection, component `:registerValue` bridging, statically-non-multiple `:value` injection) are unchanged — the name now reflects that the component-bridge path is load-bearing for every `useRegister` consumer, not a select-only transform. Per pre-1.0 + [[no back-compat]], no deprecation alias. Sign-off: confirmed.

No other observable changes. DIR-F1 / F2 / F5 / F8 / F9 / F10 are byte-identical extractions or enum-swaps; DIR-F11 is a documented-decision pin on the existing proxy factory.

### Investigation: DIR-F4

The audit flagged that the Array→`.includes` / Set→`.has` / scalar→`===` decision ladder was encoded **3×** — once in each compile-time transform and once in the runtime — and that the two compile-time emitters diverged: `input-text-area` used strict `===` while `select` used coerced `String(...) === String(...)`. Investigation surfaced a real observable hydration bug. The fix matches both compile-time emitters with the runtime `looseEqual` behaviour, killing the divergence at all three encodings.

The DIR-F4 characterization test (`test/transforms/equality-ladder-characterization.test.ts`) pins both ladders at the source-string level AND at the SSR HTML output level. Any future drift on either branch surfaces as a single failing assertion.

### Coverage gap: `test/vite/`

`test/vite/` had only `resolve-alias.test.ts`. The compile-time transform wiring onto `@vitejs/plugin-vue` and the SSR-accessed `transform()` hook were both uncovered. Six new pins in `test/vite/transform-wiring.test.ts`:

- All four compile-time transforms land on `nodeTransforms`
- Preamble appears before hint (load-bearing IIFE order)
- Idempotent push: two `attaform()` instances sharing one `vue()` register each transform once
- User-supplied `nodeTransforms` already on `vue()` survive (append, not replace)
- `transform(code, id)` injects `__ssrAccessed: true` for an SFC that binds `useForm` and references it in the template
- Returns `null` for non-`.vue` ids

### Full gate

- **Lint** ✓
- **Typecheck** ✓
- **check:site** ✓
- **3508/3508 tests** ✓ (+10 vs Phase 14: +6 from `test/vite/transform-wiring.test.ts`, +4 from `equality-ladder-characterization.test.ts`)
- **check:size** ✓
  - `index.mjs` 46.79 / 48 kB (↓ 0.04 kB from Phase 14)
  - `zod.mjs` 60.41 / 63 kB (↓ 0.04)
  - `zod-v4.mjs` 54.56 / 55 kB (↓ 0.04)
  - `zod-v3.mjs` 55.62 / 56 kB (↓ 0.03)
- **check:bench** ✓ (all within 3× floor)
- **check:coverage** ✓ (91.75% lines — unchanged from Phase 14 baseline)

The dedup actually shaved ~40 bytes off `index.mjs` — the extractions compress better than the duplicated inline copies.

### Next phase

Phase 16 (`refactor/type-dedup`) — TYPES-D2 / D3 / D4 / D7 (public type-walker dedup + naming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
