### PR TITLE
feat(release): adopt an existing release branch via tree-hash byte-match

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -221,34 +221,6 @@ jobs:
           fi
           echo "dist_tag=$TAG" >> "$GITHUB_OUTPUT"
 
-      - name: Re-dispatch detection
-        # If `release/v<version>` already exists on origin, the prior
-        # dispatch either:
-        #   (a) succeeded and the PR is still open → noop, link the PR
-        #   (b) succeeded, the PR was closed/merged → stale branch needs
-        #       manual cleanup, fail with explicit guidance
-        # Without this check, the `git push origin release/v<version>`
-        # step below would fail with a non-fast-forward error and leave
-        # an unactionable error in the log.
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NEXT_VERSION: ${{ steps.calculate-next-version.outputs.next_version }}
-          GH_REPOSITORY: ${{ github.repository }}
-          GH_SERVER_URL: ${{ github.server_url }}
-        run: |
-          set -euo pipefail
-          BRANCH="release/v$NEXT_VERSION"
-          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
-            PR_NUMBER=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
-            if [ -n "$PR_NUMBER" ]; then
-              PR_URL="${GH_SERVER_URL}/${GH_REPOSITORY}/pull/${PR_NUMBER}"
-              echo "::notice title=Release PR already open::PR #$PR_NUMBER for $BRANCH is open at $PR_URL — nothing to do."
-              exit 0
-            fi
-            echo "::error::Branch '$BRANCH' exists on origin but no open PR is associated. Either reopen the closed PR, or clean up the stale branch with: gh api -X DELETE repos/${GH_REPOSITORY}/git/refs/heads/${BRANCH}"
-            exit 1
-          fi
-
       - name: Configure git identity
         # github-actions[bot] attribution. When the PR is squash-merged,
         # the resulting commit on main is web-flow signed by GitHub
@@ -329,7 +301,92 @@ jobs:
           git diff --cached --name-only | sort -u
           git commit -m "chore(release): v${NEXT_VERSION}" -m "Bumps the package to v${NEXT_VERSION} with \`publishConfig.tag=${DIST_TAG}\`. Promotes the CHANGELOG Unreleased section and prepends a RELEASES.md entry. When merged, \`publish-npm.yml\` runs an idempotent precheck and publishes \`attaform@${NEXT_VERSION}\` to npm under the \`${DIST_TAG}\` dist-tag."
 
