### PR TITLE
docs: close out the brand-voice sweep with two micro-touches

### DIFF
--- a/docs/reading-the-form/the-form.md
+++ b/docs/reading-the-form/the-form.md
@@ -16,7 +16,7 @@ metaRows:
 ::docs-meta-table
 ::
 
-One call, one form. `useForm` hands back a reactive form that already knows your schema's shape, types, defaults, and validation. Everything below is a property of that single `form` handle: drillable value reads, per-leaf field state, error arrays, the submit handler, mutators. Wire one input, then reach for whatever else you need on the same object.
+One call, one form. `useForm` hands back a reactive form that already knows your schema's shape, types, defaults, and validation. Everything below is a property of that single `form` handle: drillable value reads, per-leaf field state, error arrays, the submit handler, mutators. Wire one input, then reach for whatever else you need on the same `form`.
 
 ```ts
 const schema = z.object({

--- a/docs/scorecard/cii-best-practices-answers.md
+++ b/docs/scorecard/cii-best-practices-answers.md
@@ -63,7 +63,7 @@ npm package: <https://www.npmjs.com/package/attaform>
 
 **Answer:** Met.
 **URL/evidence:** [apps/site/content/docs](https://github.com/attaform/Attaform/tree/main/apps/site/content/docs)
-**Notes:** Per-symbol reference pages: `useForm`, `useRegister`, `useWizard`, `injectForm`, plus schema, validation, persistence, undo/redo. Every public API symbol has its own page with the inference-first DX walkthroughs the library is built around.
+**Notes:** Per-symbol reference pages: `useForm`, `useRegister`, `useWizard`, `injectForm`, plus schema, validation, persistence, undo/redo. Every public API symbol has its own page with the inference-first DX walkthroughs Attaform is built around.
 
 ### 10. `sites_https`: Project sites MUST support HTTPS using TLS.
 


### PR DESCRIPTION
The deferred docs brand-voice sweep is effectively done. Grounding a rule-by-rule scan in main's current content (em-dashes, "the library", "Zod object", destructured `useForm`, inlined schemas, non-null assertions, stale APIs, celebrity names, negative framing outside troubleshooting) turns up 0 hits across every category except the one this PR closes.

The sweep shipped piecemeal as the source moved:

- #278 (displayState refactor) carried 18 docs files with it as `shouldShowErrors` became `getDisplayState` / `defaultDisplayState` / `field.displayState`.
- #280 / #281 (form.list, form.record, array identity) refreshed reading-the-form pages alongside the source change.
- The concept-per-page phases refit pages to the `form` handle pattern, hoisted schemas, named Attaform, and stripped em-dashes en route.
- The wizard v2 ship restructured `docs/multistep/*.md` around the list-based steps + form/step progression.

That leaves these two trailing touches:

**`docs/scorecard/cii-best-practices-answers.md:66`** — `"the library is built around"` → `"Attaform is built around"`. The lone remaining "the library" hit in docs prose.

**`docs/reading-the-form/the-form.md:19`** — `"reach for whatever else you need on the same object"` → `"on the same \`form\`"`. The closing sentence of the landing paragraph was reaching for "object" while the rest of the paragraph treats the return as a form handle.

## Verification

```sh
git grep -ni "the library" -- 'docs/*.md'         # 0 hits
git grep -n -- "—" -- 'docs/*.md'                 # 0 hits
git grep -n "shouldShowErrors\|useStepper" -- 'docs/*.md'  # 0 hits
git grep -ni "on the same object" -- 'docs/*.md'  # 0 hits
```

No source files. No demos. No tests. No public API touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)