### PR TITLE
fix(release): bootstrap the release-pr label on every dispatch

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -71,23 +71,39 @@ jobs:
           # Post a human-readable summary as a PR comment so reviewers see
           # the diff without clicking into the Actions log.
           comment-summary-in-pr: on-failure
-          # License policy — deny copyleft licenses that would legally
-          # contaminate a library published under MIT. Consumers bundle
-          # npm packages statically (via Vite / Webpack / Rollup), so the
-          # "dynamic linking" exception that usually makes LGPL OK for
-          # *applications* does NOT apply here — LGPL contamination in a
-          # bundled JS library is equivalent to GPL. Hence LGPL is on the
-          # deny list too. SPDX 3.0+ deprecated the suffix-less forms
-          # (`GPL-3.0`, `AGPL-3.0`, etc.); only the `-only` / `-or-later`
-          # variants are listed.
+          # License policy: allowlist of permissive (plus MPL-2.0 weak
+          # copyleft) SPDX identifiers safe to bundle into an MIT-licensed
+          # library. Any PR-introduced dependency with a license not on
+          # this list fails the check. The action upstream deprecated the
+          # `deny-licenses` blocklist option (issue 997) because blocklists
+          # are unbounded: new copyleft and commercial-restrictive licenses
+          # keep appearing, and a missed entry silently passes. The
+          # permissive set is finite, explicit, and reviewable.
+          #
+          # Strong copyleft (GPL, AGPL, LGPL) is intentionally omitted.
+          # npm consumers bundle packages statically (via Vite, Webpack,
+          # Rollup), so the LGPL dynamic-linking exception that usually
+          # makes LGPL safe for applications does NOT apply to bundled JS.
+          # MPL-2.0 stays in: its copyleft is file-scoped, not derivative-
+          # work-scoped, so it does not contaminate the bundle.
+          #
           # Consumers' own license audits remain their responsibility;
           # this is a belt-and-braces check at dependency-introduction time.
-          deny-licenses: >-
-            AGPL-1.0-only, AGPL-1.0-or-later,
-            AGPL-3.0-only, AGPL-3.0-or-later,
-            GPL-1.0-only, GPL-1.0-or-later,
-            GPL-2.0-only, GPL-2.0-or-later,
-            GPL-3.0-only, GPL-3.0-or-later,
-            LGPL-2.0-only, LGPL-2.0-or-later,
-            LGPL-2.1-only, LGPL-2.1-or-later,
-            LGPL-3.0-only, LGPL-3.0-or-later
+          allow-licenses: >-
+            0BSD,
+            Apache-2.0,
+            BSD-2-Clause,
+            BSD-3-Clause,
+            BlueOak-1.0.0,
+            CC-BY-3.0,
+            CC-BY-4.0,
+            CC0-1.0,
+            ISC,
+            MIT,
+            MIT-0,
+            MPL-2.0,
+            PostgreSQL,
+            Python-2.0,
+            Unlicense,
+            WTFPL,
+            Zlib

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -394,6 +394,23 @@ jobs:
           '
           echo "PR_BODY_PATH=$RUNNER_TEMP/pr-body.md" >> "$GITHUB_ENV"
 
+      - name: Ensure release-pr label exists
+        # `gh pr create --label` rejects unknown labels with
+        # `could not add label: 'release-pr' not found`, which would
+        # require a one-time `gh label create` against the repo before
+        # the workflow could open its first PR. `--force` makes this
+        # idempotent: first run creates, every run after no-op-updates
+        # color + description. Self-bootstrapping the label keeps the
+        # workflow free of out-of-repo prerequisites.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh label create release-pr \
+            --description "Mechanical version-bump PR opened by release-pr.yml" \
+            --color 0E8A16 \
+            --force
+
       - name: Open release PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Context

First dispatch of `release-pr.yml` post-merge failed at the `Open release PR` step:

```
could not add label: 'release-pr' not found
Error: Process completed with exit code 1.
```

`gh pr create --label` rejects unknown labels, and the repo did not have a `release-pr` label yet. The workflow assumed it would be set up out-of-band.

## Fix

Add an `Ensure release-pr label exists` step ahead of `Open release PR`:

```yaml
gh label create release-pr \
  --description "Mechanical version-bump PR opened by release-pr.yml" \
  --color 0E8A16 \
  --force
```

`--force` makes it idempotent: first dispatch creates the label, every dispatch after no-op-updates the color and description. The workflow now self-bootstraps with no out-of-repo prerequisites, matching the `feedback_no_one_time_fixes` standing-diagnostic shape.

## Also folded in

`actions/dependency-review-action` upstream deprecated the `deny-licenses` blocklist (issue 997) in favor of allowlists. Switched `.github/workflows/dependency-review.yml` to `allow-licenses` with the permissive (plus MPL-2.0 weak-copyleft) SPDX set safe to bundle into an MIT-licensed library. Strong copyleft (GPL, AGPL, LGPL) stays out; the action's check is PR-diff scoped, so the two existing prod-graph outliers (LGPL `sharp-libvips`, Unknown `vaul-vue`) survive unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)