### PR TITLE
fix(security): repair the null-proto leak through the SSR payload (#314)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,24 @@
 
 ## Unreleased
 
-_No unreleased changes yet._
+### Fixed
+
+- **Form values, snapshots, and every consumer-observable surface
+  carry `Object.prototype`.** `form.values`, `form.record(path)`,
+  `form.errors`, and the `renderAttaformState` SSR payload now respond
+  cleanly to `.hasOwnProperty(...)` / `in` / `Object.keys` from
+  third-party payload walkers (devalue reducers, JSON serializers,
+  loggers, devtools probes). The prototype-pollution defense flips
+  from `Object.create(null)` containers to a `safeAssign` helper that
+  uses `Object.defineProperty` for the `__proto__` key specifically;
+  `safeOwnRead` / `safeOwnHas` defend the read side against the
+  inherited accessor. Legitimate consumer-schema fields named
+  `prototype` / `constructor` / `__proto__` still round-trip through
+  `setValue`, persistence, history, and SSR alongside every other
+  key, and `Object.prototype` stays untouched. A standing diagnostic
+  (`test/core/runtime-no-null-proto-in-src.test.ts`) fails any future
+  PR that reintroduces the idiom. Closes the SSR hydration mismatch
+  observed when `@pinia/nuxt` is installed alongside attaform.
 
 ## v0.20.0
 A seventeen-phase codebase audit closes out, with prototype-pollution

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "@vue/typescript-plugin": "^3.2.7",
     "changelogen": "^0.6.2",
     "cheerio": "^1.2.0",
+    "devalue": "^5.8.1",
     "chokidar-cli": "^3.0.0",
     "eslint": "^10.2.1",
     "eslint-config-prettier": "^10.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       chokidar-cli:
         specifier: ^3.0.0
         version: 3.0.0
+      devalue:
+        specifier: ^5.8.1
+        version: 5.8.1
       eslint:
         specifier: ^10.2.1
         version: 10.4.0(jiti@2.7.0)

--- a/src/runtime/core/build-form-api.ts
+++ b/src/runtime/core/build-form-api.ts
@@ -46,6 +46,7 @@ import { PERSISTENCE_MODULE_KEY, type PersistenceModule } from './persistence'
 import { allowSensitivePersist } from './persistence/sensitive-names'
 import { applyInvalidSubmitPolicy, buildProcessForm } from './process-form'
 import { buildRegister } from './register-api'
+import { safeAssign } from './safe-assign'
 import { isUnset, unset } from './unset'
 import {
   blankForKind,
@@ -1008,12 +1009,15 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
     if (value === null || typeof value !== 'object' || Array.isArray(value)) {
       return EMPTY_FIELD_RECORD
     }
-    // Prototype-less record container — matches the runtime's
-    // value-tree shape so a frozen `record()` view's prototype chain
-    // doesn't diverge from the live data it mirrors.
-    const out: Record<string, unknown> = Object.create(null)
+    // Container carries `Object.prototype` so a third-party walker
+    // reading the frozen view (`.hasOwnProperty(...)`, `in`, JSON
+    // serializer with a reducer) sees the standard chain. The keys
+    // come from the live form value, which can include a literal
+    // `__proto__` own property after a `setValue('record.__proto__', …)`
+    // write — `safeAssign` lands it as an own data property here.
+    const out: Record<string, unknown> = {}
     for (const key of Object.keys(value as Record<string, unknown>)) {
-      out[key] = callTerminal(`${path}.${key}`)
+      safeAssign(out, key, callTerminal(`${path}.${key}`))
     }
     return Object.freeze(out)
   }

--- a/src/runtime/core/diff-apply.ts
+++ b/src/runtime/core/diff-apply.ts
@@ -1,5 +1,6 @@
 import { deleteAtPath, setAtPath } from './path-walker'
 import type { Path, Segment } from './paths'
+import { safeAssign, safeOwnRead } from './safe-assign'
 
 /**
  * Structural diff/apply walker. Used by the state layer to emit per-leaf
@@ -233,7 +234,8 @@ export function applyChangedKeys(target: unknown, source: unknown): boolean {
     }
     for (const k of changedFirstSegments) {
       if (typeof k === 'symbol') continue
-      t[String(k)] = s[String(k)]
+      const key = String(k)
+      safeAssign(t, key, safeOwnRead(s, key))
     }
   }
   return true
@@ -334,19 +336,16 @@ export function structuralSnapshot<T>(value: T): T {
     return out as unknown as T
   }
   const src = value as Record<string, unknown>
-  // Prototype-less snapshot container — pairs with the proto-less
-  // intermediates `setAtPath` allocates. With both lined up, a form
-  // value carrying a legitimate `__proto__` / `constructor` /
-  // `prototype` own property survives the snapshot pass: `out[k] = …`
-  // is an own-property write on every step regardless of `k`, instead
-  // of routing through the inherited `[[Set]]` accessor at a literal
-  // `__proto__` key. `Object.keys` enumerates own enumerable keys on
-  // both the source and the destination identically, so consumers
-  // reading `prev` see the same shape they would have read off
-  // `form.value` directly.
-  const out: Record<string, unknown> = Object.create(null)
+  // Snapshot container carries `Object.prototype` so consumer code
+  // walking `prev` with `.hasOwnProperty(...)` / `in` / Object.keys
+  // gets the shape it expects. The per-key `safeOwnRead` resolves
+  // a literal `__proto__` key to its own data slot rather than
+  // through the inherited accessor; `safeAssign` then defines it as
+  // an own data property on `out` instead of routing through the
+  // inherited setter. Every other key takes the plain branch.
+  const out: Record<string, unknown> = {}
   for (const k of Object.keys(src)) {
-    out[k] = structuralSnapshot(src[k])
+    safeAssign(out, k, structuralSnapshot(safeOwnRead(src, k)))
   }
   return out as unknown as T
 }

--- a/src/runtime/core/du-stubs.ts
+++ b/src/runtime/core/du-stubs.ts
@@ -1,6 +1,7 @@
 import type { AbstractSchema } from '../types/types-api'
 import { __DEV__ } from './dev'
 import { type Path } from './paths'
+import { safeAssign } from './safe-assign'
 
 /**
  * Walk an `initialData` / restored payload and collapse any object whose
@@ -17,11 +18,12 @@ import { type Path } from './paths'
  * variant transitions) without sharing state across calls.
  *
  * SSR hydration payloads (third-party storage JSON) flow through the
- * same walker. Pollution defense is structural: every intermediate
- * container is allocated via `Object.create(null)` so the `out[k] =
- * …` write is a plain own-property assignment regardless of `k`.
- * Legitimate fields literally named `prototype` / `constructor` /
- * `__proto__` round-trip the same way every other key does.
+ * same walker. Pollution defense routes every untrusted-key write
+ * through `safeAssign`, which uses `Object.defineProperty` for the
+ * `__proto__` key (own data property, no chain mutation) and plain
+ * bracket-assign for every other key. Legitimate fields literally
+ * named `prototype` / `constructor` / `__proto__` round-trip the same
+ * way every other key does.
  *
  * `warn: true` opts in to a `__DEV__`-only one-shot per
  * `(dotted-path, disc-value)` console warning when a non-blank
@@ -85,24 +87,22 @@ function walkDuStubs(
           )
         }
       }
-      // The disc-only stub also uses a prototype-less container so a
-      // schema whose discriminator key happens to be `__proto__` /
-      // `constructor` / `prototype` (vanishingly rare, but possible
-      // via `z.discriminatedUnion('prototype', …)`) lands the disc
-      // value as an ordinary own-property pair.
-      const stub: Record<string, unknown> = Object.create(null)
-      stub[du.discriminatorKey] = discValue
+      // The disc-only stub routes the discriminator-key write through
+      // `safeAssign` so a schema using `z.discriminatedUnion('__proto__', …)`
+      // (vanishingly rare, but possible) lands the disc value as an
+      // own data property instead of invoking the inherited setter.
+      const stub: Record<string, unknown> = {}
+      safeAssign(stub, du.discriminatorKey, discValue)
       return stub
     }
   }
-  // Prototype-less SSR-walk container. Pairs with the `setAtPath` and
-  // persistence merges already proto-less, so an SSR payload carrying
-  // a legitimate `__proto__` / `constructor` / `prototype` own
-  // property (or a hostile one) lands as a plain own-property pair
-  // with no path to `Object.prototype`.
-  const out: Record<string, unknown> = Object.create(null)
+  // SSR-walk container. The `safeAssign` per key lands a literal
+  // `__proto__` segment as an own data property; every other key
+  // takes the plain bracket-assign branch. A hostile payload carrying
+  // `__proto__` can't reassign the container's prototype chain.
+  const out: Record<string, unknown> = {}
   for (const k of Object.keys(rec)) {
-    out[k] = walkDuStubs(schema, rec[k], [...path, k], warned)
+    safeAssign(out, k, walkDuStubs(schema, rec[k], [...path, k], warned))
   }
   return out
 }

--- a/src/runtime/core/errors-proxy.ts
+++ b/src/runtime/core/errors-proxy.ts
@@ -13,6 +13,7 @@ import {
   type Segment,
 } from './paths'
 import { isArrayPath, liveKeysAtPath } from './proxy-live-keys'
+import { safeAssign, safeOwnRead } from './safe-assign'
 import { buildSurfaceProxy, type SurfaceProxy } from './surface-proxy'
 
 /**
@@ -249,17 +250,14 @@ function materializeErrors<F extends GenericForm>(
   // string-keyed object, producing `{ "0": {…} }` for an array path
   // and breaking shape parity with `form.values`.
   const liveContainer = getAtPath(state.form.value, containerSegments)
-  // Object.create(null) for the object case so the tree is incapable
-  // of routing a `__proto__` / `constructor` / `prototype` segment
-  // onto `Object.prototype` no matter what `setFieldErrors` /
-  // `setFormErrors` hands `placeAt`. Legitimate fields named
-  // `prototype` (e.g. an architecture firm tracking building
-  // prototypes) land at their declared path; the pollution arrow has
-  // nowhere to land because prototype-less containers don't inherit
-  // the `__proto__` accessor.
-  const tree: Record<string, unknown> | unknown[] = Array.isArray(liveContainer)
-    ? []
-    : Object.create(null)
+  // Object case carries `Object.prototype` so any consumer reading
+  // the materialized tree directly (or via the errors callable Proxy
+  // when a third-party walker bypasses Vue's instrumentation) sees a
+  // standard prototype chain. The `safeAssign` calls in `placeAt`
+  // land a literal `__proto__` segment as an own data property; no
+  // matter what `setFieldErrors` / `setFormErrors` hands in, the
+  // pollution arrow can't reassign the container's prototype.
+  const tree: Record<string, unknown> | unknown[] = Array.isArray(liveContainer) ? [] : {}
 
   // Two store classes with different visibility rules. Schema +
   // derived-blank: library-produced verdicts; filter out paths the
@@ -364,23 +362,27 @@ function placeAt(
     const nextSeg = path[i + 1] as Segment
     const key = typeof seg === 'number' ? String(seg) : seg
     const cursorRecord = cursor as Record<string, unknown>
-    let child = cursorRecord[key]
+    // `safeOwnRead` here is load-bearing: a literal `__proto__`
+    // segment on a freshly-allocated `{}` tree node would otherwise
+    // resolve via the inherited accessor to `Object.prototype` and
+    // skip the allocation branch, leaking the prototype as the
+    // descent cursor for the next iteration's write.
+    let child = safeOwnRead(cursorRecord, key)
     if (child === null || child === undefined || typeof child !== 'object') {
-      // Object.create(null) for intermediate containers — pairs with
-      // the tree-root construction in `materializeErrors`. Keeps
-      // `__proto__` / `constructor` / `prototype` as ordinary own-
-      // property keys with no path to `Object.prototype`. Numeric
-      // next-segments still produce arrays so the live-shape mirror
-      // (object root → object containers, array root → array
-      // containers) is preserved.
-      child = typeof nextSeg === 'number' ? [] : Object.create(null)
-      cursorRecord[key] = child
+      // Intermediate containers mirror `materializeErrors`' tree root.
+      // Numeric next-segments still produce arrays so the live-shape
+      // mirror (object root → object containers, array root → array
+      // containers) is preserved. `safeAssign` at the parent slot lands
+      // a literal `__proto__` key as an own data property, with no
+      // path to `Object.prototype`.
+      child = typeof nextSeg === 'number' ? [] : {}
+      safeAssign(cursorRecord, key, child)
     }
     cursor = child as Record<string, unknown> | unknown[]
   }
   const lastSeg = path[path.length - 1] as Segment
   const lastKey = typeof lastSeg === 'number' ? String(lastSeg) : lastSeg
   const cursorRecord = cursor as Record<string, unknown>
-  const existing = cursorRecord[lastKey]
-  cursorRecord[lastKey] = Array.isArray(existing) ? [...existing, ...errors] : errors
+  const existing = safeOwnRead(cursorRecord, lastKey)
+  safeAssign(cursorRecord, lastKey, Array.isArray(existing) ? [...existing, ...errors] : errors)
 }

--- a/src/runtime/core/merge-deep.ts
+++ b/src/runtime/core/merge-deep.ts
@@ -19,32 +19,36 @@
  * `mergeDeep` / `mergeDeepV3` bodies lived per-adapter.
  */
 import { isPlainRecord } from './path-walker'
+import { safeAssign, safeOwnRead } from './safe-assign'
 
 export function mergeDeep(base: unknown, override: unknown): unknown {
   if (override === undefined) return base
   if (!isPlainRecord(override)) return override
   if (!isPlainRecord(base)) return override
 
-  // Prototype-less merge target. `result[key] = ...` on a prototype-
-  // less object is a plain own-property write even when `key` is
-  // `__proto__`, so an `override` carrying a literal `__proto__`
-  // own property (e.g. from JSON-parsed adapter defaults that round-
-  // tripped through storage) cannot reassign the result's prototype.
-  // Legitimate consumer-schema fields named `prototype` /
-  // `constructor` / `__proto__` flow through default-value
-  // derivation alongside every other key. Spread carries `base`'s
-  // own properties via `CopyDataProperties`, which bypasses the
-  // prototype setter, so the spread + `Object.assign` pairing
-  // preserves the prototype-less shape regardless of `base`'s
-  // ancestry.
-  const result: Record<string, unknown> = Object.assign(Object.create(null), base)
+  // Object spread carries `base`'s own properties through the
+  // spec's `CreateDataProperty` step, which bypasses the
+  // `__proto__` setter — so a `base` carrying a literal
+  // `__proto__` own property (e.g. from JSON-parsed adapter
+  // defaults that round-tripped through storage) survives the
+  // spread without reassigning the result's prototype. The
+  // per-key reads route through `safeOwnRead` so a
+  // `key === '__proto__'` doesn't resolve via the inherited
+  // accessor on the regular target. The per-key `safeAssign` lands
+  // an `override`'s `__proto__` entry as an own data property via
+  // `Object.defineProperty`; every other key takes the plain
+  // bracket-assign branch. Legitimate consumer-schema fields named
+  // `prototype` / `constructor` / `__proto__` flow through default-
+  // value derivation alongside every other key, and
+  // `Object.prototype` stays untouched.
+  const result: Record<string, unknown> = { ...base }
   for (const key of Object.keys(override)) {
-    const oVal = override[key]
-    const bVal = base[key]
+    const oVal = safeOwnRead(override, key)
+    const bVal = safeOwnRead(base, key)
     if (isPlainRecord(oVal) && isPlainRecord(bVal)) {
-      result[key] = mergeDeep(bVal, oVal)
+      safeAssign(result, key, mergeDeep(bVal, oVal))
     } else {
-      result[key] = oVal
+      safeAssign(result, key, oVal)
     }
   }
   return result

--- a/src/runtime/core/multi-tab-sync.ts
+++ b/src/runtime/core/multi-tab-sync.ts
@@ -4,6 +4,7 @@ import type { FormStore } from './create-form-store'
 import { applyPatchesForward, diffAndApply, structuralSnapshot, type Patch } from './diff-apply'
 import { isPlainRecord } from './path-walker'
 import { canonicalizePath, type Path, type PathKey } from './paths'
+import { safeAssign } from './safe-assign'
 import { slimKindOf } from './slim-primitive-gate'
 
 /**
@@ -284,20 +285,22 @@ function stripSensitivePathsDeep(
   }
   const proto = Object.getPrototypeOf(value)
   if (proto !== Object.prototype && proto !== null) return value
-  // Prototype-less scrub container — mirrors the proto-less allocator
-  // in `structuralSnapshot` so a form value carrying a legitimate
-  // `__proto__` / `constructor` / `prototype` own property (the
-  // post-`setAtPath` shape) flows through the scrub without routing
-  // through the inherited `[[Set]]` accessor at the destination.
-  const out: Record<string, unknown> = Object.create(null)
+  // Scrub container mirrors `structuralSnapshot`'s allocator. The
+  // outgoing snapshot is passed through `structuredClone` by
+  // `BroadcastChannel.postMessage` before crossing the tab boundary
+  // (which would discard the prototype anyway), but matching the rest
+  // of the runtime's `Object.prototype` shape keeps the in-process
+  // shape consistent. `safeAssign` lands a literal `__proto__` key as
+  // an own data property regardless of the source.
+  const out: Record<string, unknown> = {}
   const src = value as Record<string, unknown>
   for (const key of Object.keys(src)) {
     const childPath = [...pathSoFar, key]
     if (isSensitivePath(childPath)) {
-      out[key] = undefined
+      safeAssign(out, key, undefined)
       continue
     }
-    out[key] = stripSensitivePathsDeep(src[key], childPath, isSensitivePath)
+    safeAssign(out, key, stripSensitivePathsDeep(src[key], childPath, isSensitivePath))
   }
   return out
 }

--- a/src/runtime/core/path-walker.ts
+++ b/src/runtime/core/path-walker.ts
@@ -1,4 +1,5 @@
 import type { Path, Segment } from './paths'
+import { safeAssign, safeOwnHas, safeOwnRead } from './safe-assign'
 
 /**
  * The minimal slice of `AbstractSchema` the structural-completeness
@@ -123,21 +124,21 @@ function setAtPathOffset(root: unknown, path: Path, value: unknown, offset: numb
     return arr
   }
 
-  // Prototype-less intermediate. `rec['__proto__'] = …` on a plain
-  // `{}` would invoke the `Set` accessor inherited from
-  // `Object.prototype` and reassign the prototype chain. On a
-  // prototype-less object that accessor doesn't exist, so the write
-  // is a plain own-property assignment. Schema fields literally
-  // named `__proto__` / `constructor` / `prototype` now round-trip
+  // Object spread carries existing own properties through
+  // `CopyDataProperties` — the spec step uses `CreateDataProperty`,
+  // which bypasses the `__proto__` setter accessor inherited from
+  // `Object.prototype`. So a previously-set `__proto__` own data
+  // property survives a re-spread when intermediate copy-on-write
+  // occurs, and the spread doesn't reassign the prototype chain.
+  // For the imperative own-property write at the head segment we
+  // route through `safeAssign`: a literal `__proto__` segment becomes
+  // a defineProperty call (own data property), while every other key
+  // takes the plain bracket-assign branch. Schema fields literally
+  // named `__proto__` / `constructor` / `prototype` round-trip
   // through `setValue` / `applyPatchesForward` / history undo-redo
-  // alongside every other key. Spread carries existing own properties
-  // through `CopyDataProperties` (the spec step bypasses the
-  // prototype setter), so a previously-set `__proto__` own property
-  // survives a re-spread when intermediate copy-on-write occurs.
-  const rec: Record<string, unknown> = isPlainRecord(root)
-    ? Object.assign(Object.create(null), root)
-    : Object.create(null)
-  rec[head] = setAtPathOffset(rec[head], path, value, nextOffset)
+  // alongside every other key, with no path to `Object.prototype`.
+  const rec: Record<string, unknown> = isPlainRecord(root) ? { ...root } : {}
+  safeAssign(rec, head, setAtPathOffset(safeOwnRead(rec, head), path, value, nextOffset))
   return rec
 }
 
@@ -185,9 +186,13 @@ function deleteAtPathOffset(root: unknown, path: Path, offset: number): unknown 
     delete rec[head]
     return rec
   }
-  if (!(head in root)) return root
+  // Own-property existence check — `'__proto__' in root` would
+  // otherwise resolve via the inherited accessor and report `true`
+  // for every regular target, materializing a phantom delete-path on
+  // a slot the consumer never wrote.
+  if (!safeOwnHas(root, head)) return root
   const rec: Record<string, unknown> = { ...root }
-  rec[head] = deleteAtPathOffset(rec[head], path, nextOffset)
+  safeAssign(rec, head, deleteAtPathOffset(safeOwnRead(rec, head), path, nextOffset))
   return rec
 }
 
@@ -349,20 +354,25 @@ function mergeStructuralImpl(
       return consumer
     }
     let mutated = false
-    // Prototype-less merge target, matching `setAtPath` and `mergeDeep`
-    // elsewhere in the runtime. Spread via `Object.assign` copies
-    // consumer's own properties as own properties on the proto-less
-    // container, so the merged tree stays structurally consistent
-    // with every other allocator.
-    const out: Record<string, unknown> = Object.assign(Object.create(null), consumer)
+    // Merge target carries `Object.prototype`, matching `setAtPath` and
+    // `mergeDeep` elsewhere in the runtime. Object spread uses
+    // `CreateDataProperty` per the spec, which bypasses the inherited
+    // `__proto__` setter so a consumer carrying a literal `__proto__`
+    // own property survives the spread without reassigning the result's
+    // prototype chain.
+    const out: Record<string, unknown> = { ...consumer }
     // Fill schema-default keys that are MISSING from consumer (key
     // not present at all). An explicit `consumer[key] = undefined`
     // means the consumer named the slot empty on purpose — distinct
     // from omitting the key — and the schema default doesn't override
     // it.
     for (const key of Object.keys(defaultValue)) {
-      if (!(key in consumer)) {
-        const defAtKey = defaultValue[key]
+      // Own-property check — `'__proto__' in consumer` would always
+      // be `true` for a regular consumer record, falsely declaring
+      // "consumer wrote here" and skipping the default-fill for a
+      // legitimate `__proto__` schema field.
+      if (!safeOwnHas(consumer, key)) {
+        const defAtKey = safeOwnRead(defaultValue, key)
         // Recurse so that filling produces a structurally-complete
         // sub-tree (covers nested-object defaults that themselves
         // contain wrappers / unions).
@@ -370,7 +380,7 @@ function mergeStructuralImpl(
         const filled = mergeStructuralImpl(schema, scratch, undefined, defAtKey)
         scratch.pop()
         if (filled !== undefined) {
-          out[key] = filled
+          safeAssign(out, key, filled)
           mutated = true
         }
       }
@@ -382,13 +392,13 @@ function mergeStructuralImpl(
     // default for an undefined consumer), erasing the consumer's
     // explicit empty.
     for (const key of Object.keys(consumer)) {
-      const cVal = consumer[key]
+      const cVal = safeOwnRead(consumer, key)
       if (cVal === undefined) continue
       scratch.push(key)
-      const merged = mergeStructuralImpl(schema, scratch, cVal, defaultValue[key])
+      const merged = mergeStructuralImpl(schema, scratch, cVal, safeOwnRead(defaultValue, key))
       scratch.pop()
       if (merged !== cVal) {
-        out[key] = merged
+        safeAssign(out, key, merged)
         mutated = true
       }
     }

--- a/src/runtime/core/persistence/index.ts
+++ b/src/runtime/core/persistence/index.ts
@@ -10,6 +10,7 @@ import { PERSISTENCE_KEY_PREFIX } from '../defaults'
 import { __DEV__ } from '../dev'
 import { isPlainRecord, setAtPath, getAtPath } from '../path-walker'
 import { isPathPrefix, segmentsForPathKey, type Path, type PathKey, type Segment } from '../paths'
+import { safeAssign, safeOwnHas, safeOwnRead } from '../safe-assign'
 
 /**
  * Public-ish handle returned by `wirePersistence`. Lives on
@@ -555,14 +556,16 @@ export function stripUnacknowledgedSensitiveLeaves(
     if (value === null || typeof value !== 'object') return value
     if (Array.isArray(value)) return value.map((item, i) => walk([...path, i], item))
     if (!isPlainRecord(value)) return value
-    // Prototype-less scrub container, matching the rest of the
-    // persistence layer's allocators. The sensitive-leaf scrub feeds
-    // back into the persisted payload, so the shape stays consistent
-    // with what `mergeDeep` would produce on the way back in.
-    const out: Record<string, unknown> = Object.create(null)
+    // Scrub container carries `Object.prototype` plus `safeAssign`
+    // for the per-key write so a hostile persisted payload landing a
+    // literal `__proto__` key is written as an own data property, not
+    // through the inherited setter. The sensitive-leaf scrub feeds
+    // back into the persisted payload; shape stays consistent with
+    // what `mergeDeep` produces on the way back in.
+    const out: Record<string, unknown> = {}
     for (const key of Object.keys(value as Record<string, unknown>)) {
       const walked = walk([...path, key], (value as Record<string, unknown>)[key])
-      if (walked !== undefined) out[key] = walked
+      if (walked !== undefined) safeAssign(out, key, walked)
     }
     return out
   }
@@ -657,19 +660,33 @@ function mergeDeep(
       if (sourceDisc !== undefined) {
         const variantDefault = du.getVariantDefault(sourceDisc)
         if (isPlainRecord(variantDefault)) {
-          // Prototype-less merge target. The `out[key] = ...` write
-          // below cannot reach `Object.prototype` even if `key` is
-          // `__proto__` from a hostile persisted payload, because a
-          // prototype-less object has no `__proto__` accessor — the
-          // assignment is a plain own-property write. The variant-
-          // filter below (`key in variantDefault`) still excludes
-          // prototype-corrupting keys for the DU-variant case unless
-          // the schema legitimately declares them, in which case the
-          // consumer's variant carries the value through unmolested.
-          const out: Record<string, unknown> = Object.assign(Object.create(null), variantDefault)
+          // Object spread carries `variantDefault`'s own properties
+          // via `CreateDataProperty`, bypassing the inherited
+          // `__proto__` setter — so a variant default that legitimately
+          // declares `__proto__` is copied through without reassigning
+          // the result's prototype chain. Per-key writes route through
+          // `safeAssign`: a literal `__proto__` key from a hostile
+          // persisted payload (when the variant declares it) lands as
+          // an own data property. The variant-filter below
+          // (`key in variantDefault`) still excludes prototype-
+          // corrupting keys for the DU-variant case unless the schema
+          // legitimately declares them.
+          const out: Record<string, unknown> = { ...variantDefault }
           for (const key of Object.keys(sourceRecord)) {
-            if (!(key in variantDefault) && key !== du.discriminatorKey) continue
-            out[key] = mergeDeep(out[key], sourceRecord[key], [...path, key], schema)
+            // Own-property check — the variant-filter must treat
+            // inherited slots as absent so `'__proto__' in variantDefault`
+            // doesn't smuggle a hostile payload key into the merge.
+            if (!safeOwnHas(variantDefault, key) && key !== du.discriminatorKey) continue
+            safeAssign(
+              out,
+              key,
+              mergeDeep(
+                safeOwnRead(out, key),
+                safeOwnRead(sourceRecord, key),
+                [...path, key],
+                schema
+              )
+            )
           }
           return out
         }
@@ -680,18 +697,25 @@ function mergeDeep(
     }
   }
   const mergeTarget = target
-  // Prototype-less merge target. `out['__proto__'] = ...` on a
-  // prototype-less object is a plain own-property write, not the
-  // accessor that would reassign the object's prototype, so a
-  // `__proto__` key smuggled into the persisted JSON cannot
-  // pollute `Object.prototype` regardless of what walks through.
+  // Object spread carries `mergeTarget`'s own properties via
+  // `CreateDataProperty`, which bypasses the `__proto__` setter
+  // inherited from `Object.prototype`. The per-key `safeAssign` lands
+  // a literal `__proto__` key smuggled into the persisted JSON as an
+  // own data property here too, with no path to `Object.prototype`.
   // Legitimate `prototype` / `constructor` / `__proto__` fields in
   // a consumer schema persist and restore at their declared path.
-  const out: Record<string, unknown> = isPlainRecord(mergeTarget)
-    ? Object.assign(Object.create(null), mergeTarget)
-    : Object.create(null)
+  const out: Record<string, unknown> = isPlainRecord(mergeTarget) ? { ...mergeTarget } : {}
   for (const key of Object.keys(source)) {
-    out[key] = mergeDeep(out[key], (source as Record<string, unknown>)[key], [...path, key], schema)
+    safeAssign(
+      out,
+      key,
+      mergeDeep(
+        safeOwnRead(out, key),
+        safeOwnRead(source as Record<string, unknown>, key),
+        [...path, key],
+        schema
+      )
+    )
   }
   return out
 }

--- a/src/runtime/core/persistence/wire-persistence.ts
+++ b/src/runtime/core/persistence/wire-persistence.ts
@@ -364,9 +364,8 @@ export function wirePersistence<F extends GenericForm>(
     if (isDisposed()) return
     const raw = await adapter.getItem(key)
     const existing = readPersistedPayload<F>(raw)
-    const baseForm = existing?.data.form ?? (Object.create(null) as F)
     const value = getAtPath(toRaw(state.form.value), path)
-    const nextForm = setAtPath(baseForm, path, value) as F
+    const nextForm = setAtPath(existing?.data.form ?? {}, path, value) as F
     // Refresh this path's blank entry — and any descendants
     // — while preserving entries for OTHER paths the previous mount
     // persisted. Non-leaf writes (`writePathImmediately('user')`)

--- a/src/runtime/core/register-api.ts
+++ b/src/runtime/core/register-api.ts
@@ -213,15 +213,16 @@ export function buildRegister<F extends GenericForm>(
       // Container-path misuse degrades gracefully: a consumer who
       // bound v-register at an object/array path (e.g.
       // `api.register('payment' as 'payment.last4', …)` to bypass the
-      // type system) gets the same `[object Object]` placeholder
-      // `String({})` produced pre-proto-less-storage. After the
-      // backing store flipped to prototype-less containers,
-      // `String(Object.create(null))` throws "Cannot convert object
-      // to primitive value" because there's no `toString` on the
-      // chain; catching falls back to the canonical
-      // `Object.prototype.toString` output so the directive's
-      // mounted hook never propagates the throw into the consumer's
-      // render.
+      // type system) gets the `[object Object]` placeholder
+      // `String({})` produces. Runtime values now carry
+      // `Object.prototype` so `String(raw)` succeeds for normal
+      // container shapes, but a consumer can still hand us a
+      // null-prototype value (e.g. a `defaultValues` literal made via
+      // `Object.create(null)`); for those, `String(raw)` throws
+      // "Cannot convert object to primitive value". The catch falls
+      // back to the canonical `Object.prototype.toString` output so
+      // the directive's mounted hook never propagates the throw into
+      // the consumer's render.
       try {
         return String(raw)
       } catch {

--- a/src/runtime/core/safe-assign.ts
+++ b/src/runtime/core/safe-assign.ts
@@ -1,0 +1,81 @@
+/**
+ * Own-property write that lands a `__proto__` key as an own data
+ * property instead of invoking `Object.prototype`'s inherited
+ * `__proto__` setter (which would reassign the target's prototype
+ * chain — the original prototype-pollution attack).
+ *
+ * Used by the path-walker, merge, snapshot, and persistence routines
+ * to keep a consumer-schema field literally named `__proto__` flowing
+ * end-to-end without poisoning `Object.prototype`. Pairs with object
+ * spread (`{ ...base }`) for the spreading case: spread uses
+ * `CreateDataProperty` per the spec, which already bypasses the
+ * accessor, so spreading is safe on a regular target. The explicit
+ * branch here documents "this is the defense" at every imperative
+ * write site that handles an untrusted key.
+ *
+ * For non-`__proto__` keys the call is equivalent to
+ * `target[key] = value` — `'prototype'` and `'constructor'` are plain
+ * inherited data properties on `Object.prototype`, so own-property
+ * writes at those names shadow the inherited slot without any chain
+ * mutation.
+ */
+export function safeAssign<T>(target: Record<string, T>, key: string, value: T): void {
+  if (key === '__proto__') {
+    Object.defineProperty(target, key, {
+      value,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    })
+    return
+  }
+  target[key] = value
+}
+
+/**
+ * Own-property read that returns `undefined` for an absent key or for
+ * a slot whose only source is the inherited prototype chain. Pairs
+ * with `safeAssign` at every untrusted-key read site that's about to
+ * descend into a subtree.
+ *
+ * The hazard this defends: `target[key]` for `key === '__proto__'`
+ * invokes `Object.prototype`'s inherited `__proto__` getter and
+ * returns `Object.prototype` itself when the target has no own
+ * `__proto__` slot. Naive callers then treat that result as "the
+ * value we have at this path" and either descend through it (writing
+ * inherited properties into the descendant flow) or, worse, write
+ * back at the same key — landing the next mutation on
+ * `Object.prototype` directly.
+ *
+ * Reads at any other key fall through to `target[key]`; non-
+ * `__proto__` inherited slots (`toString`, `constructor`, …) on a
+ * fresh `{}` are non-enumerable and never inhabit a payload-key path
+ * that's about to be descended into.
+ */
+export function safeOwnRead(target: Record<string, unknown>, key: string): unknown {
+  if (key === '__proto__') {
+    const desc = Object.getOwnPropertyDescriptor(target, '__proto__')
+    return desc?.value
+  }
+  return target[key]
+}
+
+/**
+ * Own-property existence check that treats the prototype chain as
+ * "not present". The companion to `safeOwnRead`. Pairs with every
+ * `key in target` test where `key` is untrusted and the surrounding
+ * code reads "this key is present" as "consumer wrote at this slot".
+ *
+ * The hazard: `'__proto__' in target` is `true` for every regular
+ * object (the inherited accessor on `Object.prototype` answers
+ * `[[HasProperty]]` affirmatively). A naive existence check would
+ * declare every consumer "already wrote at `__proto__`" and skip
+ * default-fill / variant-merge logic that should run.
+ *
+ * Routes through `Object.prototype.hasOwnProperty.call` so a consumer
+ * who shadowed `hasOwnProperty` on the target doesn't break the
+ * check.
+ */
+export function safeOwnHas(target: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(target, key)
+}

--- a/src/runtime/core/unset-walker.ts
+++ b/src/runtime/core/unset-walker.ts
@@ -1,6 +1,7 @@
 import type { AbstractSchema } from '../types/types-api'
 import type { GenericForm } from '../types/types-core'
 import { canonicalizePath, type Path, type PathKey, type Segment } from './paths'
+import { safeAssign } from './safe-assign'
 import { isUnset } from './unset'
 
 /**
@@ -134,12 +135,12 @@ function walk(
     ) {
       for (const k of Object.keys(slim as object)) allKeys.add(k)
     }
-    // Prototype-less container, matching the rest of the runtime's
-    // value-write pipeline. Schema keys can't be literal `__proto__`,
-    // so this is principle alignment rather than a new pollution gate;
-    // it keeps the walker's output structurally identical to
-    // `setAtPath`'s so a value flowing through both stays one shape.
-    const out: Record<string, unknown> = Object.create(null)
+    // Container carries `Object.prototype` and writes route through
+    // `safeAssign` so a consumer schema using a literal `__proto__`
+    // key (unusual but legal) lands as an own data property here too.
+    // Output stays structurally identical to `setAtPath`'s so a value
+    // flowing through both surfaces the same shape.
+    const out: Record<string, unknown> = {}
     let mutated = allKeys.size !== inputKeys.length
     for (const key of allKeys) {
       const orig = (input as Record<string, unknown>)[key]
@@ -150,12 +151,12 @@ function walk(
       // for the schema-error filter (the path lands in
       // `authoredPaths` and validation runs against undefined).
       if (orig === undefined && inputKeysSet.has(key)) {
-        out[key] = undefined
+        safeAssign(out, key, undefined)
         mutated = true
         continue
       }
       const walked = walk(orig, [...segments, key], schema, paths)
-      out[key] = walked
+      safeAssign(out, key, walked)
       if (walked !== orig) mutated = true
     }
     return mutated ? out : input
@@ -197,9 +198,13 @@ export function walkUnspecified(slim: unknown, segments: Segment[], paths: PathK
   // tuple-shaped fixed arrays opt-in via explicit per-element `unset`.
   if (Array.isArray(slim)) return slim
   if (slim !== null && typeof slim === 'object') {
-    const out: Record<string, unknown> = Object.create(null)
+    const out: Record<string, unknown> = {}
     for (const key of Object.keys(slim as object)) {
-      out[key] = walkUnspecified((slim as Record<string, unknown>)[key], [...segments, key], paths)
+      safeAssign(
+        out,
+        key,
+        walkUnspecified((slim as Record<string, unknown>)[key], [...segments, key], paths)
+      )
     }
     return out
   }
@@ -273,11 +278,11 @@ function substitute(
   }
   if (typeof input === 'object') {
     let mutated = false
-    const out: Record<string, unknown> = Object.create(null)
+    const out: Record<string, unknown> = {}
     for (const key of Object.keys(input as object)) {
       const orig = (input as Record<string, unknown>)[key]
       const walked = substitute(orig, [...segments, key], schema, paths)
-      out[key] = walked
+      safeAssign(out, key, walked)
       if (walked !== orig) mutated = true
     }
     return mutated ? out : input

--- a/src/runtime/core/variant-memory.ts
+++ b/src/runtime/core/variant-memory.ts
@@ -1,6 +1,7 @@
 import { toRaw } from 'vue'
 import type { WriteMeta } from '../types/types-api'
 import { isPathPrefix, segmentsForPathKey, type Path, type PathKey } from './paths'
+import { safeAssign } from './safe-assign'
 
 /**
  * Per-(union-path, outgoing-disc-value) snapshot stashed on a
@@ -146,10 +147,11 @@ export function cloneVariantSnapshot(value: unknown): unknown {
     return out
   }
   const src = raw as Record<string, unknown>
-  // Prototype-less variant snapshot. Variant memos restore back into
-  // `form.values` on union-switch reshape; matching the proto-less
-  // shape keeps the round-trip structurally identical.
-  const out: Record<string, unknown> = Object.create(null)
-  for (const k of Object.keys(src)) out[k] = cloneVariantSnapshot(src[k])
+  // Variant snapshots restore back into `form.values` on union-switch
+  // reshape; the container carries `Object.prototype` so the
+  // round-trip matches the rest of the value-write pipeline.
+  // `safeAssign` lands a `__proto__` key as an own data property.
+  const out: Record<string, unknown> = {}
+  for (const k of Object.keys(src)) safeAssign(out, k, cloneVariantSnapshot(src[k]))
   return out
 }

--- a/src/runtime/core/walk-derive-default.ts
+++ b/src/runtime/core/walk-derive-default.ts
@@ -52,6 +52,7 @@
  */
 import type { SchemaIntrospector } from './abstract-schema-factory'
 import { mergeDeep } from './merge-deep'
+import { safeAssign } from './safe-assign'
 
 export interface DeriveDefaultContext<Schema> {
   /**
@@ -201,14 +202,20 @@ export function deriveDefaultWalk<Schema>(
   switch (kind) {
     case 'object': {
       const shape = intro.getObjectShape(schema)
-      // Prototype-less default container, matching the rest of the
-      // runtime's value-write pipeline. The default flows directly into
-      // `form.values`; allocating it proto-less here keeps the entire
-      // initial-value tree structurally identical to what `setAtPath`
-      // and `mergeDeep` produce.
-      const out: Record<string, unknown> = Object.create(null)
+      // Default container carries `Object.prototype`. The default
+      // flows directly into `form.values`; matching the rest of the
+      // value-write pipeline keeps the initial tree consistent with
+      // what `setAtPath` and `mergeDeep` produce. Schema field names
+      // can legitimately include `__proto__` (an architecture firm
+      // tracking prototypes; a Zod schema with `z.object({ __proto__: … })`);
+      // `safeAssign` lands such a key as an own data property.
+      const out: Record<string, unknown> = {}
       for (const [key, subSchema] of Object.entries(shape)) {
-        out[key] = deriveDefaultWalk(subSchema, useDefault, intro, maxDepth, ctx, lazyDepth)
+        safeAssign(
+          out,
+          key,
+          deriveDefaultWalk(subSchema, useDefault, intro, maxDepth, ctx, lazyDepth)
+        )
       }
       return out
     }

--- a/test/core/form-public-api-no-null-proto-leak.test.ts
+++ b/test/core/form-public-api-no-null-proto-leak.test.ts
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+/**
+ * Class-of-bug coverage for issue #314 — beyond the SSR snapshot, the
+ * other consumer-facing surfaces (`form.values`, `form.record(path)`,
+ * `form.errors`) also need to carry `Object.prototype` so any
+ * third-party code that calls `.hasOwnProperty()` against them works.
+ *
+ * Vue's reactivity instruments `hasOwnProperty` on its proxies via
+ * `toRaw(this).hasOwnProperty(key)`. With a null-prototype raw target
+ * that call throws the same way `@pinia/nuxt` throws on the SSR
+ * payload. The fix is the same: stop emitting null-prototype objects on
+ * any consumer-observable surface.
+ *
+ * Each adapter (zod v3 + v4) gets the same coverage per
+ * `feedback_zod_v3_v4_parity` — both are first-class peers.
+ */
+import { describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, type App } from 'vue'
+import { z } from 'zod'
+import { z as zV3 } from 'zod-v3'
+import { useForm } from '../../src/zod'
+import { useForm as useFormV3 } from '../../src/zod-v3'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import type { UseFormReturnType } from '../../src/runtime/types/types-api'
+
+type AnyForm = UseFormReturnType<Record<string, unknown>>
+
+const fixtures = {
+  zod: () => {
+    const schema = z.object({
+      email: z.string(),
+      profile: z.object({ name: z.string() }),
+      contacts: z.record(z.string(), z.object({ name: z.string() })),
+    })
+    return {
+      schema,
+      defaults: {
+        email: 'ada@example.com',
+        profile: { name: 'Ada' },
+        contacts: { alice: { name: 'Alice' } },
+      },
+      useForm,
+    }
+  },
+  'zod-v3': () => {
+    const schema = zV3.object({
+      email: zV3.string(),
+      profile: zV3.object({ name: zV3.string() }),
+      contacts: zV3.record(zV3.string(), zV3.object({ name: zV3.string() })),
+    })
+    return {
+      schema,
+      defaults: {
+        email: 'ada@example.com',
+        profile: { name: 'Ada' },
+        contacts: { alice: { name: 'Alice' } },
+      },
+      useForm: useFormV3,
+    }
+  },
+} as const
+
+function mount<T extends ReturnType<(typeof fixtures)[keyof typeof fixtures]>>(
+  fixture: T
+): { app: App; form: AnyForm } {
+  const handle: { form?: AnyForm } = {}
+  const Root = defineComponent({
+    setup() {
+      handle.form = (fixture.useForm as typeof useForm)({
+        schema: fixture.schema as never,
+        key: 'public-api-null-proto-probe',
+        defaultValues: fixture.defaults as never,
+      }) as unknown as AnyForm
+      return () => h('div')
+    },
+  })
+  const app = createApp(Root).use(createAttaform())
+  const root = document.createElement('div')
+  document.body.appendChild(root)
+  app.mount(root)
+  return { app, form: handle.form as AnyForm }
+}
+
+describe('public form surfaces — no null-prototype leak into consumer reads', () => {
+  for (const [adapter, build] of Object.entries(fixtures)) {
+    describe(adapter, () => {
+      it('form.values.hasOwnProperty works at the root', () => {
+        const { app, form } = mount(build())
+        try {
+          // Direct `.hasOwnProperty(...)` is the consumer pattern this
+          // test is guarding against; routing through
+          // `Object.prototype.hasOwnProperty.call` would erase the
+          // regression. Same exemption every site below.
+          // eslint-disable-next-line no-prototype-builtins
+          expect(() => form.values.hasOwnProperty('email')).not.toThrow()
+          // eslint-disable-next-line no-prototype-builtins
+          expect(form.values.hasOwnProperty('email')).toBe(true)
+          // eslint-disable-next-line no-prototype-builtins
+          expect(form.values.hasOwnProperty('nope')).toBe(false)
+        } finally {
+          app.unmount()
+        }
+      })
+
+      it('form.values.hasOwnProperty works on a nested record', () => {
+        const { app, form } = mount(build())
+        try {
+          const profile = (form.values as Record<string, unknown>)['profile'] as Record<
+            string,
+            unknown
+          >
+          // eslint-disable-next-line no-prototype-builtins
+          expect(() => profile.hasOwnProperty('name')).not.toThrow()
+          // eslint-disable-next-line no-prototype-builtins
+          expect(profile.hasOwnProperty('name')).toBe(true)
+        } finally {
+          app.unmount()
+        }
+      })
+
+      it('form.record(path).hasOwnProperty works on the keyed view', () => {
+        const { app, form } = mount(build())
+        try {
+          const view = (
+            form as unknown as { record(path: string): Readonly<Record<string, unknown>> }
+          ).record('contacts')
+          // eslint-disable-next-line no-prototype-builtins
+          expect(() => view.hasOwnProperty('alice')).not.toThrow()
+          // eslint-disable-next-line no-prototype-builtins
+          expect(view.hasOwnProperty('alice')).toBe(true)
+        } finally {
+          app.unmount()
+        }
+      })
+
+      it('form.errors.hasOwnProperty works (regardless of whether a path has errors)', () => {
+        const { app, form } = mount(build())
+        try {
+          expect(() =>
+            // eslint-disable-next-line no-prototype-builtins
+            (form.errors as unknown as Record<string, unknown>).hasOwnProperty('email')
+          ).not.toThrow()
+        } finally {
+          app.unmount()
+        }
+      })
+
+      it('Object.getPrototypeOf(form.record(path)) is Object.prototype', () => {
+        const { app, form } = mount(build())
+        try {
+          const view = (
+            form as unknown as { record(path: string): Readonly<Record<string, unknown>> }
+          ).record('contacts')
+          expect(Object.getPrototypeOf(view)).toBe(Object.prototype)
+        } finally {
+          app.unmount()
+        }
+      })
+    })
+  }
+})

--- a/test/core/merge-deep-prototype-pollution.test.ts
+++ b/test/core/merge-deep-prototype-pollution.test.ts
@@ -71,9 +71,16 @@ describe('mergeDeep proto-less default-value derivation', () => {
     expect(merged.constructor.who).toBe('override-crew')
   })
 
-  it('produces a prototype-less result', () => {
+  it('produces an Object.prototype-backed result that responds to `.hasOwnProperty()`', () => {
     const merged = mergeDeep({ a: 1 }, { b: 2 }) as Record<string, unknown>
-    expect(Object.getPrototypeOf(merged)).toBeNull()
+    expect(Object.getPrototypeOf(merged)).toBe(Object.prototype)
+    // Direct `.hasOwnProperty(...)` is the consumer pattern this test
+    // guards against; routing through `Object.prototype.hasOwnProperty.call`
+    // would erase the regression.
+    // eslint-disable-next-line no-prototype-builtins
+    expect(merged.hasOwnProperty('a')).toBe(true)
+    // eslint-disable-next-line no-prototype-builtins
+    expect(merged.hasOwnProperty('b')).toBe(true)
     expect(merged['a']).toBe(1)
     expect(merged['b']).toBe(2)
   })

--- a/test/core/persistence/proto-pollution.test.ts
+++ b/test/core/persistence/proto-pollution.test.ts
@@ -13,20 +13,16 @@ import { fakeSchema } from '../../utils/fake-schema'
  * own data property by spec; the SSR DU-stub walk (`walkDuStubs`)
  * accepts paths from SSR hydration payloads with the same surface area.
  *
- * The persistence-side defense is now structural: `mergeDeep` allocates
- * its merge target via `Object.create(null)`, so any `out['__proto__']
- * = …` write that the iteration produces is a plain own-property
- * write with no path to `Object.prototype`. Legitimate schema fields
- * named `prototype` / `constructor` / `__proto__` (an architecture
- * firm tracking building prototypes; a construction-management form
- * naming the construction crew; a JS-tooling form that mentions
- * `__proto__` literally) land at the declared path the consumer
- * asked for.
- *
- * The SSR DU-stub walk still uses the SEC-2-era input-rejection guard
- * (`isDangerousSegment`) — the same proto-less treatment is queued
- * as a follow-up PR alongside the rest of the broader sweep. The
- * test below pins the current du-stubs contract until then.
+ * The persistence-side defense routes every untrusted-key write through
+ * `safeAssign`, which uses `Object.defineProperty` for the `__proto__`
+ * key so the write lands as an own data property on a regular
+ * `Object.prototype`-backed target. The result still responds to
+ * `.hasOwnProperty()` / `in` / serializer walkers (issue #314 is the
+ * companion test of this property). Legitimate schema fields named
+ * `prototype` / `constructor` / `__proto__` (an architecture firm
+ * tracking building prototypes; a construction-management form naming
+ * the construction crew; a JS-tooling form that mentions `__proto__`
+ * literally) land at the declared path the consumer asked for.
  */
 
 type Bag = { name: string; nested: { a: string } }
@@ -55,17 +51,17 @@ describe('SEC-2 — persistence hydration merge resists prototype pollution', ()
     // Global cleanliness — the SEC-2 invariant.
     expect(readGlobalProp('polluted')).toBeUndefined()
 
-    // Prototype-less merge target — the structural fix that makes
-    // `out['__proto__'] = …` a plain own-property write. The probe-
-    // probe (`merged['polluted']`) is undefined because the tree's
-    // `__proto__` slot is an own property, not an accessor that walks
-    // into Object.prototype.
-    expect(Object.getPrototypeOf(merged)).toBeNull()
+    // Merge target carries `Object.prototype` so consumer-observable
+    // surfaces work (`.hasOwnProperty` / `in` / serializer walkers).
+    // The `__proto__` own data property shadows the inherited
+    // accessor for reads, so `merged.polluted` doesn't traverse into
+    // the (now untouched) prototype chain.
+    expect(Object.getPrototypeOf(merged)).toBe(Object.prototype)
     expect(merged['polluted']).toBeUndefined()
+    const protoDescriptor = Object.getOwnPropertyDescriptor(merged, '__proto__')
+    expect(protoDescriptor).toBeDefined()
+    expect(protoDescriptor?.value).toEqual({ polluted: 1 })
 
-    // `isPlainRecord` accepts both `proto === null` (Object.create(null))
-    // and `proto === Object.prototype`, so downstream consumers
-    // continue to treat the result as a plain record.
     expect(isPlainRecord(merged)).toBe(true)
 
     // Legit field still merges.
@@ -79,22 +75,22 @@ describe('SEC-2 — persistence hydration merge resists prototype pollution', ()
     // Global cleanliness — the SEC-2 invariant.
     expect(readGlobalProp('polluted')).toBeUndefined()
 
-    // The merge target is prototype-less, so `constructor` lands as
-    // an ordinary own-property pair instead of being silently dropped.
-    // The structural defense still holds because the descended
-    // container is also prototype-less — there is no accessor walk
-    // that reaches Object.prototype.prototype regardless of how deep
-    // the payload nests these key names.
-    expect(Object.getPrototypeOf(merged)).toBeNull()
+    // Result carries `Object.prototype`. The `constructor` /
+    // `prototype` keys land as own data properties that shadow the
+    // inherited slots; subsequent reads stop at the own data and
+    // never traverse into `Object.prototype.constructor.prototype`.
+    expect(Object.getPrototypeOf(merged)).toBe(Object.prototype)
     expect(isPlainRecord(merged)).toBe(true)
+    expect(Object.prototype.hasOwnProperty.call(merged, 'constructor')).toBe(true)
   })
 
   it('SSR DU-stub walk keeps Object.prototype clean despite a __proto__ hydration key', () => {
-    // `walkDuStubs` is now proto-less too: a hostile `__proto__` in
-    // the SSR hydration payload lands as an ordinary own-property
-    // pair on the prototype-less form-value container, and the global
-    // prototype stays untouched. Mirrors the structural defense in
-    // `setAtPath` and the persistence merge.
+    // `walkDuStubs` routes every key write through `safeAssign`: a
+    // hostile `__proto__` in the SSR hydration payload lands as an
+    // own data property on the form-value container, and the global
+    // prototype stays untouched. Container carries `Object.prototype`
+    // so downstream `.hasOwnProperty()` walkers (issue #314 surface)
+    // continue to work.
     const hostile = JSON.parse('{"__proto__":{"polluted":1},"name":"x","nested":{"a":"y"}}')
     const state = createFormStore<Bag>({
       formKey: 'sec2-ssr',
@@ -105,10 +101,7 @@ describe('SEC-2 — persistence hydration merge resists prototype pollution', ()
 
     // The SEC-2 invariant.
     expect(readGlobalProp('polluted')).toBeUndefined()
-    // Prototype-less form-value container — `__proto__` is an own
-    // property at the top level (mirrors what `setValue` would
-    // produce for a legitimate `__proto__` schema field).
-    expect(Object.getPrototypeOf(raw)).toBeNull()
+    expect(Object.getPrototypeOf(raw)).toBe(Object.prototype)
     expect(raw['polluted']).toBeUndefined()
     // Defaults still merged through (name + nested came through SSR
     // alongside the special-key smuggle).

--- a/test/core/runtime-no-null-proto-in-src.test.ts
+++ b/test/core/runtime-no-null-proto-in-src.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Standing diagnostic for issue #314 — `Object.create(null)` must not
+ * reappear inside `src/runtime/` as a defensive idiom.
+ *
+ * The prototype-pollution hardening that landed in PRs #308-310 used
+ * `Object.create(null)` containers as the defense. That idiom leaked
+ * null-prototype objects out through `renderAttaformState`, `form.values`,
+ * `form.record(path)`, and `form.errors`, breaking any third-party
+ * code that called `.hasOwnProperty(...)` (most prominently
+ * `@pinia/nuxt`'s payload reducer, which 500s every SSR page with a
+ * form when both modules are installed).
+ *
+ * The fix swapped every container to a regular `{}` plus a `safeAssign`
+ * helper (`Object.defineProperty` for the `__proto__` key) and
+ * `safeOwnRead` / `safeOwnHas` for untrusted-key reads. After the
+ * sweep, the runtime contains no `Object.create(null)` calls.
+ *
+ * This test fails any PR that reintroduces the idiom — a contributor
+ * tempted to "tighten the defense" by reaching back for null-prototype
+ * gets caught at CI, and the failure message links to this docblock
+ * so the rationale travels with the gate.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const RUNTIME_ROOT = join(__dirname, '..', '..', 'src', 'runtime')
+
+/**
+ * Walk `dir` recursively and yield every `.ts` / `.tsx` file path.
+ * Skips `.d.ts` files (declarations have no runtime allocators).
+ */
+function* walkRuntimeFiles(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry)
+    const stat = statSync(path)
+    if (stat.isDirectory()) {
+      yield* walkRuntimeFiles(path)
+      continue
+    }
+    if (!stat.isFile()) continue
+    if (path.endsWith('.d.ts')) continue
+    if (!path.endsWith('.ts') && !path.endsWith('.tsx')) continue
+    yield path
+  }
+}
+
+/**
+ * Strip block + line comments from `source` so the audit only inspects
+ * runtime expressions. Conservative: a `//` or block-comment token
+ * inside a string literal would also be stripped, but the false-positive
+ * shape (a literal "Object.create(null)" inside a string) doesn't
+ * appear anywhere in the runtime, and would itself be worth flagging.
+ */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '')
+}
+
+describe('src/runtime contains no `Object.create(null)` defensive allocators', () => {
+  it('finds zero call sites across every runtime .ts file', () => {
+    const offenders: string[] = []
+    for (const path of walkRuntimeFiles(RUNTIME_ROOT)) {
+      const stripped = stripComments(readFileSync(path, 'utf8'))
+      if (stripped.includes('Object.create(null)')) {
+        offenders.push(path)
+      }
+    }
+    expect(offenders, offenders.join('\n')).toEqual([])
+  })
+})

--- a/test/core/serialize-no-null-proto-leak.test.ts
+++ b/test/core/serialize-no-null-proto-leak.test.ts
@@ -1,9 +1,4 @@
 // @vitest-environment jsdom
-/* eslint-disable @typescript-eslint/no-unsafe-member-access,
-                  @typescript-eslint/no-unsafe-call -- the
-   pinia-shouldHydrate simulation deliberately invokes
-   `node.hasOwnProperty(...)` on dynamically-typed payload nodes; routing
-   through typed wrappers would erase the regression we're guarding. */
 /**
  * Regression gate for issue #314 — the SSR payload `renderAttaformState`
  * produces must not carry null-prototype objects.
@@ -162,6 +157,156 @@ describe('renderAttaformState — no null-prototype leak into the SSR payload', 
           !shouldHydrate(data) ? 1 : undefined
 
         expect(() => devalueStringify(snapshot, { skipHydrate: skipHydrateReducer })).not.toThrow()
+      })
+
+      it('a deeply-nested null-prototype leaf in `defaultValues` is reparented before reaching the payload', async () => {
+        // Probe: `{ some: { nested: { path: { to: { this: Object.create(null) } } } } }`
+        // — the null-proto sits four levels deep, not at the root.
+        // Schema declares a matching nested shape so the merge has a
+        // chance to walk into the null-proto. We assert the snapshot
+        // is fully safe regardless of where the null-proto appears.
+        const innerNullProto: Record<string, unknown> = Object.create(null)
+        innerNullProto['leaf'] = 'value-at-null-proto-leaf'
+        const innerNullProtoNested: Record<string, unknown> = Object.create(null)
+        innerNullProtoNested['deeper'] = 'value-deeper-at-null-proto'
+        innerNullProto['nested'] = innerNullProtoNested
+
+        const NestedSchema = (
+          fixture.useForm === useForm
+            ? z.object({
+                email: z.string(),
+                some: z.object({
+                  nested: z.object({
+                    path: z.object({
+                      to: z.object({
+                        this: z.object({
+                          leaf: z.string(),
+                          nested: z.object({ deeper: z.string() }),
+                        }),
+                      }),
+                    }),
+                  }),
+                }),
+              })
+            : zV3.object({
+                email: zV3.string(),
+                some: zV3.object({
+                  nested: zV3.object({
+                    path: zV3.object({
+                      to: zV3.object({
+                        this: zV3.object({
+                          leaf: zV3.string(),
+                          nested: zV3.object({ deeper: zV3.string() }),
+                        }),
+                      }),
+                    }),
+                  }),
+                }),
+              })
+        ) as never
+
+        const defaults = {
+          email: 'ada@example.com',
+          some: { nested: { path: { to: { this: innerNullProto } } } },
+        }
+
+        const App = defineComponent({
+          setup() {
+            ;(fixture.useForm as typeof useForm)({
+              schema: NestedSchema,
+              key: 'serialize-null-proto-nested-leaf',
+              defaultValues: defaults as never,
+            })
+            return () => h('div')
+          },
+        })
+        const app = createSSRApp(App).use(createAttaform({ ssr: true }))
+        await renderToString(app)
+        const snapshot = renderAttaformState(app)
+
+        // The walker stands in for any third-party payload walker
+        // (pinia-style or otherwise) — every node must respond.
+        expect(() => probeHasOwnPropertyEverywhere(snapshot)).not.toThrow()
+
+        // Also walk the snapshot and assert every plain-object node
+        // carries `Object.prototype`. This catches the case where a
+        // null-proto leaf is preserved by reference (no copy step) and
+        // would otherwise crash a third-party reducer.
+        const walk = (value: unknown): void => {
+          if (value === null || value === undefined) return
+          if (Array.isArray(value)) {
+            value.forEach(walk)
+            return
+          }
+          if (typeof value !== 'object') return
+          if (Object.prototype.toString.call(value) !== '[object Object]') return
+          expect(Object.getPrototypeOf(value)).toBe(Object.prototype)
+          for (const key of Object.keys(value as Record<string, unknown>)) {
+            walk((value as Record<string, unknown>)[key])
+          }
+        }
+        walk(snapshot)
+      })
+
+      it('a null-prototype value at a stowaway (`z.unknown()`) schema path is reparented before reaching the payload', async () => {
+        // Worst-case probe: the consumer's null-prototype value sits
+        // at a schema path declared as `z.unknown()`, meaning the
+        // merge pipeline has no shape to walk into. The
+        // `mergeStructuralImpl` early-return at this branch (when
+        // `defaultValue` is non-record) would naively pass the
+        // consumer's reference through unchanged — but the downstream
+        // `structuralSnapshot` in `createFormStore` rebuilds every
+        // descendable container as a fresh `Object.prototype`-backed
+        // record, so the null-proto can't survive to the snapshot.
+        const stowaway: Record<string, unknown> = Object.create(null)
+        stowaway['hidden'] = 'value'
+        const nestedStowaway: Record<string, unknown> = Object.create(null)
+        nestedStowaway['x'] = 1
+        stowaway['nested'] = nestedStowaway
+
+        const StowawaySchema = (
+          fixture.useForm === useForm
+            ? z.object({
+                email: z.string(),
+                opaque: z.unknown(),
+              })
+            : zV3.object({
+                email: zV3.string(),
+                opaque: zV3.unknown(),
+              })
+        ) as never
+
+        const stowawayDefaults = { email: 'ada@example.com', opaque: stowaway }
+        const App = defineComponent({
+          setup() {
+            ;(fixture.useForm as typeof useForm)({
+              schema: StowawaySchema,
+              key: 'serialize-null-proto-stowaway',
+              defaultValues: stowawayDefaults as never,
+            })
+            return () => h('div')
+          },
+        })
+        const app = createSSRApp(App).use(createAttaform({ ssr: true }))
+        await renderToString(app)
+        const snapshot = renderAttaformState(app)
+
+        expect(() => probeHasOwnPropertyEverywhere(snapshot)).not.toThrow()
+
+        const walk = (value: unknown): void => {
+          if (value === null || value === undefined) return
+          if (Array.isArray(value)) {
+            value.forEach(walk)
+            return
+          }
+          if (typeof value !== 'object') return
+          if (Object.prototype.toString.call(value) !== '[object Object]') return
+          expect(Object.getPrototypeOf(value)).toBe(Object.prototype)
+          for (const key of Object.keys(value as Record<string, unknown>)) {
+            walk((value as Record<string, unknown>)[key])
+          }
+        }
+        walk(snapshot)
       })
 
       it('a consumer-supplied null-prototype `defaultValues` is reparented before reaching the payload', async () => {

--- a/test/core/serialize-no-null-proto-leak.test.ts
+++ b/test/core/serialize-no-null-proto-leak.test.ts
@@ -1,4 +1,9 @@
 // @vitest-environment jsdom
+/* eslint-disable @typescript-eslint/no-unsafe-member-access,
+                  @typescript-eslint/no-unsafe-call -- the
+   pinia-shouldHydrate simulation deliberately invokes
+   `node.hasOwnProperty(...)` on dynamically-typed payload nodes; routing
+   through typed wrappers would erase the regression we're guarding. */
 /**
  * Regression gate for issue #314 — the SSR payload `renderAttaformState`
  * produces must not carry null-prototype objects.
@@ -30,6 +35,7 @@
  * a future regression that reintroduces null-proto on the snapshot
  * surface gets caught at the same boundary the dogfooder hit.
  */
+import { stringify as devalueStringify } from 'devalue'
 import { describe, expect, it } from 'vitest'
 import { renderToString } from '@vue/server-renderer'
 import { createSSRApp, defineComponent, h } from 'vue'
@@ -125,11 +131,70 @@ describe('renderAttaformState — no null-prototype leak into the SSR payload', 
 
       it('walking the snapshot with hasOwnProperty never throws', async () => {
         const snapshot = await buildSnapshot()
-        // This is the same call shape `@pinia/nuxt`'s `shouldHydrate`
-        // reducer runs against every node of the SSR payload during
-        // devalue serialization — the exact path that 500s in
-        // production. A walker is sufficient here; pulling devalue in
-        // as a devDep just to wrap one call wouldn't add coverage.
+        // Hand-rolled walker for the simple case. Same call shape as
+        // pinia's `shouldHydrate`, fast, no extra dependencies.
+        expect(() => probeHasOwnPropertyEverywhere(snapshot)).not.toThrow()
+      })
+
+      it('round-trips through devalue with a pinia-style `shouldHydrate` reducer', async () => {
+        const snapshot = await buildSnapshot()
+        // Reproduces `@pinia/nuxt`'s payload-plugin shape exactly:
+        // `definePayloadReducer('skipHydrate', (data) => !shouldHydrate(data) && 1)`,
+        // where pinia's `shouldHydrate` does
+        // `!isPlainObject(obj) || !obj.hasOwnProperty(skipHydrateSymbol)`.
+        // devalue invokes this reducer on every node it visits during
+        // `stringify`, so the throw — when it happens — propagates out
+        // of `devalue.stringify` exactly as it propagates out of Nuxt's
+        // payload serialization in production.
+        const skipHydrateSymbol = Symbol.for('pinia:skipHydrate')
+        const isPlainObject = (obj: unknown): obj is Record<string, unknown> =>
+          obj !== null &&
+          typeof obj === 'object' &&
+          Object.prototype.toString.call(obj) === '[object Object]'
+        const shouldHydrate = (obj: unknown): boolean => {
+          if (!isPlainObject(obj)) return true
+          // eslint-disable-next-line no-prototype-builtins
+          return !(obj as Record<string | symbol, unknown>).hasOwnProperty(
+            skipHydrateSymbol as unknown as string
+          )
+        }
+        const skipHydrateReducer = (data: unknown): unknown =>
+          !shouldHydrate(data) ? 1 : undefined
+
+        expect(() => devalueStringify(snapshot, { skipHydrate: skipHydrateReducer })).not.toThrow()
+      })
+
+      it('a consumer-supplied null-prototype `defaultValues` is reparented before reaching the payload', async () => {
+        // Edge case: a consumer who hands attaform a literal
+        // `Object.create(null)` shape (rare, but legal) shouldn't be
+        // able to smuggle a null-prototype object into the SSR
+        // payload through the back door. The merge pipeline
+        // (`mergeStructural` / `mergeDeep` / `structuralSnapshot` /
+        // `applyDuStubs`) all build fresh `Object.prototype`-backed
+        // containers, so this case round-trips safe.
+        const nullProtoDefaults: Record<string, unknown> = Object.create(null)
+        nullProtoDefaults['email'] = 'ada@example.com'
+        const nullProtoProfile: Record<string, unknown> = Object.create(null)
+        nullProtoProfile['name'] = 'Ada'
+        nullProtoProfile['bio'] = 'Engineer'
+        nullProtoDefaults['profile'] = nullProtoProfile
+
+        const App = defineComponent({
+          setup() {
+            ;(fixture.useForm as typeof useForm)({
+              schema: fixture.schema as never,
+              key: 'serialize-null-proto-consumer-edge',
+              defaultValues: nullProtoDefaults as never,
+            })
+            return () => h('div')
+          },
+        })
+        const app = createSSRApp(App).use(createAttaform({ ssr: true }))
+        await renderToString(app)
+        const snapshot = renderAttaformState(app)
+        // The walker assertion stands in for every consumer surface —
+        // the snapshot must be safe even when the consumer's input was
+        // null-prototype.
         expect(() => probeHasOwnPropertyEverywhere(snapshot)).not.toThrow()
       })
 

--- a/test/core/serialize-no-null-proto-leak.test.ts
+++ b/test/core/serialize-no-null-proto-leak.test.ts
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+/**
+ * Regression gate for issue #314 — the SSR payload `renderAttaformState`
+ * produces must not carry null-prototype objects.
+ *
+ * A dogfooder reported that any Nuxt SSR page mounting an attaform form
+ * 500s with `obj.hasOwnProperty is not a function` when `@pinia/nuxt` is
+ * also installed. The crash chain:
+ *
+ *   1. Attaform's Nuxt plugin writes `renderAttaformState(app)` into
+ *      `nuxtApp.payload.attaform` on the `app:rendered` hook.
+ *   2. `@pinia/nuxt` registers a global devalue payload reducer that
+ *      runs `shouldHydrate(node)` on every node of the payload — and
+ *      `shouldHydrate` calls `node.hasOwnProperty(skipHydrateSymbol)`.
+ *   3. The form's `values` object was allocated via `Object.create(null)`
+ *      as part of the prototype-pollution defense (PRs #308-310). A
+ *      null-prototype object has no inherited `hasOwnProperty` method,
+ *      so the reducer's call throws and the SSR pipeline aborts.
+ *
+ * The fix is to keep `Object.prototype` on every container that reaches
+ * a consumer-observable surface, while keeping the prototype-pollution
+ * defense by switching to `safeAssign` (defineProperty for `__proto__`)
+ * paired with spread (which uses `CreateDataProperty`, bypassing the
+ * `__proto__` accessor on a regular target).
+ *
+ * These tests are the standing diagnostic: walk every plain-object node
+ * of the SSR snapshot and call `hasOwnProperty` on it. Pre-fix at least
+ * one node throws. Post-fix every node responds cleanly. The devalue
+ * test exercises the same call path Nuxt's payload serializer uses, so
+ * a future regression that reintroduces null-proto on the snapshot
+ * surface gets caught at the same boundary the dogfooder hit.
+ */
+import { describe, expect, it } from 'vitest'
+import { renderToString } from '@vue/server-renderer'
+import { createSSRApp, defineComponent, h } from 'vue'
+import { z } from 'zod'
+import { z as zV3 } from 'zod-v3'
+import { useForm } from '../../src/zod'
+import { useForm as useFormV3 } from '../../src/zod-v3'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import { renderAttaformState } from '../../src/runtime/core/serialize'
+
+/**
+ * Walk every plain-object node of `value` and call `hasOwnProperty` on
+ * it. Mirrors what a third-party payload walker (`@pinia/nuxt`'s
+ * `shouldHydrate`, a logger, a serializer extension) does when it sees
+ * a payload node. Throws if any node doesn't respond.
+ */
+function probeHasOwnPropertyEverywhere(value: unknown, path: string[] = []): void {
+  if (value === null || value === undefined) return
+  if (Array.isArray(value)) {
+    value.forEach((item, i) => probeHasOwnPropertyEverywhere(item, [...path, String(i)]))
+    return
+  }
+  if (typeof value !== 'object') return
+  const obj = value as Record<string, unknown>
+  // The call site that broke at the dogfooder's app — third-party code
+  // assumes Object.prototype.hasOwnProperty is reachable through the
+  // prototype chain. Switching to `Object.prototype.hasOwnProperty.call`
+  // would erase the regression we're guarding against.
+  // eslint-disable-next-line no-prototype-builtins
+  obj.hasOwnProperty('__probe-symbol-stand-in')
+  for (const key of Object.keys(obj)) {
+    probeHasOwnPropertyEverywhere(obj[key], [...path, key])
+  }
+}
+
+const SCHEMAS = {
+  zod: {
+    useForm,
+    schema: z.object({
+      email: z.string(),
+      profile: z.object({ name: z.string(), bio: z.string() }),
+      tags: z.array(z.string()),
+      contact: z.discriminatedUnion('channel', [
+        z.object({ channel: z.literal('email'), address: z.string() }),
+        z.object({ channel: z.literal('sms'), number: z.string() }),
+      ]),
+    }),
+    defaults: {
+      email: 'ada@example.com',
+      profile: { name: 'Ada', bio: 'Engineer' },
+      tags: ['one', 'two'],
+      contact: { channel: 'email' as const, address: 'ada@example.com' },
+    },
+  },
+  'zod-v3': {
+    useForm: useFormV3,
+    schema: zV3.object({
+      email: zV3.string(),
+      profile: zV3.object({ name: zV3.string(), bio: zV3.string() }),
+      tags: zV3.array(zV3.string()),
+      contact: zV3.discriminatedUnion('channel', [
+        zV3.object({ channel: zV3.literal('email'), address: zV3.string() }),
+        zV3.object({ channel: zV3.literal('sms'), number: zV3.string() }),
+      ]),
+    }),
+    defaults: {
+      email: 'ada@example.com',
+      profile: { name: 'Ada', bio: 'Engineer' },
+      tags: ['one', 'two'],
+      contact: { channel: 'email' as const, address: 'ada@example.com' },
+    },
+  },
+} as const
+
+describe('renderAttaformState — no null-prototype leak into the SSR payload', () => {
+  for (const [adapterName, fixture] of Object.entries(SCHEMAS)) {
+    describe(adapterName, () => {
+      async function buildSnapshot(): Promise<unknown> {
+        const App = defineComponent({
+          setup() {
+            ;(fixture.useForm as typeof useForm)({
+              schema: fixture.schema as never,
+              key: 'serialize-null-proto-probe',
+              defaultValues: fixture.defaults as never,
+            })
+            return () => h('div')
+          },
+        })
+        const app = createSSRApp(App).use(createAttaform({ ssr: true }))
+        await renderToString(app)
+        return renderAttaformState(app)
+      }
+
+      it('walking the snapshot with hasOwnProperty never throws', async () => {
+        const snapshot = await buildSnapshot()
+        // This is the same call shape `@pinia/nuxt`'s `shouldHydrate`
+        // reducer runs against every node of the SSR payload during
+        // devalue serialization — the exact path that 500s in
+        // production. A walker is sufficient here; pulling devalue in
+        // as a devDep just to wrap one call wouldn't add coverage.
+        expect(() => probeHasOwnPropertyEverywhere(snapshot)).not.toThrow()
+      })
+
+      it('every plain-object node in the snapshot has Object.prototype', async () => {
+        const snapshot = await buildSnapshot()
+        const walk = (value: unknown): void => {
+          if (value === null || value === undefined) return
+          if (Array.isArray(value)) {
+            value.forEach(walk)
+            return
+          }
+          if (typeof value !== 'object') return
+          // Tag-check pins "plain object" — we don't want to flag class
+          // instances (Date, RegExp, etc.) that intentionally carry
+          // their own prototype.
+          if (Object.prototype.toString.call(value) !== '[object Object]') return
+          expect(Object.getPrototypeOf(value)).toBe(Object.prototype)
+          for (const key of Object.keys(value as Record<string, unknown>)) {
+            walk((value as Record<string, unknown>)[key])
+          }
+        }
+        walk(snapshot)
+      })
+    })
+  }
+})

--- a/test/core/set-at-path-prototype-pollution.test.ts
+++ b/test/core/set-at-path-prototype-pollution.test.ts
@@ -9,18 +9,22 @@
  * plain `{}` intermediate and the inherited `[[Set]]` accessor
  * reassigns the prototype chain.
  *
- * The fix is the same shape as the errors-proxy and persistence
- * fixes: allocate intermediate containers via `Object.create(null)`
- * so `rec['__proto__'] = …` is a plain own-property write with no
- * path to `Object.prototype`. Legitimate fields literally named
+ * The fix routes every untrusted-key write through `safeAssign`,
+ * which lands the `__proto__` key via `Object.defineProperty`
+ * (own data property, no chain mutation). Intermediate containers
+ * carry `Object.prototype` so the resulting tree responds to
+ * `.hasOwnProperty(...)`, `in`, and devalue / pinia-style payload
+ * walkers; the spread (`{ ...root }`) at each copy-on-write step
+ * uses `CreateDataProperty` per the spec, which bypasses the
+ * inherited `__proto__` setter. Legitimate fields literally named
  * `prototype` / `constructor` / `__proto__` round-trip the same way
- * every other key does, without a guard silently dropping them.
+ * every other key does.
  *
  * Two invariants per case:
  *   1. No pollution — a fresh plain `{}` does NOT inherit any
  *      property the special-key write tried to plant.
  *   2. Positive roundtrip — `getAtPath` reads back the value at the
- *      declared path on the prototype-less result.
+ *      declared path on the result.
  */
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { getAtPath, setAtPath } from '../../src/runtime/core/path-walker'
@@ -71,10 +75,10 @@ describe('setAtPath proto-less intermediates', () => {
 
   it('intermediate copy-on-write preserves a prior __proto__ own property through a sibling write', () => {
     // Sequence: write tree['__proto__']['a'] = 'first', then write
-    // tree['__proto__']['b'] = 'second'. Without the spread carrying
-    // the prior `__proto__` own property through (CopyDataProperties
-    // bypasses the prototype setter), the second write would land in
-    // a fresh container and lose the first value.
+    // tree['__proto__']['b'] = 'second'. The spread at each copy-on-
+    // write step uses `CreateDataProperty`, so the prior `__proto__`
+    // own data property carries through without invoking the inherited
+    // accessor on the new container.
     const step1 = setAtPath({}, ['__proto__', 'a'], 'first')
     const step2 = setAtPath(step1, ['__proto__', 'b'], 'second')
 
@@ -86,26 +90,55 @@ describe('setAtPath proto-less intermediates', () => {
     expect(probe['b']).toBeUndefined()
   })
 
-  it('the resulting tree is prototype-less at every object node', () => {
+  it("the resulting tree's `__proto__` slot is an own data property (shadows the inherited accessor)", () => {
+    // Containers now carry `Object.prototype` so `.hasOwnProperty()` /
+    // `in` / serializer walkers work. The defense lives in the
+    // descriptor at `__proto__`: `safeAssign` installs an own data
+    // property with `configurable: true` so the inherited setter never
+    // fires. Reading `root.__proto__` returns the own value
+    // (`{ y: … }`), not `Object.prototype`.
+    const root = setAtPath({}, ['__proto__', 'y'], { z: 1 }) as Record<string, unknown>
+
+    const descriptor = Object.getOwnPropertyDescriptor(root, '__proto__')
+    expect(descriptor).toBeDefined()
+    expect(descriptor?.value).toBeDefined()
+    expect(descriptor?.enumerable).toBe(true)
+    // Container is a normal `Object.prototype`-backed record — the
+    // own `__proto__` data property shadows the accessor for reads,
+    // but `getPrototypeOf` reports the real chain.
+    expect(Object.getPrototypeOf(root)).toBe(Object.prototype)
+  })
+
+  it('object intermediates carry Object.prototype and respond to `.hasOwnProperty()` / `in`', () => {
     const root = setAtPath({}, ['x', 'y', 'z'], 1) as Record<string, unknown>
 
-    expect(Object.getPrototypeOf(root)).toBeNull()
+    expect(Object.getPrototypeOf(root)).toBe(Object.prototype)
+    // Direct `.hasOwnProperty(...)` calls below are the consumer
+    // pattern this test guards against; routing through
+    // `Object.prototype.hasOwnProperty.call` would erase the regression.
+    // eslint-disable-next-line no-prototype-builtins
+    expect(root.hasOwnProperty('x')).toBe(true)
+    expect('x' in root).toBe(true)
+
     const xNode = root['x'] as Record<string, unknown>
-    expect(Object.getPrototypeOf(xNode)).toBeNull()
+    expect(Object.getPrototypeOf(xNode)).toBe(Object.prototype)
+    // eslint-disable-next-line no-prototype-builtins
+    expect(xNode.hasOwnProperty('y')).toBe(true)
+
     const yNode = xNode['y'] as Record<string, unknown>
-    expect(Object.getPrototypeOf(yNode)).toBeNull()
+    expect(Object.getPrototypeOf(yNode)).toBe(Object.prototype)
+    // eslint-disable-next-line no-prototype-builtins
+    expect(yNode.hasOwnProperty('z')).toBe(true)
   })
 
   it('array intermediates stay as Array instances (unchanged behavior)', () => {
     const root = setAtPath({}, ['items', 0, 'name'], 'first') as Record<string, unknown>
 
-    // Array branch isn't part of the proto-less swap — arrays already
-    // didn't carry a pollution surface.
     const items = root['items']
     expect(Array.isArray(items)).toBe(true)
     const first = (items as Array<Record<string, unknown>>)[0]
     expect(first).toBeDefined()
-    expect(Object.getPrototypeOf(first)).toBeNull()
+    expect(Object.getPrototypeOf(first)).toBe(Object.prototype)
     expect(first?.['name']).toBe('first')
   })
 })

--- a/test/core/structural-snapshot-prototype-pollution.test.ts
+++ b/test/core/structural-snapshot-prototype-pollution.test.ts
@@ -66,13 +66,24 @@ describe('structuralSnapshot proto-less containers', () => {
     expect(probe[SENTINEL]).toBeUndefined()
   })
 
-  it('every snapshot container is prototype-less', () => {
+  it('every snapshot container carries Object.prototype and responds to `.hasOwnProperty()`', () => {
     const source = { a: { b: { c: 1 } } }
     const snap = structuralSnapshot(source) as Record<string, unknown>
 
-    expect(Object.getPrototypeOf(snap)).toBeNull()
-    expect(Object.getPrototypeOf(snap['a'])).toBeNull()
-    expect(Object.getPrototypeOf((snap['a'] as Record<string, unknown>)['b'])).toBeNull()
+    expect(Object.getPrototypeOf(snap)).toBe(Object.prototype)
+    // Direct `.hasOwnProperty(...)` is the consumer pattern this test
+    // guards against; routing through `Object.prototype.hasOwnProperty.call`
+    // would erase the regression.
+    // eslint-disable-next-line no-prototype-builtins
+    expect(snap.hasOwnProperty('a')).toBe(true)
+    const a = snap['a'] as Record<string, unknown>
+    expect(Object.getPrototypeOf(a)).toBe(Object.prototype)
+    // eslint-disable-next-line no-prototype-builtins
+    expect(a.hasOwnProperty('b')).toBe(true)
+    const b = a['b'] as Record<string, unknown>
+    expect(Object.getPrototypeOf(b)).toBe(Object.prototype)
+    // eslint-disable-next-line no-prototype-builtins
+    expect(b.hasOwnProperty('c')).toBe(true)
   })
 
   it('reference identity changes (deep clone is still deep)', () => {


### PR DESCRIPTION
## Why

Closes #314.

A dogfooder hit a hard SSR 500 on every page with an attaform form, in the specific shape of `obj.hasOwnProperty is not a function`. The trigger combination: attaform 0.20 + `@pinia/nuxt`. The chain:

1. Attaform's Nuxt plugin writes `renderAttaformState(app)` into `nuxtApp.payload.attaform` on `app:rendered`.
2. `@pinia/nuxt` registers a global devalue payload reducer that runs `shouldHydrate(node)` on every node of the payload during serialization. `shouldHydrate` calls `node.hasOwnProperty(skipHydrateSymbol)`.
3. The form's value tree was allocated via `Object.create(null)` (the prototype-pollution hardening from PRs #308-310). A null-prototype object has no inherited `hasOwnProperty` method, so the reducer throws and the SSR pipeline aborts.

That same null-proto leak was also latent on `form.values`, `form.record(path)`, and `form.errors` — any third-party walker calling `.hasOwnProperty(...)` against those surfaces would have hit the same fault.

## What ships

A new tiny primitive trio in `src/runtime/core/safe-assign.ts`:

- `safeAssign(target, key, value)` — `Object.defineProperty` for the `__proto__` key (own data property, no chain mutation), plain bracket-assign elsewhere.
- `safeOwnRead(target, key)` — own-data read for `__proto__` via `Object.getOwnPropertyDescriptor`, plain bracket-read elsewhere. Defends against the inherited accessor on regular targets.
- `safeOwnHas(target, key)` — `Object.prototype.hasOwnProperty.call`. Defends against `'__proto__' in target` reporting `true` for every regular object.

Every defensive container in the runtime swaps from `Object.create(null)` to a regular `{}` plus the helpers. Object spread (`{ ...base }`) is safe on `Object.prototype`-backed targets per the spec — `CopyDataProperties` uses `CreateDataProperty`, which bypasses the inherited `__proto__` setter.

| Site | File |
| --- | --- |
| `setAtPath` / `deleteAtPath` / `mergeStructural` | `src/runtime/core/path-walker.ts` |
| `mergeDeep` | `src/runtime/core/merge-deep.ts` |
| `structuralSnapshot` / `applyChangedKeys` | `src/runtime/core/diff-apply.ts` |
| `walkDuStubs` | `src/runtime/core/du-stubs.ts` |
| `walkUnsetSentinels` / `walkUnspecified` / `substitute` | `src/runtime/core/unset-walker.ts` |
| `placeAt` / `materializeErrors` | `src/runtime/core/errors-proxy.ts` |
| `form.record(path)` | `src/runtime/core/build-form-api.ts` |
| `walkDeriveDefault` | `src/runtime/core/walk-derive-default.ts` |
| `mergeSparseHydration` + sensitive-scrub + DU-variant merge + main `mergeDeep` | `src/runtime/core/persistence/index.ts` |
| `writePathImmediately` fallback | `src/runtime/core/persistence/wire-persistence.ts` |
| `cloneVariantSnapshot` | `src/runtime/core/variant-memory.ts` |
| `stripSensitivePathsDeep` | `src/runtime/core/multi-tab-sync.ts` |

The existing prototype-pollution canary tests (`set-at-path-prototype-pollution`, `structural-snapshot-prototype-pollution`, `merge-deep-prototype-pollution`, `persistence/proto-pollution`, `errors-proxy-prototype-pollution`) all stay green — the safety property (`Object.prototype` canary unpolluted, `__proto__` / `prototype` / `constructor` own-data round-trip) is preserved. Their prototype-shape assertions flipped from `getPrototypeOf().toBeNull()` to `=== Object.prototype` + `__proto__` own-data-descriptor checks.

## Verification

Twelve scenarios across both Zod adapters now pin every angle of the bug class:

- **Original repro** (zod-v4 + zod-v3): walk the snapshot calling `.hasOwnProperty()` on every node. Pre-fix throws the exact error from issue #314.
- **Real devalue + pinia-faithful `shouldHydrate`** (both adapters): runs `devalueStringify(snapshot, { skipHydrate: piniaReducer })` where the reducer is a literal recreation of `@pinia/nuxt`'s payload-plugin shape. This is the actual production code path, not a simulation.
- **Every plain-object node carries `Object.prototype`** (both adapters): structural assertion.
- **Top-level null-proto `defaultValues`** (both adapters): consumer hands `Object.create(null)` as the root, stays safe.
- **Deeply-nested null-proto leaf** (both adapters): consumer hands `{ some: { nested: { path: { to: { this: Object.create(null) } } } } }` against a typed schema; the recursive merge walks in via `isPlainRecord` (which accepts both null-proto and `Object.prototype`) and rebuilds.
- **`z.unknown()` stowaway path** (both adapters): the worst case for the merge pipeline — schema declares the path opaque so `mergeStructuralImpl` early-returns the consumer's reference. Coverage is preserved by the downstream `structuralSnapshot` in `createFormStore`, which rebuilds every descendable container before it reaches `state.form.value`.

Plus a **standing diagnostic** at `test/core/runtime-no-null-proto-in-src.test.ts` — fails any future PR that reintroduces `Object.create(null)` anywhere in `src/runtime/`.

Local suite: **3587 passed, 0 failed**, `pnpm typecheck` clean.

## Class-of-bug coverage

`form.values.hasOwnProperty(...)`, `form.record(path).hasOwnProperty(...)`, and the materialized `form.errors` tree are also now safe — verified in `test/core/form-public-api-no-null-proto-leak.test.ts` across both adapters. Per `feedback_zod_v3_v4_parity`, every scenario runs against zod-v3 and zod-v4 as first-class peers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)