### PR TITLE
docs(readme): add the OpenSSF Best Practices passing badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![License][license-src]][license-href]
 [![Node.js Test Suite](https://github.com/attaform/attaform/actions/workflows/matrix.yml/badge.svg)](https://github.com/attaform/attaform/actions/workflows/matrix.yml)
 [![OpenSSF Scorecard][scorecard-src]][scorecard-href]
+[![OpenSSF Best Practices][cii-src]][cii-href]
 [![Nuxt][nuxt-src]][nuxt-href]
 
 A type-safe, schema-driven form library for Vue 3 and Nuxt with first-class Zod support.
@@ -195,5 +196,7 @@ MIT; see [LICENSE](./LICENSE).
 [license-href]: https://npmjs.com/package/attaform
 [scorecard-src]: https://img.shields.io/ossf-scorecard/github.com/attaform/Attaform?label=OpenSSF%20Scorecard&style=flat&colorA=020420&colorB=00DC82
 [scorecard-href]: https://securityscorecards.dev/viewer/?uri=github.com/attaform/Attaform
+[cii-src]: https://img.shields.io/cii/level/13042?label=OpenSSF%20Best%20Practices&style=flat&colorA=020420&colorB=00DC82
+[cii-href]: https://www.bestpractices.dev/projects/13042
 [nuxt-src]: https://img.shields.io/badge/Nuxt-020420?logo=nuxt.js
 [nuxt-href]: https://nuxt.com


### PR DESCRIPTION
## Why

Attaform just earned the [OpenSSF Best Practices Passing badge](https://www.bestpractices.dev/projects/13042/passing) (project id `13042`, awarded 2026-05-30). This is the badge that closes Scorecard's `CII-Best-Practices` check (currently `0/10` → expected `10/10` on the next cron).

PR #315 shipped the `.bestpractices.json` answer key; bestpractices.dev auto-discovered it and pre-filled all six sections; submission flipped to passing at 100% across all 67 Passing-level criteria.

## What ships

A single line addition to the README header badge row, plus the matching reference link in the appendix.

| Before | After |
| --- | --- |
| npm version • npm downloads • License • Node.js Test Suite • OpenSSF Scorecard • Nuxt | npm version • npm downloads • License • Node.js Test Suite • OpenSSF Scorecard • **OpenSSF Best Practices** • Nuxt |

Badge URL: `https://img.shields.io/cii/level/13042` routed through shields.io for visual consistency with the existing badge row (same `colorA=020420&colorB=00DC82` brand palette).

## Verification

- `curl -sI` on the badge URL returns `HTTP/2 200`
- Badge SVG renders "passing" text (verified via `grep` on the SVG body)
- Click-through lands on https://www.bestpractices.dev/projects/13042

## Sequencing

This closes the CII-Best-Practices side-list item from the scorecard maxxing plan. After this merges:

- Mon June 1, 09:00 UTC Scorecard cron picks up the badge → CII-Best-Practices `0/10` → `10/10`
- Combined with the Branch-Protection lift from the `main protection` ruleset, the Packaging signal from softprops, and the Signed-Releases signal from the v0.20.0 attestation, the projected score is **~9.4**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)