### PR TITLE
fix(directive): unify consumer assigner fire-time contract

### DIFF
--- a/docs/binding-inputs/custom-assigners.md
+++ b/docs/binding-inputs/custom-assigners.md
@@ -70,10 +70,10 @@ type CustomDirectiveRegisterAssignerFn = (
 ) => boolean | undefined
 ```
 
-| Arg             | Use                                                                                                                                                                                               |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `value`         | What the directive extracted from the event. May be `undefined` when the assigner reads its own state.                                                                                            |
-| `registerValue` | The `RegisterValue` for the current binding. Call `rv.setValueWithInternalPath(v)` to commit a write. Omitted when installed via `el[assignKey] = fn`; the installer already has the RV in scope. |
+| Arg             | Use                                                                                                                                                                                                                                                   |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `value`         | What the directive extracted from the event, post-transforms and post-coerce. May be `undefined` when the assigner reads its own state.                                                                                                               |
+| `registerValue` | The `RegisterValue` for the current binding. Call `rv.setValueWithInternalPath(v)` to commit a write. Supplied by the directive on every fire regardless of install path, so the assigner doesn't have to capture the RV via closure at install time. |
 
 Return `true` to signal the write was accepted, `false` to reject. `undefined` is treated as success, so simple assigners can `return` nothing.
 

--- a/src/runtime/core/directive.ts
+++ b/src/runtime/core/directive.ts
@@ -158,6 +158,64 @@ function isDefaultAssigner(fn: unknown): boolean {
 }
 
 /**
+ * Symbol-tagged on wrappers `getModelAssigner` produces for the
+ * `@update:registerValue` install path. The tag lets `fireAssigner`
+ * recognize an already-wrapped consumer handler and call it raw
+ * (the wrapper already runs transforms + coerce + supplies `rv`).
+ * Without the tag, fire-time would re-wrap and apply transforms
+ * twice for that install path.
+ */
+const CONSUMER_WRAPPED_TAG: unique symbol = Symbol.for('attaform:consumer-wrapped-assigner')
+
+type ConsumerWrappedCarrier = { [CONSUMER_WRAPPED_TAG]?: boolean }
+
+function isConsumerWrapped(fn: unknown): boolean {
+  return typeof fn === 'function' && (fn as ConsumerWrappedCarrier)[CONSUMER_WRAPPED_TAG] === true
+}
+
+/**
+ * Fire-time entry point for invoking whatever currently sits at
+ * `el[assignKey]`. Replaces direct `el[assignKey]?.(value)` calls so
+ * the directive's two consumer-install paths produce the same fire-
+ * time contract:
+ *
+ *   - `@update:registerValue` (vnode-prop listener): wrapped at
+ *     `created`-time by `getModelAssigner`, tagged with
+ *     `CONSUMER_WRAPPED_TAG`. Called raw here — its own body runs
+ *     `runTransforms` + `applyCoerce` and supplies `rv` to the user
+ *     handler.
+ *   - `el[assignKey] = fn` (pre- or post-install via companion
+ *     directive / `onMounted` / ref-callback): raw consumer fn,
+ *     untagged. JIT-wrapped here so the user sees the same
+ *     `(post-transform-post-coerce value, rv)` shape.
+ *
+ * The default-tagged sentinel runs its own pipeline internally and is
+ * also called raw. A `registerValue` that isn't a `RegisterValue`
+ * (e.g. `useRegister` returned `undefined` AND a consumer pre-
+ * installed an assigner before `setAssignFunction` would have
+ * installed the noop) falls through with `(value, undefined)` —
+ * defensive; the documented happy path always has a real `rv`.
+ */
+function fireAssigner(
+  el: HTMLElement & { [k: symbol]: CustomDirectiveRegisterAssignerFn },
+  registerValue: unknown,
+  value: unknown
+): boolean | undefined {
+  const fn = el[assignKey]
+  if (fn === undefined) return undefined
+  if (isDefaultAssigner(fn) || isConsumerWrapped(fn)) {
+    return fn(value)
+  }
+  if (!isRegisterValue(registerValue)) {
+    return fn(value, undefined)
+  }
+  const r = runTransforms(value, registerValue)
+  if (!r.ok) return false
+  const coerced = applyCoerce(r.value, registerValue)
+  return fn(coerced, registerValue)
+}
+
+/**
  * Listener-body bail. Called at the top of every event handler the
  * directive attaches. Bails when:
  *  - the rendered root is a non-supported tag (where `el.value` is
@@ -330,7 +388,7 @@ const getModelAssigner = (
     vnode.props?.['onUpdate:registerValue'] ?? vnode.props?.['on:update:registerValue']
   if (isArray(fn)) {
     const fnArr = fn.filter((x) => isFunction(x)) as ((...args: unknown[]) => unknown)[]
-    return (value) => {
+    const wrapped: CustomDirectiveRegisterAssignerFn = (value) => {
       // Transforms run BEFORE the override sees the value. A consumer
       // who declared `transforms: [...]` intended "always normalize"; a
       // silent bypass on override would be the surprise. If they want
@@ -345,18 +403,22 @@ const getModelAssigner = (
       invokeArrayFns(fnArr, coerced, registerValue)
       // Multi-listener case: no single boolean to surface. Return
       // undefined so the listener treats this as "succeeded" — matches
-      // the back-compat contract for consumer-installed assigners.
+      // the contract for single-handler consumer assigners.
       return undefined
     }
+    ;(wrapped as unknown as ConsumerWrappedCarrier)[CONSUMER_WRAPPED_TAG] = true
+    return wrapped
   }
   if (isFunction(fn)) {
     const handler = fn as CustomDirectiveRegisterAssignerFn
-    return (value) => {
+    const wrapped: CustomDirectiveRegisterAssignerFn = (value) => {
       const r = runTransforms(value, registerValue)
       if (!r.ok) return false
       const coerced = applyCoerce(r.value, registerValue)
       return handler(coerced, registerValue)
     }
+    ;(wrapped as unknown as ConsumerWrappedCarrier)[CONSUMER_WRAPPED_TAG] = true
+    return wrapped
   }
   // Default-installed assigner. Tagged so the listener-body bail
   // (`shouldBailListener`) can distinguish it from consumer overrides
@@ -596,7 +658,7 @@ const vRegisterText: RegisterTextCustomDirective = {
       }
       const commit =
         domValue === '' && isRegisterValue(value) && value.acceptsUndefined ? undefined : domValue
-      el[assignKey]?.(commit)
+      fireAssigner(el, value, commit)
       // After the default assigner runs, force-sync the DOM when
       // storage diverges from the post-cast/post-trim `domValue`.
       // Two cases produce no Vue re-render and so leave the
@@ -654,7 +716,7 @@ const vRegisterText: RegisterTextCustomDirective = {
             // handler.
             if (isRegisterValue(value)) writeLastTypedForm(value, null)
             el.value = String(cast)
-            if (lazy !== true) el[assignKey]?.(cast)
+            if (lazy !== true) fireAssigner(el, value, cast)
           } else {
             // Uncastable mid-edit residue (lone '.', '-', 'abc') OR
             // overflow (`1e309` parses to Infinity). Native
@@ -681,7 +743,7 @@ const vRegisterText: RegisterTextCustomDirective = {
         // `change`) already wrote the trimmed value, so this branch
         // skips to avoid a redundant duplicate write.
         if (trim === true && lazy !== true) {
-          el[assignKey]?.(normalized)
+          fireAssigner(el, value, normalized)
         }
       })
     }
@@ -806,7 +868,6 @@ const vRegisterCheckbox: RegisterCheckboxCustomDirective = {
       const rawElementValue = getValue(el, explicitValueRequired)
 
       const checked = el.checked
-      const assign = el[assignKey]
       if (isArray(modelValue)) {
         if (rawElementValue === undefined) {
           warn(
@@ -829,11 +890,11 @@ const vRegisterCheckbox: RegisterCheckboxCustomDirective = {
         const index = looseIndexOf(modelValue, elementValue)
         const found = index !== -1
         if (checked && !found) {
-          assign?.(modelValue.concat(elementValue))
+          fireAssigner(el, value, modelValue.concat(elementValue))
         } else if (!checked && found) {
           const filtered = [...modelValue]
           filtered.splice(index, 1)
-          assign?.(filtered)
+          fireAssigner(el, value, filtered)
         }
       } else if (isSet(modelValue)) {
         if (rawElementValue === undefined) {
@@ -855,9 +916,9 @@ const vRegisterCheckbox: RegisterCheckboxCustomDirective = {
         } else {
           cloned.delete(elementValue)
         }
-        assign?.(cloned)
+        fireAssigner(el, value, cloned)
       } else {
-        assign?.(getCheckboxValue(el, checked))
+        fireAssigner(el, value, getCheckboxValue(el, checked))
       }
       // After the default assigner runs, force-sync `el.checked` to
       // current storage. Catches the no-op-write case: a transform
@@ -954,7 +1015,7 @@ const vRegisterRadio: RegisterRadioCustomDirective = {
     addTrackedListener(el, 'change', () => {
       if (shouldBailListener(el)) return
       noteInteraction(value)
-      el[assignKey]?.(getValue(el))
+      fireAssigner(el, value, getValue(el))
       // After the default assigner runs, force-sync `el.checked` to
       // current storage. Catches the no-op-write case where a
       // transform maps the click's value to current storage — no
@@ -1020,7 +1081,9 @@ const vRegisterSelect: RegisterSelectCustomDirective = {
       const selectedVal = Array.prototype.filter
         .call(el.options, (o: HTMLOptionElement) => o.selected)
         .map((o: HTMLOptionElement) => (number === true ? looseToNumber(getValue(o)) : getValue(o)))
-      const wrote = el[assignKey]?.(
+      const wrote = fireAssigner(
+        el,
+        value,
         el.multiple ? (isSetModel ? new Set(selectedVal) : selectedVal) : selectedVal[0]
       )
       // Only set `_assigning` when the write actually landed. A

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -2329,9 +2329,9 @@ export type InternalRegisterValue<Value = unknown> = RegisterValue<Value> & {
  * on the bound element.
  *
  * The directive passes the extracted value plus the `RegisterValue`
- * the directive is currently bound to. The second arg lets a
- * top-level handler write back to form state without having to
- * capture the RV via closure:
+ * the directive is currently bound to, regardless of install path.
+ * The second arg lets a top-level handler write back to form state
+ * without having to capture the RV via closure:
  *
  * ```ts
  * function upperCaseAssigner(value: unknown, rv: RegisterValue): void {
@@ -2339,9 +2339,10 @@ export type InternalRegisterValue<Value = unknown> = RegisterValue<Value> & {
  * }
  * ```
  *
- * `registerValue` is omitted only for assigners installed directly
- * via `el[assignKey] = fn` — those callers already have the RV in
- * scope at install time.
+ * The `registerValue` parameter is typed optional only to keep
+ * standalone invocations from outside the directive (rare; manual
+ * dispatch in tests, for example) type-checkable; the directive
+ * itself always supplies it at fire time.
  *
  * Return `true` when the write was accepted, `false` when it was
  * rejected (e.g. the value didn't match the path's expected type).

--- a/test/core/custom-assigner-fire-time-contract.test.ts
+++ b/test/core/custom-assigner-fire-time-contract.test.ts
@@ -1,0 +1,197 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, onMounted, ref, withDirectives, type App } from 'vue'
+import { z } from 'zod'
+import { useForm, type UseFormReturn } from '../../src/zod'
+import { assignKey, vRegister } from '../../src/runtime/core/directive'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import type {
+  CustomDirectiveRegisterAssignerFn,
+  RegisterValue,
+} from '../../src/runtime/types/types-api'
+import { waitUntil } from '../utils/form-harness'
+
+/**
+ * Fire-time contract for consumer-supplied assigners.
+ *
+ * The library exposes two install paths for an assigner override:
+ *   1. `@update:registerValue` vnode-prop listener — wrapped at
+ *      `created`-time by `getModelAssigner`.
+ *   2. `el[assignKey] = fn` symbol assignment — installed pre- (a
+ *      companion directive ordered first) or post- (`onMounted` /
+ *      ref-callback).
+ *
+ * Both paths must hand the consumer's function the SAME fire-time
+ * arg shape: `(post-transform-post-coerce value, registerValue)`. The
+ * second arg is what `/demos/custom-assigners` relies on to commit
+ * `rv.setValueWithInternalPath(el.dataset.color)`.
+ *
+ * Pre-fix, the directive bodies invoked the symbol-installed fn with
+ * one argument and without running the field's transform pipeline or
+ * coerce closure. The two paths diverged silently.
+ */
+describe('fire-time contract: consumer-installed assigner sees (value, rv) consistently', () => {
+  let app: App | undefined
+  let root: HTMLElement | undefined
+
+  afterEach(() => {
+    app?.unmount()
+    app = undefined
+    if (root?.parentNode) {
+      root.parentNode.removeChild(root)
+    }
+    root = undefined
+    document.body.innerHTML = ''
+  })
+
+  it('mirrors the custom-assigners demo: dataset write + input dispatch commits via rv.setValueWithInternalPath', async () => {
+    const demoSchema = z.object({ color: z.string() })
+    let capturedApi: UseFormReturn<typeof demoSchema> | undefined
+    let widgetEl: HTMLDivElement | undefined
+
+    const Parent = defineComponent({
+      setup() {
+        const api = useForm({
+          schema: demoSchema,
+          defaultValues: { color: '#2563eb' },
+          key: `assigner-demo-${Math.random().toString(36).slice(2)}`,
+        })
+        capturedApi = api
+        const widget = ref<HTMLDivElement | null>(null)
+
+        const colorAssigner: CustomDirectiveRegisterAssignerFn = (_value, rv) => {
+          const el = widget.value
+          if (!el || !rv) return false
+          rv.setValueWithInternalPath(el.dataset['color'] ?? '')
+          return true
+        }
+
+        onMounted(() => {
+          const el = widget.value
+          if (el === null) return
+          widgetEl = el
+          ;(el as HTMLDivElement & { [k: symbol]: CustomDirectiveRegisterAssignerFn })[assignKey] =
+            colorAssigner
+        })
+
+        return () =>
+          withDirectives(h('div', { ref: widget, 'data-color': api.values['color'] }), [
+            [vRegister, api.register('color')],
+          ])
+      },
+    })
+
+    app = createApp(Parent).use(createAttaform())
+    root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await waitUntil(() => (widgetEl !== undefined ? true : null))
+
+    if (widgetEl === undefined) throw new Error('widget element never resolved')
+    if (capturedApi === undefined) throw new Error('api never captured')
+
+    widgetEl.dataset['color'] = '#16a34a'
+    widgetEl.dispatchEvent(new Event('input', { bubbles: true }))
+
+    await waitUntil(() => (capturedApi?.values['color'] === '#16a34a' ? true : null), 200)
+    expect(capturedApi.values['color']).toBe('#16a34a')
+  })
+
+  it('the assigner receives the bound RegisterValue at the second argument', async () => {
+    const schema = z.object({ name: z.string() })
+    const calls: { value: unknown; rv: unknown }[] = []
+    let widgetEl: HTMLDivElement | undefined
+
+    const Parent = defineComponent({
+      setup() {
+        const api = useForm({
+          schema,
+          key: `assigner-rv-${Math.random().toString(36).slice(2)}`,
+        })
+        const widget = ref<HTMLDivElement | null>(null)
+
+        const recordingAssigner: CustomDirectiveRegisterAssignerFn = (value, rv) => {
+          calls.push({ value, rv })
+          return true
+        }
+
+        onMounted(() => {
+          const el = widget.value
+          if (el === null) return
+          widgetEl = el
+          ;(el as HTMLDivElement & { [k: symbol]: CustomDirectiveRegisterAssignerFn })[assignKey] =
+            recordingAssigner
+        })
+
+        return () => withDirectives(h('div', { ref: widget }), [[vRegister, api.register('name')]])
+      },
+    })
+
+    app = createApp(Parent).use(createAttaform())
+    root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await waitUntil(() => (widgetEl !== undefined ? true : null))
+
+    if (widgetEl === undefined) throw new Error('widget element never resolved')
+
+    widgetEl.dispatchEvent(new Event('input', { bubbles: true }))
+    await waitUntil(() => (calls.length >= 1 ? true : null), 200)
+
+    expect(calls.length).toBeGreaterThanOrEqual(1)
+    const rv = calls[0]?.rv as Partial<RegisterValue> | undefined
+    expect(typeof rv?.setValueWithInternalPath).toBe('function')
+    expect(rv?.path).toBeDefined()
+    expect(rv?.innerRef).toBeDefined()
+  })
+
+  it('field transforms run before a consumer-installed assigner sees the value', async () => {
+    const schema = z.object({ name: z.string() })
+    const calls: unknown[] = []
+    let inputEl: HTMLInputElement | undefined
+
+    const Parent = defineComponent({
+      setup() {
+        const api = useForm({
+          schema,
+          key: `assigner-transforms-${Math.random().toString(36).slice(2)}`,
+        })
+        const input = ref<HTMLInputElement | null>(null)
+
+        const recordingAssigner: CustomDirectiveRegisterAssignerFn = (value) => {
+          calls.push(value)
+          return true
+        }
+
+        onMounted(() => {
+          const el = input.value
+          if (el === null) return
+          inputEl = el
+          ;(el as HTMLInputElement & { [k: symbol]: CustomDirectiveRegisterAssignerFn })[
+            assignKey
+          ] = recordingAssigner
+        })
+
+        return () =>
+          withDirectives(h('input', { type: 'text', ref: input }), [
+            [vRegister, api.register('name', { transforms: [(v) => String(v).toUpperCase()] })],
+          ])
+      },
+    })
+
+    app = createApp(Parent).use(createAttaform())
+    root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await waitUntil(() => (inputEl !== undefined ? true : null))
+
+    if (inputEl === undefined) throw new Error('input element never resolved')
+
+    inputEl.value = 'hi'
+    inputEl.dispatchEvent(new Event('input', { bubbles: true }))
+    await waitUntil(() => (calls.length >= 1 ? true : null), 200)
+
+    expect(calls.length).toBeGreaterThanOrEqual(1)
+    expect(calls[0]).toBe('HI')
+  })
+})


### PR DESCRIPTION
## What

The directive exposed two install paths for a consumer assigner override that silently produced different runtime contracts:

1. `@update:registerValue` vnode-prop listener (wrapped at `created`-time by `getModelAssigner`)
2. `el[assignKey] = fn` symbol assignment (raw consumer fn, no wrap)

Three divergences:

1. `rv` was supplied to the consumer fn on the vnode-prop path but **dropped** on the symbol path. `/demos/custom-assigners` relied on it to commit via `rv.setValueWithInternalPath`, which is why the demo's color swatches did not write to `form.values.color`.
2. Field `transforms` ran on the vnode-prop path but were **bypassed** on the symbol path.
3. The coerce closure ran on the vnode-prop path but was **bypassed** on the symbol path.

## How

One architectural seam: a new `fireAssigner` helper that replaces the eight direct `el[assignKey]?.(value)` call sites. It distinguishes assigner provenance via two symbol tags:

- `DEFAULT_ASSIGNER_TAG` (already present) — the directive's own default
- `CONSUMER_WRAPPED_TAG` (new) — wrappers stamped by `getModelAssigner`

Tagged fns are called raw (they already run the pipeline internally). Untagged consumer fns (symbol pre-install) get JIT-wrapped at fire time so the user sees the same `(post-transform-post-coerce value, rv)` shape on both paths.

## Tests

Three red-green test cases in `test/core/custom-assigner-fire-time-contract.test.ts`:

- Demo gesture mirror — dataset write + input dispatch commits via `rv.setValueWithInternalPath`
- Assigner receives the bound `RegisterValue` at arg 2 across install paths
- Transforms run before a consumer-installed assigner sees the value (`'hi'` → `'HI'`)

All three were red on `main`, green after the fix. Full suite stays at 3607 passing.

## Docs

`docs/binding-inputs/custom-assigners.md` and the `CustomDirectiveRegisterAssignerFn` docstring drop the now-incorrect "omitted when installed via `el[assignKey] = fn`" claim. The second arg is supplied on every fire regardless of install path.

## Verified

User confirmed the fix works on localhost: `/demos/custom-assigners` color swatches now update `form.values.color` as documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)