+      - name: Classify dispatch state
+        id: classify
+        # The bump steps above always produce a local `release/v<version>`
+        # branch with the bump commit. This step inspects the matching
+        # state on origin and decides what to do with the local result:
+        #
+        #   (1) No branch on origin.
+        #         mode=fresh. Push the local branch, open the PR.
+        #   (2) Branch on origin + open PR.
+        #         mode=noop. The prior dispatch already landed everything;
+        #         discard the local bump.
+        #   (3) Branch on origin + no PR + remote tree == local tree.
+        #         mode=adopt. The remote branch is byte-identical to what
+        #         this run just produced (same files, same contents, same
+        #         modes), so it is the artifact of a prior dispatch that
+        #         died before opening the PR. Skip the push, open the
+        #         missing PR against the existing remote branch.
+        #   (4) Branch on origin + no PR + remote tree != local tree.
+        #         Fail with a tree-diff dump. Either a stale branch from
+        #         an abandoned attempt, or a hand-pushed branch with
+        #         contents the workflow did not produce. The user makes
+        #         the call (delete vs. investigate). Refusing adoption
+        #         here is the defense: a malicious actor with write
+        #         access cannot pre-stage `release/v<next>` with a
+        #         backdoored tree and wait for the workflow to merge and
+        #         publish it.
+        #
+        # Tree-hash equality (`git rev-parse <ref>^{tree}`) is the
+        # byte-identity check. Two refs with the same tree SHA are
+        # guaranteed identical for every file, file mode, and directory
+        # structure they contain (git's content-addressed storage gives
+        # us this for free). Commit metadata (author, timestamps, parent)
+        # is NOT in the tree object, so author-email forgery cannot fake
+        # a tree match.
+        #
+        # Adoption requires the bump steps to be deterministic across
+        # dispatches. `pnpm version` + `promote-changelog.mjs` already
+        # are; `generate-release-notes.mjs` uses HEAD's committer date
+        # (not `new Date()`) so RELEASES.md is also deterministic for a
+        # given target_branch HEAD. If the auto-notes API response varies
+        # between runs (PR title edited, label changed), adoption fails
+        # closed; the user cleans up and re-dispatches.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEXT_VERSION: ${{ steps.calculate-next-version.outputs.next_version }}
+          GH_REPOSITORY: ${{ github.repository }}
+          GH_SERVER_URL: ${{ github.server_url }}
+        run: |
+          set -euo pipefail
+          BRANCH="release/v$NEXT_VERSION"
+
+          if ! git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "mode=fresh" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Fresh dispatch::$BRANCH does not exist on origin; pushing the local bump and opening the PR."
+            exit 0
+          fi
+
+          PR_NUMBER=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+          if [ -n "$PR_NUMBER" ]; then
+            PR_URL="${GH_SERVER_URL}/${GH_REPOSITORY}/pull/${PR_NUMBER}"
+            echo "mode=noop" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Release PR already open::PR #$PR_NUMBER for $BRANCH is open at $PR_URL; discarding local bump and exiting."
+            exit 0
+          fi
+
+          git fetch --depth=1 origin "$BRANCH"
+          LOCAL_TREE=$(git rev-parse HEAD^{tree})
+          REMOTE_TREE=$(git rev-parse FETCH_HEAD^{tree})
+
+          if [ "$LOCAL_TREE" = "$REMOTE_TREE" ]; then
+            echo "mode=adopt" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Adopting existing branch::$BRANCH already has the byte-identical bump on origin (tree=$LOCAL_TREE) but no open PR; skipping push, opening the missing PR."
+            exit 0
+          fi
+
+          {
+            echo "::error::Branch '$BRANCH' exists on origin but its tree ($REMOTE_TREE) does not byte-match what this run just produced ($LOCAL_TREE)."
+            echo "::error::Diff (local HEAD vs. origin/$BRANCH):"
+            git --no-pager diff --stat HEAD FETCH_HEAD 2>&1 | sed 's/^/::error::  /' || true
+            echo "::error::Either a stale branch from an abandoned attempt, or a hand-pushed branch with contents this workflow did not produce."
+            echo "::error::Clean up the branch via the GitHub Branches UI (trash icon on '$BRANCH') and re-dispatch, or investigate the divergence."
+          }
+          exit 1
+
       - name: Push release branch
+        if: steps.classify.outputs.mode == 'fresh'
         env:
           NEXT_VERSION: ${{ steps.calculate-next-version.outputs.next_version }}
         run: |
@@ -337,6 +394,7 @@ jobs:
           git push origin "release/v$NEXT_VERSION"
 
       - name: Build PR body
+        if: steps.classify.outputs.mode != 'noop'
         # Build the PR body to a file via Node (no shell interpolation)
         # rather than a heredoc with dispatch-input interpolation —
         # eliminates the template-injection footprint that a heredoc
@@ -395,6 +453,7 @@ jobs:
           echo "PR_BODY_PATH=$RUNNER_TEMP/pr-body.md" >> "$GITHUB_ENV"
 
       - name: Ensure release-pr label exists
+        if: steps.classify.outputs.mode != 'noop'
         # `gh pr create --label` rejects unknown labels with
         # `could not add label: 'release-pr' not found`, which would
         # require a one-time `gh label create` against the repo before
@@ -412,6 +471,7 @@ jobs:
             --force
 
       - name: Open release PR
+        if: steps.classify.outputs.mode != 'noop'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEXT_VERSION: ${{ steps.calculate-next-version.outputs.next_version }}

--- a/scripts/generate-release-notes.mjs
+++ b/scripts/generate-release-notes.mjs
@@ -155,7 +155,30 @@ function main() {
     return
   }
 
