### PR TITLE
fix(persistence): auto-attach per-element meta inside RegisterValue

### DIFF
--- a/src/runtime/core/directive-lifecycle.ts
+++ b/src/runtime/core/directive-lifecycle.ts
@@ -112,10 +112,15 @@ export function syncMultiTabOptOut(value: unknown, oldValue: unknown): void {
  *     `created` hook skipped this when the binding mounted with an
  *     undefined value, so we have to catch up here).
  *   - RV → undefined: deregister the old RV's element.
- *   - RV → RV (same path + same form): no-op. `register('foo')`
- *     returns a fresh closure on every parent re-render; without
- *     the early-out, every tick would deregister-and-re-register
- *     the element, thrashing the `connected` flag.
+ *   - RV → RV (same path + same form): skip the deregister side so
+ *     the `connected` flag doesn't thrash false → true on every
+ *     parent re-render. STILL call `registerElement` on the new RV:
+ *     `register('foo')` returns a fresh handle per render, and the
+ *     new RV owns its own bound-element reference (consumed by
+ *     `setValueWithInternalPath` to auto-attach per-element
+ *     persistence meta). `state.registerElement(path, el)` is
+ *     idempotent — a single Set membership check on the path's
+ *     element record.
  *   - RV → RV (different path or different form): deregister old,
  *     register new. Covers dynamic-path templates
  *     (`v-register="form.register(\`item.${i}\`)"`) and the
