### PR TITLE
ci(security): SLSA attestation + Packaging signal for Scorecard

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -264,6 +264,19 @@ jobs:
           # permission on this job (declared above) is what lets npm
           # mint that token.
           registry-url: 'https://registry.npmjs.org/'
+          # Disable setup-node's package-manager-cache auto-detection.
+          # By default, setup-node honours `package.json#packageManager`
+          # (currently `pnpm@11.3.0`) and mounts the pnpm cache into the
+          # job. That cache surface is shared across workflow runs —
+          # a poisoned entry from an earlier run could ride
+          # `--frozen-lockfile`'s integrity check (pnpm rejects mismatched
+          # hashes, but defence-in-depth wins here) and reach the
+          # publish artifact. The validate job's setup-node keeps the
+          # cache for CI throughput; this job eats the install cost
+          # (~30s) for cache-free reproducibility, matching zizmor's
+          # `cache-poisoning` audit recommendation for steps that
+          # publish runtime artifacts.
+          package-manager-cache: false
 
       # No `npm install -g npm@latest` step. pnpm 11 dropped the
       # npm-CLI publish fallback in favor of pnpm's native publish

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -133,7 +133,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # Push the version-bump commit + tag to protected `main` via `git push --follow-tags`. Read alone would 403 at the GitHub API layer.
-      id-token: write # Mint an ephemeral npm publish credential from this run's GitHub OIDC token under Trusted Publishing. No NPM_TOKEN secret is involved.
+      id-token: write # Mint an ephemeral npm publish credential from this run's GitHub OIDC token under Trusted Publishing, AND request the Sigstore audience for `actions/attest-build-provenance` below. No NPM_TOKEN secret is involved.
+      attestations: write # Write the SLSA build-provenance attestation produced by `actions/attest-build-provenance` to GitHub Attestations (`gh attestation verify`). The same `.intoto.jsonl` bundle is also attached to the GitHub Release below so OpenSSF Scorecard's `Signed-Releases` check picks it up.
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -393,6 +394,30 @@ jobs:
             exit 1
           fi
           echo "TARBALL_PATH=$(pwd)/$TARBALL" >> "$GITHUB_ENV"
+
+      # Sigstore-backed SLSA build-provenance attestation. Issued
+      # under this workflow's OIDC token (audience: sigstore),
+      # recorded to the Sigstore transparency log, and stored as a
+      # GitHub Attestation that consumers verify with
+      # `gh attestation verify ./attaform-X.Y.Z.tgz --repo attaform/Attaform`.
+      #
+      # Runs BEFORE `pnpm publish` below: if attestation fails (a
+      # Sigstore outage, an OIDC misconfiguration) the publish is
+      # short-circuited rather than producing an npm tarball with no
+      # matching GitHub attestation. Order is intentional — `pnpm
+      # publish --provenance` and this step share the same OIDC
+      # primitive but land in different verification surfaces, and
+      # the audit story relies on both paths being present together.
+      #
+      # The `.intoto.jsonl` bundle written to `steps.attest.outputs.bundle-path`
+      # is also attached to the GitHub Release via the `files:` input
+      # of `softprops/action-gh-release` further down, which is what
+      # OpenSSF Scorecard's `Signed-Releases` check looks for.
+      - name: Attest build provenance
+        id: attest
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: ${{ env.TARBALL_PATH }}
 
       - name: Publish to npm
         # `--provenance` attaches an OIDC-signed statement linking the

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -477,36 +477,32 @@ jobs:
           gh auth setup-git
           git push --follow-tags
 
-      # Create the GitHub Release for the just-pushed tag. Runs AFTER
-      # npm publish + git push so a release on
-      # https://github.com/<owner>/<repo>/releases always corresponds
-      # to a published tarball and a remote tag. Best-effort: a failure
-      # here (transient API, auth hiccup, quota) does NOT roll back the
-      # publish — the user can re-run `gh release create` manually from
-      # the tag if needed.
+      # Build the release-notes body to a file on the runner. Split
+      # off the release-create step below for two reasons:
       #
