### PR TITLE
ci(release): signal bump type in commit headline + publish run-name

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,5 +1,18 @@
 name: Publish to NPM
-run-name: Publish attaform from ${{ github.ref_name }}@${{ github.sha }}
+# For push triggers (the normal release path — release-pr.yml merges
+# its bump commit and the push fires this workflow), the run-name
+# pulls the head commit's headline directly. `release-pr.yml` shapes
+# that headline as `chore(release/<bump_type>): vX.Y.Z`, so the
+# Actions run list reads "Publish: chore(release/patch): v0.20.2"
+# without any parsing or `contains()` ladder. For workflow_dispatch
+# (manual recovery re-runs), fall back to `ref@sha` because there's
+# no `head_commit` context to characterize.
+run-name: >-
+  ${{
+    github.event_name == 'push'
+      && format('Publish: {0}', github.event.head_commit.message)
+      || format('Publish attaform from {0}@{1}', github.ref_name, github.sha)
+  }}
 
 # Step two of the two-workflow publish topology. The release-PR workflow
 # (`release-pr.yml`) opens a PR with the version bump + CHANGELOG /

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -209,6 +209,25 @@ jobs:
           EXACT_VERSION: ${{ github.event.inputs.exact_version }}
         run: |
           set -euo pipefail
+
+          # Classify the dispatch shape. Precedence matches the version
+          # computation below: explicit exact_version wins, else
+          # prerelease_id wins (any base bump it carries is implicit in
+          # the prerelease cycle), else fall back to version_type.
+          # Surfaced as a step output so downstream commit headline + PR
+          # title can encode the bump shape (e.g.
+          # `chore(release/patch): v0.20.2`), giving publish-npm.yml's
+          # run-name a parse-free signal of the release type via
+          # `github.event.head_commit.message`.
+          if [ -n "$EXACT_VERSION" ]; then
+            BUMP_TYPE=exact
+          elif [ -n "$PRERELEASE_ID" ]; then
+            BUMP_TYPE=prerelease
+          else
+            BUMP_TYPE="$VERSION_TYPE"
+          fi
+          echo "bump_type=$BUMP_TYPE" >> "$GITHUB_OUTPUT"
+
           # exact_version short-circuit: caller dictates the version
           # verbatim, skipping version_type / prerelease_id math. Used
           # for hotfix releases to older major lines (e.g. opening a PR
@@ -509,6 +528,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEXT_VERSION: ${{ steps.calculate-next-version.outputs.next_version }}
+          BUMP_TYPE: ${{ steps.calculate-next-version.outputs.bump_type }}
           DIST_TAG: ${{ steps.compute-dist-tag.outputs.dist_tag }}
           BASE_SHA: ${{ steps.classify.outputs.base_sha }}
           GH_REPOSITORY: ${{ github.repository }}
@@ -519,6 +539,7 @@ jobs:
             const { execFileSync } = require("node:child_process");
 
             const version = process.env.NEXT_VERSION;
+            const bumpType = process.env.BUMP_TYPE;
             const distTag = process.env.DIST_TAG;
             const baseSha = process.env.BASE_SHA;
             const repo = process.env.GH_REPOSITORY;
@@ -568,8 +589,8 @@ jobs:
                     branchName: branch,
                   },
                   message: {
-                    headline: `chore(release): v${version}`,
-                    body: `Bumps the package to v${version} with \`publishConfig.tag=${distTag}\`. Promotes the CHANGELOG Unreleased section and prepends a RELEASES.md entry. When merged, \`publish-npm.yml\` runs an idempotent precheck and publishes \`attaform@${version}\` to npm under the \`${distTag}\` dist-tag.`,
+                    headline: `chore(release/${bumpType}): v${version}`,
+                    body: `Bumps the package to v${version} (${bumpType}) with \`publishConfig.tag=${distTag}\`. Promotes the CHANGELOG Unreleased section and prepends a RELEASES.md entry. When merged, \`publish-npm.yml\` runs an idempotent precheck and publishes \`attaform@${version}\` to npm under the \`${distTag}\` dist-tag.`,
                   },
                   expectedHeadOid: baseSha,
                   fileChanges: { additions },
@@ -703,12 +724,13 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           NEXT_VERSION: ${{ steps.calculate-next-version.outputs.next_version }}
+          BUMP_TYPE: ${{ steps.calculate-next-version.outputs.bump_type }}
           TARGET_BRANCH: ${{ github.event.inputs.target_branch }}
         run: |
           set -euo pipefail
           gh pr create \
             --base "$TARGET_BRANCH" \
             --head "release/v$NEXT_VERSION" \
-            --title "chore(release): v$NEXT_VERSION" \
+            --title "chore(release/$BUMP_TYPE): v$NEXT_VERSION" \
             --label "release-pr" \
             --body-file "$PR_BODY_PATH"


### PR DESCRIPTION
## Why

`publish-npm.yml`'s run-name was `Publish attaform from main@<sha>` — the SHA alone gives no signal of what kind of release the publish is doing (patch / minor / major / prerelease / exact). The Actions run list reads identically whether the merged PR was a v0.20.2 patch or a v1.0.0 major.

## What

Two coordinated changes; the bump type now flows from `release-pr.yml`'s dispatch input → bump commit headline → `publish-npm.yml`'s run-name, no parsing required.

### `release-pr.yml`

- `calculate-next-version` step gains a `bump_type` output, derived in shell (precedence matches the version computation): `exact` if `exact_version` is set, else `prerelease` if `prerelease_id` is set, else `version_type` verbatim (`patch` / `minor` / `major`).
- `createCommitOnBranch` headline shifts from `chore(release): v${version}` to `chore(release/${bumpType}): v${version}`. Body also gets a parenthetical `(${bumpType})` next to the version mention.
- `gh pr create --title` shifts from `chore(release): v$NEXT_VERSION` to `chore(release/$BUMP_TYPE): v$NEXT_VERSION` so the PR title (and therefore the squash-merge headline on main) carries the same shape.

### `publish-npm.yml`

`run-name` switches from the static `Publish attaform from ${{ github.ref_name }}@${{ github.sha }}` to a conditional:

- Push triggers (the normal release path — release-PR merges, push fires the workflow): `format('Publish: {0}', github.event.head_commit.message)` → run list reads `Publish: chore(release/patch): v0.20.2 (#NNN)`.
- `workflow_dispatch` reruns (manual recovery, no `head_commit` context): falls back to the original `Publish attaform from ${ref}@${sha}` form.

## Smoke

- `python3 -c "import yaml; yaml.safe_load(...)"` parses both files.
- `zizmor --persona=pedantic` clean on both files (no new findings).
- No source / test changes.

## Out of scope

- `exact_version` short-circuit's `bump_type=exact` value is the only one not validated against an explicit allowlist — workflow_dispatch inputs aren't `type: choice` today, so a free-text `version_type=whatever` would yield `chore(release/whatever): vX.Y.Z`. The Node math already falls through to patch semantics for unknown types; not worth tightening the input shape in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)