### PR TITLE
fix(directive): close three stale-closure sites

### DIFF
--- a/src/runtime/core/directive.ts
+++ b/src/runtime/core/directive.ts
@@ -1098,10 +1098,14 @@ const vRegisterSelect: RegisterSelectCustomDirective = {
     if (!isRegisterValue(value)) return
 
     value.registerElement(el)
-    const isSetModel = isSet(value.innerRef.value)
     addTrackedListener(el, 'change', () => {
       if (shouldBailListener(el)) return
       noteInteraction(value)
+      // Re-derive each fire so an Array ↔ Set swap on the bound path
+      // (a `form.setValue('picks', new Set([...]))` against a union
+      // schema, or any other write that lands a different container
+      // shape) routes the next change through the matching constructor.
+      const isSetModel = isSet(value.innerRef.value)
       const selectedVal = Array.prototype.filter
         .call(el.options, (o: HTMLOptionElement) => o.selected)
         .map((o: HTMLOptionElement) => (number === true ? looseToNumber(getValue(o)) : getValue(o)))

--- a/src/runtime/core/directive.ts
+++ b/src/runtime/core/directive.ts
@@ -530,7 +530,14 @@ function setAssignFunction(
 // be tree-shaken in case v-model is never used.
 const vRegisterText: RegisterTextCustomDirective = {
   created(el, { value, modifiers: { lazy, trim, number } }, vnode) {
-    const castToNumber = number === true || vnode.props?.['type'] === 'number'
+    // Static "would this listener ever want to cast?" gate for the
+    // optional blur normalizer below. Read straight off vnode.props
+    // at created-time because the modifier is what we're allowed to
+    // freeze. Listener bodies re-derive `castToNumber` each fire
+    // (see `liveCastToNumber`) so a dynamic `:type="..."` swap is
+    // honored against the post-patch DOM.
+    const castToNumberAtCreated = number === true || vnode.props?.['type'] === 'number'
+    const liveCastToNumber = (): boolean => number === true || el.getAttribute('type') === 'number'
     if (isRegisterValue(value)) {
       value.registerElement(el)
       setAssignFunction(el, vnode, value)
@@ -546,6 +553,9 @@ const vRegisterText: RegisterTextCustomDirective = {
       const target = e.target as ComposingTarget
       if (target === null || target.composing) return
       noteInteraction(value)
+      // Re-read per fire so a dynamic `:type="..."` swap (text → number
+      // or back) routes the next keystroke through the right branch.
+      const castToNumber = liveCastToNumber()
       let domValue: string | number = el.value
       // Deferred-to-blur trim: only trim here when this listener is
       // already on `change` (i.e. `.lazy.trim`). Per-keystroke trim
@@ -703,7 +713,7 @@ const vRegisterText: RegisterTextCustomDirective = {
         }
       }
     })
-    if (trim === true || castToNumber) {
+    if (trim === true || castToNumberAtCreated) {
       addTrackedListener(el, 'change', () => {
         if (shouldBailListener(el)) return
         // Mirror Vue's `castValue(el.value, trim, castToNumber)` so the
@@ -712,6 +722,11 @@ const vRegisterText: RegisterTextCustomDirective = {
         // sees ` 12 ` stick after blur instead of `12`.
         let normalized: string | number = el.value
         if (trim === true) normalized = normalized.trim()
+        // Re-derive each fire so a `:type` swap is honored at blur too.
+        // The installation gate above is the static "could this input
+        // ever want cast-on-blur" check, but the body's branch picks
+        // up the current type per fire.
+        const castToNumber = liveCastToNumber()
         if (castToNumber) {
           const cast = looseToNumber(normalized)
           if (typeof cast === 'number' && Number.isFinite(cast)) {

--- a/src/runtime/core/directive.ts
+++ b/src/runtime/core/directive.ts
@@ -486,7 +486,16 @@ function setAssignFunction(
   // entire directive lifecycle. The default assigner is a fallback
   // for the common case where nobody overrides; it should NEVER
   // clobber an explicit consumer override.
-  if (el[assignKey] !== undefined && !isDefaultAssigner(el[assignKey])) {
+  //
+  // Wrappers produced by `getModelAssigner` for the
+  // `@update:registerValue` install path are tagged with
+  // `CONSUMER_WRAPPED_TAG`; bailing on them too would freeze the
+  // listener at the first vnode's prop value, so a parent re-render
+  // that swaps the handler reference would never take effect. Allow
+  // re-derivation in that case — the freshly produced wrapper closes
+  // over the new vnode's prop function.
+  const current = el[assignKey]
+  if (current !== undefined && !isDefaultAssigner(current) && !isConsumerWrapped(current)) {
     return
   }
 

--- a/test/core/directive-prop-reactivity.test.ts
+++ b/test/core/directive-prop-reactivity.test.ts
@@ -1,0 +1,249 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DirectiveBinding } from 'vue'
+import { computed, ref, type Ref } from 'vue'
+import { vRegister } from '../../src/runtime/core/directive'
+import { createPersistOptInRegistry } from '../../src/runtime/core/persistence/opt-in-registry'
+import type { PathKey } from '../../src/runtime/core/paths'
+import type {
+  CustomDirectiveRegisterAssignerFn,
+  InternalRegisterValue,
+  RegisterValue,
+} from '../../src/runtime/types/types-api'
+
+/**
+ * Three stale-closure sites that diverge between `created` capture and
+ * fire-time read. Each pre-fix listener reads a value frozen at the
+ * directive's `created` hook, even though Vue patches the DOM (or the
+ * vnode props) on every render — so a consumer's dynamic `:type`,
+ * dynamic `@update:registerValue`, or path-level container-type swap
+ * sails past the listener invisibly.
+ *
+ *   A. `setAssignFunction` early-return — once an `onUpdate:registerValue`
+ *      handler is installed, subsequent renders never re-read the prop.
+ *   B. `vRegisterText` `castToNumber` — captured from `vnode.props.type`
+ *      at `created`-time; `:type="..."` swaps are invisible.
+ *   C. `vRegisterSelect` `isSetModel` — captured from
+ *      `value.innerRef.value` at `created`-time; an Array ↔ Set swap on
+ *      the path routes writes to the stale container shape.
+ *
+ * All three exercise the directive's hooks directly so the assertions
+ * pin behavior at the listener body — no Vue render cycle, no schema
+ * gate, no slim-primitive interference.
+ */
+
+type Spy = ReturnType<typeof vi.fn>
+
+type MutableMockRv<T> = {
+  -readonly [K in keyof InternalRegisterValue<T>]: InternalRegisterValue<T>[K]
+}
+
+function makeRegisterValue<T>(initial: T): {
+  value: MutableMockRv<T>
+  setValue: Spy
+} {
+  const innerRef = ref(initial)
+  const setValue = vi.fn((v: unknown) => {
+    innerRef.value = v as T
+    return true
+  })
+  const value: MutableMockRv<T> = {
+    innerRef: innerRef as InternalRegisterValue<T>['innerRef'],
+    displayValue: computed(() => {
+      const v = innerRef.value
+      return v == null ? '' : String(v)
+    }) as Readonly<Ref<string>>,
+    markBlank: () => true,
+    markInteracted: () => undefined,
+    lastTypedForm: ref<string | null>(null),
+    registerElement: vi.fn(),
+    deregisterElement: vi.fn(),
+    setValueWithInternalPath: setValue,
+    markConnectedOptimistically: () => undefined,
+    path: 'mock' as PathKey,
+    segments: Object.freeze(['mock']),
+    formKey: 'mock-form',
+    formInstanceId: 'mock-inst',
+    persist: false,
+    acknowledgeSensitive: false,
+    persistOptIns: createPersistOptInRegistry(),
+    isSensitivePath: () => false,
+    multiTab: true,
+    acceptsUndefined: false,
+    acceptsString: true,
+  }
+  return { value, setValue }
+}
+
+function makeBinding<T>(
+  rv: RegisterValue<T> | undefined,
+  modifiers: Record<string, true> = {}
+): DirectiveBinding {
+  return {
+    value: rv,
+    oldValue: null,
+    modifiers,
+    arg: undefined,
+    dir: {},
+    instance: null,
+  } as unknown as DirectiveBinding
+}
+
+type FakeVNode = { props: Record<string, unknown> }
+function makeVNode(props: Record<string, unknown> = {}): FakeVNode {
+  return { props }
+}
+
+type DirectiveHook = (
+  el: Element,
+  binding: DirectiveBinding,
+  vnode: FakeVNode,
+  prevNode: null
+) => void
+
+const hooks = vRegister as unknown as {
+  created?: DirectiveHook
+  mounted?: DirectiveHook
+  beforeUpdate?: DirectiveHook
+  updated?: DirectiveHook
+  beforeUnmount?: DirectiveHook
+}
+
+// ─────────────────────────────────────────────────────────────────
+// A — `setAssignFunction` re-derives on every render
+// ─────────────────────────────────────────────────────────────────
+
+describe('setAssignFunction — @update:registerValue prop reactivity', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('a fresh handler in onUpdate:registerValue fires on the next input event', () => {
+    const input = document.createElement('input')
+    input.type = 'text'
+    document.body.appendChild(input)
+    const { value } = makeRegisterValue('')
+
+    const handlerA = vi.fn<CustomDirectiveRegisterAssignerFn>((_v, _rv) => undefined)
+    const handlerB = vi.fn<CustomDirectiveRegisterAssignerFn>((_v, _rv) => undefined)
+
+    // Created with handler A in the vnode prop.
+    hooks.created?.(
+      input,
+      makeBinding(value, {}),
+      makeVNode({ 'onUpdate:registerValue': handlerA }),
+      null
+    )
+
+    input.value = 'first'
+    input.dispatchEvent(new Event('input'))
+    expect(handlerA).toHaveBeenCalledTimes(1)
+    expect(handlerB).toHaveBeenCalledTimes(0)
+
+    // Parent re-renders with handler B in the vnode prop. The
+    // directive's beforeUpdate must re-derive — pre-fix, the early
+    // return in `setAssignFunction` bailed once any non-default
+    // assigner was installed, so the handler swap was silently dropped.
+    hooks.beforeUpdate?.(
+      input,
+      makeBinding(value, {}),
+      makeVNode({ 'onUpdate:registerValue': handlerB }),
+      null
+    )
+
+    input.value = 'second'
+    input.dispatchEvent(new Event('input'))
+    expect(handlerA).toHaveBeenCalledTimes(1)
+    expect(handlerB).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────
+// B — `vRegisterText` derives `castToNumber` per fire
+// ─────────────────────────────────────────────────────────────────
+
+describe('vRegisterText — :type swap reactivity', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('mutating el.type from text to number activates .number-style casting on the next input', () => {
+    const input = document.createElement('input')
+    input.type = 'text'
+    document.body.appendChild(input)
+    const { value, setValue } = makeRegisterValue<unknown>('')
+
+    hooks.created?.(input, makeBinding(value, {}), makeVNode({ type: 'text' }), null)
+
+    // Pre-swap: the listener writes the raw string.
+    input.value = '42'
+    input.dispatchEvent(new Event('input'))
+    expect(setValue).toHaveBeenLastCalledWith('42', expect.objectContaining({}))
+
+    // Vue patches the DOM attribute when `:type="..."` swaps; mirror
+    // that here. Pre-fix the listener stayed on the created-time
+    // `castToNumber === false` decision and continued writing strings.
+    input.type = 'number'
+
+    input.value = '100'
+    input.dispatchEvent(new Event('input'))
+    expect(setValue).toHaveBeenLastCalledWith(100, expect.objectContaining({}))
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────
+// C — `vRegisterSelect` derives `isSetModel` per fire
+// ─────────────────────────────────────────────────────────────────
+
+describe('vRegisterSelect — Array ↔ Set model swap reactivity', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  function makeSelect(options: string[]): HTMLSelectElement {
+    const select = document.createElement('select')
+    select.multiple = true
+    for (const v of options) {
+      const opt = document.createElement('option')
+      opt.value = v
+      opt.text = v
+      select.appendChild(opt)
+    }
+    return select
+  }
+
+  it('swapping innerRef.value from Array to Set routes the next change write to a Set', () => {
+    const select = makeSelect(['a', 'b', 'c'])
+    document.body.appendChild(select)
+    const { value, setValue } = makeRegisterValue<string[] | Set<string>>([])
+
+    hooks.created?.(select, makeBinding(value, {}), makeVNode({}), null)
+
+    // Pre-swap: Array model, change writes an Array.
+    const opt0 = select.options[0]
+    if (opt0 === undefined) throw new Error('unreachable')
+    opt0.selected = true
+    select.dispatchEvent(new Event('change'))
+    const arrayWrite = setValue.mock.calls[0]?.[0]
+    expect(Array.isArray(arrayWrite)).toBe(true)
+    expect(arrayWrite).toEqual(['a'])
+
+    // The path's container type swaps — production trigger would be
+    // a `form.setValue('picks', new Set([...]))` against a union
+    // schema. Pre-fix the listener kept the created-time
+    // `isSetModel === false` and wrote an Array on every subsequent
+    // change.
+    ;(value.innerRef as { value: string[] | Set<string> }).value = new Set(['a'])
+
+    opt0.selected = true
+    const opt1 = select.options[1]
+    if (opt1 === undefined) throw new Error('unreachable')
+    opt1.selected = true
+    select.dispatchEvent(new Event('change'))
+    const setWrite = setValue.mock.calls[1]?.[0]
+    expect(setWrite).toBeInstanceOf(Set)
+    expect([...(setWrite as Set<string>)].sort()).toEqual(['a', 'b'])
+  })
+})


### PR DESCRIPTION
Three directive sites captured a value at `created`-time and never re-read it. Each is the same shape as the just-shipped `fireAssigner` work — `el[assignKey]` is read fresh per event, while these neighboring reads were still frozen.

## A — `setAssignFunction` early-return

Pre-fix: any non-default assigner installed at `el[assignKey]` bailed `setAssignFunction`, including the `getModelAssigner` wrapper we install for the `@update:registerValue` prop path. A parent re-render that swapped the prop's handler reference produced a fresh wrapper that never replaced the prior one — the stale wrapper kept handing input events to the original handler.

Fix: extend the bail check to use `isConsumerWrapped` (already present for the fire-time contract). Genuine raw pre-installs (untagged, non-default) still win permanently; our own wrappers fall through so each `beforeUpdate` re-derives off the fresh vnode.

## B — `vRegisterText` `castToNumber`

Pre-fix: `castToNumber = number === true || vnode.props?.['type'] === 'number'` captured once at `created`. Dynamic `:type="isNumber ? 'number' : 'text'"` swaps patched the DOM but the listener body kept routing through the stale branch.

Fix: both listeners (input/change-lazy keystroke + optional blur normalizer) call `liveCastToNumber()` per fire and read `el.getAttribute('type')`, which Vue has already patched by the time the next event runs. The blur normalizer's install gate stays static (`castToNumberAtCreated`) — the gate is the "could this listener ever want to cast" decision; the per-fire read handles the dynamic case from there.

## C — `vRegisterSelect` `isSetModel`

Pre-fix: `const isSetModel = isSet(value.innerRef.value)` captured once at `created`. A union-schema path that swapped between Array and Set under the same directive instance (e.g. `form.setValue('picks', new Set([...]))`) kept wrapping new selections in the stale shape.

Fix: read `isSet(value.innerRef.value)` inside the change listener — cheap reactive ref access, exact tracking of the current model.

## Tests

New `test/core/directive-prop-reactivity.test.ts` — three direct-hook tests, one per site. Each fails red on main without the fix and passes green after:

- `@update:registerValue` swap fires the new handler on next input
- `el.type = 'number'` swap activates `.number` casting on next input
- `value.innerRef.value = new Set([...])` routes the next change to a Set write

## Verification

- Full suite: 3624 pass, 48 skipped (was 3621 + 3 new).
- Docs-demo smoke harness clean.

Plan: `~/.claude/plans/rustling-whistling-planet.md`, Issue 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)