-      # Body shape: a metadata prelude (version, commit, author,
-      # workflow run, npm link) plus GitHub's auto-generated
-      # PR-grouped changelog (same API the `generate-release-notes.mjs`
-      # hook script uses for RELEASES.md, so the two stay consistent).
-      - name: Create GitHub Release
+      #   1. `softprops/action-gh-release` reads the body via
+      #      `body_path` rather than inline interpolation, so the body
+      #      stays out of the action's argument surface (smaller
+      #      template-injection footprint than a multi-line `with:` value).
+      #   2. The flag-matrix is computed in a separate step below so
+      #      the action invocation reads cleanly without a per-mode
+      #      branch around `gh release create`.
+      #
+      # Body shape unchanged from the prior single-step version: a
+      # metadata prelude (version, commit, author, workflow run, npm
+      # link) plus GitHub's auto-generated PR-grouped changelog (same
+      # API the `generate-release-notes.mjs` hook script uses for
+      # RELEASES.md, so the two stay consistent).
+      - name: Build release notes body
         if: success()
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Bind workflow-dispatch inputs into env vars so the `run:`
-          # block below can reference them as ordinary shell variables.
-          # Direct `${{ github.event.inputs.* }}` interpolation inside a
-          # shell context lets an attacker-controlled input value expand
-          # into the runner's bash before quoting takes effect — the
-          # classic GitHub Actions template-injection pattern.
-          INPUT_DIST_TAG: ${{ github.event.inputs.dist_tag }}
-          INPUT_PRERELEASE_ID: ${{ github.event.inputs.prerelease_id }}
-          # Bind workflow-context values + step output the same way.
-          # github.server_url / .repository / .run_id are GitHub-set and
-          # not attacker-controllable, but env-binding eliminates the
-          # template-injection finding without leaving a suppression
-          # comment behind.
+          # Bind workflow-context values + step output into env vars
+          # so the `run:` block below references them as ordinary
+          # shell variables. github.server_url / .repository / .run_id
+          # are GitHub-set and not attacker-controllable, but
+          # env-binding eliminates the template-injection finding
+          # without leaving a suppression comment behind.
           NEXT_VERSION: ${{ steps.calculate-next-version.outputs.next_version }}
           GH_SERVER_URL: ${{ github.server_url }}
           GH_REPOSITORY: ${{ github.repository }}
@@ -546,33 +542,91 @@ jobs:
             echo "$AUTO_NOTES"
           } > "$RUNNER_TEMP/release-body.md"
 
-          # `--verify-tag` confirms the tag exists on the remote before
-          # creating the release, so a failed `git push --follow-tags`
-          # above would short-circuit here rather than produce an
-          # orphan release. Stable releases use `--latest` (primary on
-          # the repo's releases page); prereleases use `--prerelease`
-          # so they don't shadow the stable line. Off-latest stable
-          # hotfixes (any non-empty, non-`latest` dist_tag) get neither
-          # flag — they appear in the release list but don't claim
-          # the "Latest" badge that the current major's release holds.
-          if [ -n "${INPUT_DIST_TAG:-}" ] && [ "$INPUT_DIST_TAG" != "latest" ]; then
-            gh release create "$TAG" \
-              --title "$TAG" \
-              --notes-file "$RUNNER_TEMP/release-body.md" \
-              --verify-tag
+      # Compute the `prerelease` and `make_latest` flags for the
+      # release-create step below. The flag matrix matches the
+      # earlier single-step gh-release-create branching:
+      #
+      #   off-latest stable hotfix  → prerelease=false, make_latest=false
+      #     (non-empty `dist_tag` other than `latest` — the release
+      #      appears in the list but does not claim the "Latest"
+      #      badge that the current major's release holds).
+      #   prerelease                → prerelease=true,  make_latest=false
+      #     (so beta / alpha / rc / next don't shadow the stable line).
+      #   normal stable             → prerelease=false, make_latest=true
+      #     (includes the explicit `dist_tag=latest` case).
+      #
+      # Computed in its own step so the action invocation below stays
+      # declarative — a single `softprops/action-gh-release` with two
+      # output-bound inputs, rather than the prior per-mode `if/elif/else`
+      # tree around `gh release create`.
+      - name: Compute release flags
+        id: release-flags
+        if: success()
+        env:
+          # Bind workflow-dispatch inputs into env vars so the `run:`
+          # block below references them as ordinary shell variables.
+          # Direct `${{ github.event.inputs.* }}` interpolation inside
+          # a shell context lets an attacker-controlled input value
+          # expand into the runner's bash before quoting takes effect
+          # — the classic GitHub Actions template-injection pattern.
+          INPUT_DIST_TAG: ${{ github.event.inputs.dist_tag }}
+          INPUT_PRERELEASE_ID: ${{ github.event.inputs.prerelease_id }}
+        run: |
+          set -euo pipefail
+          if [ -n "${INPUT_DIST_TAG:-}" ] && [ "${INPUT_DIST_TAG}" != "latest" ]; then
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "make_latest=false" >> "$GITHUB_OUTPUT"
           elif [ -n "${INPUT_PRERELEASE_ID:-}" ]; then
