### PR TITLE
chore(security): polish-pass proto-less containers across schema-driven walks

### DIFF
--- a/src/runtime/core/build-form-api.ts
+++ b/src/runtime/core/build-form-api.ts
@@ -1008,7 +1008,10 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
     if (value === null || typeof value !== 'object' || Array.isArray(value)) {
       return EMPTY_FIELD_RECORD
     }
-    const out: Record<string, unknown> = {}
+    // Prototype-less record container — matches the runtime's
+    // value-tree shape so a frozen `record()` view's prototype chain
+    // doesn't diverge from the live data it mirrors.
+    const out: Record<string, unknown> = Object.create(null)
     for (const key of Object.keys(value as Record<string, unknown>)) {
       out[key] = callTerminal(`${path}.${key}`)
     }

--- a/src/runtime/core/path-walker.ts
+++ b/src/runtime/core/path-walker.ts
@@ -349,7 +349,12 @@ function mergeStructuralImpl(
       return consumer
     }
     let mutated = false
-    const out: Record<string, unknown> = { ...consumer }
+    // Prototype-less merge target, matching `setAtPath` and `mergeDeep`
+    // elsewhere in the runtime. Spread via `Object.assign` copies
+    // consumer's own properties as own properties on the proto-less
+    // container, so the merged tree stays structurally consistent
+    // with every other allocator.
+    const out: Record<string, unknown> = Object.assign(Object.create(null), consumer)
     // Fill schema-default keys that are MISSING from consumer (key
     // not present at all). An explicit `consumer[key] = undefined`
     // means the consumer named the slot empty on purpose — distinct

