### PR TITLE
fix(security): proto-less storage closes proto-pollution + sanitizes-not-blocks legit keys

### DIFF
--- a/src/runtime/core/errors-proxy.ts
+++ b/src/runtime/core/errors-proxy.ts
@@ -6,7 +6,6 @@ import { getAtPath, hasAtPath } from './path-walker'
 import {
   canonicalizePath,
   FORM_ERRORS_PATH_KEY,
-  isDangerousSegment,
   isPathPrefix,
   segmentsForPathKey,
   type PathKey,
@@ -250,7 +249,17 @@ function materializeErrors<F extends GenericForm>(
   // string-keyed object, producing `{ "0": {…} }` for an array path
   // and breaking shape parity with `form.values`.
   const liveContainer = getAtPath(state.form.value, containerSegments)
-  const tree: Record<string, unknown> | unknown[] = Array.isArray(liveContainer) ? [] : {}
+  // Object.create(null) for the object case so the tree is incapable
+  // of routing a `__proto__` / `constructor` / `prototype` segment
+  // onto `Object.prototype` no matter what `setFieldErrors` /
+  // `setFormErrors` hands `placeAt`. Legitimate fields named
+  // `prototype` (e.g. an architecture firm tracking building
+  // prototypes) land at their declared path; the pollution arrow has
+  // nowhere to land because prototype-less containers don't inherit
+  // the `__proto__` accessor.
+  const tree: Record<string, unknown> | unknown[] = Array.isArray(liveContainer)
+    ? []
+    : Object.create(null)
 
   // Two store classes with different visibility rules. Schema +
   // derived-blank: library-produced verdicts; filter out paths the
@@ -349,15 +358,6 @@ function placeAt(
   errors: ValidationError[]
 ): void {
   if (path.length === 0) return
-  // Prototype-pollution guard. Path segments flow from consumer input
-  // (server replies wired through `setFieldErrors` / `setFormErrors`);
-  // a segment of `__proto__` / `constructor` / `prototype` would
-  // otherwise reach the `cursorRecord[key] = ...` writes below and
-  // mutate `Object.prototype` for the whole process. Matches the
-  // SEC-2 shape applied to `mergeDeep` in the persistence layer.
-  for (const seg of path) {
-    if (isDangerousSegment(seg)) return
-  }
   let cursor: Record<string, unknown> | unknown[] = tree
   for (let i = 0; i < path.length - 1; i++) {
     const seg = path[i] as Segment
@@ -366,7 +366,14 @@ function placeAt(
     const cursorRecord = cursor as Record<string, unknown>
     let child = cursorRecord[key]
     if (child === null || child === undefined || typeof child !== 'object') {
-      child = typeof nextSeg === 'number' ? [] : {}
+      // Object.create(null) for intermediate containers — pairs with
+      // the tree-root construction in `materializeErrors`. Keeps
+      // `__proto__` / `constructor` / `prototype` as ordinary own-
+      // property keys with no path to `Object.prototype`. Numeric
+      // next-segments still produce arrays so the live-shape mirror
+      // (object root → object containers, array root → array
+      // containers) is preserved.
+      child = typeof nextSeg === 'number' ? [] : Object.create(null)
       cursorRecord[key] = child
     }
     cursor = child as Record<string, unknown> | unknown[]

--- a/src/runtime/core/persistence/index.ts
+++ b/src/runtime/core/persistence/index.ts
@@ -9,14 +9,7 @@ import type {
 import { PERSISTENCE_KEY_PREFIX } from '../defaults'
 import { __DEV__ } from '../dev'
 import { isPlainRecord, setAtPath, getAtPath } from '../path-walker'
-import {
-  isDangerousSegment,
-  isPathPrefix,
-  segmentsForPathKey,
-  type Path,
-  type PathKey,
-  type Segment,
-} from '../paths'
+import { isPathPrefix, segmentsForPathKey, type Path, type PathKey, type Segment } from '../paths'
 
 /**
  * Public-ish handle returned by `wirePersistence`. Lives on
@@ -660,12 +653,17 @@ function mergeDeep(
       if (sourceDisc !== undefined) {
         const variantDefault = du.getVariantDefault(sourceDisc)
         if (isPlainRecord(variantDefault)) {
-          const out: Record<string, unknown> = { ...variantDefault }
+          // Prototype-less merge target. The `out[key] = ...` write
+          // below cannot reach `Object.prototype` even if `key` is
+          // `__proto__` from a hostile persisted payload, because a
+          // prototype-less object has no `__proto__` accessor — the
+          // assignment is a plain own-property write. The variant-
+          // filter below (`key in variantDefault`) still excludes
+          // prototype-corrupting keys for the DU-variant case unless
+          // the schema legitimately declares them, in which case the
+          // consumer's variant carries the value through unmolested.
+          const out: Record<string, unknown> = Object.assign(Object.create(null), variantDefault)
           for (const key of Object.keys(sourceRecord)) {
-            // Untrusted payload: a prototype-corrupting key (`__proto__`
-            // etc.) is `in variantDefault` via inheritance, so it would
-            // pass the variant filter below — reject it up front.
-            if (isDangerousSegment(key)) continue
             if (!(key in variantDefault) && key !== du.discriminatorKey) continue
             out[key] = mergeDeep(out[key], sourceRecord[key], [...path, key], schema)
           }
@@ -678,12 +676,17 @@ function mergeDeep(
     }
   }
   const mergeTarget = target
-  const out: Record<string, unknown> = isPlainRecord(mergeTarget) ? { ...mergeTarget } : {}
+  // Prototype-less merge target. `out['__proto__'] = ...` on a
+  // prototype-less object is a plain own-property write, not the
+  // accessor that would reassign the object's prototype, so a
+  // `__proto__` key smuggled into the persisted JSON cannot
+  // pollute `Object.prototype` regardless of what walks through.
+  // Legitimate `prototype` / `constructor` / `__proto__` fields in
+  // a consumer schema persist and restore at their declared path.
+  const out: Record<string, unknown> = isPlainRecord(mergeTarget)
+    ? Object.assign(Object.create(null), mergeTarget)
+    : Object.create(null)
   for (const key of Object.keys(source)) {
-    // Reject prototype-corrupting keys from untrusted storage / hydration
-    // JSON before the bracket-assign reaches `out`. `out['__proto__'] =`
-    // would reassign the merged object's prototype.
-    if (isDangerousSegment(key)) continue
     out[key] = mergeDeep(out[key], (source as Record<string, unknown>)[key], [...path, key], schema)
   }
   return out

--- a/test/core/errors-proxy-prototype-pollution.test.ts
+++ b/test/core/errors-proxy-prototype-pollution.test.ts
@@ -3,18 +3,29 @@
  * Prototype-pollution gate for `placeAt` (errors-proxy.ts).
  *
  * `setFieldErrors` accepts a `path` from consumer input — server
- * replies, manual marks. Without a guard, a path whose first segment
+ * replies, manual marks. Without protection, a path whose first segment
  * is `__proto__` reaches `placeAt`'s `cursorRecord[lastKey] = errors`
- * writes (errors-proxy.ts:360,368, CodeQL alerts #12 and #13, rule
- * `js/prototype-polluting-assignment`). The two-segment shape
- * `['__proto__', 'polluted']` walks via `tree.__proto__` straight onto
- * `Object.prototype` and assigns the global there, breaking every
- * object in the process.
+ * write and pollutes `Object.prototype` for the whole process (CodeQL
+ * alerts #12 and #13, rule `js/prototype-polluting-assignment`).
  *
- * The guard at the top of `placeAt` matches the SEC-2 shape from the
- * persistence layer's `mergeDeep` — `isDangerousSegment` rejects
- * `__proto__`, `constructor`, and `prototype`, and the whole placement
- * is dropped.
+ * The fix sanitises the storage shape, not the input. The error-tree
+ * containers are allocated via `Object.create(null)` so a `__proto__`
+ * segment is just another own-property key with no path to
+ * `Object.prototype`. Legitimate fields named `prototype` (an
+ * architecture firm tracking building prototypes, a JS-tooling form
+ * mentioning `__proto__` literally) land their errors at the declared
+ * path the consumer asked for, instead of being silently dropped by a
+ * dangerous-segment guard.
+ *
+ * Each special-key case asserts two invariants in sequence:
+ *   1. Positive roundtrip — the errors are present in the materialised
+ *      error tree at the path the consumer set them at. Probed via
+ *      `form.errors.toJSON()` because the `form.errors(path)` callable
+ *      applies the active-path filter for unreachable paths (correct
+ *      for the schema-error case it's tuned for, irrelevant for raw
+ *      placement verification here).
+ *   2. No pollution — a fresh plain `{}` does NOT inherit the canary
+ *      property, confirming the write never reached `Object.prototype`.
  */
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { z as zV4 } from 'zod'
@@ -42,7 +53,17 @@ const adapters = [
 // `{}` without disturbing global state for unrelated suites.
 const SENTINEL = 'attaformProtoPollutionCanary'
 
-describe.each(adapters)('errors-proxy `placeAt` prototype-pollution guard — $name', ({ mount }) => {
+type ErrorTree = Record<string, unknown>
+
+function materialisedErrorTree(api: { errors: unknown }): ErrorTree {
+  const errors = api.errors as { toJSON?: () => ErrorTree }
+  if (typeof errors.toJSON !== 'function') {
+    throw new Error('form.errors did not expose toJSON — surface-proxy contract changed')
+  }
+  return errors.toJSON()
+}
+
+describe.each(adapters)('errors-proxy `placeAt` proto-less storage — $name', ({ mount }) => {
   beforeEach(() => {
     // Pre-test invariant: the canary must NOT be present. A leaked
     // pollution from earlier in the test process would otherwise
@@ -52,64 +73,96 @@ describe.each(adapters)('errors-proxy `placeAt` prototype-pollution guard — $n
   })
 
   afterEach(() => {
-    // Defensive cleanup: even though the fix should prevent any
-    // mutation, scrub the canary so a leak from a regression never
+    // Defensive cleanup: even though the prototype-less tree should
+    // prevent any mutation, scrub the canary so a regression never
     // bleeds into the rest of the suite.
     delete (Object.prototype as Record<string, unknown>)[SENTINEL]
   })
 
-  it("setFieldErrors with path: ['__proto__', X] does not pollute Object.prototype", () => {
+  it("['__proto__', X] lands at the declared path AND does not pollute Object.prototype", () => {
     const { api, app } = mount()
+    const message = 'legit field literally named __proto__'
     api.setFieldErrors([
       {
         path: ['__proto__', SENTINEL],
-        message: 'attempted pollution',
+        message,
         formKey: api.key,
         code: 'atta:server',
       },
     ])
-    // Reading `form.errors` triggers materialisation, which is the
-    // codepath that invokes `placeAt`. Without that read, the guard
-    // is never exercised.
-    void api.errors
+
+    // Positive roundtrip — the materialised tree carries the entry as
+    // a plain own-property pair on prototype-less containers, so
+    // bracket access lands exactly where the consumer set the path.
+    const tree = materialisedErrorTree(api)
+    const protoSlot = tree['__proto__'] as ErrorTree | undefined
+
+    // Negative invariant — Object.prototype is unchanged. A plain `{}`
+    // probe inherits nothing because the tree's `__proto__` slot is a
+    // regular own property on a prototype-less container, not the
+    // accessor that would walk into Object.prototype.
     const probe: Record<string, unknown> = {}
+
     app.unmount()
+
+    expect(protoSlot).toBeDefined()
+    expect(protoSlot?.[SENTINEL]).toEqual(
+      expect.arrayContaining([expect.objectContaining({ message })])
+    )
     expect(probe[SENTINEL]).toBeUndefined()
   })
 
-  it("setFieldErrors with path: ['constructor', X] does not surface on plain objects", () => {
+  it("['constructor', X] lands at the declared path AND does not pollute Object.prototype", () => {
     const { api, app } = mount()
+    const message = 'legit field literally named constructor'
     api.setFieldErrors([
       {
         path: ['constructor', SENTINEL],
-        message: 'attempted pollution',
+        message,
         formKey: api.key,
         code: 'atta:server',
       },
     ])
-    void api.errors
+
+    const tree = materialisedErrorTree(api)
+    const ctorSlot = tree['constructor'] as ErrorTree | undefined
     const probe: Record<string, unknown> = {}
+
     app.unmount()
+
+    expect(ctorSlot).toBeDefined()
+    expect(ctorSlot?.[SENTINEL]).toEqual(
+      expect.arrayContaining([expect.objectContaining({ message })])
+    )
     expect(probe[SENTINEL]).toBeUndefined()
   })
 
-  it("setFieldErrors with path: ['prototype', X] does not surface on plain objects", () => {
+  it("['prototype', X] lands at the declared path AND does not pollute Object.prototype", () => {
     const { api, app } = mount()
+    const message = 'building-A spec mismatch (architecture firm prototype field)'
     api.setFieldErrors([
       {
         path: ['prototype', SENTINEL],
-        message: 'attempted pollution',
+        message,
         formKey: api.key,
         code: 'atta:server',
       },
     ])
-    void api.errors
+
+    const tree = materialisedErrorTree(api)
+    const protoSlot = tree['prototype'] as ErrorTree | undefined
     const probe: Record<string, unknown> = {}
+
     app.unmount()
+
+    expect(protoSlot).toBeDefined()
+    expect(protoSlot?.[SENTINEL]).toEqual(
+      expect.arrayContaining([expect.objectContaining({ message })])
+    )
     expect(probe[SENTINEL]).toBeUndefined()
   })
 
-  it('setFormErrors at the synthetic root path is unaffected by the guard', () => {
+  it('setFormErrors at the synthetic root path still lands at the form level', () => {
     const { api, app } = mount()
     api.setFormErrors([{ message: 'root-level error' }])
     const formLevel = api.errors('')

--- a/test/core/persistence-prototype-pollution.test.ts
+++ b/test/core/persistence-prototype-pollution.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+/**
+ * Prototype-pollution gate for the persistence layer's `mergeDeep`
+ * (persistence/index.ts).
+ *
+ * The persistence hydration path reads a JSON blob out of localStorage,
+ * `JSON.parse`s it, and merges it into the form's default values via
+ * `mergeSparseHydration` → `mergeDeep`. JSON.parse promotes a literal
+ * `__proto__` token to an OWN data property on the parsed object (the
+ * `[[DefineOwnProperty]]` step in the spec, bypassing the prototype
+ * setter that an `{ __proto__: ... }` literal would trip). Without
+ * protection, `out['__proto__'] = ...` on a plain-`{}` merge target
+ * then reaches `Object.prototype` and pollutes every object in the
+ * process — a real attack surface for any consumer whose localStorage
+ * is reachable from untrusted JS (XSS, a third-party tag, a
+ * compromised dependency).
+ *
+ * The fix matches the errors-proxy treatment: allocate the merge
+ * target via `Object.create(null)` so `out['__proto__'] = …` is a
+ * plain own-property write with no path to `Object.prototype`. The
+ * SEC-2 `isDangerousSegment` early-skip from the prior audit is no
+ * longer load-bearing and gets dropped — that guard silently
+ * discarded legitimate `prototype` / `constructor` keys whose only
+ * sin was sharing a name with a builtin.
+ *
+ * Two invariants per case:
+ *   1. Positive roundtrip — a schema field literally named `prototype`
+ *      / `constructor` carries its persisted value through hydration
+ *      and lands at the declared path on the rehydrated form values.
+ *   2. No pollution — a fresh plain `{}` does NOT inherit any canary
+ *      property a hostile payload tried to inject.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mergeSparseHydration } from '../../src/runtime/core/persistence'
+
+const SENTINEL = 'attaformPersistenceProtoPollutionCanary'
+
+describe('persistence mergeDeep proto-less storage', () => {
+  beforeEach(() => {
+    const preProbe: Record<string, unknown> = {}
+    expect(preProbe[SENTINEL]).toBeUndefined()
+  })
+
+  afterEach(() => {
+    // Defensive cleanup: even though the prototype-less merge target
+    // should prevent any mutation, scrub the canary so a regression
+    // never bleeds into the rest of the suite.
+    delete (Object.prototype as Record<string, unknown>)[SENTINEL]
+  })
+
+  it('hostile `__proto__` in persisted JSON does not pollute Object.prototype', () => {
+    // JSON.parse promotes `__proto__` to an own data property — this
+    // is the only way to land such a property short of
+    // `Object.defineProperty`. A real attacker reaching localStorage
+    // (XSS, third-party script, compromised dependency) drops this
+    // shape into the persisted entry.
+    const hostilePayload = JSON.parse(
+      `{"__proto__": {"${SENTINEL}": "polluted"}, "email": "alice@example.com"}`
+    )
+
+    const merged = mergeSparseHydration({ email: '' }, hostilePayload) as {
+      email: string
+    }
+
+    // Negative invariant — Object.prototype is unchanged.
+    const probe: Record<string, unknown> = {}
+    expect(probe[SENTINEL]).toBeUndefined()
+
+    // The legitimate part of the payload still merged.
+    expect(merged.email).toBe('alice@example.com')
+  })
+
+  it('legitimate `prototype` field round-trips through hydration', () => {
+    // Architecture firm: form tracks building prototypes. The schema
+    // declares a `prototype` container; the persisted payload restores
+    // its name on rehydration.
+    const defaults = { prototype: { name: '' } }
+    const persisted = { prototype: { name: 'building-A' } }
+    const merged = mergeSparseHydration(defaults, persisted) as {
+      prototype: { name: string }
+    }
+
+    expect(merged.prototype.name).toBe('building-A')
+
+    const probe: Record<string, unknown> = {}
+    expect(probe[SENTINEL]).toBeUndefined()
+  })
+
+  it('legitimate `constructor` field round-trips through hydration', () => {
+    // Construction-management form with a `constructor` field naming
+    // who built the unit. Pre-fix this key was silently dropped by
+    // the SEC-2 `isDangerousSegment` guard.
+    const defaults = { constructor: { name: '' } }
+    const persisted = { constructor: { name: 'east-wing-crew' } }
+    const merged = mergeSparseHydration(defaults, persisted) as {
+      constructor: { name: string }
+    }
+
+    expect(merged.constructor.name).toBe('east-wing-crew')
+  })
+
+  it('positive roundtrip survives a same-payload `__proto__` smuggle attempt', () => {
+    // Defense in depth: even when a single payload mixes a legit
+    // field write with a pollution attempt, the legit field still
+    // round-trips correctly and Object.prototype stays untouched.
+    const hostilePayload = JSON.parse(
+      `{"__proto__": {"${SENTINEL}": "polluted"}, "prototype": {"name": "building-B"}}`
+    )
+    const merged = mergeSparseHydration({ prototype: { name: '' } }, hostilePayload) as {
+      prototype: { name: string }
+    }
+
+    expect(merged.prototype.name).toBe('building-B')
+
+    const probe: Record<string, unknown> = {}
+    expect(probe[SENTINEL]).toBeUndefined()
+  })
+})

--- a/test/core/persistence/proto-pollution.test.ts
+++ b/test/core/persistence/proto-pollution.test.ts
@@ -7,14 +7,26 @@ import { fakeSchema } from '../../utils/fake-schema'
 
 /**
  * SEC-2 regression: untrusted persisted-draft / SSR-hydration JSON must
- * never reassign the merged object's prototype chain. `multi-tab-sync`
- * already rejects `__proto__` / `constructor` / `prototype` segments;
- * the persistence hydration merge (`mergeDeep`) and the SSR DU-stub walk
- * (`walkDuStubs`) did not. A `__proto__` key in the payload trips the
- * inherited `__proto__` setter on plain bracket-assign, silently
- * rewriting `getPrototypeOf(result)` to the attacker's object so
- * inherited keys leak into reads and `isPlainRecord` (which gates the
- * downstream persistence + scrub walks) returns false.
+ * never reach `Object.prototype` and pollute every plain object in the
+ * process. The persistence hydration merge (`mergeDeep`) accepts paths
+ * from `JSON.parse(localStorage)`, which can carry `__proto__` as an
+ * own data property by spec; the SSR DU-stub walk (`walkDuStubs`)
+ * accepts paths from SSR hydration payloads with the same surface area.
+ *
+ * The persistence-side defense is now structural: `mergeDeep` allocates
+ * its merge target via `Object.create(null)`, so any `out['__proto__']
+ * = …` write that the iteration produces is a plain own-property
+ * write with no path to `Object.prototype`. Legitimate schema fields
+ * named `prototype` / `constructor` / `__proto__` (an architecture
+ * firm tracking building prototypes; a construction-management form
+ * naming the construction crew; a JS-tooling form that mentions
+ * `__proto__` literally) land at the declared path the consumer
+ * asked for.
+ *
+ * The SSR DU-stub walk still uses the SEC-2-era input-rejection guard
+ * (`isDangerousSegment`) — the same proto-less treatment is queued
+ * as a follow-up PR alongside the rest of the broader sweep. The
+ * test below pins the current du-stubs contract until then.
  */
 
 type Bag = { name: string; nested: { a: string } }
@@ -36,25 +48,52 @@ afterEach(() => {
 })
 
 describe('SEC-2 — persistence hydration merge resists prototype pollution', () => {
-  it('mergeSparseHydration ignores a __proto__ payload key', () => {
+  it('mergeSparseHydration keeps Object.prototype clean despite a __proto__ payload key', () => {
     const hostile = JSON.parse('{"__proto__":{"polluted":1},"name":"real"}')
     const merged = mergeSparseHydration(defaults, hostile) as Record<string, unknown>
-    expect(readGlobalProp('polluted')).toBeUndefined() // global clean
-    expect(merged['polluted']).toBeUndefined() // no inherited leak on the result
-    expect(Object.getPrototypeOf(merged)).toBe(Object.prototype)
+
+    // Global cleanliness — the SEC-2 invariant.
+    expect(readGlobalProp('polluted')).toBeUndefined()
+
+    // Prototype-less merge target — the structural fix that makes
+    // `out['__proto__'] = …` a plain own-property write. The probe-
+    // probe (`merged['polluted']`) is undefined because the tree's
+    // `__proto__` slot is an own property, not an accessor that walks
+    // into Object.prototype.
+    expect(Object.getPrototypeOf(merged)).toBeNull()
+    expect(merged['polluted']).toBeUndefined()
+
+    // `isPlainRecord` accepts both `proto === null` (Object.create(null))
+    // and `proto === Object.prototype`, so downstream consumers
+    // continue to treat the result as a plain record.
     expect(isPlainRecord(merged)).toBe(true)
-    expect(merged['name']).toBe('real') // legit keys still merge
+
+    // Legit field still merges.
+    expect(merged['name']).toBe('real')
   })
 
-  it('mergeSparseHydration ignores constructor / prototype payload keys', () => {
+  it('mergeSparseHydration keeps Object.prototype clean despite a constructor/prototype payload', () => {
     const hostile = JSON.parse('{"constructor":{"prototype":{"polluted":1}}}')
     const merged = mergeSparseHydration(defaults, hostile) as Record<string, unknown>
+
+    // Global cleanliness — the SEC-2 invariant.
     expect(readGlobalProp('polluted')).toBeUndefined()
-    expect(Object.prototype.hasOwnProperty.call(merged, 'constructor')).toBe(false)
-    expect(Object.getPrototypeOf(merged)).toBe(Object.prototype)
+
+    // The merge target is prototype-less, so `constructor` lands as
+    // an ordinary own-property pair instead of being silently dropped.
+    // The structural defense still holds because the descended
+    // container is also prototype-less — there is no accessor walk
+    // that reaches Object.prototype.prototype regardless of how deep
+    // the payload nests these key names.
+    expect(Object.getPrototypeOf(merged)).toBeNull()
+    expect(isPlainRecord(merged)).toBe(true)
   })
 
   it('SSR DU-stub walk ignores a __proto__ hydration key', () => {
+    // `walkDuStubs` still uses the SEC-2-era input-rejection guard;
+    // a follow-up PR will apply the proto-less storage treatment here
+    // alongside the rest of the sweep. This case pins the current
+    // behavior until then.
     const hostile = JSON.parse('{"__proto__":{"polluted":1},"name":"x","nested":{"a":"y"}}')
     const state = createFormStore<Bag>({
       formKey: 'sec2-ssr',


### PR DESCRIPTION
## Why

Closes the remaining CodeQL alerts from PR #307's first-pass triage by flipping the proto-pollution defense from **input rejection** (silently drop paths whose segments are `__proto__` / `constructor` / `prototype`) to **prototype-less storage** (the merge target can't reach `Object.prototype` regardless of what the input contains).

The earlier guard was wrong-tail: every consumer with a legitimate `prototype` schema field (an architecture firm tracking building prototypes, a JS-tooling form mentioning `__proto__` literally, any schema with a `constructor` field) had their errors and persisted state silently discarded. Sanitising the storage shape closes the attack vector AND lets legitimate special-key fields work end-to-end.

## Commits

| | Commit | Closes |
| - | --- | --- |
| 1 | `fix(security): proto-less placeAt tree supersedes segment guard` | CodeQL #12, #13 |
| 2 | `fix(security): proto-less persistence merge target supersedes segment guard` | SEC-2 latent silent-drop |

Both flip `Object.create(null)` for the merge / placement target, drop the SEC-2-era `isDangerousSegment` early-return, and ship regression tests asserting BOTH invariants (no `Object.prototype` mutation AND legitimate special-key fields round-trip).

## Observable behavior change

Three previously-rejected segments now land:
- `setFieldErrors([{ path: ['prototype', 'name'], … }])` surfaces in the error tree at the declared path instead of being silently dropped.
- A persisted JSON payload containing a top-level `prototype` / `constructor` key restores its value through `mergeSparseHydration` instead of being filtered out at the merge boundary.
- `setFieldErrors` / `setFormErrors` paths with a literal `__proto__` first segment land their errors at `tree['__proto__']` (a regular own-property write on a prototype-less container — `Object.prototype` is untouched).

The fix is strictly more permissive than both pre-PR-307 (where `__proto__` was a real pollution vector) and post-PR-307 (where legitimate keys were silently dropped).

## Out-of-band — alerts dismissed as won't-fix

Three CodeQL alerts on dev-tooling scripts are dismissed via the code-scanning API rather than fixed in code:

| Alert | File | Rule | Rationale |
| --- | --- | --- | --- |
| [#15](https://github.com/attaform/Attaform/security/code-scanning/15) | `apps/site/scripts/indexnow-ping.mjs` | `js/file-access-to-http` | URL validation via `new URL().host === HOST` is the genuine sanitizer. CodeQL's stock taint model doesn't recognize it as one, but the host equality check is the right gate at the script's actual security boundary. Script never runs in published-package contexts. |
| [#16](https://github.com/attaform/Attaform/security/code-scanning/16), [#17](https://github.com/attaform/Attaform/security/code-scanning/17) | `apps/site/scripts/download-fonts.mjs` | `js/http-to-file-access` | The script's purpose IS HTTP→FS (fetch fonts from Google, write to disk). Family whitelist (`r.family === name`), filename slug (`replace(/[^A-Za-z0-9 -]/g, '')`), and unicode-range regex bound every flow from network into the disk write. No path-traversal surface. |

All three are dev-only build tooling, not shipped to consumers via the npm tarball. Justifications reproduced in the alert dismissal API call so the rationale is recorded in the alert history.

## Verification

- `pnpm test test/core/errors-proxy-prototype-pollution.test.ts` — 8/8 green (4 cases × v3/v4 adapters)
- `pnpm test test/core/persistence-prototype-pollution.test.ts` — 4/4 green
- `pnpm test test/composables/persistence.test.ts test/composables/blank-persistence.test.ts test/composables/du-variant-persistence.test.ts test/composables/persist-hydration-validate.test.ts` — 63/63 green (no regression on the broader persistence suite)
- `pnpm check` — full local gate (lint + typecheck + check:site + test + check:size + check:bench + check:coverage)
- CodeQL gate fires on this PR's `pull_request` trigger; #12 and #13 should drop to "fixed" on the analysis run.

## Sequencing — broader prototype-safety sweep deferred

This PR resolves the SEC-2 sites flagged today by CodeQL or the prior audit. A follow-up sweep PR will apply the same `Object.create(null)` + drop-guard principle to the other write sites with externally-controlled keys (`merge-deep.ts` default-value derivation, `du-stubs.ts` SSR hydration, `multi-tab-sync.ts` patch suppression, and the direct `setValue` / `setValues` write paths). Sequenced after this PR per `feedback_iterative_collab`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
