### PR TITLE
fix(release): differentiate 404 from real branch existence in classify step

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -435,13 +435,33 @@ jobs:
           # `.git/config`; `gh api` uses the explicit `GH_TOKEN` env
           # binding instead, which keeps the credential out of the
           # working tree (zizmor `artipacked` rule).
-          BRANCH_INFO=$(gh api "repos/$GH_REPOSITORY/branches/$BRANCH" 2>/dev/null || true)
+          #
+          # `gh api -i` includes the HTTP status line in stdout. Parse
+          # the status explicitly rather than treating any non-empty
+          # output as "branch exists" — on a 404 the response body is
+          # an error JSON (not an empty string), so an `[ -z "$body" ]`
+          # check would misclassify "absent" as "orphan".
+          set +e
+          RAW=$(gh api -i "repos/$GH_REPOSITORY/branches/$BRANCH" 2>/dev/null)
+          set -e
+          HTTP_STATUS=$(echo "$RAW" | head -n1 | awk '{print $2}')
 
-          if [ -z "$BRANCH_INFO" ]; then
-            echo "mode=fresh" >> "$GITHUB_OUTPUT"
-            echo "::notice title=Fresh dispatch::$BRANCH does not exist on origin; creating the branch + signed bump commit via createCommitOnBranch and opening the PR."
-            exit 0
-          fi
+          case "${HTTP_STATUS:-}" in
+            200)
+              # Branch exists. Continue to PR / orphan classification.
+              BRANCH_BODY=$(echo "$RAW" | awk 'body{print} /^\r?$/{body=1}')
+              ;;
+            404)
+              echo "mode=fresh" >> "$GITHUB_OUTPUT"
+              echo "::notice title=Fresh dispatch::$BRANCH does not exist on origin; creating the branch + signed bump commit via createCommitOnBranch and opening the PR."
+              exit 0
+              ;;
+            *)
+              echo "::error::Unexpected HTTP status checking branch existence: ${HTTP_STATUS:-(no response)}"
+              echo "$RAW"
+              exit 1
+              ;;
+          esac
 
           PR_NUMBER=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
           if [ -n "$PR_NUMBER" ]; then
@@ -457,7 +477,7 @@ jobs:
           # commit object reachable via `refs/pull/<n>/head`, so the
           # audit trail of the prior attempt is preserved even with
           # the branch ref gone.
-          ORPHAN_SHA=$(echo "$BRANCH_INFO" | jq -r .commit.sha)
+          ORPHAN_SHA=$(echo "$BRANCH_BODY" | jq -r .commit.sha)
           echo "::notice title=Cleaning up orphan branch::$BRANCH exists on origin (sha=$ORPHAN_SHA) without an open PR; deleting before re-creating with a fresh signed bump commit."
           gh api -X DELETE "repos/$GH_REPOSITORY/git/refs/heads/$BRANCH"
           echo "mode=fresh" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Fix the Classify step's 404 misclassification

The Classify step in `release-pr.yml` was treating a 404 response from
`gh api repos/.../branches/<name>` as if the branch existed. On a
404, `gh api` writes the error JSON body to stdout (the actual
response body, not an empty string), so the `[ -z "$BRANCH_INFO" ]`
check was false and the workflow took the orphan-cleanup path even
when the branch was genuinely absent.

### Observed failure

Run [26699940187](https://github.com/attaform/Attaform/actions/runs/26699940187)
dispatched against a clean origin (no `release/v0.20.1` branch):

```
::notice::release/v0.20.1 exists on origin (sha=null) without an
open PR; deleting before re-creating with a fresh signed bump commit.
::error::Process completed with exit code 1.
```

The `sha=null` is the smoking gun — the response body was the 404
error JSON, so `jq .commit.sha` returned `null`, and the subsequent
`gh api -X DELETE` 404'd because the branch genuinely did not exist.

### Fix

Switch to `gh api -i` (HTTP status line included in stdout) and parse
the status code explicitly. Three-branch case statement:

- `200`: branch exists; extract body via `awk 'body{print} /^\r?$/{body=1}'`
  (skip past the header/body separator) and continue to the PR /
  orphan classification logic.
- `404`: branch does not exist; emit `mode=fresh` and exit.
- anything else: bail loudly with the raw response. The old code
  would have silently misclassified a real transient (rate limit,
  auth, 5xx) as "branch absent"; this surfaces it.

### Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-pr.yml'))"` → OK
- `zizmor --persona auditor .github/workflows/release-pr.yml` → `No findings to report`
- Body-extraction awk smoke-tested locally against `gh api -i repos/.../branches/main` → returns the real commit SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)