@@ -127,13 +132,21 @@ export function syncElementRegistration(el: HTMLElement, value: unknown, oldValu
   const isRegistered = isRegisterValue(value)
   if (!wasRegistered && !isRegistered) return
 
-  if (wasRegistered && isRegistered) {
-    const old = oldValue
-    const next = value
-    if (old.path === next.path && old.persistOptIns === next.persistOptIns) return
-  }
+  // Same path + same store: skip the deregister-then-register sequence
+  // so the `connected` flag doesn't thrash false-true on every parent
+  // re-render. But STILL call `registerElement` on the freshly closed-
+  // over RV — `register()` returns a new RV per render, and the new RV
+  // owns its own bound-element reference (consumed by
+  // `setValueWithInternalPath` to auto-attach persistence meta).
+  // `state.registerElement` is idempotent on (path, element) so the
+  // re-call is a single Set membership check.
+  const samePathAndStore =
+    wasRegistered &&
+    isRegistered &&
+    oldValue.path === value.path &&
+    oldValue.persistOptIns === value.persistOptIns
 
-  if (wasRegistered) {
+  if (wasRegistered && !samePathAndStore) {
     oldValue.deregisterElement(el)
   }
   if (isRegistered) {

--- a/src/runtime/core/directive.ts
+++ b/src/runtime/core/directive.ts
@@ -54,7 +54,6 @@ import type {
   RegisterTextCustomDirective,
   RegisterTransform,
   RegisterValue,
-  WriteMeta,
 } from '../types/types-api'
 import type { PathKey } from './paths'
 import { getOrAssignElementId } from './persistence/opt-in-registry'
@@ -119,23 +118,6 @@ type ComposingTarget = (EventTarget & { composing: boolean }) | null
  */
 function writeLastTypedForm(rv: RegisterValue, next: string | null): void {
   ;(rv as InternalRegisterValue).lastTypedForm.value = next
-}
-
-/**
- * Compute the WriteMeta the default assigner attaches to its
- * `setValueWithInternalPath` call. Per-element semantics: only THIS
- * element's writes carry `persist: true`, and only if THIS element opted
- * in via `register('foo', { persist: true })`. Other elements bound to
- * the same path get `persist: false` from their own assigners.
- *
- * The assigner closure captures `el` and `registerValue` directly.
- * `el` is stable across the assigner's lifetime; `registerValue` is the
- * latest one, since the assigner is recreated on every `beforeUpdate`
- * via `setAssignFunction`.
- */
-function computePersistMeta(el: HTMLElement, registerValue: RegisterValue): WriteMeta {
-  const elementId = getOrAssignElementId(el)
-  return { persist: registerValue.persistOptIns.hasOptIn(elementId, registerValue.path) }
 }
 
 /**
@@ -359,7 +341,6 @@ function logTransformAsync(path: PathKey): void {
 }
 
 const getModelAssigner = (
-  el: HTMLElement,
   vnode: VNode,
   registerValue: RegisterValue
 ): CustomDirectiveRegisterAssignerFn => {
@@ -370,9 +351,11 @@ const getModelAssigner = (
   // Both shapes invoke the consumer's handler as `(value, registerValue)` so
   // a top-level handler can call `rv.setValueWithInternalPath(value)` to
   // forward the write into form state without having to capture `rv` via
-  // closure. Consumers wanting persistence-aware writes pass their own
-  // `meta` to `setValueWithInternalPath`; the default assigner below
-  // auto-attaches per-element meta.
+  // closure. The RV auto-attaches per-element persistence meta from its
+  // bound element when no `meta` is supplied — same code path the
+  // default assigner below uses. Advanced consumers who want to suppress
+  // (or override) persistence on a specific write pass an explicit
+  // `meta` second argument; the RV honors it verbatim.
   //
   // Vue 3.5's compiler emits TWO different prop keys for `@update:registerValue`
   // depending on context. For native elements with an uppercase letter in the
@@ -437,15 +420,16 @@ const getModelAssigner = (
     // bypasses normalization. Coerce already passes undefined cleanly
     // for paths that admit it, so skipping is a clarity win.
     if (value === undefined && registerValue.acceptsUndefined) {
-      return registerValue.setValueWithInternalPath(
-        undefined,
-        computePersistMeta(el, registerValue)
-      )
+      // Meta omitted on purpose: the RV's `setValueWithInternalPath`
+      // auto-derives `{ persist: hasOptIn(elementId, path) }` from its
+      // bound element when no meta is supplied. Same auto-derivation
+      // path consumer-installed assigners get for free.
+      return registerValue.setValueWithInternalPath(undefined)
     }
     const r = runTransforms(value, registerValue)
     if (!r.ok) return false
     const coerced = applyCoerce(r.value, registerValue)
-    return registerValue.setValueWithInternalPath(coerced, computePersistMeta(el, registerValue))
+    return registerValue.setValueWithInternalPath(coerced)
   }
   ;(defaultAssigner as unknown as DefaultAssignerCarrier)[DEFAULT_ASSIGNER_TAG] = true
   return defaultAssigner
@@ -523,7 +507,7 @@ function setAssignFunction(
     return
   }
 
-  el[assignKey] = getModelAssigner(el, vnode, value)
+  el[assignKey] = getModelAssigner(vnode, value)
 }
 
 // We are exporting the v-model runtime directly as vnode hooks so that it can

--- a/src/runtime/core/register-api.ts
+++ b/src/runtime/core/register-api.ts
@@ -17,6 +17,7 @@ import { computeFieldIdentity } from './field-ids'
 import { INTERACTIVE_TAG_NAMES } from './interactive-tags'
 import { canonicalizePath, type Path, type PathKey } from './paths'
 import { PERSISTENCE_MODULE_KEY } from './persistence'
+import { getOrAssignElementId } from './persistence/opt-in-registry'
 import { buildCoerceFn, buildElementCoerceFn, resolveCoercionIndex } from './schema-coerce'
 
 /**
@@ -334,6 +335,18 @@ export function buildRegister<F extends GenericForm>(
         ? (computed(() => getDisplayStateAt(segments)) as Readonly<Ref<DisplayState>>)
         : undefined
 
+    // Per-RV bound-element reference. Set by `registerElement` (called
+    // by the directive's `created` hook and by `syncElementRegistration`
+    // on every parent re-render to keep the freshly closed-over RV in
+    // step with the underlying DOM node). Cleared by
+    // `deregisterElement`. Consulted by `setValueWithInternalPath` to
+    // auto-derive persistence meta from the per-element opt-in
+    // registry, so a consumer-installed assigner that simply calls
+    // `rv.setValueWithInternalPath(value)` participates in the same
+    // per-element persistence contract the directive's default assigner
+    // honors.
+    let boundElement: HTMLElement | null = null
+
     // `shallowReadonly` is what makes `rv.path`, `rv.formKey`, and the
     // other top-level string fields feel like reactive state in
     // wrapper components: property reads track in computeds /
@@ -368,9 +381,23 @@ export function buildRegister<F extends GenericForm>(
       },
 
       registerElement: (element: HTMLElement): void => {
-        // Skip non-form elements. Prevents accidental registration of
-        // component wrapper divs when fallthrough attributes carry the
-        // directive past the intended `<input>` / `<select>` / `<textarea>`.
+        // Track the bound element on the RV regardless of tag name.
+        // The custom-assigner shape (`<div v-register>` + an
+        // `el[assignKey]` install) targets a non-form element on
+        // purpose; the rv still needs to know which element it was
+        // bound to so `setValueWithInternalPath` can auto-derive the
+        // per-element persistence meta. Single element per RV: each
+        // `form.register('path')` call returns a fresh handle, so the
+        // directive's lifecycle never asks one RV to track two
+        // elements; last-wins covers the corner case of a consumer who
+        // manually re-binds. Closure-private so a consumer can't read
+        // it off the public `RegisterValue` surface.
+        boundElement = element
+        // Form-element semantics (state-side registration + focus
+        // listeners) are gated behind the interactive tag set —
+        // prevents accidental registration of component wrapper divs
+        // when fallthrough attributes carry the directive past the
+        // intended `<input>` / `<select>` / `<textarea>`.
         if (!INTERACTIVE_TAG_NAMES.has(element.tagName)) return
         const added = state.registerElement(segments, element, formInstanceId)
         if (added) attachFocusListeners(state, segments, element, instanceMeta)
@@ -379,10 +406,31 @@ export function buildRegister<F extends GenericForm>(
       deregisterElement: (element: HTMLElement): void => {
         detachFocusListeners(element)
         state.deregisterElement(segments, element)
+        // Drop the bound-element reference if it matches the element
+        // being torn down. A post-teardown write (e.g. a captured RV
+        // ref held by a parent's `onBeforeUnmount` cleanup callback)
+        // therefore falls back to the "no auto-meta" path — safe,
+        // since the element id has gone out of scope on the WeakMap
+        // and the persist gate would drop the write either way.
+        if (boundElement === element) boundElement = null
       },
 
       setValueWithInternalPath: (value: unknown, meta?: WriteMeta): boolean => {
-        return state.setValueAtPath(segments, value, withInstanceMeta(meta))
+        // Auto-attach persistence meta when the consumer didn't supply
+        // their own AND this RV has a bound element. Lets a custom
+        // assigner call `rv.setValueWithInternalPath(value)` and have
+        // the per-element opt-in registry consulted automatically —
+        // the directive's default assigner takes this same path. An
+        // explicit `meta` (including `{}` or `{ persist: false }`)
+        // opts out of the derivation and passes through unchanged, so
+        // the documented "imperative writes via `form.setValue` don't
+        // auto-persist" contract is preserved (`form.setValue` calls
+        // `state.setValueAtPath` directly, not through RV).
+        const resolvedMeta =
+          meta === undefined && boundElement !== null
+            ? { persist: state.persistOptIns.hasOptIn(getOrAssignElementId(boundElement), pathKey) }
+            : meta
+        return state.setValueAtPath(segments, value, withInstanceMeta(resolvedMeta))
       },
 
       // Called by the `vRegisterHint` compile-time transform's wrapping

--- a/test/composables/persistence.test.ts
+++ b/test/composables/persistence.test.ts
@@ -1,11 +1,12 @@
 // @vitest-environment jsdom
 import 'fake-indexeddb/auto'
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createApp, defineComponent, h, withDirectives, type App } from 'vue'
+import { createApp, defineComponent, h, onMounted, ref, withDirectives, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
 import type { UseFormConfig, UseFormReturn } from '../../src/zod'
-import { vRegister } from '../../src/runtime/core/directive'
+import { assignKey, vRegister } from '../../src/runtime/core/directive'
+import type { CustomDirectiveRegisterAssignerFn } from '../../src/runtime/types/types-api'
 import { AnonPersistError } from '../../src/runtime/core/errors'
 import { resetSensitivePersistWarnDedup } from '../../src/runtime/core/persistence/sensitive-names'
 import { __resetIndexedDbForTests } from '../../src/runtime/core/persistence/indexeddb'
@@ -817,6 +818,128 @@ describe('persistence — per-element opt-in', () => {
     expect(raw).not.toBeNull()
     const payload = JSON.parse(raw as string) as { data: { form: { email: string } } }
     expect(payload.data.form.email).toBe('from-a@example.com')
+  })
+})
+
+/**
+ * Custom assigners installed via `el[assignKey] = fn` write through
+ * `rv.setValueWithInternalPath(value)`. The RV auto-attaches
+ * `{ persist: hasOptIn(elementId, path) }` from its bound element so a
+ * consumer's assigner picks up the per-element opt-in registered via
+ * `register('path', { persist: true })` without having to thread meta
+ * by hand. Pre-fix, the meta home lived only in the directive's
+ * default assigner; consumer overrides silently dropped the persist
+ * flag, the in-memory `form.values` updated, storage stayed empty,
+ * and the next mount rehydrated to the schema default.
+ */
+describe('persistence — consumer-installed assigner', () => {
+  const apps: App[] = []
+  beforeEach(() => localStorage.clear())
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+    localStorage.clear()
+  })
+
+  it('rv.setValueWithInternalPath(value) from a consumer assigner persists when register opted in', async () => {
+    const handle: { widget?: HTMLDivElement } = {}
+    const App = defineComponent({
+      setup() {
+        const api = useForm({
+          schema,
+          defaultValues: { email: '#000', password: '' },
+          key: 'consumer-assigner-persist',
+          persist: { storage: 'local', key: 'test-consumer-assigner', debounceMs: 20 },
+        })
+        const widget = ref<HTMLDivElement | null>(null)
+        const widgetAssigner: CustomDirectiveRegisterAssignerFn = (_value, rv) => {
+          const el = widget.value
+          if (!el || !rv) return false
+          // The demo's exact pattern: read picked value off the
+          // element's own state, forward via rv with NO explicit meta.
+          rv.setValueWithInternalPath(el.dataset['picked'] ?? '')
+          return true
+        }
+        onMounted(() => {
+          const el = widget.value
+          if (el === null) return
+          handle.widget = el
+          ;(el as HTMLDivElement & { [k: symbol]: CustomDirectiveRegisterAssignerFn })[assignKey] =
+            widgetAssigner
+        })
+        return () =>
+          withDirectives(h('div', { ref: widget }), [
+            [vRegister, api.register('email', { persist: true })],
+          ])
+      },
+    })
+    const app = createApp(App).use(createAttaform())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    apps.push(app)
+
+    await waitUntil(() => (handle.widget !== undefined ? true : null))
+    const widget = handle.widget as HTMLDivElement
+    widget.dataset['picked'] = 'consumer-write@example.com'
+    widget.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const raw = await waitUntil(() => localStorage.getItem(fpKey('test-consumer-assigner')))
+    expect(raw).not.toBeNull()
+    const payload = JSON.parse(raw as string) as { data: { form: { email: string } } }
+    expect(payload.data.form.email).toBe('consumer-write@example.com')
+  })
+
+  it('a consumer assigner that passes explicit meta keeps that meta verbatim (no auto-override)', async () => {
+    // Advanced override: a consumer who actively wants to suppress
+    // persistence on a specific write supplies `{ persist: false }`
+    // (or any non-undefined meta). The RV must NOT replace it with
+    // its auto-derived value, otherwise the escape hatch is closed.
+    const handle: { widget?: HTMLDivElement } = {}
+    const App = defineComponent({
+      setup() {
+        const api = useForm({
+          schema,
+          defaultValues: { email: '', password: '' },
+          key: 'consumer-assigner-override',
+          persist: { storage: 'local', key: 'test-consumer-override', debounceMs: 20 },
+        })
+        const widget = ref<HTMLDivElement | null>(null)
+        const overrideAssigner: CustomDirectiveRegisterAssignerFn = (_value, rv) => {
+          const el = widget.value
+          if (!el || !rv) return false
+          rv.setValueWithInternalPath(el.dataset['picked'] ?? '', { persist: false })
+          return true
+        }
+        onMounted(() => {
+          const el = widget.value
+          if (el === null) return
+          handle.widget = el
+          ;(el as HTMLDivElement & { [k: symbol]: CustomDirectiveRegisterAssignerFn })[assignKey] =
+            overrideAssigner
+        })
+        return () =>
+          withDirectives(h('div', { ref: widget }), [
+            [vRegister, api.register('email', { persist: true })],
+          ])
+      },
+    })
+    const app = createApp(App).use(createAttaform())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    apps.push(app)
+
+    await waitUntil(() => (handle.widget !== undefined ? true : null))
+    const widget = handle.widget as HTMLDivElement
+    widget.dataset['picked'] = 'should-not-persist@example.com'
+    widget.dispatchEvent(new Event('input', { bubbles: true }))
+
+    // 1.5x the 20 ms debounce — any in-flight write would have fired.
+    await wait(30)
+    await waitUntil(() =>
+      localStorage.getItem(fpKey('test-consumer-override')) === null ? true : null
+    )
+    expect(localStorage.getItem(fpKey('test-consumer-override'))).toBeNull()
   })
 })
 

--- a/test/core/custom-assigner-fire-time-contract.test.ts
+++ b/test/core/custom-assigner-fire-time-contract.test.ts
@@ -194,4 +194,94 @@ describe('fire-time contract: consumer-installed assigner sees (value, rv) consi
     expect(calls.length).toBeGreaterThanOrEqual(1)
     expect(calls[0]).toBe('HI')
   })