-            gh release create "$TAG" \
-              --title "$TAG" \
-              --notes-file "$RUNNER_TEMP/release-body.md" \
-              --verify-tag \
-              --prerelease
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "make_latest=false" >> "$GITHUB_OUTPUT"
           else
-            gh release create "$TAG" \
-              --title "$TAG" \
-              --notes-file "$RUNNER_TEMP/release-body.md" \
-              --verify-tag \
-              --latest
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "make_latest=true" >> "$GITHUB_OUTPUT"
           fi
+
+      # Create the GitHub Release for the just-pushed tag and attach
+      # the SLSA build-provenance attestation (`.intoto.jsonl`)
+      # produced by the `Attest build provenance` step above. Runs
+      # AFTER `pnpm publish` + `git push` so a release on
+      # https://github.com/<owner>/<repo>/releases always corresponds
+      # to a published tarball and a remote tag.
+      #
+      # Why `softprops/action-gh-release` (vs the prior `gh release create`):
+      #
+      #   1. OpenSSF Scorecard's `Packaging` check matches workflow
+      #      patterns from a known publish-action list;
+      #      `softprops/action-gh-release` is in that list while raw
+      #      `gh release create` is not. Using the action surfaces
+      #      the canonical Packaging signal.
+      #   2. The `files:` input accepts the
+      #      `steps.attest.outputs.bundle-path` from the attestation
+      #      step above, attaching the `.intoto.jsonl` to the release.
+      #      That attachment is what Scorecard's `Signed-Releases`
+      #      check inspects.
+      #
+      # Best-effort: `continue-on-error: true` preserves the prior
+      # behaviour — a transient API hiccup creating the release does
+      # NOT roll back the npm publish that already happened above.
+      # The user can re-run `gh release create` manually from the
+      # tag if needed.
+      #
+      # `fail_on_unmatched_files: true` makes the action fail if the
+      # attestation bundle isn't present, so an empty attach is
+      # surfaced rather than silently producing a release without
+      # the `.intoto.jsonl`.
+      - name: Publish GitHub Release with attestation
+        if: success()
+        continue-on-error: true
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        with:
+          tag_name: v${{ steps.calculate-next-version.outputs.next_version }}
+          name: v${{ steps.calculate-next-version.outputs.next_version }}
+          body_path: ${{ runner.temp }}/release-body.md
+          files: |
+            ${{ steps.attest.outputs.bundle-path }}
+          prerelease: ${{ steps.release-flags.outputs.prerelease }}
+          make_latest: ${{ steps.release-flags.outputs.make_latest }}
+          fail_on_unmatched_files: true
 
       - name: Rollback version bump if failed
         if: failure()

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,23 @@
+# zizmor configuration — per-rule suppressions for findings consciously
+# evaluated and accepted, applied workflow-by-workflow.
+#
+# Policy: per the workflow-lint workflow header, suppression is the
+# tool for findings that are either false positives or load-bearing-by-
+# design. Persona stays at `pedantic`; the suppression lives here in
+# version control so the next maintainer (or auditor) sees exactly
+# which rules were waived against which files and why.
+
+rules:
+  # `softprops/action-gh-release` is in OpenSSF Scorecard's recognised
+  # publish-action pattern list (see `checks/raw/packaging.go` upstream);
+  # raw `gh release create` calls are not. Switching to the gh CLI would
+  # silently drop Scorecard's `Packaging` signal back to `?`, which is
+  # the explicit thing this workflow exists to fix.
+  #
+  # The action's argument surface is `body_path`, `files`, and a couple
+  # of flag inputs — all bound to step outputs or non-attacker-controlled
+  # values — so the marginal-attack-surface concern zizmor highlights
+  # does not apply here.
+  superfluous-actions:
+    ignore:
+      - publish-npm.yml


### PR DESCRIPTION
## Why

OpenSSF Scorecard's `Signed-Releases` and `Packaging` checks both currently read `?` (indeterminate) at the [public report](https://securityscorecards.dev/viewer/?uri=github.com/attaform/Attaform). This PR lands the publish-time signals that flip both checks to determinate PASS, plus the hardening sweep that fell out of the zizmor pedantic audit on the new diff.

