### PR TITLE
test(perf): cut test-suite execution time by ~27%

### DIFF
--- a/test/composables/api-surface-contract.test.ts
+++ b/test/composables/api-surface-contract.test.ts
@@ -439,7 +439,7 @@ describe('multi-tab sync — BroadcastChannel', () => {
   it('inbound sensitive-path REJECTION — hostile sibling cannot inject a `password` write', async () => {
     const { hashStableString } = await import('../../src/runtime/core/hash')
     const { fingerprintZodSchema } = await import('../../src/runtime/adapters/zod-v4/fingerprint')
-    const { wait } = await import('../utils/form-harness')
+    const { waitUntil } = await import('../utils/form-harness')
     const { z: zod } = await import('zod')
 
     const secretSchema = zod.object({
@@ -484,8 +484,11 @@ describe('multi-tab sync — BroadcastChannel', () => {
       blankPathsAdded: [],
       blankPathsRemoved: [],
     })
-    await wait(100)
-    // `password` was filtered; `name` (non-sensitive) was applied.
+    // The non-sensitive `name` patch is the delivery signal: once it
+    // lands, the hostile `password` patch has also been processed by
+    // the same listener invocation. Asserting on the negative arm
+    // becomes a true post-delivery check.
+    await waitUntil(() => (api.values.name === 'name-ok' ? true : null))
     expect(api.values.password).toBe('')
     expect(api.values.name).toBe('name-ok')
 
@@ -778,8 +781,9 @@ describe('multi-tab sync — BroadcastChannel', () => {
     await waitUntil(() => (api.values.name === 'from-tab-B' ? true : null), 500)
 
     // Persistence listener skipped on crossTab apply — the sentinel
-    // we set above is untouched.
-    await wait(100)
+    // we set above is untouched. Sleep ~3x the configured debounceMs
+    // (5 ms above) so any in-flight write would have fired by now.
+    await wait(15)
     expect(localStorage.getItem(persistKey)).toBe(sentinel)
 
     external.close()
@@ -801,7 +805,7 @@ describe('multi-tab sync — BroadcastChannel', () => {
     const { hashStableString } = await import('../../src/runtime/core/hash')
     const { fingerprintZodSchema } = await import('../../src/runtime/adapters/zod-v4/fingerprint')
     const { DEFAULT_SENSITIVE_NAMES } = await import('../../src/index')
-    const { wait } = await import('../utils/form-harness')
+    const { waitUntil } = await import('../utils/form-harness')
     const { z: zod } = await import('zod')
 
     const medSchema = zod.object({ name: zod.string(), mrn: zod.string() })
@@ -843,7 +847,11 @@ describe('multi-tab sync — BroadcastChannel', () => {
       blankPathsAdded: [],
       blankPathsRemoved: [],
     })
-    await wait(100)
+    // The non-sensitive `name` patch is the delivery signal: once it
+    // lands, the sensitive `mrn` patch has also been processed by the
+    // same listener invocation. Asserting on the negative arm becomes
+    // a true post-delivery check.
+    await waitUntil(() => (api.values.name === 'Alice' ? true : null))
     // Custom global sensitiveNames added `'mrn'` → filtered. `name`
     // passes through.
     expect(api.values.mrn).toBe('')

--- a/test/composables/api-surface-contract.test.ts
+++ b/test/composables/api-surface-contract.test.ts
@@ -341,7 +341,7 @@ describe('multi-tab sync — BroadcastChannel', () => {
   it('echo drop: own outbound messages do NOT mutate own state on receive', async () => {
     const { hashStableString } = await import('../../src/runtime/core/hash')
     const { fingerprintZodSchema } = await import('../../src/runtime/adapters/zod-v4/fingerprint')
-    const { wait } = await import('../utils/form-harness')
+    const { waitUntil } = await import('../utils/form-harness')
 
     const formKey = `b19-echo-${Math.random().toString(36).slice(2)}`
     const channelName = `attaform:sync:${formKey}:${hashStableString(fingerprintZodSchema(schema))}`
@@ -388,7 +388,20 @@ describe('multi-tab sync — BroadcastChannel', () => {
       blankPathsAdded: [],
       blankPathsRemoved: [],
     })
-    await wait(100)
+    // Sentinel: a non-echo patch on a different path. BC delivers
+    // FIFO per channel, so once the sentinel lands, the prior echo
+    // message has already been processed (and dropped) by the same
+    // listener invocation. The assertion below is a true post-delivery
+    // check, not a "we waited some time and nothing changed" guess.
+    external.postMessage({
+      v: 1,
+      kind: 'patches',
+      senderId: 'sentinel-tab',
+      formPatches: [{ kind: 'changed', path: ['email'], oldValue: '', newValue: 'sentinel@x.io' }],
+      blankPathsAdded: [],
+      blankPathsRemoved: [],
+    })
+    await waitUntil(() => (api.values.email === 'sentinel@x.io' ? true : null))
     expect(api.values.name).toBe('')
 
     external.close()
@@ -398,7 +411,7 @@ describe('multi-tab sync — BroadcastChannel', () => {
   it('protocol-version drop: messages with unknown `v` are ignored', async () => {
     const { hashStableString } = await import('../../src/runtime/core/hash')
     const { fingerprintZodSchema } = await import('../../src/runtime/adapters/zod-v4/fingerprint')
-    const { wait } = await import('../utils/form-harness')
+    const { waitUntil } = await import('../utils/form-harness')
 
     const formKey = `b19-vdrop-${Math.random().toString(36).slice(2)}`
     const channelName = `attaform:sync:${formKey}:${hashStableString(fingerprintZodSchema(schema))}`
@@ -429,7 +442,17 @@ describe('multi-tab sync — BroadcastChannel', () => {
       blankPathsAdded: [],
       blankPathsRemoved: [],
     })
-    await wait(100)
+    // Sentinel: a current-version patch on a different path. Once it
+    // lands, the v: 999 message has already been processed (and dropped).
+    external.postMessage({
+      v: 1,
+      kind: 'patches',
+      senderId: 'sentinel-tab',
+      formPatches: [{ kind: 'changed', path: ['email'], oldValue: '', newValue: 'sentinel@x.io' }],
+      blankPathsAdded: [],
+      blankPathsRemoved: [],
+    })
+    await waitUntil(() => (api.values.email === 'sentinel@x.io' ? true : null))
     expect(api.values.name).toBe('')
 
     external.close()
@@ -499,7 +522,7 @@ describe('multi-tab sync — BroadcastChannel', () => {
   it('inbound prototype-pollution defense — patch with `__proto__` segment rejected', async () => {
     const { hashStableString } = await import('../../src/runtime/core/hash')
     const { fingerprintZodSchema } = await import('../../src/runtime/adapters/zod-v4/fingerprint')
-    const { wait } = await import('../utils/form-harness')
+    const { waitUntil } = await import('../utils/form-harness')
 
     const formKey = `b19-proto-${Math.random().toString(36).slice(2)}`
     const channelName = `attaform:sync:${formKey}:${hashStableString(fingerprintZodSchema(schema))}`
@@ -518,6 +541,7 @@ describe('multi-tab sync — BroadcastChannel', () => {
     })
     const app = createApp(App).use(createAttaform())
     app.mount(document.createElement('div'))
+    const api = handle.api as Api
     await waitForSyncEstablished(app, formKey)
 
     const external = new BroadcastChannel(channelName)
@@ -529,7 +553,18 @@ describe('multi-tab sync — BroadcastChannel', () => {
       blankPathsAdded: [],
       blankPathsRemoved: [],
     })
-    await wait(100)
+    // Sentinel: a clean patch on a normal path. Once it lands, the
+    // __proto__ patch has been processed (and dropped) by the same
+    // listener invocation.
+    external.postMessage({
+      v: 1,
+      kind: 'patches',
+      senderId: 'sentinel-tab',
+      formPatches: [{ kind: 'changed', path: ['email'], oldValue: '', newValue: 'sentinel@x.io' }],
+      blankPathsAdded: [],
+      blankPathsRemoved: [],
+    })
+    await waitUntil(() => (api.values.email === 'sentinel@x.io' ? true : null))
     expect((Object.prototype as Record<string, unknown>)['polluted']).toBeUndefined()
 
     external.close()
@@ -540,7 +575,7 @@ describe('multi-tab sync — BroadcastChannel', () => {
     const { hashStableString } = await import('../../src/runtime/core/hash')
     const { fingerprintZodSchema } = await import('../../src/runtime/adapters/zod-v4/fingerprint')
     const { MULTI_TAB_SYNC_MODULE_KEY } = await import('../../src/runtime/core/multi-tab-sync')
-    const { wait } = await import('../utils/form-harness')
+    const { waitUntil } = await import('../utils/form-harness')
 
     const formKey = `b19-form-off-${Math.random().toString(36).slice(2)}`
     const channelName = `attaform:sync:${formKey}:${hashStableString(fingerprintZodSchema(schema))}`
@@ -568,6 +603,15 @@ describe('multi-tab sync — BroadcastChannel', () => {
     expect(state).toBeDefined()
     expect(state!.modules.has(MULTI_TAB_SYNC_MODULE_KEY)).toBe(false)
 
+    // The form has no sync listener, so we can't observe delivery
+    // through it. Stand up a separate BroadcastChannel as a delivery
+    // witness: when it sees the message, the channel has demonstrably
+    // delivered, and the form's unchanged state is a true assertion.
+    const observer = new BroadcastChannel(channelName)
+    let observerReceived = 0
+    observer.onmessage = (): void => {
+      observerReceived += 1
+    }
     const external = new BroadcastChannel(channelName)
     external.postMessage({
       v: 1,
@@ -577,9 +621,10 @@ describe('multi-tab sync — BroadcastChannel', () => {
       blankPathsAdded: [],
       blankPathsRemoved: [],
     })
-    await wait(100)
+    await waitUntil(() => (observerReceived > 0 ? true : null))
     expect(api.values.name).toBe('')
 
+    observer.close()
     external.close()
     app.unmount()
   })
@@ -588,7 +633,7 @@ describe('multi-tab sync — BroadcastChannel', () => {
     const { hashStableString } = await import('../../src/runtime/core/hash')
     const { fingerprintZodSchema } = await import('../../src/runtime/adapters/zod-v4/fingerprint')
     const { MULTI_TAB_SYNC_MODULE_KEY } = await import('../../src/runtime/core/multi-tab-sync')
-    const { wait } = await import('../utils/form-harness')
+    const { waitUntil } = await import('../utils/form-harness')
 
     const formKey = `b19-insecure-${Math.random().toString(36).slice(2)}`
     const channelName = `attaform:sync:${formKey}:${hashStableString(fingerprintZodSchema(schema))}`
@@ -619,6 +664,15 @@ describe('multi-tab sync — BroadcastChannel', () => {
       expect(state).toBeDefined()
       expect(state!.modules.has(MULTI_TAB_SYNC_MODULE_KEY)).toBe(false)
 
+      // Same delivery-witness pattern as the multiTab:false test:
+      // the form has no listener here either (secure-context gate
+      // suppressed the sync module), so we observe through a separate
+      // channel.
+      const observer = new BroadcastChannel(channelName)
+      let observerReceived = 0
+      observer.onmessage = (): void => {
+        observerReceived += 1
+      }
       const external = new BroadcastChannel(channelName)
       external.postMessage({
         v: 1,
@@ -630,9 +684,10 @@ describe('multi-tab sync — BroadcastChannel', () => {
         blankPathsAdded: [],
         blankPathsRemoved: [],
       })
-      await wait(100)
+      await waitUntil(() => (observerReceived > 0 ? true : null))
       expect(api.values.name).toBe('')
 
+      observer.close()
       external.close()
       app.unmount()
     } finally {
@@ -646,7 +701,7 @@ describe('multi-tab sync — BroadcastChannel', () => {
     const { vRegister } = await import('../../src/runtime/core/directive')
     const { MULTI_TAB_SYNC_MODULE_KEY } = await import('../../src/runtime/core/multi-tab-sync')
     const { withDirectives } = await import('vue')
-    const { wait, waitUntil } = await import('../utils/form-harness')
+    const { waitUntil } = await import('../utils/form-harness')
 
     const formKey = `b19-reg-off-${Math.random().toString(36).slice(2)}`
     const channelName = `attaform:sync:${formKey}:${hashStableString(fingerprintZodSchema(schema))}`
@@ -699,7 +754,10 @@ describe('multi-tab sync — BroadcastChannel', () => {
       blankPathsAdded: [],
       blankPathsRemoved: [],
     })
-    await wait(50)
+    // The `email` patch is the delivery signal: once it lands, the
+    // hostile `name` patch in the same message has been processed by
+    // the same listener invocation.
+    await waitUntil(() => (api.values.email === 'a@b.co' ? true : null))
     // `name` was opted out of sync via the register call → rejected.
     expect(api.values.name).toBe('')
     // `email` rode the form-level default (multiTab on) → applied.

--- a/test/composables/coerce.test.ts
+++ b/test/composables/coerce.test.ts
@@ -19,7 +19,7 @@ import type { UseFormConfigV4, UseFormReturnV4 } from '../../src/zod'
 import { vRegister, isRegisterValue, assignKey } from '../../src/runtime/core/directive'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import { defineCoercion, defaultCoercionRules } from '../../src/runtime/core/schema-coerce'
-import { waitUntil } from '../utils/form-harness'
+import { awaitSettle, waitUntil } from '../utils/form-harness'
 
 let app: App | undefined
 afterEach(() => {
@@ -438,8 +438,9 @@ describe('checkbox with true-value / false-value — composes with coerce', () =
     const cb = root.querySelector('[data-field="cb"]') as HTMLInputElement
     cb.checked = true
     cb.dispatchEvent(new Event('change', { bubbles: true }))
-    // The gate rejects, so the value won't change. Wait for the post-tick state.
-    await waitUntil(() => (cb.checked === true ? true : null))
+    // The gate rejects, so the value won't change. Settle the cycle so
+    // any write that would have fired has had its chance.
+    await awaitSettle()
     // 'yes' isn't 'true'/'false' post-trim+lowercase → coerce passes
     // through → gate rejects → state preserves the original `false`.
     expect(api.values.accepted).toBe(false)
@@ -484,8 +485,9 @@ describe('NaN passthrough + gate rejection', () => {
     const input = root.querySelector('[data-field="age"]') as HTMLInputElement
     input.value = 'abc'
     input.dispatchEvent(new Event('input', { bubbles: true }))
-    // Gate rejects; wait for post-input tick to settle.
-    await waitUntil(() => (input.value === 'abc' ? true : null))
+    // Gate rejects; settle the cycle so any write that would have
+    // fired has had its chance.
+    await awaitSettle()
     // 'abc' is non-coercible; coerce passes through; gate rejects.
     expect(api.values.age).toBe(5)
   })
@@ -498,8 +500,9 @@ describe('programmatic write bypass', () => {
     const { api } = mount(schema, { age: 0 }, () => h('div'))
     await waitUntil(() => (api.values.age === 0 ? true : null))
     api.setValue('age', '25' as unknown as number)
-    // Gate rejects; the value should remain 0. Wait briefly for any tick.
-    await waitUntil(() => (api.values.age === 0 ? true : null))
+    // Gate rejects; the value should remain 0. Settle the cycle so any
+    // tick-scheduled write has had its chance.
+    await awaitSettle()
     // Coerce only fires on directive-driven writes. Programmatic
     // writes go through the slim gate untouched, which rejects.
     expect(api.values.age).toBe(0)
@@ -525,8 +528,9 @@ describe('plugin-default off', () => {
     const input = root.querySelector('[data-field="age"]') as HTMLInputElement
     input.value = '25'
     input.dispatchEvent(new Event('input', { bubbles: true }))
-    // Gate rejects; wait for the input event to be processed.
-    await waitUntil(() => (input.value === '25' ? true : null))
+    // Gate rejects; settle the cycle so any write that would have
+    // fired has had its chance.
+    await awaitSettle()
     // Coerce off → string write rejected by gate; state unchanged.
     expect(api.values.age).toBe(0)
   })
@@ -594,8 +598,9 @@ describe('per-form override beats plugin default (both directions)', () => {
     const input = root.querySelector('[data-field="age"]') as HTMLInputElement
     input.value = '25'
     input.dispatchEvent(new Event('input', { bubbles: true }))
-    // Gate rejects; wait for input event to settle.
-    await waitUntil(() => (input.value === '25' ? true : null))
+    // Gate rejects; settle the cycle so any write that would have
+    // fired has had its chance.
+    await awaitSettle()
     expect(handle.api.values.age).toBe(0)
   })
 })

--- a/test/composables/du-variant-error-regressions.test.ts
+++ b/test/composables/du-variant-error-regressions.test.ts
@@ -196,9 +196,13 @@ describe('DU variant switch — error materialisation regressions', () => {
     // entry itself should not survive the re-validation either, or
     // `form.meta.errors` will leak it).
     api.setValue('notify.channel', 'sms')
+    // Wait for the new variant's leaf error (notify.number) to land —
+    // that's the positive signal the re-validation pass has completed.
+    // A predicate on `errs === undefined` would never resolve because
+    // the active-path filter returns `[]`, not undefined.
     await waitUntil(() => {
-      const errs = (api.errors as unknown as (p: string) => ValidationError[])('notify.address')
-      return errs === undefined ? true : null
+      const errs = (api.errors as unknown as (p: string) => ValidationError[])('notify.number')
+      return errs?.[0]?.code?.startsWith('zod:') ? true : null
     })
 
     // The stale leaf entry must NOT show up anywhere — not in the

--- a/test/composables/file.test.ts
+++ b/test/composables/file.test.ts
@@ -321,7 +321,12 @@ describe('<input type="file" v-register> — persistence carve-out', () => {
     textInput.value = 'release notes'
     textInput.dispatchEvent(new Event('input', { bubbles: true }))
 
-    await waitUntil(() => (localStorage.getItem('file-persist-test') !== null ? true : null), 200)
+    // The persisted key has a schema-hash suffix (`file-persist-test:<hash>`),
+    // so a bare `getItem('file-persist-test')` predicate would burn the
+    // full ceiling waiting for an exact key that is never written.
+    await waitUntil(() => {
+      return Object.keys(localStorage).some((k) => k.startsWith('file-persist-test:')) ? true : null
+    }, 200)
 
     const raw = Object.keys(localStorage).find((k) => k.startsWith('file-persist-test:'))
     expect(raw).toBeDefined()

--- a/test/composables/persistence.test.ts
+++ b/test/composables/persistence.test.ts
@@ -701,8 +701,10 @@ describe('persistence — per-element opt-in', () => {
     apps.push(app)
 
     handle.api?.setValue('email', 'leak@example.com')
-    // Generous wait — debounce is 20 ms, so 80 ms covers timer + drain.
-    await wait(80)
+    // 1.5x the 20 ms debounce — any in-flight write would have fired
+    // and reached localStorage by now; the waitUntil that follows is
+    // an extra defensive poll, not a long pessimistic ceiling.
+    await wait(30)
     await waitUntil(() => (localStorage.getItem(fpKey('test-noop')) === null ? true : null))
     expect(localStorage.getItem(fpKey('test-noop'))).toBeNull()
   })
@@ -744,7 +746,9 @@ describe('persistence — per-element opt-in', () => {
     const input = handle.el as HTMLInputElement
     input.value = 'no-opt-in@example.com'
     input.dispatchEvent(new Event('input', { bubbles: true }))
-    await wait(80)
+    // 1.5x the 20 ms debounce — any in-flight write would have fired
+    // by now.
+    await wait(30)
     await waitUntil(() => (localStorage.getItem(fpKey('test-no-flag')) === null ? true : null))
     expect(localStorage.getItem(fpKey('test-no-flag'))).toBeNull()
     // Sanity: the value still landed in the form ref (writes work, just
@@ -799,7 +803,9 @@ describe('persistence — per-element opt-in', () => {
     const b = handle.b as HTMLInputElement
     b.value = 'from-b@example.com'
     b.dispatchEvent(new Event('input', { bubbles: true }))
-    await wait(80)
+    // 1.5x the 20 ms debounce — any in-flight write would have fired
+    // by now.
+    await wait(30)
     await waitUntil(() => (localStorage.getItem(fpKey('test-mixed')) === null ? true : null))
     expect(localStorage.getItem(fpKey('test-mixed'))).toBeNull()
 

--- a/test/composables/persistence.test.ts
+++ b/test/composables/persistence.test.ts
@@ -1385,6 +1385,12 @@ describe('persistence — shorthand config', () => {
     // generates a unique formKey, so the resolved storage key is unique
     // per test and we read back via the same scheme. Fake timers step
     // the default 300 ms debounce window in virtual time.
+    //
+    // Pre-warm the local-storage adapter module before swapping to
+    // fake timers — `getStorageAdapter('local')` does a dynamic import
+    // on first call, which runs in real time and can't be advanced.
+    // Subsequent calls hit the module cache.
+    await import('../../src/runtime/core/persistence/local-storage')
     vi.useFakeTimers()
     try {
       const handle: { api?: ApiReturn; el?: HTMLInputElement } = {}
@@ -1473,8 +1479,11 @@ describe('persistence — shorthand config', () => {
       const el = handle.el as HTMLInputElement
       el.value = 'custom@example.com'
       el.dispatchEvent(new Event('input', { bubbles: true }))
-      // Step past the 300 ms default debounce window.
+      // Step past the 300 ms default debounce window, then drain the
+      // adapter chain's microtasks so the awaited setItem has actually
+      // committed to storage by the time we read it.
       await vi.advanceTimersByTimeAsync(310)
+      await vi.runAllTimersAsync()
       expect(writes.length).toBeGreaterThan(0)
       const [writtenKey, writtenValue] = writes[writes.length - 1]!
       expect(writtenKey).toBe(`attaform:${formKey}:${FP}`)

--- a/test/composables/persistence.test.ts
+++ b/test/composables/persistence.test.ts
@@ -1383,93 +1383,106 @@ describe('persistence — shorthand config', () => {
   it("persist: 'local' (string shorthand) writes to localStorage with default key", async () => {
     // The default key is `attaform:${formKey}` — mountForm
     // generates a unique formKey, so the resolved storage key is unique
-    // per test and we read back via the same scheme.
-    const handle: { api?: ApiReturn; el?: HTMLInputElement } = {}
-    const formKey = `shorthand-${Math.random().toString(36).slice(2)}`
-    const App = defineComponent({
-      setup() {
-        const api = useForm({ schema, key: formKey, persist: 'local' })
-        handle.api = api
-        return () =>
-          h(
-            'div',
-            withDirectives(
-              h('input', {
-                type: 'text',
-                ref: (el): void => {
-                  if (el !== null) handle.el = el as HTMLInputElement
-                },
-              }),
-              [[vRegister, api.register('email', { persist: true })]]
+    // per test and we read back via the same scheme. Fake timers step
+    // the default 300 ms debounce window in virtual time.
+    vi.useFakeTimers()
+    try {
+      const handle: { api?: ApiReturn; el?: HTMLInputElement } = {}
+      const formKey = `shorthand-${Math.random().toString(36).slice(2)}`
+      const App = defineComponent({
+        setup() {
+          const api = useForm({ schema, key: formKey, persist: 'local' })
+          handle.api = api
+          return () =>
+            h(
+              'div',
+              withDirectives(
+                h('input', {
+                  type: 'text',
+                  ref: (el): void => {
+                    if (el !== null) handle.el = el as HTMLInputElement
+                  },
+                }),
+                [[vRegister, api.register('email', { persist: true })]]
+              )
             )
-          )
-      },
-    })
-    const app = createApp(App).use(createAttaform())
-    const root = document.createElement('div')
-    document.body.appendChild(root)
-    app.mount(root)
-    apps.push(app)
+        },
+      })
+      const app = createApp(App).use(createAttaform())
+      const root = document.createElement('div')
+      document.body.appendChild(root)
+      app.mount(root)
+      apps.push(app)
 
-    const el = handle.el as HTMLInputElement
-    el.value = 'shorthand@example.com'
-    el.dispatchEvent(new Event('input', { bubbles: true }))
-    // Default debounceMs is 300 — allow 600 ms for the timer + adapter chain.
-    const expectedKey = `attaform:${formKey}:${FP}`
-    const raw = await waitUntil(() => localStorage.getItem(expectedKey), 1000)
-    expect(raw).not.toBeNull()
-    const payload = JSON.parse(raw as string) as { v: number; data: { form: { email: string } } }
-    expect(payload.v).toBe(6)
-    expect(payload.data.form.email).toBe('shorthand@example.com')
+      const el = handle.el as HTMLInputElement
+      el.value = 'shorthand@example.com'
+      el.dispatchEvent(new Event('input', { bubbles: true }))
+      // Step past the 300 ms default debounce window.
+      await vi.advanceTimersByTimeAsync(310)
+      const expectedKey = `attaform:${formKey}:${FP}`
+      const raw = localStorage.getItem(expectedKey)
+      expect(raw).not.toBeNull()
+      const payload = JSON.parse(raw as string) as { v: number; data: { form: { email: string } } }
+      expect(payload.v).toBe(6)
+      expect(payload.data.form.email).toBe('shorthand@example.com')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('persist: customAdapter (object shorthand) routes writes to the adapter', async () => {
     // A custom FormStorage with no `storage` key — disambiguator picks
     // it up as a custom adapter, NOT as a malformed options bag.
-    const writes: Array<[string, unknown]> = []
-    const customAdapter = {
-      getItem: (): Promise<unknown> => Promise.resolve(undefined),
-      setItem: (key: string, value: unknown): Promise<void> => {
-        writes.push([key, value])
-        return Promise.resolve()
-      },
-      removeItem: (): Promise<void> => Promise.resolve(),
-      listKeys: (): Promise<string[]> => Promise.resolve([]),
-    }
-    const handle: { el?: HTMLInputElement } = {}
-    const formKey = `custom-${Math.random().toString(36).slice(2)}`
-    const App = defineComponent({
-      setup() {
-        const api = useForm({ schema, key: formKey, persist: customAdapter })
-        return () =>
-          h(
-            'div',
-            withDirectives(
-              h('input', {
-                type: 'text',
-                ref: (el): void => {
-                  if (el !== null) handle.el = el as HTMLInputElement
-                },
-              }),
-              [[vRegister, api.register('email', { persist: true })]]
+    vi.useFakeTimers()
+    try {
+      const writes: Array<[string, unknown]> = []
+      const customAdapter = {
+        getItem: (): Promise<unknown> => Promise.resolve(undefined),
+        setItem: (key: string, value: unknown): Promise<void> => {
+          writes.push([key, value])
+          return Promise.resolve()
+        },
+        removeItem: (): Promise<void> => Promise.resolve(),
+        listKeys: (): Promise<string[]> => Promise.resolve([]),
+      }
+      const handle: { el?: HTMLInputElement } = {}
+      const formKey = `custom-${Math.random().toString(36).slice(2)}`
+      const App = defineComponent({
+        setup() {
+          const api = useForm({ schema, key: formKey, persist: customAdapter })
+          return () =>
+            h(
+              'div',
+              withDirectives(
+                h('input', {
+                  type: 'text',
+                  ref: (el): void => {
+                    if (el !== null) handle.el = el as HTMLInputElement
+                  },
+                }),
+                [[vRegister, api.register('email', { persist: true })]]
+              )
             )
-          )
-      },
-    })
-    const app = createApp(App).use(createAttaform())
-    const root = document.createElement('div')
-    document.body.appendChild(root)
-    app.mount(root)
-    apps.push(app)
-    const el = handle.el as HTMLInputElement
-    el.value = 'custom@example.com'
-    el.dispatchEvent(new Event('input', { bubbles: true }))
-    await waitUntil(() => (writes.length > 0 ? true : null), 1000)
-    expect(writes.length).toBeGreaterThan(0)
-    const [writtenKey, writtenValue] = writes[writes.length - 1]!
-    expect(writtenKey).toBe(`attaform:${formKey}:${FP}`)
-    const payload = writtenValue as { data: { form: { email: string } } }
-    expect(payload.data.form.email).toBe('custom@example.com')
+        },
+      })
+      const app = createApp(App).use(createAttaform())
+      const root = document.createElement('div')
+      document.body.appendChild(root)
+      app.mount(root)
+      apps.push(app)
+      const el = handle.el as HTMLInputElement
+      el.value = 'custom@example.com'
+      el.dispatchEvent(new Event('input', { bubbles: true }))
+      // Step past the 300 ms default debounce window.
+      await vi.advanceTimersByTimeAsync(310)
+      expect(writes.length).toBeGreaterThan(0)
+      const [writtenKey, writtenValue] = writes[writes.length - 1]!
+      expect(writtenKey).toBe(`attaform:${formKey}:${FP}`)
+      const payload = writtenValue as { data: { form: { email: string } } }
+      expect(payload.data.form.email).toBe('custom@example.com')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 

--- a/test/composables/preprocess-late-authoring.test.ts
+++ b/test/composables/preprocess-late-authoring.test.ts
@@ -4,6 +4,7 @@ import { createApp, defineComponent, h, nextTick } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
 import { createAttaform } from '../../src/runtime/core/plugin'
+import { waitUntil } from '../utils/form-harness'
 
 /**
  * Pins the "authored" set's lifecycle past construction.
@@ -78,12 +79,13 @@ describe('authored-paths updates beyond construction', () => {
     // against the runtime "no value yet").
     await nextTick()
 
-    // Lazy activation: kick the factory explicitly, then let the
-    // post-resolution validation sweep complete. Without this the
-    // form stays dormant until the first reactive read below, leaving
-    // no time for validation to land.
+    // Lazy activation: kick the factory explicitly, then wait for the
+    // validation verdict to land. The post-resolution validation sweep
+    // runs through preprocess + refine asynchronously; poll the
+    // positive signal (errors populated) rather than guessing a wall-
+    // clock budget.
     await api.activate()
-    await new Promise((r) => setTimeout(r, 30))
+    await waitUntil(() => (api.errors.url.length > 0 ? true : null))
 
     // The factory landed `{ url: undefined }`. The path is now
     // authored — distinct from "no consumer input." Validation runs
@@ -103,8 +105,7 @@ describe('authored-paths updates beyond construction', () => {
     expect(api.errors.url).toEqual([])
 
     api.reset({ url: undefined })
-    await nextTick()
-    await new Promise((r) => setTimeout(r, 30))
+    await waitUntil(() => (api.errors.url.length > 0 ? true : null))
 
     expect(api.values.url).toBeUndefined()
     expect(api.errors.url.length).toBeGreaterThan(0)
@@ -130,8 +131,7 @@ describe('authored-paths updates beyond construction', () => {
     // change-mode validation sweep that follows the write picks up
     // the verdict.
     api.setValue('url', undefined as never)
-    await nextTick()
-    await new Promise((r) => setTimeout(r, 30))
+    await waitUntil(() => (api.errors.url.length > 0 ? true : null))
 
     expect(api.values.url).toBeUndefined()
     expect(api.errors.url.length).toBeGreaterThan(0)

--- a/test/composables/spike-no-debounce.test.ts
+++ b/test/composables/spike-no-debounce.test.ts
@@ -12,7 +12,7 @@
 // `await Promise.resolve()` between keystrokes is enough to surface
 // errors. A form with an explicit positive `debounceMs` needs a real
 // `setTimeout(>0)` flush to surface anything.
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, withDirectives, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
@@ -198,59 +198,63 @@ describe('spike — persist.debounceMs: 0 writes immediately on every form chang
   const schema = z.object({ note: z.string() })
 
   it('default debounce: storage is empty until the 300 ms timer fires', async () => {
-    const writes: { key: string; value: unknown }[] = []
-    const memoryAdapter = {
-      async getItem(): Promise<unknown> {
-        return null
-      },
-      async setItem(key: string, value: unknown): Promise<void> {
-        writes.push({ key, value })
-      },
-      async removeItem(): Promise<void> {},
-      async listKeys(): Promise<string[]> {
-        return []
-      },
+    // Fake timers step the persistence debounce timer in virtual time
+    // — the test verifies BEFORE / AFTER the 300 ms window without
+    // burning wall-clock seconds, and the contract is sharper than a
+    // wall-clock poll (which could not distinguish "timer fired" from
+    // "wall-clock ran past it").
+    vi.useFakeTimers()
+    try {
+      const writes: { key: string; value: unknown }[] = []
+      const memoryAdapter = {
+        async getItem(): Promise<unknown> {
+          return null
+        },
+        async setItem(key: string, value: unknown): Promise<void> {
+          writes.push({ key, value })
+        },
+        async removeItem(): Promise<void> {},
+        async listKeys(): Promise<string[]> {
+          return []
+        },
+      }
+
+      const handle: { api?: UseFormReturn<typeof schema> } = {}
+      const Parent = defineComponent({
+        setup() {
+          handle.api = useForm({
+            schema,
+            defaultValues: { note: '' },
+            key: `persist-default-${Math.random().toString(36).slice(2)}`,
+            persist: { storage: memoryAdapter },
+          })
+          const rv = handle.api.register('note', { persist: true })
+          return () =>
+            h('div', null, [
+              withDirectives(h('input', { type: 'text', 'data-field': 'note' }), [[vRegister, rv]]),
+            ])
+        },
+      })
+      app = createApp(Parent).use(createAttaform())
+      const root = document.createElement('div')
+      document.body.appendChild(root)
+      app.mount(root)
+
+      const input = root.querySelector('[data-field="note"]') as HTMLInputElement
+      input.value = 'hello'
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+
+      // Advance to just BEFORE the 300 ms debounce window — the timer
+      // hasn't fired, so no write should have landed.
+      await vi.advanceTimersByTimeAsync(299)
+      expect(writes.length).toBe(0)
+
+      // Cross the threshold — exactly one coalesced write lands.
+      await vi.advanceTimersByTimeAsync(2)
+      expect(writes.length).toBe(1)
+    } finally {
+      vi.useRealTimers()
     }
-
-    const handle: { api?: UseFormReturn<typeof schema> } = {}
-    const Parent = defineComponent({
-      setup() {
-        handle.api = useForm({
-          schema,
-          defaultValues: { note: '' },
-          key: `persist-default-${Math.random().toString(36).slice(2)}`,
-          persist: { storage: memoryAdapter },
-        })
-        const rv = handle.api.register('note', { persist: true })
-        return () =>
-          h('div', null, [
-            withDirectives(h('input', { type: 'text', 'data-field': 'note' }), [[vRegister, rv]]),
-          ])
-      },
-    })
-    app = createApp(Parent).use(createAttaform())
-    const root = document.createElement('div')
-    document.body.appendChild(root)
-    app.mount(root)
-    // Allow mount-time setup to settle. No persist write expected yet
-    // since the user hasn't typed.
-    await waitUntil(() => (writes.length === 0 ? true : null), 50)
-
-    const input = root.querySelector('[data-field="note"]') as HTMLInputElement
-    input.value = 'hello'
-    input.dispatchEvent(new Event('input', { bubbles: true }))
-
-    // Microtask flush — write hasn't happened yet (300 ms timer
-    // pending). Short timeout: a longer wait would let the timer fire
-    // and hide the contract.
-    await waitUntil(() => (writes.length === 0 ? true : null), 50)
-    expect(writes.length).toBe(0)
-
-    // After the debounce timer fires, exactly one coalesced write
-    // lands. Poll on the side-effect rather than time-pumping so a
-    // contended CI doesn't flake before the timer has a chance.
-    await waitUntil(() => (writes.length >= 1 ? true : null))
-    expect(writes.length).toBe(1)
   })
 
   it('debounceMs: 0: every keystroke kicks off a write immediately', async () => {

--- a/test/composables/use-form-lazy-activation.test.ts
+++ b/test/composables/use-form-lazy-activation.test.ts
@@ -5,7 +5,7 @@ import { z } from 'zod'
 import { useForm } from '../../src/zod'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import type { UseFormReturnType } from '../../src/runtime/types/types-api'
-import { wait, waitUntil } from '../utils/form-harness'
+import { awaitSettle, waitUntil } from '../utils/form-harness'
 
 /**
  * Lazy activation contract for `useForm`. The factory passed via
@@ -73,9 +73,10 @@ describe('useForm — lazy activation', () => {
   it('dormant form: factory does not fire on mount or after microtask flush', async () => {
     const { app, calls } = mountInert(() => Promise.resolve({ email: 'fetched@x.io', name: 'Z' }))
     apps.push(app)
-    // Drain any historical microtask defer window so a residual fire
-    // would show up here, not on a later expect.
-    await wait(30)
+    // Drain any pending microtask defer window so a residual fire would
+    // show up here, not on a later expect. The lazy-init code schedules
+    // its first fire via queueMicrotask; two nextTicks flushes it.
+    await awaitSettle()
     expect(calls.count).toBe(0)
   })
 
@@ -83,14 +84,14 @@ describe('useForm — lazy activation', () => {
     const { app, api, calls } = mountInert(() => Promise.resolve({ email: 'a@b', name: 'A' }))
     apps.push(app)
     expect(api.key).toMatch(/^lazy-/)
-    await wait(30)
+    await awaitSettle()
     expect(calls.count).toBe(0)
   })
 
   it('reading form.values activates the factory', async () => {
     const { app, api, calls } = mountInert(() => Promise.resolve({ email: 'a@b', name: 'A' }))
     apps.push(app)
-    await wait(20)
+    await awaitSettle()
     expect(calls.count).toBe(0)
     void api.values.email
     await waitUntil(() => (calls.count >= 1 ? true : null))
@@ -100,7 +101,7 @@ describe('useForm — lazy activation', () => {
   it('reading form.fields activates the factory', async () => {
     const { app, api, calls } = mountInert(() => Promise.resolve({ email: 'a@b', name: 'A' }))
     apps.push(app)
-    await wait(20)
+    await awaitSettle()
     expect(calls.count).toBe(0)
     void api.fields.email
     await waitUntil(() => (calls.count >= 1 ? true : null))
@@ -110,7 +111,7 @@ describe('useForm — lazy activation', () => {
   it('reading form.meta activates the factory', async () => {
     const { app, api, calls } = mountInert(() => Promise.resolve({ email: 'a@b', name: 'A' }))
     apps.push(app)
-    await wait(20)
+    await awaitSettle()
     expect(calls.count).toBe(0)
     void api.meta.valid
     await waitUntil(() => (calls.count >= 1 ? true : null))
@@ -120,7 +121,7 @@ describe('useForm — lazy activation', () => {
   it('reading form.errors activates the factory', async () => {
     const { app, api, calls } = mountInert(() => Promise.resolve({ email: 'a@b', name: 'A' }))
     apps.push(app)
-    await wait(20)
+    await awaitSettle()
     expect(calls.count).toBe(0)
     void api.errors
     await waitUntil(() => (calls.count >= 1 ? true : null))
@@ -130,7 +131,7 @@ describe('useForm — lazy activation', () => {
   it('reading form.hydrating activates the factory', async () => {
     const { app, api, calls } = mountInert(() => Promise.resolve({ email: 'a@b', name: 'A' }))
     apps.push(app)
-    await wait(20)
+    await awaitSettle()
     expect(calls.count).toBe(0)
     void api.hydrating
     await waitUntil(() => (calls.count >= 1 ? true : null))
@@ -140,7 +141,7 @@ describe('useForm — lazy activation', () => {
   it('reading form.hydrateError activates the factory', async () => {
     const { app, api, calls } = mountInert(() => Promise.resolve({ email: 'a@b', name: 'A' }))
     apps.push(app)
-    await wait(20)
+    await awaitSettle()
     expect(calls.count).toBe(0)
     void api.hydrateError
     await waitUntil(() => (calls.count >= 1 ? true : null))
@@ -150,7 +151,7 @@ describe('useForm — lazy activation', () => {
   it('reading form.ready activates the factory', async () => {
     const { app, api, calls } = mountInert(() => Promise.resolve({ email: 'a@b', name: 'A' }))
     apps.push(app)
-    await wait(20)
+    await awaitSettle()
     expect(calls.count).toBe(0)
     void api.ready
     await waitUntil(() => (calls.count >= 1 ? true : null))
@@ -160,7 +161,7 @@ describe('useForm — lazy activation', () => {
   it('calling form.setValue activates the factory', async () => {
     const { app, api, calls } = mountInert(() => Promise.resolve({ email: 'a@b', name: 'A' }))
     apps.push(app)
-    await wait(20)
+    await awaitSettle()
     expect(calls.count).toBe(0)
     api.setValue('email', 'typed@x.io')
     await waitUntil(() => (calls.count >= 1 ? true : null))
@@ -170,7 +171,7 @@ describe('useForm — lazy activation', () => {
   it('calling form.register activates the factory', async () => {
     const { app, api, calls } = mountInert(() => Promise.resolve({ email: 'a@b', name: 'A' }))
     apps.push(app)
-    await wait(20)
+    await awaitSettle()
     expect(calls.count).toBe(0)
     void api.register('email')
     await waitUntil(() => (calls.count >= 1 ? true : null))
@@ -180,7 +181,7 @@ describe('useForm — lazy activation', () => {
   it('calling form.handleSubmit activates the factory', async () => {
     const { app, api, calls } = mountInert(() => Promise.resolve({ email: 'a@b', name: 'A' }))
     apps.push(app)
-    await wait(20)
+    await awaitSettle()
     expect(calls.count).toBe(0)
     void api.handleSubmit(() => {})
     await waitUntil(() => (calls.count >= 1 ? true : null))

--- a/test/core/multi-tab-sync-join-snapshot.test.ts
+++ b/test/core/multi-tab-sync-join-snapshot.test.ts
@@ -4,6 +4,7 @@ import { defineComponent, h, createApp, type App } from 'vue'
 import { z } from 'zod'
 
 import { useForm } from '../../src/zod'
+import { awaitSettle, waitUntil } from '../utils/form-harness'
 
 /**
  * Cross-tab snapshot handshake MUST adopt the leader's live state on
@@ -101,8 +102,9 @@ describe('multi-tab sync: opt-in default', () => {
     })
     if (captureA.form === undefined) throw new Error('setup did not capture formA')
 
-    // Allow any potential lazy-init window to elapse.
-    await new Promise((r) => setTimeout(r, 100))
+    // Lazy-init schedules via queueMicrotask; two nextTicks flush the
+    // window where a sync module would (incorrectly) install itself.
+    await awaitSettle()
 
     const registry = appA._attaform
     if (registry === undefined) throw new Error('app has no attaform registry')
@@ -136,7 +138,10 @@ describe('multi-tab sync: opt-in default', () => {
     if (formA === undefined || formB === undefined) throw new Error('setup did not capture form')
 
     formA.setValue('email', 'alice@example.com')
-    await new Promise((r) => setTimeout(r, 100))
+    // Neither form has multiTab, so no BroadcastChannel is opened on
+    // either side — nothing to deliver, nothing to drop. Settle the
+    // local reactive cycle and assert.
+    await awaitSettle()
 
     // No multiTab on either form, so Tab A's write stays local.
     expect(formA.values.email).toBe('alice@example.com')
@@ -451,7 +456,21 @@ describe('multi-tab sync: File values stay local (security gate)', () => {
         blankPathsAdded: [],
         blankPathsRemoved: [],
       })
-      await new Promise((r) => setTimeout(r, 100))
+      // Sentinel: a valid string patch on a different path, in the
+      // accepted `kind: 'changed'` shape. BC delivers FIFO, so once
+      // the sentinel lands, the hostile File patch has already been
+      // processed (and dropped) by the same listener.
+      evil.postMessage({
+        v: 1,
+        kind: 'patches',
+        senderId: 'evil-sender',
+        formPatches: [
+          { kind: 'changed', path: ['caption'], oldValue: '', newValue: '__sentinel__' },
+        ],
+        blankPathsAdded: [],
+        blankPathsRemoved: [],
+      })
+      await waitUntil(() => (formA.values.caption === '__sentinel__' ? true : null))
     } finally {
       evil.close()
     }
@@ -493,8 +512,20 @@ describe('multi-tab sync: structural type-mismatch defense', () => {
         blankPathsAdded: [],
         blankPathsRemoved: [],
       })
-      // Give the channel time to deliver and the receiver time to apply.
-      await new Promise((r) => setTimeout(r, 100))
+      // Sentinel: a valid string patch on the `comment` path, in the
+      // accepted `kind: 'changed'` shape. Once it lands, the bad-type
+      // patch has been processed (and dropped) by the same listener.
+      evil.postMessage({
+        v: 1,
+        kind: 'patches',
+        senderId: 'evil-tab',
+        formPatches: [
+          { kind: 'changed', path: ['comment'], oldValue: '', newValue: '__sentinel__' },
+        ],
+        blankPathsAdded: [],
+        blankPathsRemoved: [],
+      })
+      await waitUntil(() => (formA.values.comment === '__sentinel__' ? true : null))
     } finally {
       evil.close()
     }
@@ -629,7 +660,20 @@ describe('multi-tab sync: hostile-message no-uncaught guard (SEC-3)', () => {
         blankPathsAdded: [null],
         blankPathsRemoved: [],
       })
-      await new Promise((r) => setTimeout(r, 100))
+      // Sentinel: a clean patch in the accepted `kind: 'changed'` shape.
+      // Once it lands, the malformed message has already been processed;
+      // any uncaught exception it would throw is now visible.
+      evil.postMessage({
+        v: 1,
+        kind: 'patches',
+        senderId: 'evil-malformed',
+        formPatches: [
+          { kind: 'changed', path: ['comment'], oldValue: '', newValue: '__sentinel__' },
+        ],
+        blankPathsAdded: [],
+        blankPathsRemoved: [],
+      })
+      await waitUntil(() => (formA.values.comment === '__sentinel__' ? true : null))
     } finally {
       evil.close()
       process.off('uncaughtException', onProcessError)

--- a/test/utils/form-harness.ts
+++ b/test/utils/form-harness.ts
@@ -7,7 +7,7 @@
  * Parameterised on `useFormFn` so v3 and v4 callers can pass their
  * own typed import without the harness coupling to either zod major.
  */
-import { createApp, defineComponent, h, type App } from 'vue'
+import { createApp, defineComponent, h, nextTick, type App } from 'vue'
 import { createAttaform } from '../../src/runtime/core/plugin'
 
 /**
@@ -53,6 +53,24 @@ export async function waitUntil<T>(
     if (Date.now() >= deadline) return null
     await wait(intervalMs)
   }
+}
+
+/**
+ * Yield twice through Vue's microtask queue so the directive's
+ * input/change cycle (handler → gate → reactive patch → DOM sync) has
+ * fired. Use for "prove the write was rejected / nothing happened"
+ * assertions where there is no positive state change to poll on — a
+ * `waitUntil` predicate that's structurally never true burns the full
+ * timeout ceiling on every run.
+ *
+ * Two ticks because the cycle can be: handler fires → schedules a
+ * reactive write → first nextTick flushes that write → directive's
+ * model→DOM sync watcher runs on the next tick. One yield isn't enough
+ * for the round-trip; three would be overkill.
+ */
+export async function awaitSettle(): Promise<void> {
+  await nextTick()
+  await nextTick()
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary

Sweeps the 300+ test files for runtime hotspots and ergonomic wins per Issue 4 of the
foundational-sweep plan. Seven commits, each a small surgical refactor pinned to one bug
class. **Tests time: 31.78 s → 23.07 s average (-8.7 s, -27%). Wall time: 18.96 s → 16.85 s
average (-2.1 s, -11%).** All 3621 tests pass; verified clean across multiple shuffled-order
runs.

## Bug classes addressed (by commit, oldest first)

| # | Pattern | Saved |
|---|---|---|
| 1 | New `awaitSettle()` primitive in `test/utils/form-harness.ts`. 5 sites in `coerce.test.ts` + `du-variant-error-regressions.test.ts` used `waitUntil` with a predicate that was structurally never satisfied post-rejection (e.g. `cb.checked === true` after the directive reverts a rejected write) — they burned the full 1000 ms ceiling every run. | ~5 s |
| 2 | `api-surface-contract.test.ts`: 2 multi-tab tests with a positive arm swapped to `waitUntil(positive)` (rigor improvement); 1 persistence-debounce `wait(100)` → `wait(15)` (3× the configured `debounceMs: 5`). | ~285 ms |
| 3 | `use-form-lazy-activation.test.ts`: 12 `wait(20-30)` drains → `awaitSettle()` — the lazy-init code uses `queueMicrotask` (per `create-form-store.ts:1634`), so two nextTicks is the right primitive. `persistence.test.ts`: 3 prove-negative `wait(80)` → `wait(30)` (1.5× the 20 ms debounce). | ~410 ms |
| 4 | `file.test.ts`: persistence carve-out test polled `localStorage.getItem('file-persist-test')` for non-null, but the actual key has a schema-hash suffix (`file-persist-test:<hash>`) — the predicate could never be satisfied; fixed prefix match. `preprocess-late-authoring.test.ts`: 3 `nextTick + setTimeout(30)` → `waitUntil(positive)` against the async-refine verdict. | ~250 ms |
| 5 | Sentinel-ack pattern for multi-tab prove-negative tests across `api-surface-contract.test.ts` + `multi-tab-sync-join-snapshot.test.ts`. Post hostile, post known-good followup on a different path; BC delivers FIFO per channel, so once the sentinel lands, the hostile has been processed by the same listener invocation. The two no-listener tests (`multiTab: false`, secure-context gate) use an observer BC to witness delivery instead. 9 sites total. Rigor improvement (true post-delivery assertion) + speed. | ~1.4 s |
| 6 | Fake timers for default-debounce window tests: `vi.useFakeTimers()` + `vi.advanceTimersByTimeAsync(310)` steps past the 300 ms debounce in virtual time. Sharper contract too — the spike test now verifies BEFORE (length === 0 at 299 ms) AND AFTER (length === 1 at 301 ms). 3 sites. | ~900 ms |
| 7 | Follow-up to commit 6: the `persist: 'local'` shorthand test flaked under shuffle because `getStorageAdapter('local')` does a dynamic `import('./local-storage')` on first call. Fake timers can't advance a real-time dynamic import. Pre-warm the adapter module with `await import(...)` before swapping to fake timers; subsequent calls hit the module cache. Verified 8/8 isolated repeats + 3/3 full-suite runs pass. | (flake fix) |

## Test-design patterns introduced

These show up across multiple commits and are worth highlighting for review:

- **`awaitSettle()`** — explicit primitive for "wait for the input/change cycle to complete with no positive state to poll on" (`test/utils/form-harness.ts`). Two nextTicks: directive handler → reactive write → DOM sync. Use it instead of a `waitUntil` predicate that's never true after a rejection.
- **Sentinel-ack** — for BroadcastChannel prove-negative tests with a listener, post the hostile message, then post a known-good followup on a different path; wait for the followup to land. The assertion is a true post-delivery check.
- **Observer BC** — for no-listener tests, stand up a separate `BroadcastChannel` on the same name purely to witness delivery; assert form state unchanged after the observer fires.
- **Fake timers + pre-warm** — for tests that wait the default debounce, switch to virtual time; pre-warm any dynamic-imported adapter beforehand so the writer's `await import(...)` chain doesn't stall.

## Structural floors (not addressed)

Two clusters of slow tests are at their structural floor without bigger surgery:

1. **Real BC handshake** (multi-tab snapshot tests at ~120-320 ms each): the `hello → announce → requestSnapshot → snapshot` exchange touches multiple macrotasks. Shrinking this means restructuring the lifecycle protocol.
2. **End-to-end docs-demo smoke tests** (330-660 ms each, default debounce + first-load SFC compile via `import.meta.glob`): switching to fake timers would undercut the "what users actually see" spirit of the smoke harness; the SFC compile cost is inherent to lazy loading.

Past these, all remaining tests are sub-100 ms.

## Verification

- `pnpm test` — 3621 pass, 48 skipped, 0 fail.
- Three back-to-back full-suite runs: all 3621 pass each time.
- Eight isolated runs of the previously-flaky shorthand test: all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)