### PR TITLE
docs(persistence): describe rv-side persist-meta auto-attach

### DIFF
--- a/docs/binding-inputs/custom-assigners.md
+++ b/docs/binding-inputs/custom-assigners.md
@@ -83,6 +83,25 @@ If you just want to reshape the value before write (uppercase, trim, parse), rea
 
 `assignKey` is for cases where the extracted value isn't right at all: different source, different shape, different element type. Web Components, custom widgets, third-party libraries that don't speak the standard DOM event surface.
 
+## Persistence integrates automatically
+
+If the bound element opted in via `register('path', { persist: true })`, `rv.setValueWithInternalPath(value)` auto-attaches the persist meta. The write flows to the configured storage backend without the assigner threading anything explicit.
+
+```ts
+const colorAssigner: CustomDirectiveRegisterAssignerFn = (_value, rv) => {
+  const el = widgetEl.value
+  if (!el || !rv) return false
+  // No second arg, no meta to assemble: the rv consults the
+  // per-element opt-in registered against this element.
+  rv.setValueWithInternalPath(el.dataset.color ?? '')
+  return true
+}
+```
+
+Template pairing: `<div ref="widget" v-register="form.register('color', { persist: true })" />`. The opt-in lives at the `register` call site, per the [two-gate policy](/docs/persistence/per-field-opt-in); the assigner just commits the write.
+
+Bypass the auto-attach by passing an explicit second arg, e.g. `rv.setValueWithInternalPath(value, { persist: false })` for a transient write that shouldn't persist even when the element is opted in.
+
 ## Where to next
 
 - [Register transforms](/docs/binding-inputs/transforms): the higher-level option for value reshaping.

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -2044,18 +2044,34 @@ export type RegisterValue<Value = unknown> = Readonly<{
    * Attach an HTML element to this binding. Called by `v-register`
    * automatically; expose it to custom integrations that need to
    * register an element manually.
+   *
+   * Recording the element also enables `setValueWithInternalPath` to
+   * auto-attach per-element persist meta on writes that don't carry
+   * their own.
    */
   registerElement: (el: HTMLElement) => void
   /**
    * Detach an HTML element from this binding. Pair with
-   * `registerElement` for custom integrations.
+   * `registerElement` for custom integrations. Clears the recorded
+   * element so subsequent writes without explicit `meta` fall back to
+   * "no auto-persist".
    */
   deregisterElement: (el: HTMLElement) => void
   /**
    * Write the field's value programmatically. Returns `true` when the
    * write was accepted, `false` when it was rejected (e.g. wrong
-   * primitive type for the path). The optional `meta` lets custom
-   * directives signal whether the write should be persisted.
+   * primitive type for the path).
+   *
+   * When `meta` is undefined and the binding has a registered element,
+   * the rv consults the per-element opt-in (set by
+   * `register(path, { persist: true })` against that element) and
+   * auto-attaches `{ persist: true }` when opted in. Custom directives
+   * and consumer assigners can omit `meta` to participate in the same
+   * persistence channel the default assigner uses.
+   *
+   * Pass an explicit `meta` to override the auto-derivation, e.g.
+   * `{ persist: false }` to skip persistence for a transient write
+   * even when the element is opted in.
    */
   setValueWithInternalPath: (value: unknown, meta?: WriteMeta) => boolean
   /**


### PR DESCRIPTION
Follow-up docs sweep for [PR #333](https://github.com/attaform/Attaform/pull/333) (per-element persist-meta auto-attach inside `RegisterValue.setValueWithInternalPath`).

Two doc surfaces still described the pre-#333 shape, where the directive's default assigner alone attached `{ persist: true }` and any consumer-installed assigner that called `rv.setValueWithInternalPath(value)` silently dropped persistence:

### `docs/binding-inputs/custom-assigners.md`

New "Persistence integrates automatically" section showing the assigner + persist-opted `register` pairing:

```ts
const colorAssigner: CustomDirectiveRegisterAssignerFn = (_value, rv) => {
  const el = widgetEl.value
  if (!el || !rv) return false
  // No second arg, no meta to assemble: the rv consults the
  // per-element opt-in registered against this element.
  rv.setValueWithInternalPath(el.dataset.color ?? '')
  return true
}
```

Template pairing: `<div ref="widget" v-register="form.register('color', { persist: true })" />`. Inline hop-link to the [two-gate policy](https://attaform.dev/docs/persistence/per-field-opt-in) page covers where the opt-in actually lives. Explicit-meta bypass (`{ persist: false }`) is called out for transient-write cases.

### `RegisterValue` JSDoc

Three docblocks describe the new behavior:

- `registerElement` — notes that recording the element also enables `setValueWithInternalPath` to auto-attach per-element persist meta.
- `deregisterElement` — notes the matched clear-on-detach so post-teardown writes fall back to "no auto-persist".
- `setValueWithInternalPath` — describes the auto-derive-when-meta-undefined behavior and the explicit-meta override path.

### Verification

- `pnpm typecheck` clean.
- No em-dashes (per docs brand voice).
- No behavior change — docs/JSDoc only catching up to PR #333.

🤖 Generated with [Claude Code](https://claude.com/claude-code)