-  const date = new Date().toISOString().slice(0, 10)
+  // HEAD committer date rather than `new Date()` so the release entry
+  // is deterministic across dispatches for a given target_branch HEAD.
+  // release-pr.yml's `Classify dispatch state` step byte-matches the
+  // local bump against any existing `release/v<version>` on origin
+  // (tree-hash equality); an entry date that drifted day-to-day would
+  // break the adoption recovery loop on dispatches that happen on a
+  // different calendar day than the first attempt. HEAD here is
+  // target_branch's tip — `pnpm version --no-git-tag-version` has not
+  // yet created the bump commit.
+  let date
+  try {
+    date = execFileSync('git', ['log', '-1', '--pretty=%cI', 'HEAD'], {
+      encoding: 'utf8',
+    })
+      .trim()
+      .slice(0, 10)
+  } catch (err) {
+    warn(`git log HEAD date lookup failed: ${String(err)}`)
+    return
+  }
+  if (date === '') {
+    warn('git log HEAD date returned empty; skipping')
+    return
+  }
   const entry = `## ${newTag} — ${date}\n\n${body}\n\n---\n\n`
 
   const releasesPath = resolve(repoRoot, 'RELEASES.md')


### PR DESCRIPTION
## What this changes

Restructures `release-pr.yml` so the bump steps run locally first, then a new `Classify dispatch state` step compares the local result against any existing `release/v<version>` on origin and emits a `mode` output:

| Remote state | mode | Behavior |
|---|---|---|
| No branch | `fresh` | Push the local bump, open the PR (current flow) |
| Branch + open PR | `noop` | Discard the local bump, exit cleanly (current flow) |
| Branch + no PR + remote tree == local tree | `adopt` | Skip push, open the missing PR against the existing remote branch |
| Branch + no PR + tree mismatch | _(fail)_ | Exit 1 with a tree-diff dump |

The `Push release branch` step now gates on `mode == 'fresh'`. `Build PR body` / `Ensure release-pr label exists` / `Open release PR` gate on `mode != 'noop'` so they run on both `fresh` and `adopt`.

## Why

A prior dispatch can die between \"push the branch\" and \"open the PR\" (label missing, \"Allow Actions to create PRs\" org-disabled, etc.). Today, the only recovery is: delete the orphan branch via the GitHub UI, then re-dispatch. This PR turns that two-step recovery into a one-step re-dispatch: the workflow recognises its own half-completed work and finishes it.

## Security

Adoption requires byte-identity via tree-hash equality (\`git rev-parse <ref>^{tree}\`). Two refs with the same tree SHA are guaranteed identical for every file, content, and mode they contain; commit metadata (author, timestamps, parent) is **not** in the tree object, so author-email forgery cannot fake a match.

This closes the defense-in-depth gap where an actor with repo write access could pre-stage \`release/v<next>\` with a backdoored tree and wait for the workflow to adopt + merge + publish it. The author-email check that an earlier draft used would have been forgeable; tree-hash equality is not.

## Determinism fix

For the byte-match to survive a re-dispatch on a different calendar day, the bump must be deterministic. \`scripts/generate-release-notes.mjs\` previously used \`new Date()\` for the RELEASES.md entry header, which drifted day-to-day. It now uses HEAD's committer date (\`git log -1 --pretty=%cI HEAD\`), so the same \`target_branch\` HEAD produces the same RELEASES.md bytes regardless of when the dispatch runs.

If the auto-notes API response itself varies between runs (PR title edited, label changed), adoption fails closed and the user cleans up manually. That's the intended failure mode: byte-match takes priority over smooth recovery.

## Verification

- [x] YAML syntax valid (\`python3 -c \"import yaml; yaml.safe_load(open(...))\"\`)
- [x] zizmor lint clean (\`zizmor .github/workflows/release-pr.yml\` reports no new findings)
- [ ] End-to-end: on next release dispatch, log line should read \`mode=fresh\` and the flow should match the current path

End-to-end verification of the adopt path itself defers until either a future dispatch happens to hit a half-completed state, or we synthesise one for testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)