+
+  /**
+   * Persistence-meta auto-attach: the demo pattern is
+   * `rv.setValueWithInternalPath(value)` with no explicit `meta`. The
+   * RV's `registerElement` (called by the directive at bind time) stores
+   * the el; `setValueWithInternalPath` consults the per-element opt-in
+   * registry on writes that don't carry their own meta. So a consumer
+   * assigner installed against an element registered with
+   * `register('path', { persist: true })` participates in the same
+   * persistence channel the directive's default assigner uses.
+   *
+   * Pre-fix: meta home lived in the directive's default assigner only;
+   * consumer-installed assigners silently dropped the persist flag,
+   * `form.values` updated, storage stayed empty, the next mount
+   * rehydrated to schema default.
+   */
+  it('a consumer-installed assigner participates in per-element persistence opt-in', async () => {
+    const schema = z.object({ color: z.string() })
+    const writes: { key: string; value: unknown }[] = []
+    const memoryAdapter = {
+      getItem(): Promise<unknown> {
+        return Promise.resolve(null)
+      },
+      setItem(key: string, value: unknown): Promise<void> {
+        writes.push({ key, value })
+        return Promise.resolve()
+      },
+      removeItem(): Promise<void> {
+        return Promise.resolve()
+      },
+      listKeys(): Promise<string[]> {
+        return Promise.resolve([])
+      },
+    }
+
+    let widgetEl: HTMLDivElement | undefined
+    const Parent = defineComponent({
+      setup() {
+        const api = useForm({
+          schema,
+          defaultValues: { color: '#000' },
+          key: `assigner-persist-${Math.random().toString(36).slice(2)}`,
+          persist: { storage: memoryAdapter, debounceMs: 0 },
+        })
+        const widget = ref<HTMLDivElement | null>(null)
+
+        // The demo's exact shape: read picked color off dataset and
+        // forward via `rv.setValueWithInternalPath(value)` with no meta.
+        // The RV auto-attaches the per-element persist meta from its
+        // bound element's opt-in.
+        const colorAssigner: CustomDirectiveRegisterAssignerFn = (_value, rv) => {
+          const el = widget.value
+          if (!el || !rv) return false
+          rv.setValueWithInternalPath(el.dataset['color'] ?? '')
+          return true
+        }
+
+        onMounted(() => {
+          const el = widget.value
+          if (el === null) return
+          widgetEl = el
+          ;(el as HTMLDivElement & { [k: symbol]: CustomDirectiveRegisterAssignerFn })[assignKey] =
+            colorAssigner
+        })
+
+        return () =>
+          withDirectives(h('div', { ref: widget, 'data-color': api.values['color'] }), [
+            [vRegister, api.register('color', { persist: true })],
+          ])
+      },
+    })
+
+    app = createApp(Parent).use(createAttaform())
+    root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await waitUntil(() => (widgetEl !== undefined ? true : null))
+
+    if (widgetEl === undefined) throw new Error('widget element never resolved')
+
+    widgetEl.dataset['color'] = '#16a34a'
+    widgetEl.dispatchEvent(new Event('input', { bubbles: true }))
+
+    await waitUntil(() => (writes.length >= 1 ? true : null), 200)
+    expect(writes.length).toBeGreaterThanOrEqual(1)
+    const envelope = writes[writes.length - 1]?.value as {
+      data: { form: { color: string } }
+    }
+    expect(envelope.data.form.color).toBe('#16a34a')
+  })
 })