--- a/src/runtime/core/persistence/index.ts
+++ b/src/runtime/core/persistence/index.ts
@@ -555,7 +555,11 @@ export function stripUnacknowledgedSensitiveLeaves(
     if (value === null || typeof value !== 'object') return value
     if (Array.isArray(value)) return value.map((item, i) => walk([...path, i], item))
     if (!isPlainRecord(value)) return value
-    const out: Record<string, unknown> = {}
+    // Prototype-less scrub container, matching the rest of the
+    // persistence layer's allocators. The sensitive-leaf scrub feeds
+    // back into the persisted payload, so the shape stays consistent
+    // with what `mergeDeep` would produce on the way back in.
+    const out: Record<string, unknown> = Object.create(null)
     for (const key of Object.keys(value as Record<string, unknown>)) {
       const walked = walk([...path, key], (value as Record<string, unknown>)[key])
       if (walked !== undefined) out[key] = walked

--- a/src/runtime/core/unset-walker.ts
+++ b/src/runtime/core/unset-walker.ts
@@ -134,7 +134,12 @@ function walk(
     ) {
       for (const k of Object.keys(slim as object)) allKeys.add(k)
     }
-    const out: Record<string, unknown> = {}
+    // Prototype-less container, matching the rest of the runtime's
+    // value-write pipeline. Schema keys can't be literal `__proto__`,
+    // so this is principle alignment rather than a new pollution gate;
+    // it keeps the walker's output structurally identical to
+    // `setAtPath`'s so a value flowing through both stays one shape.
+    const out: Record<string, unknown> = Object.create(null)
     let mutated = allKeys.size !== inputKeys.length
     for (const key of allKeys) {
       const orig = (input as Record<string, unknown>)[key]
@@ -192,7 +197,7 @@ export function walkUnspecified(slim: unknown, segments: Segment[], paths: PathK
   // tuple-shaped fixed arrays opt-in via explicit per-element `unset`.
   if (Array.isArray(slim)) return slim
   if (slim !== null && typeof slim === 'object') {
-    const out: Record<string, unknown> = {}
+    const out: Record<string, unknown> = Object.create(null)
     for (const key of Object.keys(slim as object)) {
       out[key] = walkUnspecified((slim as Record<string, unknown>)[key], [...segments, key], paths)
     }
@@ -268,7 +273,7 @@ function substitute(
   }
   if (typeof input === 'object') {
     let mutated = false
-    const out: Record<string, unknown> = {}
+    const out: Record<string, unknown> = Object.create(null)
     for (const key of Object.keys(input as object)) {
       const orig = (input as Record<string, unknown>)[key]
       const walked = substitute(orig, [...segments, key], schema, paths)

--- a/src/runtime/core/variant-memory.ts
+++ b/src/runtime/core/variant-memory.ts
@@ -146,7 +146,10 @@ export function cloneVariantSnapshot(value: unknown): unknown {
     return out
   }
   const src = raw as Record<string, unknown>
-  const out: Record<string, unknown> = {}
+  // Prototype-less variant snapshot. Variant memos restore back into
+  // `form.values` on union-switch reshape; matching the proto-less
+  // shape keeps the round-trip structurally identical.
+  const out: Record<string, unknown> = Object.create(null)
   for (const k of Object.keys(src)) out[k] = cloneVariantSnapshot(src[k])
   return out
 }

--- a/src/runtime/core/walk-derive-default.ts
+++ b/src/runtime/core/walk-derive-default.ts
@@ -201,7 +201,12 @@ export function deriveDefaultWalk<Schema>(
   switch (kind) {
     case 'object': {
       const shape = intro.getObjectShape(schema)
-      const out: Record<string, unknown> = {}
+      // Prototype-less default container, matching the rest of the
+      // runtime's value-write pipeline. The default flows directly into
+      // `form.values`; allocating it proto-less here keeps the entire
+      // initial-value tree structurally identical to what `setAtPath`
+      // and `mergeDeep` produce.
+      const out: Record<string, unknown> = Object.create(null)
       for (const [key, subSchema] of Object.entries(shape)) {
         out[key] = deriveDefaultWalk(subSchema, useDefault, intro, maxDepth, ctx, lazyDepth)
       }


### PR DESCRIPTION
## Why

Finishes the proto-less storage principle from PR #308 + #309. The remaining six container allocators in the runtime's schema-driven walks were flagged as deferred in #309's PR body — pollution-safe today (schema keys can't be literal `__proto__` because the JS parser treats `{ __proto__: … }` as a prototype setter, not an own key), but inconsistent with the rest of the value pipeline.

After this lands, **every container the runtime allocates is `Object.create(null)`-rooted**. A value flowing through any chain of walks (defaults → `setValue` → snapshot → persistence restore → cross-tab → undo → variant snapshot) keeps one consistent shape end-to-end. `toRaw(form.values)` returns a uniformly prototype-less tree instead of a mix of plain `{}` and `Object.create(null)` containers depending on which code path last touched a given subtree.

## Sites flipped

| File | Site | What it produces |
|---|---|---|
| `unset-walker.ts:137,195,271` | three walkers | Cleaned values for `setValue` and the unspecified-default sweep |
| `walk-derive-default.ts:204` | object-default case | The default container that becomes `form.values` on mount |
| `variant-memory.ts:149` | `cloneVariantSnapshot` | Variant snapshots that restore into `form.values` on union-switch |
| `path-walker.ts:355` | `mergeStructural`'s fill target | Schema-fill merge result for `mergeStructural` |
| `build-form-api.ts:1011` | `record(path)` view | The frozen field-record enumeration |
| `persistence/index.ts:558` | sensitive-leaf scrub | The persisted-payload subset after stripping unacknowledged sensitive leaves |

Each is a one-line swap: `const out: Record<string, unknown> = {}` → `Object.create(null)` (or `Object.assign(Object.create(null), src)` where a spread was present).

## No behavior change

- 3,580 tests pass with no test updates needed.
- `isPlainRecord` already accepted both `proto === null` and `proto === Object.prototype`, so every internal check continues to validate the new containers as plain records.
- No surface exposed by `form.values` / `form.fields` / `form.errors` changes shape; the proxy machinery interposes, and `JSON.stringify` / `Object.keys` / spread / dot-access all behave identically on prototype-less own-property bags.
- The only `toRaw` consumer-visible difference (`Object.getPrototypeOf(toRaw(form.values).<container>) === null` instead of `Object.prototype`) was already the case for any subtree touched by `setAtPath` post-#309, so this PR just extends that consistency to the subtrees the schema-driven walks own.

## Verification

- `pnpm check` — full pipeline (lint + typecheck + check:site + tests + check:size + check:bench + check:coverage) green
- 3,580 tests pass; no new tests added because there's no behavior change to lock — the proto-less invariant on the schema-driven walks is held by the broader pollution-roundtrip coverage already in place from #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)