The `?` on Signed-Releases is the legitimate one: `pnpm publish --provenance` already attests to the npm registry, but the GitHub Release for each tag carries no asset that Scorecard can inspect. The fix attaches a Sigstore-backed SLSA build-provenance attestation (`.intoto.jsonl`) to every future release via `actions/attest-build-provenance` + `softprops/action-gh-release`. Same OIDC trust root as the npm provenance; different verification surface (`gh attestation verify ./attaform-X.Y.Z.tgz --repo attaform/Attaform` vs `npm audit signatures`).

The `?` on Packaging looks like a parsing/matching gap on the prior `gh release create` shape — `softprops/action-gh-release` is the canonical pattern in Scorecard's [`checks/raw/packaging.go`](https://github.com/ossf/scorecard/blob/main/checks/raw/packaging.go) recognition list.

## Commits

1. **`ci(security): attest npm tarballs to GitHub Attestations`** (46b3550) — adds `actions/attest-build-provenance@v4.1.0` between `pnpm pack` and `pnpm publish`. Grants `attestations: write` on the publish job. Runs BEFORE `pnpm publish` so a Sigstore outage short-circuits the publish rather than producing an npm tarball without a matching GitHub attestation.

2. **`ci(security): attach attestation to GitHub Release via softprops/action-gh-release`** (0ac3a2a) — splits the prior `Create GitHub Release` step into `Build release notes body` (writes `$RUNNER_TEMP/release-body.md`) + `Compute release flags` (outputs `prerelease` / `make_latest` matching the prior if/elif/else) + `Publish GitHub Release with attestation` (uses `softprops/action-gh-release@v3.0.0`, consumes `steps.attest.outputs.bundle-path` via the `files:` input). `fail_on_unmatched_files: true` surfaces an empty attach rather than silently producing a release without the `.intoto.jsonl`.

3. **`ci(security): disable setup-node auto-cache in the publish job`** (7fccbd2) — `actions/setup-node` auto-mounts the package-manager cache when `package.json#packageManager` is set; attaform's `packageManager: pnpm@11.3.0` field triggers this. zizmor's `cache-poisoning` audit flagged the cache-aware setup running in the same workflow as the new publishing action. Fix: `package-manager-cache: false` on the publish job's setup-node. Validate job keeps caching for CI throughput; publish job eats the ~30s install cost for cache-free reproducibility — matches zizmor's recommended structural separation for release workflows.

4. **`ci(security): add .github/zizmor.yml with publish-npm.yml superfluous-actions waiver`** (db9b6b7) — zizmor's `superfluous-actions` audit (info severity) recommends `gh release` in a script step instead of `softprops/action-gh-release`. The action choice is deliberate — softprops is the Scorecard-recognised pattern, the gh CLI is not — so per the workflow-lint workflow's documented suppression policy, this lands a per-rule `.github/zizmor.yml` waiver for `publish-npm.yml`. Persona stays pedantic.

## Scorecard impact (projected)

| Check | Before | After | How |
| --- | --- | --- | --- |
| Signed-Releases | `?` | 10/10 | `.intoto.jsonl` attached to every future GitHub Release |
| Packaging | `?` | 10/10 | `softprops/action-gh-release` is in the recognised pattern list |

Score lift: **8.0 → ~9.0**, with further lift from CII-Best-Practices (PR 2, follow-up) and Branch-Protection (out-of-band Repo Rules) pending.

## Verification

- `pnpm check` — full pipeline green locally (no source changes, no test changes)
- `zizmor --persona=pedantic .github/workflows/` — `No findings to report. Good job! (1 ignored)`
- YAML parses cleanly via `python3 -c "yaml.safe_load(...)"`
- Step order audited: `Pack → Attest → Publish → Push → Build notes → Compute flags → Publish Release`

## Behavior-change ledger

- **New observable surface**: every future GitHub Release carries a `.intoto.jsonl` SLSA build-provenance attestation as a release asset. The same attestation is also discoverable via `gh attestation verify`. Pre-PR releases have no attestation attached — this is additive.
- **Behavior preserved on the publish path**: npm publish flow, version-bump, GPG signing, tarball-size budget, validate-then-publish split, scoped install — all unchanged. Release notes body shape unchanged (just relocated into its own step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