--- a/test/core/directive-blank.test.ts
+++ b/test/core/directive-blank.test.ts
@@ -101,7 +101,7 @@ describe('directive — blank on numeric clear', () => {
 
     input.value = '5'
     input.dispatchEvent(new Event('input'))
-    expect(setValue).toHaveBeenLastCalledWith(5, expect.objectContaining({}))
+    expect(setValue).toHaveBeenLastCalledWith(5)
 
     setValue.mockClear()
     markBlank.mockClear()
@@ -122,7 +122,7 @@ describe('directive — blank on numeric clear', () => {
 
     input.value = '7'
     input.dispatchEvent(new Event('input'))
-    expect(setValue).toHaveBeenLastCalledWith(7, expect.objectContaining({}))
+    expect(setValue).toHaveBeenLastCalledWith(7)
 
     setValue.mockClear()
     markBlank.mockClear()
@@ -165,7 +165,7 @@ describe('directive — blank on numeric clear', () => {
 
     input.value = '12'
     input.dispatchEvent(new Event('input'))
-    expect(setValue).toHaveBeenLastCalledWith(12, expect.objectContaining({}))
+    expect(setValue).toHaveBeenLastCalledWith(12)
   })
 
   it('text inputs without `.number` do NOT auto-mark on clear (string clear is ambiguous)', () => {
@@ -189,7 +189,7 @@ describe('directive — blank on numeric clear', () => {
     // The DOM doesn't tell us "user typed empty" vs "user hasn't typed",
     // so the dev opts in to blank via the unset symbol if
     // they want that semantic.
-    expect(setValue).toHaveBeenCalledWith('', expect.objectContaining({}))
+    expect(setValue).toHaveBeenCalledWith('')
     expect(markBlank).not.toHaveBeenCalled()
   })
 })
@@ -584,19 +584,19 @@ describe('directive — `.number` real-time storage updates with mid-typing DOM 
 
     input.value = '1'
     input.dispatchEvent(new Event('input'))
-    expect(setValue).toHaveBeenLastCalledWith(1, expect.objectContaining({}))
+    expect(setValue).toHaveBeenLastCalledWith(1)
     expect(value.lastTypedForm.value).toBe('1')
 
     // `parseFloat('1e')` is 1 (permissive); storage stays at 1, but
     // the typed form updates so the DOM keeps showing `1e`.
     input.value = '1e'
     input.dispatchEvent(new Event('input'))
-    expect(setValue).toHaveBeenLastCalledWith(1, expect.objectContaining({}))
+    expect(setValue).toHaveBeenLastCalledWith(1)
     expect(value.lastTypedForm.value).toBe('1e')
 
     input.value = '1e2'
     input.dispatchEvent(new Event('input'))
-    expect(setValue).toHaveBeenLastCalledWith(100, expect.objectContaining({}))
+    expect(setValue).toHaveBeenLastCalledWith(100)
     expect(value.lastTypedForm.value).toBe('1e2')
   })
 
@@ -610,7 +610,7 @@ describe('directive — `.number` real-time storage updates with mid-typing DOM 
 
     input.value = '2E10'
     input.dispatchEvent(new Event('input'))
-    expect(setValue).toHaveBeenLastCalledWith(2e10, expect.objectContaining({}))
+    expect(setValue).toHaveBeenLastCalledWith(2e10)
     expect(value.lastTypedForm.value).toBe('2E10')
   })
 
@@ -698,17 +698,17 @@ describe('directive — `.number` real-time storage updates with mid-typing DOM 
 
     input.value = '1'
     input.dispatchEvent(new Event('input'))
-    expect(setValue).toHaveBeenLastCalledWith(1, expect.objectContaining({}))
+    expect(setValue).toHaveBeenLastCalledWith(1)
     expect(value.lastTypedForm.value).toBe('1')
 
     input.value = '1.'
     input.dispatchEvent(new Event('input'))
-    expect(setValue).toHaveBeenLastCalledWith(1, expect.objectContaining({}))
+    expect(setValue).toHaveBeenLastCalledWith(1)
     expect(value.lastTypedForm.value).toBe('1.')
 
     input.value = '1.50'
     input.dispatchEvent(new Event('input'))
-    expect(setValue).toHaveBeenLastCalledWith(1.5, expect.objectContaining({}))
+    expect(setValue).toHaveBeenLastCalledWith(1.5)
     expect(value.lastTypedForm.value).toBe('1.50')
   })
 
@@ -726,7 +726,7 @@ describe('directive — `.number` real-time storage updates with mid-typing DOM 
 
     input.value = '3e45'
     input.dispatchEvent(new Event('change'))
-    expect(setValue).toHaveBeenCalledWith(3e45, expect.objectContaining({}))
+    expect(setValue).toHaveBeenCalledWith(3e45)
     expect(input.value).toBe(String(3e45))
     expect(value.lastTypedForm.value).toBeNull()
   })
@@ -759,7 +759,7 @@ describe('directive — `.number` overflow (Infinity) refusal', () => {
     // restore to.
     input.value = '1e308'
     input.dispatchEvent(new Event('input'))
-    expect(setValue).toHaveBeenLastCalledWith(1e308, expect.objectContaining({}))
+    expect(setValue).toHaveBeenLastCalledWith(1e308)
     setValue.mockClear()
 
     // Push past Number.MAX_VALUE — parseFloat returns Infinity.
@@ -825,7 +825,7 @@ describe('directive — `.number` overflow (Infinity) refusal', () => {
 
     input.value = '1.7976931348623157e308'
     input.dispatchEvent(new Event('input'))
-    expect(setValue).toHaveBeenLastCalledWith(Number.MAX_VALUE, expect.objectContaining({}))
+    expect(setValue).toHaveBeenLastCalledWith(Number.MAX_VALUE)
   })
 })
 
@@ -909,7 +909,7 @@ describe('directive — `<input type="number">` mid-typing badInput is not a cle
     input.value = '1'
     withBadInput(input, false)
     input.dispatchEvent(new Event('input'))
-    expect(setValue).toHaveBeenLastCalledWith(1, expect.objectContaining({}))
+    expect(setValue).toHaveBeenLastCalledWith(1)
 
     setValue.mockClear()
     // `1e` — browser blanks el.value, sets badInput.
@@ -923,6 +923,6 @@ describe('directive — `<input type="number">` mid-typing badInput is not a cle
     input.value = '1e2'
     withBadInput(input, false)
     input.dispatchEvent(new Event('input'))
-    expect(setValue).toHaveBeenLastCalledWith(100, expect.objectContaining({}))
+    expect(setValue).toHaveBeenLastCalledWith(100)
   })
 })

--- a/test/core/directive-cleanup.test.ts
+++ b/test/core/directive-cleanup.test.ts
@@ -470,7 +470,7 @@ describe('v-register directive — runtime value swap', () => {
     input.dispatchEvent(new Event('input'))
 
     expect(next.setValue).toHaveBeenCalledTimes(1)
-    expect(next.setValue).toHaveBeenCalledWith('typed', expect.objectContaining({}))
+    expect(next.setValue).toHaveBeenCalledWith('typed')
   })
 
   it('RegisterValue → undefined: deregisterElement on the prior RV is called', () => {
@@ -534,13 +534,16 @@ describe('v-register directive — runtime value swap', () => {
     expect(second.setValue).toHaveBeenCalledTimes(1)
   })
 
-  it('same path, fresh RV reference (parent re-render): no spurious deregister/register thrash', () => {
+  it('same path, fresh RV reference (parent re-render): no deregister-then-register thrash; new RV picks up the element', () => {
     // form.register('email') returns a fresh object each call; every
     // parent re-render hands beforeUpdate a referentially-different
-    // value at the same conceptual path. The diff must short-circuit
-    // (same path + same persistOptIns registry → already registered)
-    // so the element doesn't deregister-and-re-register on every
-    // tick.
+    // value at the same conceptual path. The diff skips the
+    // deregister-then-register sequence (so the `connected` flag
+    // doesn't thrash false → true on every tick) but STILL calls
+    // `registerElement` on the new RV so its private
+    // bound-element reference is current — `setValueWithInternalPath`
+    // reads it to auto-attach per-element persistence meta on writes
+    // that don't supply their own.
     const input = document.createElement('input')
     document.body.appendChild(input)
     const vnode = makeVNode({})
@@ -561,7 +564,7 @@ describe('v-register directive — runtime value swap', () => {
     hooks.beforeUpdate?.(input, swap, vnode, null)
 
     expect(first.deregister).not.toHaveBeenCalled()
-    expect(fresh.register).not.toHaveBeenCalled()
+    expect(fresh.register).toHaveBeenCalledTimes(1)
   })
 
   it('same form, different path (dynamic v-register expression): deregisters old path, registers new', () => {

--- a/test/core/directive-modifiers.test.ts
+++ b/test/core/directive-modifiers.test.ts
@@ -146,7 +146,7 @@ describe('vRegisterText — `.lazy`', () => {
     // Dispatching `change` writes.
     input.dispatchEvent(new Event('change'))
     expect(setValue).toHaveBeenCalledTimes(1)
-    expect(setValue).toHaveBeenCalledWith('typing', expect.objectContaining({}))
+    expect(setValue).toHaveBeenCalledWith('typing')
   })
 
   it('does NOT attach composition handlers under `.lazy`', () => {
@@ -166,7 +166,7 @@ describe('vRegisterText — `.lazy`', () => {
     input.dispatchEvent(new Event('compositionstart'))
     input.value = 'lazy-write'
     input.dispatchEvent(new Event('change'))
-    expect(setValue).toHaveBeenCalledWith('lazy-write', expect.objectContaining({}))
+    expect(setValue).toHaveBeenCalledWith('lazy-write')
   })
 })
 
@@ -189,7 +189,7 @@ describe('vRegisterText — `.trim`', () => {
 
     input.value = '  hello  '
     input.dispatchEvent(new Event('input'))
-    expect(setValue).toHaveBeenCalledWith('  hello  ', expect.objectContaining({}))
+    expect(setValue).toHaveBeenCalledWith('  hello  ')
   })
 
   it('change event commits the trimmed value to the model AND normalizes the DOM', () => {
@@ -204,7 +204,7 @@ describe('vRegisterText — `.trim`', () => {
     input.dispatchEvent(new Event('change'))
     // Both DOM and model arrive at the canonical trimmed form.
     expect(input.value).toBe('hello')
-    expect(setValue).toHaveBeenLastCalledWith('hello', expect.objectContaining({}))
+    expect(setValue).toHaveBeenLastCalledWith('hello')
   })
 })
 
@@ -223,12 +223,12 @@ describe('vRegisterText — `.number`', () => {
 
     input.value = '42'
     input.dispatchEvent(new Event('input'))
-    expect(setValue).toHaveBeenCalledWith(42, expect.objectContaining({}))
+    expect(setValue).toHaveBeenCalledWith(42)
 
     setValue.mockClear()
     input.value = '12.5'
     input.dispatchEvent(new Event('input'))
-    expect(setValue).toHaveBeenCalledWith(12.5, expect.objectContaining({}))
+    expect(setValue).toHaveBeenCalledWith(12.5)
   })
 
   it('input event marks blank for non-numeric strings instead of attempting the write', () => {
@@ -284,7 +284,7 @@ describe('vRegisterText — `.number`', () => {
 
     input.value = '7'
     input.dispatchEvent(new Event('input'))
-    expect(setValue).toHaveBeenCalledWith(7, expect.objectContaining({}))
+    expect(setValue).toHaveBeenCalledWith(7)
   })
 })
 
@@ -306,7 +306,7 @@ describe('vRegisterText — combined modifiers', () => {
     input.dispatchEvent(new Event('input'))
     expect(setValue).not.toHaveBeenCalled()
     input.dispatchEvent(new Event('change'))
-    expect(setValue).toHaveBeenCalledWith('spaced', expect.objectContaining({}))
+    expect(setValue).toHaveBeenCalledWith('spaced')
   })
 
   it('`.lazy.number`: change event writes the cast value', () => {
@@ -321,7 +321,7 @@ describe('vRegisterText — combined modifiers', () => {
     input.dispatchEvent(new Event('input'))
     expect(setValue).not.toHaveBeenCalled()
     input.dispatchEvent(new Event('change'))
-    expect(setValue).toHaveBeenCalledWith(99, expect.objectContaining({}))
+    expect(setValue).toHaveBeenCalledWith(99)
   })
 
   it('`.trim.number`: input writes the cast value (trim is deferred); change commits and normalizes', () => {
@@ -337,7 +337,7 @@ describe('vRegisterText — combined modifiers', () => {
     // handles surrounding whitespace, so the model still lands on 42.
     input.value = '  42  '
     input.dispatchEvent(new Event('input'))
-    expect(setValue).toHaveBeenCalledWith(42, expect.objectContaining({}))
+    expect(setValue).toHaveBeenCalledWith(42)
 
     input.value = '  7  '
     input.dispatchEvent(new Event('change'))
@@ -360,10 +360,10 @@ describe('vRegisterText — <textarea> reuses the same variant', () => {
 
     ta.value = '  multi line  '
     ta.dispatchEvent(new Event('input'))
-    expect(setValue).toHaveBeenLastCalledWith('  multi line  ', expect.objectContaining({}))
+    expect(setValue).toHaveBeenLastCalledWith('  multi line  ')
 
     ta.dispatchEvent(new Event('change'))
-    expect(setValue).toHaveBeenLastCalledWith('multi line', expect.objectContaining({}))
+    expect(setValue).toHaveBeenLastCalledWith('multi line')
     expect(ta.value).toBe('multi line')
   })
 })
@@ -397,7 +397,7 @@ describe('vRegisterSelect — `.number`', () => {
 
     select.value = '20'
     select.dispatchEvent(new Event('change'))
-    expect(setValue).toHaveBeenCalledWith(20, expect.objectContaining({}))
+    expect(setValue).toHaveBeenCalledWith(20)
   })
 
   it('multi-select with `.number` produces a numeric array', () => {
@@ -414,7 +414,7 @@ describe('vRegisterSelect — `.number`', () => {
     opt0.selected = true
     opt2.selected = true
     select.dispatchEvent(new Event('change'))
-    expect(setValue).toHaveBeenCalledWith([1, 3], expect.objectContaining({}))
+    expect(setValue).toHaveBeenCalledWith([1, 3])
   })
 
   it('multi-select WITHOUT `.number` writes string values', () => {
@@ -429,7 +429,7 @@ describe('vRegisterSelect — `.number`', () => {
     if (opt0 === undefined) throw new Error('unreachable')
     opt0.selected = true
     select.dispatchEvent(new Event('change'))
-    expect(setValue).toHaveBeenCalledWith(['1'], expect.objectContaining({}))
+    expect(setValue).toHaveBeenCalledWith(['1'])
   })
 
   it('mounted: selects the option matching a numeric model (16f regression)', () => {
@@ -565,7 +565,7 @@ describe('vRegisterSelect — multi-select (Array / Set models)', () => {
     opt0.selected = true
     opt2.selected = true
     select.dispatchEvent(new Event('change'))
-    expect(setValue).toHaveBeenCalledWith(['a', 'c'], expect.objectContaining({}))
+    expect(setValue).toHaveBeenCalledWith(['a', 'c'])
   })
 
   it('change event writes a Set when the initial model was a Set', () => {
@@ -598,7 +598,7 @@ describe('vRegisterSelect — multi-select (Array / Set models)', () => {
     // Deselect everything.
     opt0.selected = false
     select.dispatchEvent(new Event('change'))
-    expect(setValue).toHaveBeenCalledWith([], expect.objectContaining({}))
+    expect(setValue).toHaveBeenCalledWith([])
   })
 
   it('updated: re-syncs DOM when model array changes', () => {
@@ -836,7 +836,7 @@ describe('attaform interactions: `.lazy` × value-swap', () => {
     // `change` event routes the write to the new RV.
     input.dispatchEvent(new Event('change'))
     expect(next.setValue).toHaveBeenCalledTimes(1)
-    expect(next.setValue).toHaveBeenCalledWith('typed', expect.objectContaining({}))
+    expect(next.setValue).toHaveBeenCalledWith('typed')
   })
 })
 
@@ -865,7 +865,7 @@ describe('vRegisterDynamic — propagates modifiers to the per-tag variant', () 
     expect(setValue).not.toHaveBeenCalled()
 
     input.dispatchEvent(new Event('change'))
-    expect(setValue).toHaveBeenCalledWith('x', expect.objectContaining({}))
+    expect(setValue).toHaveBeenCalledWith('x')
   })
 
   it('`.number` on a select reaches vRegisterSelect', () => {
@@ -883,7 +883,7 @@ describe('vRegisterDynamic — propagates modifiers to the per-tag variant', () 
 
     select.value = '2'
     select.dispatchEvent(new Event('change'))
-    expect(setValue).toHaveBeenCalledWith(2, expect.objectContaining({}))
+    expect(setValue).toHaveBeenCalledWith(2)
   })
 })
 
@@ -925,14 +925,14 @@ describe('regression: vRegisterText × `.trim` × spacebar after text', () => {
     // User types "hello"
     input.value = 'hello'
     input.dispatchEvent(new Event('input'))
-    expect(setValue).toHaveBeenLastCalledWith('hello', expect.objectContaining({}))
+    expect(setValue).toHaveBeenLastCalledWith('hello')
 
     // User then types a trailing space. With deferred trim the model
     // sees the raw "hello " so Vue's :value patch stays in sync
     // with the DOM and the space the user is mid-typing survives.
     input.value = 'hello '
     input.dispatchEvent(new Event('input'))
-    expect(setValue).toHaveBeenLastCalledWith('hello ', expect.objectContaining({}))
+    expect(setValue).toHaveBeenLastCalledWith('hello ')
     expect(input.value).toBe('hello ')
   })
 
@@ -952,7 +952,7 @@ describe('regression: vRegisterText × `.trim` × spacebar after text', () => {
 
     // After the full sequence the form holds the raw "hello w" —
     // deferred trim does not strip the trailing space until blur.
-    expect(setValue).toHaveBeenLastCalledWith('hello w', expect.objectContaining({}))
+    expect(setValue).toHaveBeenLastCalledWith('hello w')
     expect(input.value).toBe('hello w')
   })
 
@@ -974,17 +974,17 @@ describe('regression: vRegisterText × `.trim` × spacebar after text', () => {
     const tenSpaces = ' '.repeat(10)
     input.value = tenSpaces
     input.dispatchEvent(new Event('input'))
-    expect(setValue).toHaveBeenLastCalledWith(tenSpaces, expect.objectContaining({}))
+    expect(setValue).toHaveBeenLastCalledWith(tenSpaces)
 
     // First real character — model still receives the raw value.
     input.value = `${tenSpaces}a`
     input.dispatchEvent(new Event('input'))
-    expect(setValue).toHaveBeenLastCalledWith(`${tenSpaces}a`, expect.objectContaining({}))
+    expect(setValue).toHaveBeenLastCalledWith(`${tenSpaces}a`)
     expect(input.value).toBe(`${tenSpaces}a`)
 
     // Blur commits the trim — DOM and model agree on "a".
     input.dispatchEvent(new Event('change'))
-    expect(setValue).toHaveBeenLastCalledWith('a', expect.objectContaining({}))
+    expect(setValue).toHaveBeenLastCalledWith('a')
     expect(input.value).toBe('a')
   })
 })
@@ -1022,7 +1022,7 @@ describe('regression: vRegisterText × type="number" × backspace-to-empty', () 
     input.value = '1'
     input.dispatchEvent(new Event('input'))
     expect(setValue).toHaveBeenCalledTimes(1)
-    expect(setValue).toHaveBeenLastCalledWith(1, expect.objectContaining({}))
+    expect(setValue).toHaveBeenLastCalledWith(1)
 
     // Backspace to empty: directive must NOT call setValue with "".
     // The form stays at the previously-accepted numeric value; the
@@ -1043,7 +1043,7 @@ describe('regression: vRegisterText × type="number" × backspace-to-empty', () 
 
     input.value = '42'
     input.dispatchEvent(new Event('input'))
-    expect(setValue).toHaveBeenLastCalledWith(42, expect.objectContaining({}))
+    expect(setValue).toHaveBeenLastCalledWith(42)
 
     setValue.mockClear()
     input.value = ''
@@ -1091,7 +1091,7 @@ describe('regression: vRegisterText × type="number" × backspace-to-empty', () 
     input.value = '1'
     input.dispatchEvent(new Event('input'))
     expect(setValue).toHaveBeenCalledTimes(1)
-    expect(setValue).toHaveBeenLastCalledWith(1, expect.objectContaining({}))
+    expect(setValue).toHaveBeenLastCalledWith(1)
 
     setValue.mockClear()
     input.value = ''

--- a/test/core/directive-prop-reactivity.test.ts
+++ b/test/core/directive-prop-reactivity.test.ts
@@ -180,7 +180,7 @@ describe('vRegisterText — :type swap reactivity', () => {
     // Pre-swap: the listener writes the raw string.
     input.value = '42'
     input.dispatchEvent(new Event('input'))
-    expect(setValue).toHaveBeenLastCalledWith('42', expect.objectContaining({}))
+    expect(setValue).toHaveBeenLastCalledWith('42')
 
     // Vue patches the DOM attribute when `:type="..."` swaps; mirror
     // that here. Pre-fix the listener stayed on the created-time
@@ -189,7 +189,7 @@ describe('vRegisterText — :type swap reactivity', () => {
 
     input.value = '100'
     input.dispatchEvent(new Event('input'))
-    expect(setValue).toHaveBeenLastCalledWith(100, expect.objectContaining({}))
+    expect(setValue).toHaveBeenLastCalledWith(100)
   })
 })
 


### PR DESCRIPTION
## Closes the silent-drop bug for consumer-installed assigners + persistence

Issue 3 of the rustling-whistling-planet plan (foundational sweep follow-up to the assigner-receives-register-value fix). Stacks on PRs #330 (smoke harness), #331 (test perf), and #332 (stale-closure sweep), all merged.

### Problem

A consumer-installed assigner via \`el[assignKey] = fn\` (the documented [Custom Assigners](https://attaform.dev/docs/binding-inputs/custom-assigners) shape) writes through \`rv.setValueWithInternalPath(value)\` without supplying \`meta\`. Pre-fix the per-element persist meta lived only in the directive's default assigner, so a custom assigner against an element registered with \`register('path', { persist: true })\` silently dropped the persist flag: \`form.values\` updated, storage stayed empty, the next mount rehydrated to schema default. No throw, no warn — the kind of bug that makes a Friday demo go sideways.

### Shape change

Meta home moves from the directive's default assigner **into the RV**:

- \`registerElement(el)\` tracks the bound element on a closure-private slot — runs regardless of the \`INTERACTIVE_TAG_NAMES\` gate, since custom-assigner widgets are usually \`<div>\`.
- \`setValueWithInternalPath(value, meta?)\` auto-derives \`{ persist: hasOptIn(elementId, path) }\` from that bound element when no meta is supplied.
- Explicit \`meta\` (including \`{ persist: false }\` or empty \`{}\`) passes through verbatim — the advanced-override escape hatch stays open.
- \`form.setValue(...)\` doesn't go through the RV, so the documented \"imperative writes don't auto-persist\" contract is preserved.

The directive's default assigner now just calls \`rv.setValueWithInternalPath(value)\` with no meta — one code path, one source of truth. \`computePersistMeta\` and the unused \`el\` parameter on \`getModelAssigner\` go away.

\`syncElementRegistration\` learns to call \`registerElement\` on the fresh RV when the parent re-renders with a referentially-different \`form.register('path')\` result, while still skipping the deregister side so the \`connected\` flag doesn't thrash. The underlying \`state.registerElement(path, el)\` is idempotent so the re-call is a single Set membership check.

### Coverage

- New persistence test pinning \`rv.setValueWithInternalPath(value)\` from a consumer assigner reaches localStorage when the binding opted in. **RED on main, GREEN here.**
- New custom-assigner-contract test pinning the same shape against a memory adapter. **RED on main, GREEN here.**
- New override test pinning explicit \`{ persist: false }\` from an advanced consumer suppresses the auto-derivation.
- Existing mock-rv directive tests had asserted on \`setValue.toHaveBeenCalledWith(<value>, expect.objectContaining({}))\`, pinning a now-obsolete fact about the directive→rv contract. Stripped to single-arg assertions across \`directive-modifiers\`, \`directive-blank\`, \`directive-cleanup\`, and \`directive-prop-reactivity\`.
- \`directive-cleanup\` \"same path, fresh RV\" test updated: the new RV now does get a register call so its bound-element ref is current; the thrash claim is about the deregister-then-register sequence specifically.

### Verification

- \`pnpm test\` — **3627 pass** (+3 over main) / 48 skipped / 0 fail.
- Docs-demo smoke harness from PR #330 — clean. This is the standing-diagnostic payoff for landing the harness first: every persist-using demo (\`persistence-overview\`, \`per-field-opt-in\`, \`multi-tab-sync\`, \`custom-assigners\`) re-exercised end-to-end after the shape change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)