### PR TITLE
feat: anti-flash validation display timing (timed getDisplayState)

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -220,7 +220,13 @@ export default [
     // and losing cross-module dedup, so the total ticks up ~0.5 kB even
     // as first-paint bytes drop. The real win lives in the eager gate;
     // this number is the full-feature ceiling. Measured at 48.06 KB.
-    limit: '49 KB',
+    //
+    // Raised 49 → 50 KB on the timed-display-state branch (#343): the
+    // anti-flash display engine (display-state.ts timed reducer +
+    // display-engine.ts per-form clock / single timer / machine map) lands in
+    // the shared core chunk, read synchronously on every field access so it
+    // cannot defer behind an async seam. Measured at 49.48 KB.
+    limit: '50 KB',
     gzip: true,
     modifyEsbuildConfig: asEsm,
   },
@@ -344,7 +350,11 @@ export default [
     // gap). The unified zod.mjs absorbs the full v3 delta. Phase 12
     // dedup reclaims the introspect-walker duplication. Measured at
     // 62.33 KB.
-    limit: '63 KB',
+    //
+    // Raised 63 → 64 KB tracking index.mjs's timed-display-state bump (#343):
+    // same shared core chunk (timed getDisplayState reducer + per-form display
+    // engine). Measured at 63.23 KB.
+    limit: '64 KB',
     gzip: true,
     ignore: ['zod'],
     modifyEsbuildConfig: asEsm,
@@ -431,7 +441,11 @@ export default [
     // though the EAGER set drops 45.61 -> 44.60 KB gz. The real D-metric
     // is scripts/check-eager-size.mjs (splitting:true); this cap tracks
     // only the inlined whole. Measured at 56.03 KB.
-    limit: '57 KB',
+    //
+    // Raised 57 → 58 KB tracking index.mjs's timed-display-state bump (#343):
+    // same shared core chunk (timed display reducer + per-form engine).
+    // Measured at 57.46 KB.
+    limit: '58 KB',
     gzip: true,
     ignore: ['zod'],
     modifyEsbuildConfig: asEsm,
@@ -575,7 +589,11 @@ export default [
     // import back (it cannot see the eager/async split), so the inlined
     // total ticks up ~0.5 kB. See the index.mjs note plus the eager gate
     // (scripts/check-eager-size.mjs). Measured at 57.16 KB.
-    limit: '58 KB',
+    //
+    // Raised 58 → 59 KB tracking index.mjs's timed-display-state bump (#343):
+    // same shared core chunk (timed display reducer + per-form engine).
+    // Measured at 58.63 KB.
+    limit: '59 KB',
     gzip: true,
     ignore: ['zod'],
     modifyEsbuildConfig: asEsm,

--- a/apps/site/docs-demos/async-refinements.vue
+++ b/apps/site/docs-demos/async-refinements.vue
@@ -23,7 +23,6 @@
 
   const form = useForm({
     schema,
-    validateOn: 'blur',
     key: 'docs-demo-async-refinements',
   })
 

--- a/apps/site/docs-demos/container-display-state.vue
+++ b/apps/site/docs-demos/container-display-state.vue
@@ -1,0 +1,264 @@
+<script setup lang="ts">
+  import { useForm } from 'attaform/zod'
+  import { z } from 'zod'
+
+  const wait = (ms: number) => new Promise((r) => setTimeout(r, ms))
+  const takenEmails = new Set(['ada@team.dev', 'champ@team.dev'])
+
+  async function isAvailable(email: string): Promise<boolean> {
+    await wait(700)
+    return !takenEmails.has(email.toLowerCase())
+  }
+
+  const schema = z.object({
+    account: z.object({
+      email: z
+        .string()
+        .email('Enter a valid email')
+        .refine(async (v) => isAvailable(v), { message: 'That email is taken' }),
+      password: z.string().min(8, 'At least 8 characters'),
+    }),
+    profile: z.object({
+      name: z.string().min(1, 'Tell us your name'),
+      nickname: z.string().optional(),
+    }),
+  })
+
+  const form = useForm({
+    schema,
+    key: 'docs-demo-container-display-state',
+  })
+
+  const bannerText = {
+    idle: 'Fill in your details',
+    pending: 'Checking…',
+    error: 'A few fields need attention',
+    success: 'Looking good, ready to submit',
+  }
+
+  const onSubmit = form.handleSubmit(() => {})
+</script>
+
+<template>
+  <form @submit.prevent="onSubmit">
+    <div class="banner" :class="form.meta.displayState">
+      <span class="badge" :class="form.meta.displayState">{{ form.meta.displayState }}</span>
+      <span class="banner-text">{{ bannerText[form.meta.displayState] }}</span>
+      <span class="chips">
+        <span class="chip" :class="{ on: form.meta.showIdle }">showIdle</span>
+        <span class="chip" :class="{ on: form.meta.showPending }">showPending</span>
+        <span class="chip" :class="{ on: form.meta.showErrors }">showErrors</span>
+        <span class="chip" :class="{ on: form.meta.showSuccess }">showSuccess</span>
+      </span>
+    </div>
+
+    <fieldset>
+      <legend>
+        Account
+        <span class="badge" :class="form.fields('account').displayState">{{
+          form.fields('account').displayState
+        }}</span>
+      </legend>
+
+      <label>
+        <span>Email (taken: ada@team.dev, champ@team.dev)</span>
+        <input v-register="form.register('account.email')" />
+        <small v-if="form.fields.account.email.showErrors" class="msg msg--error">{{
+          form.fields.account.email.firstError?.message
+        }}</small>
+        <small v-else-if="form.fields.account.email.showPending" class="msg msg--pending"
+          >Checking availability…</small
+        >
+      </label>
+
+      <label>
+        <span>Password</span>
+        <input type="password" v-register="form.register('account.password')" />
+        <small v-if="form.fields.account.password.showErrors" class="msg msg--error">{{
+          form.fields.account.password.firstError?.message
+        }}</small>
+      </label>
+    </fieldset>
+
+    <fieldset>
+      <legend>
+        Profile
+        <span class="badge" :class="form.fields('profile').displayState">{{
+          form.fields('profile').displayState
+        }}</span>
+      </legend>
+
+      <label>
+        <span>Name</span>
+        <input v-register="form.register('profile.name')" />
+        <small v-if="form.fields.profile.name.showErrors" class="msg msg--error">{{
+          form.fields.profile.name.firstError?.message
+        }}</small>
+      </label>
+
+      <label>
+        <span>Nickname (optional)</span>
+        <input v-register="form.register('profile.nickname')" />
+      </label>
+    </fieldset>
+
+    <button type="submit">Create account</button>
+
+    <p class="hint">
+      Every group carries the same <code>displayState</code> as a leaf, rolled up from its fields. A
+      group rests at <code>idle</code> until one of its fields earns a verdict, shows
+      <code>pending</code> while any child is checking, flips to <code>error</code> the moment a
+      child's error becomes visible, and greens only once every child is earned. An untouched
+      optional like Nickname never holds the group back, and a field you have not engaged with yet
+      never drags the group into <code>error</code>. <code>form.meta</code> is the same rollup at
+      the root, so the banner reflects the whole form.
+    </p>
+  </form>
+</template>
+
+<style scoped>
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    max-width: 32rem;
+  }
+  .banner {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem 0.75rem;
+    padding: 0.65rem 0.85rem;
+    border-radius: 0.5rem;
+    border: 1px solid #e5e7eb;
+    background: #f9fafb;
+  }
+  .banner.error {
+    border-color: #fecaca;
+    background: #fef2f2;
+  }
+  .banner.pending {
+    border-color: #bfdbfe;
+    background: #eff6ff;
+  }
+  .banner.success {
+    border-color: #bbf7d0;
+    background: #f0fdf4;
+  }
+  .banner-text {
+    font-size: 0.875rem;
+    font-weight: 500;
+  }
+  fieldset {
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    padding: 1rem 1rem 1.15rem;
+  }
+  legend {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0 0.4rem;
+    font-size: 0.875rem;
+    font-weight: 600;
+  }
+  label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+  }
+  input {
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.375rem;
+    border: 1px solid #d1d5db;
+    font-size: 0.875rem;
+  }
+  input:focus {
+    outline: 2px solid #2563eb;
+    outline-offset: -1px;
+  }
+  .badge {
+    min-width: 4.25rem;
+    text-align: center;
+    padding: 0.15rem 0.55rem;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    font-family: ui-monospace, monospace;
+  }
+  .badge.idle {
+    background: #f3f4f6;
+    color: #6b7280;
+  }
+  .badge.pending {
+    background: #dbeafe;
+    color: #1d4ed8;
+  }
+  .badge.error {
+    background: #fee2e2;
+    color: #dc2626;
+  }
+  .badge.success {
+    background: #dcfce7;
+    color: #16a34a;
+  }
+  .chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+    margin-left: auto;
+  }
+  .chip {
+    padding: 0.1rem 0.4rem;
+    border-radius: 0.25rem;
+    border: 1px solid #e5e7eb;
+    font-size: 0.6875rem;
+    font-family: ui-monospace, monospace;
+    color: #9ca3af;
+  }
+  .chip.on {
+    border-color: #2563eb;
+    color: #1d4ed8;
+    font-weight: 600;
+  }
+  .msg {
+    font-size: 0.8125rem;
+    line-height: 1.2rem;
+  }
+  .msg--error {
+    color: #dc2626;
+  }
+  .msg--pending {
+    color: #2563eb;
+  }
+  button {
+    align-self: flex-start;
+    padding: 0.5rem 1rem;
+    border-radius: 0.375rem;
+    border: 1px solid #2563eb;
+    background: #2563eb;
+    color: #fff;
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+  }
+  button:hover {
+    background: #1d4ed8;
+  }
+  .hint {
+    font-size: 0.8rem;
+    color: #6b7280;
+    margin: 0;
+    line-height: 1.5;
+  }
+  .hint code {
+    font-family: ui-monospace, monospace;
+    font-size: 0.75rem;
+    color: #374151;
+  }
+</style>

--- a/apps/site/docs-demos/container-display-state.vue
+++ b/apps/site/docs-demos/container-display-state.vue
@@ -73,7 +73,7 @@
 
       <label>
         <span>Password</span>
-        <input type="password" v-register="form.register('account.password')" />
+        <input v-register="form.register('account.password')" type="password" />
         <small v-if="form.fields.account.password.showErrors" class="msg msg--error">{{
           form.fields.account.password.firstError?.message
         }}</small>

--- a/apps/site/docs-demos/defaults-sync-factory.vue
+++ b/apps/site/docs-demos/defaults-sync-factory.vue
@@ -25,7 +25,6 @@
     schema,
     defaultValues: buildDefaults,
     key: 'docs-demo-defaults-sync-factory',
-    validateOn: 'blur',
   })
 
   async function onNewSession() {

--- a/apps/site/docs-demos/display-state.vue
+++ b/apps/site/docs-demos/display-state.vue
@@ -19,7 +19,6 @@
 
   const form = useForm({
     schema,
-    validateOn: 'blur',
     key: 'docs-demo-display-state',
   })
 

--- a/apps/site/docs-demos/preprocess.vue
+++ b/apps/site/docs-demos/preprocess.vue
@@ -12,7 +12,6 @@
   const form = useForm({
     schema,
     key: 'docs-demo-preprocess',
-    validateOn: 'blur',
   })
 
   const parsePreview = computed(() => normalize(form.values.email))

--- a/apps/site/docs-demos/url-availability-check.vue
+++ b/apps/site/docs-demos/url-availability-check.vue
@@ -67,7 +67,6 @@
   const form = useForm({
     schema,
     key: 'docs-demo-url-availability-check',
-    validateOn: 'blur',
   })
 
   const submittedShape = ref<unknown>(null)

--- a/apps/site/docs-demos/validate-on-modes.vue
+++ b/apps/site/docs-demos/validate-on-modes.vue
@@ -1,0 +1,194 @@
+<script setup lang="ts">
+  import { useForm } from 'attaform/zod'
+  import { z } from 'zod'
+
+  const schema = z.object({
+    handle: z.string().min(3, 'At least 3 characters'),
+  })
+
+  const changeForm = useForm({
+    schema,
+    key: 'docs-demo-validate-on-change',
+    validateOn: 'change',
+    strict: false,
+  })
+  const blurForm = useForm({
+    schema,
+    key: 'docs-demo-validate-on-blur',
+    validateOn: 'blur',
+    strict: false,
+  })
+  const submitForm = useForm({
+    schema,
+    key: 'docs-demo-validate-on-submit',
+    validateOn: 'submit',
+    strict: false,
+  })
+
+  const modes = [
+    {
+      mode: 'change',
+      form: changeForm,
+      onSubmit: changeForm.handleSubmit(() => {}),
+      caption: 'Checks on every keystroke.',
+    },
+    {
+      mode: 'blur',
+      form: blurForm,
+      onSubmit: blurForm.handleSubmit(() => {}),
+      caption: 'Checks when the field loses focus.',
+    },
+    {
+      mode: 'submit',
+      form: submitForm,
+      onSubmit: submitForm.handleSubmit(() => {}),
+      caption: 'Checks only when you submit.',
+    },
+  ]
+</script>
+
+<template>
+  <div class="layout">
+    <p class="lede">
+      The same schema runs in all three. What changes is <em>when</em>. Type one or two characters
+      into each, then tab away or submit, and watch when the message lands.
+    </p>
+
+    <div class="modes">
+      <section v-for="item in modes" :key="item.mode" class="mode">
+        <header>
+          <code>validateOn: '{{ item.mode }}'</code>
+          <p>{{ item.caption }}</p>
+        </header>
+
+        <form @submit.prevent="item.onSubmit">
+          <label>
+            Handle
+            <input
+              v-register="item.form.register('handle')"
+              placeholder="3+ characters"
+              autocomplete="off"
+              spellcheck="false"
+            />
+          </label>
+          <button type="submit">Submit</button>
+        </form>
+
+        <div class="readout" :class="{ invalid: item.form.fields.handle.firstError }">
+          {{ item.form.fields.handle.firstError?.message ?? 'No error yet' }}
+        </div>
+      </section>
+    </div>
+
+    <p class="note">
+      These panels read the raw validation result so the timing is the only variable. In real UI you
+      gate what shows with <code>showErrors</code>, which adds its own reveal-on-submit rhythm.
+    </p>
+  </div>
+</template>
+
+<style scoped>
+  .layout {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  .lede {
+    margin: 0;
+    font-size: 0.8125rem;
+    color: #374151;
+  }
+  .modes {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.875rem;
+  }
+  @media (min-width: 720px) {
+    .modes {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+  .mode {
+    display: flex;
+    flex-direction: column;
+    gap: 0.625rem;
+    padding: 0.875rem;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    background: #fafafa;
+  }
+  header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+  header p {
+    margin: 0;
+    font-size: 0.75rem;
+    color: #6b7280;
+  }
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.8125rem;
+    color: #374151;
+  }
+  input {
+    padding: 0.5rem 0.625rem;
+    border-radius: 0.375rem;
+    border: 1px solid #d1d5db;
+    font-size: 0.875rem;
+    font-family: inherit;
+  }
+  input:focus {
+    outline: 2px solid #2563eb;
+    outline-offset: -1px;
+  }
+  button {
+    align-self: flex-start;
+    padding: 0.4375rem 0.75rem;
+    border-radius: 0.375rem;
+    border: 1px solid #2563eb;
+    background: #2563eb;
+    color: white;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    cursor: pointer;
+    font-family: inherit;
+  }
+  button:hover {
+    background: #1d4ed8;
+  }
+  .readout {
+    padding: 0.5rem 0.625rem;
+    border-radius: 0.375rem;
+    background: #f3f4f6;
+    color: #6b7280;
+    font-size: 0.75rem;
+    font-family: ui-monospace, monospace;
+    min-height: 1.25rem;
+  }
+  .readout.invalid {
+    background: #fef2f2;
+    color: #b91c1c;
+    font-weight: 500;
+  }
+  .note {
+    margin: 0;
+    font-size: 0.75rem;
+    color: #6b7280;
+  }
+  code {
+    font-family: ui-monospace, monospace;
+    background: #f3f4f6;
+    padding: 0.05rem 0.3rem;
+    border-radius: 0.25rem;
+    font-size: 0.75rem;
+  }
+</style>

--- a/docs/cross-cutting-state/app-defaults.md
+++ b/docs/cross-cutting-state/app-defaults.md
@@ -116,7 +116,7 @@ type AttaformDefaults = {
 }
 ```
 
-`getDisplayState` resolves `field.displayState` and its `show*` projections: the centralized "what should this field surface right now?" heuristic, one of idle, pending, error, or success. Set it once at the app level so every form follows the same convention. See [Display state and showing errors](/docs/validation/showing-errors) for the full contract.
+`getDisplayState` resolves `field.displayState` and its `show*` projections: the centralized "what should this field surface right now?" reducer, returning one of idle, pending, error, or success. Set it once at the app level so every form follows the same convention. To keep the default behavior but retune the anti-flash spinner timing, pass `makeDefaultDisplayState({ showDelay, minVisible })`. See [Display state and showing errors](/docs/validation/showing-errors) for the full contract.
 
 `sensitiveNames` extends the heuristic that gates persistence opt-ins and multi-tab broadcasts. See [Sensitive-name protection](/docs/persistence/sensitive-names).
 

--- a/docs/reading-the-form/fields.md
+++ b/docs/reading-the-form/fields.md
@@ -90,7 +90,7 @@ The error surface at this path: raw, ergonomic, and gated.
 | `validating`   | `boolean`                                     | `true` while a per-field validation run is in flight.                                               |
 | `displayState` | `'idle' \| 'pending' \| 'error' \| 'success'` | The single display-state verdict, resolved by [`getDisplayState`](/docs/validation/showing-errors). |
 | `showErrors`   | `boolean`                                     | `displayState === 'error'`. The display-time error gate.                                            |
-| `showPending`  | `boolean`                                     | `displayState === 'pending'`. An async check is in flight.                                          |
+| `showPending`  | `boolean`                                     | `displayState === 'pending'`. A check has run long enough to earn a spinner.                        |
 | `showSuccess`  | `boolean`                                     | `displayState === 'success'`. The field has passed.                                                 |
 | `showIdle`     | `boolean`                                     | `displayState === 'idle'`. Nothing to surface yet.                                                  |
 

--- a/docs/validation/showing-errors.md
+++ b/docs/validation/showing-errors.md
@@ -22,7 +22,7 @@ metaRows:
 Every path on a form carries a single display-state verdict, `field.displayState`, that is one of four values:
 
 - `'idle'`: nothing to surface yet.
-- `'pending'`: an async check is in flight.
+- `'pending'`: a check has been running long enough to earn a spinner.
 - `'error'`: a blocking error is ready to show.
 - `'success'`: the field has passed and earned its green check.
 
@@ -70,7 +70,7 @@ Until the gate opens, `displayState` is `'idle'` no matter what is in the store.
 
 Once the gate is open, the default resolves in order:
 
-1. **Pending.** A per-field validation run in flight (`field.validating`) wins. The verdict in `field.errors` is stale by definition, so Attaform surfaces a spinner rather than a possibly-wrong message.
+1. **Pending (timed).** While a per-field validation runs, the field is heading for a spinner, but Attaform holds the prior verdict for a short window first. A fast check that settles inside that window never shows `'pending'` at all; a slow one flips to the spinner and is then held a minimum so it cannot blink off. This anti-flash timing is tunable, see [Tune the timing](#tune-the-timing).
 2. **Error.** An own-path error resolves to `'error'`.
 3. **Success.** No error, `field.valid`, and the green check is earned: the field is non-blank and `dirty`, so the user put valid content there themselves. An empty field that happens to pass, a pre-filled field merely tabbed through, and the post-submit flood of every valid field all stay `'idle'` rather than greening for free. `valid` already waits on the form-wide first validation pass for async schemas, so success never fires before the first real verdict lands.
 4. **Idle.** Anything else, including a valid-but-unearned field (blank or unchanged), stays `'idle'`.
@@ -89,15 +89,16 @@ That means `form.meta.displayState` only reaches `'error'` for root-level (cross
 ```ts
 useForm({
   schema,
-  getDisplayState: (field) => (field.errors.length > 0 && field.touched ? 'error' : 'idle'),
+  getDisplayState: (prev, ctx) =>
+    ctx.field.errors.length > 0 && ctx.field.touched ? { display: 'error' } : { display: 'idle' },
 })
 ```
 
-Pass a custom predicate to bend the rule, for example to reveal errors the moment a field is touched (ignoring focus and submit state). The predicate receives the field's `FieldState` and the form's `FormMeta`, both with the derived `displayState` / `show*` / `firstError` keys omitted so an accidental self-reference is impossible, and returns the verdict.
+Pass a custom reducer to bend the rule, for example to reveal errors the moment a field is touched (ignoring focus and submit state). A reducer receives `(prev, ctx)`: `prev` is the field's previous `DisplayMachine`, and `ctx` carries the field's `FieldState` and the form's `FormMeta` (both with the derived `displayState` / `show*` / `firstError` keys omitted, so an accidental self-reference is impossible) plus `ctx.validatingSince` and `ctx.now` for timing. It returns the next machine: `{ display }` at minimum, optionally with a `reviewAt` timestamp telling Attaform when to look again.
 
 ## Compose with the default
 
-Adopter predicates can layer on top of `defaultDisplayState`. Defer to it for the common case and special-case only the paths you care about:
+Adopter reducers can layer on top of `defaultDisplayState`. Defer to it for the common case and special-case only the paths you care about:
 
 ```ts
 import { defaultDisplayState } from 'attaform'
@@ -105,12 +106,35 @@ import { defaultDisplayState } from 'attaform'
 useForm({
   schema,
   // Defer everywhere, but never show a success check on `username`.
-  getDisplayState: (field, formMeta) => {
-    const state = defaultDisplayState(field, formMeta)
-    return field.path[0] === 'username' && state === 'success' ? 'idle' : state
+  getDisplayState: (prev, ctx) => {
+    const next = defaultDisplayState(prev, ctx)
+    return next.display === 'success' && ctx.field.path[0] === 'username'
+      ? { display: 'idle' }
+      : next
   },
 })
 ```
+
+## Tune the timing
+
+The spinner is anti-flash by default. A validation that settles quickly never shows `'pending'` at all, and once a spinner appears it stays up for a minimum so it cannot blink off the instant the check lands. Two timings shape this, both in milliseconds:
+
+- `showDelay` (default `100`): how long a validation may run before its spinner is allowed to show. Anything that settles inside this window stays on its prior verdict, so a synchronous or microtask-fast check never flashes a spinner on every keystroke.
+- `minVisible` (default `120`): once shown, the minimum the spinner stays up, so a check that lands just past `showDelay` does not flash it on and immediately off.
+
+The shipped values live in `DEFAULT_TIMINGS`. To retune, build a default with `makeDefaultDisplayState`:
+
+```ts
+import { makeDefaultDisplayState } from 'attaform'
+
+useForm({
+  schema,
+  // Tighter: a spinner after 50ms, held for 200ms once shown.
+  getDisplayState: makeDefaultDisplayState({ showDelay: 50, minVisible: 200 }),
+})
+```
+
+This shapes only the display projection. `errors`, `valid`, `validating`, and the underlying validation all run exactly as before; only when the spinner appears and how long it lingers change. For total control, a from-scratch reducer owns its own timing by returning a `reviewAt` (an absolute `Date.now()` stamp) to tell Attaform when to re-evaluate the field.
 
 ## Where to next
 

--- a/docs/validation/showing-errors.md
+++ b/docs/validation/showing-errors.md
@@ -71,18 +71,23 @@ Until the gate opens, `displayState` is `'idle'` no matter what is in the store.
 Once the gate is open, the default resolves in order:
 
 1. **Pending (timed).** While a per-field validation runs, the field is heading for a spinner, but Attaform holds the prior verdict for a short window first. A fast check that settles inside that window never shows `'pending'` at all; a slow one flips to the spinner and is then held a minimum so it cannot blink off. This anti-flash timing is tunable, see [Tune the timing](#tune-the-timing).
-2. **Error.** An own-path error resolves to `'error'`.
+2. **Error.** An error at the field resolves to `'error'` (containers roll up their descendants, see below).
 3. **Success.** No error, `field.valid`, and the green check is earned: the field is non-blank and `dirty`, so the user put valid content there themselves. An empty field that happens to pass, a pre-filled field merely tabbed through, and the post-submit flood of every valid field all stay `'idle'` rather than greening for free. `valid` already waits on the form-wide first validation pass for async schemas, so success never fires before the first real verdict lands.
 4. **Idle.** Anything else, including a valid-but-unearned field (blank or unchanged), stays `'idle'`.
 
-### The own-path filter
+### Rollup at containers and the form
 
-The error arm fires only on an error whose path equals the field's own path.
+A container resolves over the gated verdicts of everything beneath it, so one verdict reflects the whole subtree.
 
-- **Leaves** always satisfy this when they have errors (a leaf's errors are at its own path).
-- **Containers** (intermediate AND root) resolve to `'error'` only for errors that point directly at them. Descendant errors are rendered by the descendant fields, so binding `field.showErrors` at a container never duplicates them.
+- **Leaves** resolve on their own error.
+- **Containers** (an object, an array row, the array itself, and the root `form.meta`) resolve to `'error'` when any descendant is showing an error, or when a cross-field error is pinned at the container itself. Each descendant counts only once its own gate has opened, so a sibling that has been blurred never drags an untouched field's error up to the group.
 
-That means `form.meta.displayState` only reaches `'error'` for root-level (cross-field or object-level) errors. Aggregate "fix the errors below" banners should bind to `form.meta.errorCount > 0` paired with whatever timing signal fits, not to `form.meta.showErrors`.
+Precedence rolls up too: a container shows `'pending'` while any descendant is still checking, `'error'` if a gated descendant (or the container's own cross-field check) failed, `'success'` once every field is valid and at least one is earned, and `'idle'` otherwise. An untouched optional sibling sits `'idle'` without holding the group's success back.
+
+That makes `form.meta.showErrors` the natural binding for a form-level "fix the errors below" banner: it turns on the moment a field's error becomes visible and off when the last one clears.
+
+::docs-demo{slug="container-display-state" label="Container rollup demo"}
+::
 
 ## Override per form
 

--- a/docs/validation/url-availability-check.md
+++ b/docs/validation/url-availability-check.md
@@ -97,7 +97,7 @@ const schema = z.object({
   ),
 })
 
-const form = useForm({ schema, key: 'url-check', validateOn: 'blur' })
+const form = useForm({ schema, key: 'url-check' })
 ```
 
 ## How the layers split the work
@@ -112,12 +112,12 @@ Preprocess and refine each own a single decision.
 
 ## Three messages, one validator
 
-| User input                 | Preprocess returns       | Refine outcome | Error message                          |
-| -------------------------- | ------------------------ | -------------- | -------------------------------------- |
-| `''` (blur on empty input) | `EMPTY_URL`              | invalid        | "Please enter a URL."                  |
-| `'###'`                    | `INVALID_URL`            | invalid        | "That doesn't look like a URL."        |
-| `'google.com'`             | `'https://google.com'`   | invalid        | "https://google.com is already taken." |
-| `'attaform.dev'`           | `'https://attaform.dev'` | valid          | (none, form submits)                   |
+| User input         | Preprocess returns       | Refine outcome | Error message                          |
+| ------------------ | ------------------------ | -------------- | -------------------------------------- |
+| `''` (empty input) | `EMPTY_URL`              | invalid        | "Please enter a URL."                  |
+| `'###'`            | `INVALID_URL`            | invalid        | "That doesn't look like a URL."        |
+| `'google.com'`     | `'https://google.com'`   | invalid        | "https://google.com is already taken." |
+| `'attaform.dev'`   | `'https://attaform.dev'` | valid          | (none, form submits)                   |
 
 Every message comes out of the refine layer. Preprocess never raises an error itself; it just hands a value over for refine to grade. This is the cleanest division: validation messages all live in one place.
 
@@ -143,7 +143,7 @@ If you need the typed shape outside submit, call `form.validateAsync()` or `form
 ## Tweaks
 
 - **One sentinel instead of two.** If you only need a single "rejected" message ("That URL won't work"), collapse `EMPTY_URL` and `INVALID_URL` into one sentinel and short-circuit refine on that single check. You lose the empty-vs-malformed distinction but the schema gets a few lines shorter.
-- **Validate on submit only.** Change `validateOn: 'blur'` to `validateOn: 'submit'` for forms where the network round-trip on blur is too noisy. The cache still pays for itself once the user clicks Submit and retries.
+- **Throttle the network round-trip.** The form checks on every change by default. For a network-backed check you'll usually want `validateOn: 'blur'` (hit the endpoint when the field loses focus) or `validateOn: 'submit'` (defer entirely), optionally paired with `debounceMs` to coalesce bursts. The cache absorbs repeat checks regardless.
 - **Invalidate on success.** After a successful signup, call `availabilityCache.delete(submittedUrl)` so a subsequent re-check picks up the new "taken" state on the server.
 - **Real backend.** Swap the `setTimeout`-based `checkAvailability` for your API call. A library like TanStack Query gives you the cache + de-duplication for free; the schema stays exactly as written.
 

--- a/docs/validation/when-validation-runs.md
+++ b/docs/validation/when-validation-runs.md
@@ -39,6 +39,9 @@ The directive's commit cadence and the validation trigger are independent. With 
 
 The same schema runs in every mode: the only thing that changes is _when_ a refinement gets evaluated.
 
+::docs-demo{slug="validate-on-modes" label="validateOn modes"}
+::
+
 Under `validateOn: 'blur'`, leaving a field you never edited can't change any verdict, so Attaform skips the pass: it tracks whether the form has changed since the last validation and only revalidates when it has. Refocus a field that's showing an error, then tab away, and the error holds steady instead of blinking through `'pending'` and back.
 
 ## Debouncing

--- a/scripts/check-eager-size.mjs
+++ b/scripts/check-eager-size.mjs
@@ -169,11 +169,19 @@ export async function measureEager(define = PROD_DEFINE) {
 // own dynamic-imported module, so a prod build orphans that chunk instead of
 // shipping it as dead code (esbuild keeps a top-level function called only
 // from a dead `__DEV__` branch — tree-shaking runs before the define-fold),
-// landing the eager set at 43.91 kB gz. ~0.5 kB headroom absorbs minifier-
-// version drift. The lazy-loading work tightens this as optional features
-// move to the async path; never loosen it without a recorded reason in the
-// commit.
-const BUDGET_GZ = 45_470
+// landing the eager set at 43.91 kB gz.
+//
+// RECORDED LOOSENING (anti-flash display timing): the timed `getDisplayState`
+// reducer + the per-form display engine (clock / single timer / machine map)
+// sit on the eager path because `field.displayState` is read synchronously on
+// every field access — there is no async seam to defer them behind. That is a
+// deliberate capability-for-bytes trade (a polished, tunable anti-flash
+// spinner baked into every form, otherwise re-built ad hoc by each consumer),
+// landing the eager set at 44.51 kB gz. Budget raised to keep ~0.5 kB headroom
+// for minifier-version drift. The lazy-loading work tightens this as optional
+// features move to the async path; never loosen it without a recorded reason
+// in the commit.
+const BUDGET_GZ = 46_080
 
 const isMain = import.meta.url === pathToFileURL(realpathSync(argv[1])).href
 if (isMain) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,8 @@ export type {
   CoercionResult,
   CustomDirectiveRegisterAssignerFn,
   DefaultValuesResponse,
+  DisplayCtx,
+  DisplayMachine,
   DisplayState,
   ErrorsProxyShape,
   FieldMetaPayload,
@@ -160,10 +162,17 @@ export {
   SubmitErrorHandlerError,
 } from './runtime/core/errors'
 
-// Library-default heuristic for `getDisplayState`. Public so adopter
-// predicates can compose with it (a layered predicate that defers to
-// the library default for the unhandled cases).
-export { defaultDisplayState } from './runtime/core/display-state'
+// Library-default reducer for `getDisplayState`. Public so adopter
+// reducers can compose with it (a layered reducer that defers to the
+// library default for the unhandled cases). `makeDefaultDisplayState`
+// rebuilds it with custom anti-flash timing; `DEFAULT_TIMINGS` is the
+// shipped `{ showDelay, minVisible }`.
+export {
+  DEFAULT_TIMINGS,
+  defaultDisplayState,
+  makeDefaultDisplayState,
+} from './runtime/core/display-state'
+export type { DisplayTimings } from './runtime/core/display-state'
 
 // Library-default list of identifier name stems flagged as sensitive
 // (password, ssn, cvv, token, etc.). Compose with `sensitiveNames` at

--- a/src/runtime/composables/use-wizard.ts
+++ b/src/runtime/composables/use-wizard.ts
@@ -1131,7 +1131,16 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
         // always bumps once per invocation.
         for (const key of results.keys()) {
           const store = registry.forms.get(key)
-          if (store !== undefined) store.submissionAttempts.value += 1
+          if (store !== undefined) {
+            store.submissionAttempts.value += 1
+            // Mirror the form's own handleSubmit: a wizard submit is an
+            // explicit reveal, so abort any in-flight per-field validation
+            // (clearing `fieldValidatingSince`) and drop the anti-flash
+            // display state, so leftover show-delay holds or min-visible
+            // spinner timers can't outlive the submit and delay the verdict.
+            store.cancelFieldValidation()
+            store.displayEngine.clear()
+          }
         }
         submissionAttempts.value += 1
 

--- a/src/runtime/core/array-bookkeeping.ts
+++ b/src/runtime/core/array-bookkeeping.ts
@@ -156,16 +156,21 @@ export function createArrayBookkeeping(deps: ArrayBookkeepingDeps): ArrayBookkee
     }))
     migrateSetSubtree(blankPaths, arrayPath, remap)
     migrateSetSubtree(originalBlankPaths, arrayPath, remap)
+    // The validation-streak anchor leads its count, mirroring
+    // `incFieldValidation`: relocating `fieldValidatingSince` before
+    // `fieldValidationCounts` keeps `validatingSince !== null` an outer bracket
+    // around `count > 0` at the destination key, so a synchronous reader
+    // catching the gap between the two relocations never sees `validating: true,
+    // validatingSince: null` (which would flash idle). The anchor travels with
+    // the count it parallels, so a moved element's show-delay clock keeps
+    // measuring from when ITS streak opened rather than inheriting the slot's.
+    migrateMapSubtree(fieldValidatingSince, arrayPath, remap, (since) => since)
     // In-flight field-validation counter (`field.validating` mirror).
     // Same identity reasoning as the other path-keyed maps: the spinner
     // belongs to the validating element, not the slot. Self-heals on the
     // next validation pass; this migration just spares the wrong-row
     // visible flicker in between.
     migrateMapSubtree(fieldValidationCounts, arrayPath, remap, (count) => count)
-    // The validation-streak anchor travels with the count it parallels, so
-    // a moved element's show-delay clock keeps measuring from when ITS
-    // streak opened rather than inheriting the slot's.
-    migrateMapSubtree(fieldValidatingSince, arrayPath, remap, (since) => since)
     // Nested-array identity: relocate every tracked array sitting under
     // `arrayPath`'s element slots so a nested `v-for :key` stays stable
     // across an outer-array mutation (no token leak, no collision on the

--- a/src/runtime/core/array-bookkeeping.ts
+++ b/src/runtime/core/array-bookkeeping.ts
@@ -52,6 +52,7 @@ export type ArrayBookkeepingDeps = {
   readonly blankPaths: Set<PathKey>
   readonly originalBlankPaths: Set<PathKey>
   readonly fieldValidationCounts: Map<PathKey, number>
+  readonly fieldValidatingSince: Map<PathKey, number>
   readonly fieldValidationState: Map<PathKey, FieldValidationEntry>
   readonly schemaErrors: Map<PathKey, ValidationError[]>
   readonly activeValidations: Ref<number>
@@ -131,6 +132,7 @@ export function createArrayBookkeeping(deps: ArrayBookkeepingDeps): ArrayBookkee
     blankPaths,
     originalBlankPaths,
     fieldValidationCounts,
+    fieldValidatingSince,
     fieldValidationState,
     schemaErrors,
     activeValidations,
@@ -160,6 +162,10 @@ export function createArrayBookkeeping(deps: ArrayBookkeepingDeps): ArrayBookkee
     // next validation pass; this migration just spares the wrong-row
     // visible flicker in between.
     migrateMapSubtree(fieldValidationCounts, arrayPath, remap, (count) => count)
+    // The validation-streak anchor travels with the count it parallels, so
+    // a moved element's show-delay clock keeps measuring from when ITS
+    // streak opened rather than inheriting the slot's.
+    migrateMapSubtree(fieldValidatingSince, arrayPath, remap, (since) => since)
     // Nested-array identity: relocate every tracked array sitting under
     // `arrayPath`'s element slots so a nested `v-for :key` stays stable
     // across an outer-array mutation (no token leak, no collision on the

--- a/src/runtime/core/array-bookkeeping.ts
+++ b/src/runtime/core/array-bookkeeping.ts
@@ -34,6 +34,11 @@ export type FieldValidationEntry = {
   controller: AbortController
   timer: ReturnType<typeof setTimeout> | null
   settled: boolean
+  // Set true when an external caller (a path-scoped reset) has already released
+  // this run's counters synchronously. The run's own `.finally` then skips its
+  // decrements, so it can't double-count against a run rescheduled at the same
+  // key in the meantime.
+  released: boolean
 }
 
 /**

--- a/src/runtime/core/build-form-api.ts
+++ b/src/runtime/core/build-form-api.ts
@@ -138,7 +138,15 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
   // going through the accessor would recurse through the root path's
   // own showErrors computation.
   const getFormMetaBase = (): FormMetaBase => {
-    const rootBase = buildContainerFieldStateBase(state, ROOT_PATH, ROOT_PATH_KEY, formInstanceId)
+    // `validatingSince` is for the field machine, not the predicate's
+    // meta arg — discard it here and let the root field-state computed
+    // thread the root's own anchor when it resolves `form.meta.displayState`.
+    const { base: rootBase } = buildContainerFieldStateBase(
+      state,
+      ROOT_PATH,
+      ROOT_PATH_KEY,
+      formInstanceId
+    )
     return {
       ...rootBase,
       submitting: state.submitting.value,

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -2354,7 +2354,7 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
       prev.controller.abort()
     }
     const controller = new AbortController()
-    const fresh: FieldValidationEntry = { controller, timer: null, settled: false }
+    const fresh: FieldValidationEntry = { controller, timer: null, settled: false, released: false }
     fieldValidationState.set(key, fresh)
     // Capture a fresh epoch at schedule time. Closed over by `run`
     // below and re-checked at the commit site so a later-scheduled
@@ -2474,8 +2474,14 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
           // branch for adapter-level throws (see process-form.ts).
         })
         .finally(() => {
-          activeValidations.value = Math.max(0, activeValidations.value - 1)
-          decFieldValidation(key)
+          // Skip the decrements if an external release (a path-scoped reset)
+          // already did them — otherwise this late `.finally` would
+          // double-count against a run rescheduled at the same key after the
+          // release. Normal runs leave `released` false and decrement here.
+          if (!fresh.released) {
+            activeValidations.value = Math.max(0, activeValidations.value - 1)
+            decFieldValidation(key)
+          }
           fresh.settled = true
         })
     }
@@ -2515,6 +2521,31 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
       entry.controller.abort()
     }
     fieldValidationState.clear()
+  }
+
+  // Path-scoped counterpart to `cancelFieldValidation`: abort and release only
+  // the in-flight runs whose path sits at or under `prefix`, leaving sibling
+  // fields' validations untouched. Used by `resetField` so resetting one field
+  // tears down its own validation. Releases the count + streak anchor in
+  // lockstep through `decFieldValidation` (preserving the bracket invariant)
+  // and marks each entry `released` so the run's late `.finally` can't
+  // double-decrement a run rescheduled at the same key (the change-mode restore
+  // write that follows `resetField`'s call schedules exactly such a run).
+  function cancelFieldValidationUnder(prefix: Path): void {
+    for (const [key, entry] of [...fieldValidationState]) {
+      const segs = segmentsForPathKey(key)
+      if (segs === null) continue
+      if (!isPathPrefix(prefix, segs)) continue
+      if (entry.timer !== null) {
+        clearTimeout(entry.timer)
+      } else if (!entry.settled && !entry.released) {
+        activeValidations.value = Math.max(0, activeValidations.value - 1)
+        decFieldValidation(key)
+        entry.released = true
+      }
+      entry.controller.abort()
+      fieldValidationState.delete(key)
+    }
   }
 
   function onFormChange(listener: (next: F, meta?: WriteMeta) => void): () => void {
@@ -3352,6 +3383,22 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     // is intentionally preserved — the snapshot self-corrects on the
     // next switch-out.
     variantMemory.clearUnderPath(targetSegments)
+
+    // Tear down any in-flight validation for this subtree BEFORE the restore.
+    // Without this the run validating the pre-reset value outlives the reset:
+    // `validating` stays true on the field and, when it settles, it commits its
+    // verdict back over the errors cleared below. In change mode the restore
+    // write reschedules a fresh run for the restored value (the cancel's
+    // `released` flag keeps the orphan's late `.finally` off the new run's
+    // counters); in blur / submit mode no run follows and the field rests
+    // clean. Drop the subtree's blur-dedup snapshots too, so a post-reset blur
+    // re-validates instead of skipping against a pre-reset anchor.
+    cancelFieldValidationUnder(targetSegments)
+    for (const [snapKey] of [...pathSnapshots]) {
+      const segs = segmentsForPathKey(snapKey)
+      if (segs === null) continue
+      if (isPathPrefix(targetSegments, segs)) pathSnapshots.delete(snapKey)
+    }
 
     // Storage restore: leaf > container > nothing.
     //

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -10,6 +10,7 @@ import type {
   WriteMeta,
 } from '../types/types-api'
 import { resolveGetDisplayState } from './display-state'
+import { createDisplayEngine, type DisplayEngine } from './display-engine'
 import { applyDuStubs } from './du-stubs'
 import { cloneVariantSnapshot, createVariantMemory } from './variant-memory'
 import { createArrayIdentity } from './array-identity'
@@ -291,6 +292,17 @@ export type FormStore<F extends GenericForm, G extends GenericForm = F> = {
    */
   readonly getDisplayState: GetDisplayState
 
+  /**
+   * Per-form display engine: owns the clock and the single timer the timed
+   * `getDisplayState` reducer policy needs, keeping the reducer itself a
+   * pure `(prev, ctx) => next` function. The field-state computeds route
+   * every `displayState` read through `displayEngine.resolve(...)`, which
+   * threads the path's previous machine, persists or evicts the result, and
+   * re-arms the nearest-deadline timer. Constructed once at form
+   * construction; torn down via `registerCleanup` on store eviction.
+   */
+  readonly displayEngine: DisplayEngine
+
   // --- submission lifecycle ---
   // Driven by buildProcessForm's handleSubmit wrapper. See use-abstract-form.ts
   // for the public readonly surface. Mutations happen in exactly one place
@@ -481,6 +493,21 @@ export type FormStore<F extends GenericForm, G extends GenericForm = F> = {
    * computed only re-runs when the count for ITS key changes.
    */
   readonly fieldValidationCounts: Map<PathKey, number>
+  /**
+   * Per-path `Date.now()` stamp marking when the field's current
+   * validation streak opened (the `0 → 1` count edge), deleted on the
+   * `→ 0` edge. Parallels `fieldValidationCounts` and anchors on the same
+   * edges, so the stamp pins to the start of the continuous streak —
+   * overlapping sub-runs that briefly push the count past 1 do not reset
+   * it. The display reducer reads it as `ctx.validatingSince` to time the
+   * anti-flash spinner; the field-state container walk takes the
+   * descendant-min so a row spinner anchors at its earliest active leaf.
+   * Runtime-only, never hydrated, like the counts. Plain (non-reactive)
+   * Map: every write to it coincides with a `fieldValidationCounts` write,
+   * which already re-runs the field-state computed, so a second reactive
+   * source would only duplicate triggers.
+   */
+  readonly fieldValidatingSince: Map<PathKey, number>
 
   // --- form mutations ---
   /**
@@ -1154,6 +1181,16 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
   const cleanupHooks: (() => void)[] = []
   const modules = new Map<string, unknown>()
 
+  // Anti-flash display engine + its episode-timing companion. The engine
+  // owns the clock and the single timer the timed `getDisplayState` reducer
+  // needs; `fieldValidatingSince` records when each path's validation streak
+  // opened (set / cleared on the count edges in inc/decFieldValidation
+  // below). Disposed with the store so a held spinner can't outlive
+  // eviction.
+  const fieldValidatingSince = new Map<PathKey, number>()
+  const displayEngine = createDisplayEngine(ssr)
+  registerCleanup(() => displayEngine.dispose())
+
   // Schema is ALWAYS consulted: we need the schema-derived originals even
   // when hydrating, so pristine/dirty computation survives SSR round-trip.
   // The form's actual starting value, though, prefers hydration data.
@@ -1548,12 +1585,26 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
   // `FormStore.fieldValidationCounts` for semantics.
   const fieldValidationCounts: Map<PathKey, number> = reactive(new Map<PathKey, number>())
   function incFieldValidation(key: PathKey): void {
-    fieldValidationCounts.set(key, (fieldValidationCounts.get(key) ?? 0) + 1)
+    const prevCount = fieldValidationCounts.get(key) ?? 0
+    fieldValidationCounts.set(key, prevCount + 1)
+    // 0 → 1 edge: a validation streak just opened at this path. Stamp the
+    // start (the show-delay clock measures `now - validatingSince`).
+    // Guarded on the edge so overlapping sub-runs don't reset the anchor
+    // mid-streak. `ssr` never gets here in practice (no field validation is
+    // scheduled server-side); the `0` keeps the stamp clock-free if it does.
+    if (prevCount === 0) fieldValidatingSince.set(key, ssr ? 0 : Date.now())
   }
   function decFieldValidation(key: PathKey): void {
     const next = (fieldValidationCounts.get(key) ?? 0) - 1
-    if (next <= 0) fieldValidationCounts.delete(key)
-    else fieldValidationCounts.set(key, next)
+    if (next <= 0) {
+      fieldValidationCounts.delete(key)
+      // → 0 edge: the streak closed; drop the anchor so the next streak
+      // re-stamps fresh. Co-extensive with the count delete, so the abort /
+      // cancel / migrate paths that release a count clear this in lockstep.
+      fieldValidatingSince.delete(key)
+    } else {
+      fieldValidationCounts.set(key, next)
+    }
   }
 
   // Populate originals by diffing from empty-form to schema-initial. This is
@@ -1701,6 +1752,7 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     blankPaths,
     originalBlankPaths,
     fieldValidationCounts,
+    fieldValidatingSince,
     fieldValidationState,
     schemaErrors,
     activeValidations,
@@ -2494,6 +2546,7 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     drainHooks.length = 0
     modules.clear()
     cancelFieldValidation()
+    fieldValidatingSince.clear()
     formChangeListeners.clear()
     submitSuccessListeners.clear()
     resetListeners.clear()
@@ -3220,6 +3273,11 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     // that reached the controller-aborted branch resolve to a no-op, so
     // the error store stays clean after the reset clears it above.
     cancelFieldValidation()
+    // Drop any held spinner state so an in-flight min-visible hold can't
+    // outlive the reset; clear the streak anchors to match (the cancel above
+    // already released the counts, this wipes the parallel map wholesale).
+    displayEngine.clear()
+    fieldValidatingSince.clear()
     // Reset the per-path blur-dedup snapshots and the form-level epoch
     // counters. After `cancelFieldValidation` no in-flight run can
     // commit, so clearing here can't be raced by a late commit
@@ -3470,6 +3528,8 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     pathHasAsyncValidation,
     pathHasAsyncValidationByKey,
     fieldValidationCounts,
+    fieldValidatingSince,
+    displayEngine,
 
     applyFormReplacement,
     setValueAtPath,

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -494,18 +494,25 @@ export type FormStore<F extends GenericForm, G extends GenericForm = F> = {
    */
   readonly fieldValidationCounts: Map<PathKey, number>
   /**
-   * Per-path `Date.now()` stamp marking when the field's current
-   * validation streak opened (the `0 → 1` count edge), deleted on the
-   * `→ 0` edge. Parallels `fieldValidationCounts` and anchors on the same
-   * edges, so the stamp pins to the start of the continuous streak —
-   * overlapping sub-runs that briefly push the count past 1 do not reset
-   * it. The display reducer reads it as `ctx.validatingSince` to time the
-   * anti-flash spinner; the field-state container walk takes the
-   * descendant-min so a row spinner anchors at its earliest active leaf.
-   * Runtime-only, never hydrated, like the counts. Plain (non-reactive)
-   * Map: every write to it coincides with a `fieldValidationCounts` write,
-   * which already re-runs the field-state computed, so a second reactive
-   * source would only duplicate triggers.
+   * Per-path `Date.now()` stamp marking when the field's LATEST validation
+   * run started, re-anchored on every run start (every increment), deleted
+   * on the `→ 0` edge. The display reducer reads it as `ctx.validatingSince`
+   * to time the anti-flash spinner, which measures `now - validatingSince`:
+   * re-anchoring on each run means a burst of keystrokes (each aborting the
+   * prior run and starting a new one) keeps pushing the stamp forward, so the
+   * spinner stays suppressed until the user pauses rather than surfacing
+   * mid-typing. Anchoring only at the streak start would pin it to the first
+   * keystroke, because with `debounceMs: 0` the aborted run's decrement lands
+   * after the next run's increment and the count never returns to 0 between
+   * fast keystrokes. The field-state container walk takes the descendant-min
+   * so a row spinner anchors at its earliest still-active leaf. Runtime-only,
+   * never hydrated, like the counts. REACTIVE: the display computed reads this
+   * (as `ctx.validatingSince`) but not the `validating` flag, and a long
+   * validation that settles with an unchanged verdict (same error, still
+   * invalid) leaves `errors` / `valid` untouched — so a non-reactive map would
+   * leave a held `pending` spinner stranded after the run ends, until some
+   * unrelated reactive change happened to re-run the computed. Reactivity ties
+   * the computed to both the streak start (set) and end (delete).
    */
   readonly fieldValidatingSince: Map<PathKey, number>
 
@@ -1183,11 +1190,18 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
 
   // Anti-flash display engine + its episode-timing companion. The engine
   // owns the clock and the single timer the timed `getDisplayState` reducer
-  // needs; `fieldValidatingSince` records when each path's validation streak
-  // opened (set / cleared on the count edges in inc/decFieldValidation
-  // below). Disposed with the store so a held spinner can't outlive
-  // eviction.
-  const fieldValidatingSince = new Map<PathKey, number>()
+  // needs; `fieldValidatingSince` records when each path's latest validation
+  // run started (re-stamped on every run, cleared on the → 0 edge, in
+  // inc/decFieldValidation below). Disposed with the store so a held spinner
+  // can't outlive eviction.
+  //
+  // Reactive: the display computed reads `validatingSince` but NOT the
+  // `validating` flag, and a long validation that settles with an unchanged
+  // verdict (same error, still invalid) leaves `errors` / `valid` untouched —
+  // so without reactivity here the held spinner would never re-evaluate when
+  // the run ends, stranding `pending` until some unrelated reactive change.
+  // Reactivity ties the computed to the streak's start AND end.
+  const fieldValidatingSince: Map<PathKey, number> = reactive(new Map<PathKey, number>())
   const displayEngine = createDisplayEngine(ssr)
   registerCleanup(() => displayEngine.dispose())
 
@@ -1585,22 +1599,44 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
   // `FormStore.fieldValidationCounts` for semantics.
   const fieldValidationCounts: Map<PathKey, number> = reactive(new Map<PathKey, number>())
   function incFieldValidation(key: PathKey): void {
+    // Stamp `validatingSince` BEFORE bumping the count so the two signals can
+    // never disagree mid-flight. The count drives `field.validating` (and so
+    // clamps `field.valid` to false for the duration of a run); `validatingSince`
+    // is what the display reducer reads to decide "settled vs in-flight". If the
+    // count led, a synchronous reader landing between the two writes would see
+    // `validating: true, validatingSince: null` — the reducer would read the run
+    // as settled and return the in-flight verdict (idle, because `valid` is
+    // clamped), flashing idle at the start of every re-validation. Stamping the
+    // anchor first makes `validatingSince !== null` an outer bracket around
+    // `count > 0` (it is cleared only AFTER the count reaches 0, in
+    // `decFieldValidation`), so the reducer never sees a run as settled while
+    // `valid` is still clamped.
+    //
+    // Re-anchored on every run start, not just the 0 → 1 edge: the anti-flash
+    // show-delay measures `now - validatingSince`, so a burst of keystrokes —
+    // each aborting the prior run and starting a new one — keeps pushing the
+    // anchor forward and the spinner stays suppressed until the user pauses.
+    // Anchoring only at the streak start would surface the spinner mid-typing:
+    // with `debounceMs: 0` the aborted run's `.finally` decrement lands a
+    // microtask AFTER the next run's increment, so the count oscillates
+    // 1 → 2 → 1 and never returns to 0 between fast keystrokes, pinning the
+    // stamp to the first keystroke. `ssr` never reaches here in practice (no
+    // field validation is scheduled server-side); the `0` keeps the stamp
+    // clock-free.
+    fieldValidatingSince.set(key, ssr ? 0 : Date.now())
     const prevCount = fieldValidationCounts.get(key) ?? 0
     fieldValidationCounts.set(key, prevCount + 1)
-    // 0 → 1 edge: a validation streak just opened at this path. Stamp the
-    // start (the show-delay clock measures `now - validatingSince`).
-    // Guarded on the edge so overlapping sub-runs don't reset the anchor
-    // mid-streak. `ssr` never gets here in practice (no field validation is
-    // scheduled server-side); the `0` keeps the stamp clock-free if it does.
-    if (prevCount === 0) fieldValidatingSince.set(key, ssr ? 0 : Date.now())
   }
   function decFieldValidation(key: PathKey): void {
     const next = (fieldValidationCounts.get(key) ?? 0) - 1
     if (next <= 0) {
+      // → 0 edge: clear the count FIRST (so `field.valid` is accurate again),
+      // THEN drop the anchor — the trailing edge of the bracket described in
+      // `incFieldValidation`. Whenever the reducer sees `validatingSince ===
+      // null` the count is already 0 and `valid` is settled, so a run is never
+      // read as settled while `valid` is still clamped. Co-extensive across the
+      // abort / cancel / migrate paths that release a count.
       fieldValidationCounts.delete(key)
-      // → 0 edge: the streak closed; drop the anchor so the next streak
-      // re-stamps fresh. Co-extensive with the count delete, so the abort /
-      // cancel / migrate paths that release a count clear this in lockstep.
       fieldValidatingSince.delete(key)
     } else {
       fieldValidationCounts.set(key, next)

--- a/src/runtime/core/display-engine.ts
+++ b/src/runtime/core/display-engine.ts
@@ -1,0 +1,128 @@
+import { ref, type Ref } from 'vue'
+import type { DisplayCtx, DisplayMachine, GetDisplayState } from '../types/types-api'
+import type { PathKey } from './paths'
+
+/**
+ * Per-form display engine: owns the clock and the timers that the pure
+ * `getDisplayState` reducer policy needs, so the reducer itself stays a
+ * deterministic `(prev, ctx) => next` function.
+ *
+ * It keeps a `Map` of the machines that are still *active* (a spinner is
+ * showing, a verdict is being held, or a `reviewAt` deadline is pending),
+ * a single reactive `tick` ref, and a single `setTimeout` aimed at the
+ * nearest `reviewAt` across every active field. When a field-state
+ * computed reads `resolve`, it subscribes to `tick`; when the timer
+ * fires, `tick` bumps and every dependent computed re-runs the reducer,
+ * so a field whose deadline elapsed transitions (verdict → spinner, or
+ * spinner → settled verdict) without any per-field watcher.
+ *
+ * Eviction: a machine is dropped once it reaches a terminal *idle* state
+ * with no pending review. Error / success / pending machines are retained
+ * so the reducer can hold the prior verdict under the show-delay window of
+ * the *next* validation streak (no success → idle → success flicker). The
+ * retained set is bounded by the rendered non-idle fields; none of them
+ * arm a timer, so retention costs memory, never CPU.
+ *
+ * SSR: no clock, no timers. With `now` frozen and nothing validating at
+ * render, the reducer returns the plain verdict (never pending) and the
+ * engine stores nothing, so the server HTML and the client's first render
+ * agree — no hydration mismatch on the display projection.
+ */
+export type DisplayEngine = {
+  /**
+   * Resolve a path's next `DisplayMachine`. Subscribes the calling
+   * computed to the engine clock, threads the path's previous machine
+   * through `reducer`, persists or evicts the result, and re-arms the
+   * single timer to the nearest deadline.
+   */
+  resolve(key: PathKey, ctx: DisplayCtx, reducer: GetDisplayState): DisplayMachine
+  /** Drop every retained machine and cancel the timer (used by `reset()`). */
+  clear(): void
+  /** Tear down for good — same as `clear()`, wired to `FormStore.dispose()`. */
+  dispose(): void
+  /** Introspection for tests: count of retained machines. */
+  size(): number
+  /** Introspection for tests: whether a path currently has a retained machine. */
+  has(key: PathKey): boolean
+  /** Introspection for tests: whether a deadline timer is currently armed. */
+  hasTimer(): boolean
+}
+
+const IDLE: DisplayMachine = Object.freeze({ display: 'idle' })
+
+export function createDisplayEngine(ssr: boolean): DisplayEngine {
+  const machines = new Map<PathKey, DisplayMachine>()
+  const tick: Ref<number> = ref(0)
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let timerTarget: number | null = null
+
+  function clearTimer(): void {
+    if (timer !== null) {
+      clearTimeout(timer)
+      timer = null
+      timerTarget = null
+    }
+  }
+
+  function nearestReviewAt(): number | null {
+    let min: number | null = null
+    for (const m of machines.values()) {
+      if (m.reviewAt === undefined) continue
+      if (min === null || m.reviewAt < min) min = m.reviewAt
+    }
+    return min
+  }
+
+  function rearm(now: number): void {
+    const target = nearestReviewAt()
+    if (target === null) {
+      clearTimer()
+      return
+    }
+    // Already aimed at this deadline — leave the live timer alone so a
+    // flush that re-resolves many fields doesn't churn clear/set.
+    if (timer !== null && timerTarget === target) return
+    clearTimer()
+    timerTarget = target
+    timer = setTimeout(
+      () => {
+        timer = null
+        timerTarget = null
+        tick.value++
+      },
+      Math.max(0, target - now)
+    )
+  }
+
+  function resolve(key: PathKey, ctx: DisplayCtx, reducer: GetDisplayState): DisplayMachine {
+    // Subscribe the caller's computed to the clock: a fired deadline bumps
+    // `tick` and re-invalidates it. Read before the reducer call so the
+    // subscription is registered even if the reducer throws.
+    void tick.value
+    const prev = machines.get(key) ?? IDLE
+    const machine = reducer(prev, ctx)
+    // Server render: never persist, never schedule. `prev` is always IDLE
+    // here (nothing stored), nothing is validating, so `machine` is the
+    // plain verdict the client reproduces on hydration.
+    if (ssr) return machine
+    const active = machine.display !== 'idle' || machine.reviewAt !== undefined
+    if (active) machines.set(key, machine)
+    else machines.delete(key)
+    rearm(ctx.now)
+    return machine
+  }
+
+  function clear(): void {
+    machines.clear()
+    clearTimer()
+  }
+
+  return {
+    resolve,
+    clear,
+    dispose: clear,
+    size: () => machines.size,
+    has: (key) => machines.has(key),
+    hasTimer: () => timer !== null,
+  }
+}

--- a/src/runtime/core/display-engine.ts
+++ b/src/runtime/core/display-engine.ts
@@ -23,10 +23,26 @@ import type { PathKey } from './paths'
  * retained set is bounded by the rendered non-idle fields; none of them
  * arm a timer, so retention costs memory, never CPU.
  *
- * SSR: no clock, no timers. With `now` frozen and nothing validating at
- * render, the reducer returns the plain verdict (never pending) and the
- * engine stores nothing, so the server HTML and the client's first render
- * agree — no hydration mismatch on the display projection.
+ * Untrusted reducer: `getDisplayState` is consumer-overridable, so the
+ * engine treats the returned `reviewAt` as untrusted. A non-finite deadline
+ * (NaN / ±Infinity from a custom predicate's bad arithmetic) is ignored
+ * rather than handed to `setTimeout`, where it coerces to 0 and spins; an
+ * over-large finite deadline is clamped below the 32-bit `setTimeout`
+ * overflow; and the timer refuses to re-arm for the exact deadline it just
+ * fired, so a predicate re-emitting a fixed or past `reviewAt` can't drive an
+ * infinite fire loop. None of these arise from the library default, which
+ * always advances its deadline or drops it.
+ *
+ * Background tabs: `setTimeout` is throttled to >= 1s while a tab is hidden,
+ * so a min-visible hold can overshoot. A `visibilitychange` listener bumps
+ * the clock on return to the foreground, so any overdue deadline resolves at
+ * once instead of lingering.
+ *
+ * SSR: no clock, no timers, no listener. With `now` frozen and nothing
+ * validating at render, the reducer returns the plain verdict (never
+ * pending) and the engine stores nothing, so the server HTML and the
+ * client's first render agree — no hydration mismatch on the display
+ * projection.
  */
 export type DisplayEngine = {
   /**
@@ -38,7 +54,7 @@ export type DisplayEngine = {
   resolve(key: PathKey, ctx: DisplayCtx, reducer: GetDisplayState): DisplayMachine
   /** Drop every retained machine and cancel the timer (used by `reset()`). */
   clear(): void
-  /** Tear down for good — same as `clear()`, wired to `FormStore.dispose()`. */
+  /** Tear down for good: `clear()` plus detaching the visibility listener. */
   dispose(): void
   /** Introspection for tests: count of retained machines. */
   size(): number
@@ -50,11 +66,20 @@ export type DisplayEngine = {
 
 const IDLE: DisplayMachine = Object.freeze({ display: 'idle' })
 
+// `setTimeout` truncates a delay past 2^31-1 ms to a 32-bit int (firing
+// almost immediately); clamp below it so an over-large `reviewAt` waits
+// quietly instead of busy-firing.
+const MAX_DELAY = 2_147_483_647
+
 export function createDisplayEngine(ssr: boolean): DisplayEngine {
   const machines = new Map<PathKey, DisplayMachine>()
   const tick: Ref<number> = ref(0)
   let timer: ReturnType<typeof setTimeout> | null = null
   let timerTarget: number | null = null
+  // The deadline the live timer most recently fired for. The forward-progress
+  // guard in `rearm` refuses to re-arm for this exact value, so a reducer that
+  // re-emits one fixed `reviewAt` can't drive an infinite fire loop.
+  let lastFiredTarget: number | null = null
 
   function clearTimer(): void {
     if (timer !== null) {
@@ -67,7 +92,9 @@ export function createDisplayEngine(ssr: boolean): DisplayEngine {
   function nearestReviewAt(): number | null {
     let min: number | null = null
     for (const m of machines.values()) {
-      if (m.reviewAt === undefined) continue
+      // Ignore an absent or non-finite deadline: a custom reducer may return
+      // `reviewAt: NaN` / `Infinity`, which must never reach `setTimeout`.
+      if (m.reviewAt === undefined || !Number.isFinite(m.reviewAt)) continue
       if (min === null || m.reviewAt < min) min = m.reviewAt
     }
     return min
@@ -82,15 +109,24 @@ export function createDisplayEngine(ssr: boolean): DisplayEngine {
     // Already aimed at this deadline — leave the live timer alone so a
     // flush that re-resolves many fields doesn't churn clear/set.
     if (timer !== null && timerTarget === target) return
+    // Forward-progress guard: never re-arm for the exact deadline we just
+    // fired. Legit timing always advances the deadline (show-delay → pending,
+    // pending → settled) or drops it, so this only blocks a misbehaving
+    // reducer that re-emits a fixed or past `reviewAt`.
+    if (target === lastFiredTarget) {
+      clearTimer()
+      return
+    }
     clearTimer()
     timerTarget = target
     timer = setTimeout(
       () => {
         timer = null
         timerTarget = null
+        lastFiredTarget = target
         tick.value++
       },
-      Math.max(0, target - now)
+      Math.min(MAX_DELAY, Math.max(0, target - now))
     )
   }
 
@@ -105,7 +141,12 @@ export function createDisplayEngine(ssr: boolean): DisplayEngine {
     // here (nothing stored), nothing is validating, so `machine` is the
     // plain verdict the client reproduces on hydration.
     if (ssr) return machine
-    const active = machine.display !== 'idle' || machine.reviewAt !== undefined
+    // Retain anything non-idle, plus an idle machine that still carries a
+    // usable (finite) deadline. An idle machine whose only claim to be kept
+    // is a non-finite `reviewAt` is junk — evict it.
+    const active =
+      machine.display !== 'idle' ||
+      (machine.reviewAt !== undefined && Number.isFinite(machine.reviewAt))
     if (active) machines.set(key, machine)
     else machines.delete(key)
     rearm(ctx.now)
@@ -115,12 +156,34 @@ export function createDisplayEngine(ssr: boolean): DisplayEngine {
   function clear(): void {
     machines.clear()
     clearTimer()
+    lastFiredTarget = null
+  }
+
+  // Background tabs throttle `setTimeout` to >= 1s, so a min-visible hold can
+  // overshoot when hidden. On return to the foreground, bump the clock so
+  // every held machine re-evaluates against the real `now` and any overdue
+  // deadline resolves at once. Client-only; SSR keeps no clock to nudge.
+  let detachVisibility: (() => void) | null = null
+  if (!ssr && typeof document !== 'undefined') {
+    const onVisible = (): void => {
+      if (document.visibilityState === 'visible' && machines.size > 0) tick.value++
+    }
+    document.addEventListener('visibilitychange', onVisible)
+    detachVisibility = () => document.removeEventListener('visibilitychange', onVisible)
+  }
+
+  function dispose(): void {
+    clear()
+    if (detachVisibility !== null) {
+      detachVisibility()
+      detachVisibility = null
+    }
   }
 
   return {
     resolve,
     clear,
-    dispose: clear,
+    dispose,
     size: () => machines.size,
     has: (key) => machines.has(key),
     hasTimer: () => timer !== null,

--- a/src/runtime/core/display-state.ts
+++ b/src/runtime/core/display-state.ts
@@ -88,6 +88,21 @@ export const DEFAULT_TIMINGS: DisplayTimings = { showDelay: 100, minVisible: 120
 export const FOCUS_OUT_GRACE = 16
 
 /**
+ * The reducers produced by {@link makeDefaultDisplayState} — the exported
+ * {@link defaultDisplayState} and every custom-timing variant. The container
+ * `displayState` rollup (surfacing a descendant's gated error at its container
+ * and at `form.meta`) is a behavior of the library default, applied around the
+ * reducer rather than inside it, so a fully custom `getDisplayState` owns
+ * container verdicts outright. WeakSet so it never pins a reducer against GC.
+ */
+const defaultFamily = new WeakSet<GetDisplayState>()
+
+/** True for any reducer built by {@link makeDefaultDisplayState}. */
+export function isDefaultDisplayState(fn: GetDisplayState): boolean {
+  return defaultFamily.has(fn)
+}
+
+/**
  * Build a default `getDisplayState` reducer with custom anti-flash timing.
  * Power users who want a tighter or looser spinner than {@link DEFAULT_TIMINGS}
  * pass their own `{ showDelay, minVisible }`:
@@ -110,7 +125,7 @@ export function makeDefaultDisplayState({
   showDelay,
   minVisible,
 }: DisplayTimings): GetDisplayState {
-  return (prev, { field, formMeta, validatingSince, now }) => {
+  const reducer: GetDisplayState = (prev, { field, formMeta, validatingSince, now }) => {
     const verdict = computeVerdict(field, formMeta)
     // The reveal gate governs the spinner too: until it opens, a field stays
     // idle — no spinner mid-first-entry — exactly as errors and success are
@@ -167,6 +182,8 @@ export function makeDefaultDisplayState({
     // Window elapsed and still validating: the spinner has earned its place.
     return { display: 'pending', pendingShownAt: now, reviewAt: now + minVisible }
   }
+  defaultFamily.add(reducer)
+  return reducer
 }
 
 /**

--- a/src/runtime/core/display-state.ts
+++ b/src/runtime/core/display-state.ts
@@ -1,82 +1,44 @@
-import type { GetDisplayState } from '../types/types-api'
+import type { DisplayCtx, GetDisplayState } from '../types/types-api'
 
 /**
- * Library-default `getDisplayState` heuristic. Resolves every path's
- * `field.displayState` — and thus `field.show*` and the `form.meta`
- * rollups — whenever the consumer has not configured an override at the
- * per-form or plugin level.
- *
- * One timing gate, then precedence:
+ * The settled half of the display verdict: the value a field should show
+ * once nothing is in flight. Pending is deliberately absent — it is a
+ * timing decision the reducer layers on top, never a property of the
+ * settled state.
+ */
+type Verdict = 'idle' | 'error' | 'success'
+
+/**
+ * The gate + precedence rules, with pending factored out. Resolves the
+ * settled verdict from a field's reactive state:
  *
  * 1. **Timing gate.** `gateOpen` once the form has been submitted
- *    (`submissionAttempts > 0`) OR the field has been edited and then
- *    left (`blurredAfterInteraction === true`). Before the gate opens
- *    the verdict is `'idle'` regardless of errors. This is the "reward
- *    early, punish late" rule:
- *      - A clean tab-through never engages. `blurredAfterInteraction`
- *        only flips on a blur that follows an edit, so visiting a field
- *        and moving on without editing it stays quiet until a submit
- *        forces the issue, even if the field was tabbed through before.
- *      - The first pass stays quiet. Editing alone (`interacted`) does
- *        not open the gate; the error reveals only once the user
- *        finishes that pass and leaves the field, never mid-entry.
- *      - Recovery is live. The bit is sticky and carries no not-focused
- *        term, so once a field has been revealed it stays open through a
- *        re-focus: a shown error clears (or greens) the instant the
- *        value becomes valid, without forcing another blur.
- *
- *    The submit arm covers `form.handleSubmit` directly and
- *    `wizard.handleSubmit` (which bumps `submissionAttempts` on the
- *    active form at intermediate steps and on every form at the final
- *    step, lighting up the whole flow at once).
- *
- * 2. **Pending.** With the gate open, a per-field run in flight
- *    (`validating === true`) wins: the verdict in `errors` is stale by
- *    definition, so surface `'pending'` (a spinner) rather than a
- *    possibly-wrong error or success. Containers roll `validating` up as
- *    a disjunction, so any descendant under revalidation reads
- *    `'pending'` at the container too.
- *
- * 3. **Error.** An own-path error (one whose path equals the field's own
- *    path) resolves to `'error'`. The own-path filter means a container
- *    never duplicates an error a more-specific descendant already
- *    renders; aggregate banners bind to `form.meta.errorCount` instead.
- *
- * 4. **Success.** No error, `valid === true`, and the green check is
- *    earned: the field is non-blank and `dirty` (its value diverges from
- *    the hydration original). Gating success on `dirty && !blank` keeps
- *    the check meaningful — an empty field that happens to pass, a
+ *    (`submissionAttempts > 0`) OR the field has been edited and then left
+ *    (`blurredAfterInteraction === true`). Before the gate opens the
+ *    verdict is `'idle'` regardless of errors — the "reward early, punish
+ *    late" rule: a clean tab-through never engages, the first pass stays
+ *    quiet until the user leaves the field, and recovery is live (the bit
+ *    is sticky and carries no not-focused term, so a shown error clears
+ *    the instant the value becomes valid).
+ * 2. **Error.** An own-path error (one whose path equals the field's own
+ *    path) resolves to `'error'`. The own-path filter keeps a container
+ *    from duplicating an error a more-specific descendant already renders.
+ * 3. **Success.** No error, `valid === true`, and the green check is
+ *    earned: the field is non-blank and `dirty`. Gating on `dirty && !blank`
+ *    keeps the check meaningful — an empty field that happens to pass, a
  *    pre-filled field merely tabbed through, and the post-submit flood of
  *    every valid field all stay `'idle'` rather than greening for free.
- *    `valid` already gates async schemas on the form-wide first
- *    validation pass, so success never fires before the first verdict
- *    lands.
+ * 4. **Idle.** Anything else.
  *
- * 5. **Idle.** Anything else — gate open but not validating, no own-path
- *    error, and either not yet `valid` or valid-but-unearned (blank or
- *    unchanged) — stays `'idle'`.
- *
- * Public re-export so adopters can compose with this without
- * copy-pasting the rule body — a layered predicate that special-cases a
- * subtree but otherwise defers picks up future refinements
- * automatically:
- *
- * ```ts
- * import { defaultDisplayState } from 'attaform'
- *
- * useForm({
- *   schema,
- *   getDisplayState: (field, formMeta) => {
- *     const state = defaultDisplayState(field, formMeta)
- *     return field.path[0] === 'username' && state === 'success' ? 'idle' : state
- *   },
- * })
- * ```
+ * `'pending'` (the spinner) is owned by `makeDefaultDisplayState` below,
+ * which decides — from the validation clock — when to surface it and how
+ * long to hold it. This function is consulted both for the settled verdict
+ * and, during a validation streak, for the verdict to hold under the
+ * spinner once it lands.
  */
-export const defaultDisplayState: GetDisplayState = (field, formMeta) => {
+function computeVerdict(field: DisplayCtx['field'], formMeta: DisplayCtx['formMeta']): Verdict {
   const gateOpen = formMeta.submissionAttempts > 0 || field.blurredAfterInteraction === true
   if (!gateOpen) return 'idle'
-  if (field.validating === true) return 'pending'
   const hasOwnError = field.errors.some(
     (e) => e.path.length === field.path.length && e.path.every((s, i) => s === field.path[i])
   )
@@ -86,10 +48,110 @@ export const defaultDisplayState: GetDisplayState = (field, formMeta) => {
 }
 
 /**
- * Resolve a `getDisplayState` config (function | undefined) to a
- * concrete predicate. `undefined` falls back to the library default.
- * Called once at form construction; the resolved predicate is then
- * stored on `FormStore` for the field-state computeds to read directly.
+ * Anti-flash timing for the library-default display reducer.
+ *
+ * - `showDelay` — how long a validation may run before its spinner is
+ *   allowed to show. A validation that settles inside this window never
+ *   reveals `'pending'` at all, so a fast (often synchronous) check does
+ *   not flash a spinner on every keystroke.
+ * - `minVisible` — once shown, the minimum time the spinner stays up. A
+ *   validation that lands just past `showDelay` is held here so the
+ *   spinner does not itself flash on and immediately off.
+ *
+ * Both are milliseconds.
+ */
+export type DisplayTimings = { readonly showDelay: number; readonly minVisible: number }
+
+/**
+ * Library-default anti-flash timings. `showDelay: 100` cleanly swallows
+ * synchronous, microtask-resolved, and tiny-async validators (no spinner
+ * for any of them); `minVisible: 120` keeps a shown spinner snappy.
+ * Retune via {@link makeDefaultDisplayState} without touching the engine.
+ */
+export const DEFAULT_TIMINGS: DisplayTimings = { showDelay: 100, minVisible: 120 }
+
+/**
+ * Build a default `getDisplayState` reducer with custom anti-flash timing.
+ * Power users who want a tighter or looser spinner than {@link DEFAULT_TIMINGS}
+ * pass their own `{ showDelay, minVisible }`:
+ *
+ * ```ts
+ * import { makeDefaultDisplayState } from 'attaform'
+ *
+ * useForm({
+ *   schema,
+ *   getDisplayState: makeDefaultDisplayState({ showDelay: 50, minVisible: 200 }),
+ * })
+ * ```
+ *
+ * The returned reducer is pure: the engine injects `now` and threads the
+ * previous machine, so the same `(prev, ctx)` always yields the same next
+ * machine. It shapes only the display projection — `errors`, `valid`,
+ * `validating`, and the underlying validation run exactly as before.
+ */
+export function makeDefaultDisplayState({
+  showDelay,
+  minVisible,
+}: DisplayTimings): GetDisplayState {
+  return (prev, { field, formMeta, validatingSince, now }) => {
+    const verdict = computeVerdict(field, formMeta)
+    // Settled — nothing in flight. Show the true verdict, unless a spinner
+    // is still inside its minimum-visible window: hold it so a validation
+    // that landed just past the show-delay does not flash on and off.
+    if (validatingSince === null) {
+      if (prev.display === 'pending') {
+        const shownAt = prev.pendingShownAt ?? now
+        if (now < shownAt + minVisible)
+          return { display: 'pending', pendingShownAt: shownAt, reviewAt: shownAt + minVisible }
+      }
+      return { display: verdict }
+    }
+    // Validating, spinner already up: keep it. No `reviewAt` — the next
+    // re-evaluation comes from the run settling (a reactive change), so
+    // there is nothing for the engine's timer to wait on.
+    if (prev.display === 'pending')
+      return { display: 'pending', pendingShownAt: prev.pendingShownAt ?? now }
+    // Validating, still inside the show-delay window: hold whatever was on
+    // screen before the run began (`prev.display`) rather than the in-flight
+    // verdict, which reads `valid: false` only because a check is running.
+    // A fast validation settles before `reviewAt` and the spinner never shows.
+    if (now - validatingSince < showDelay)
+      return { display: prev.display, reviewAt: validatingSince + showDelay }
+    // Window elapsed and still validating: the spinner has earned its place.
+    return { display: 'pending', pendingShownAt: now, reviewAt: now + minVisible }
+  }
+}
+
+/**
+ * Library-default `getDisplayState` reducer. Resolves every path's
+ * `field.displayState` — and thus `field.show*` and the `form.meta`
+ * rollups — whenever the consumer has not configured an override at the
+ * per-form or plugin level. Built from {@link DEFAULT_TIMINGS}; publicly
+ * re-exported so an override can compose with it (a layered reducer that
+ * special-cases a subtree but otherwise defers picks up future
+ * refinements for free):
+ *
+ * ```ts
+ * import { defaultDisplayState } from 'attaform'
+ *
+ * useForm({
+ *   schema,
+ *   getDisplayState: (prev, ctx) => {
+ *     const next = defaultDisplayState(prev, ctx)
+ *     return next.display === 'success' && ctx.field.path[0] === 'username'
+ *       ? { display: 'idle' }
+ *       : next
+ *   },
+ * })
+ * ```
+ */
+export const defaultDisplayState: GetDisplayState = makeDefaultDisplayState(DEFAULT_TIMINGS)
+
+/**
+ * Resolve a `getDisplayState` config (function | undefined) to a concrete
+ * reducer. `undefined` falls back to the library default. Called once at
+ * form construction; the resolved reducer is then stored on `FormStore`
+ * for the field-state computeds to read directly.
  */
 export function resolveGetDisplayState(config: GetDisplayState | undefined): GetDisplayState {
   return config ?? defaultDisplayState

--- a/src/runtime/core/display-state.ts
+++ b/src/runtime/core/display-state.ts
@@ -74,6 +74,20 @@ export type DisplayTimings = { readonly showDelay: number; readonly minVisible: 
 export const DEFAULT_TIMINGS: DisplayTimings = { showDelay: 100, minVisible: 120 }
 
 /**
+ * How long the show-delay collapses to once the field is focused out. The
+ * full `showDelay` exists to swallow the spinner during active typing; the
+ * instant the user leaves the field that rationale is gone, so a still-running
+ * validation should surface its spinner promptly rather than waiting out the
+ * rest of a window meant for editing. This brief grace (one frame) still lets a
+ * synchronous / microtask-settling check resolve to its real verdict before the
+ * review fires, so a fast validation the user blurs past never flashes a
+ * spinner; only one genuinely in flight a frame later reveals `'pending'`.
+ * Capped at `showDelay`, so a custom timing shorter than a frame never widens
+ * the window on blur. Exported for tests; not part of the package surface.
+ */
+export const FOCUS_OUT_GRACE = 16
+
+/**
  * Build a default `getDisplayState` reducer with custom anti-flash timing.
  * Power users who want a tighter or looser spinner than {@link DEFAULT_TIMINGS}
  * pass their own `{ showDelay, minVisible }`:
@@ -102,6 +116,13 @@ export function makeDefaultDisplayState({
     // idle — no spinner mid-first-entry — exactly as errors and success are
     // withheld. computeVerdict already returns idle for a closed gate; this
     // short-circuit keeps a still-closed gate out of the timed-pending machine.
+    //
+    // Load-bearing for hydration: at first paint the gate is closed (no submit
+    // yet, not yet blurred-after-interaction), so a field validating on the
+    // client renders the same idle verdict the server produced with `now`
+    // frozen — no display-projection mismatch. Opening the gate during SSR (or
+    // at first client render) would surface a timed verdict the server never
+    // emitted and break that guarantee.
     if (!isGateOpen(field, formMeta)) return { display: verdict }
     // Settled — nothing in flight. Show the true verdict, unless a spinner
     // is still inside its minimum-visible window: hold it so a validation
@@ -121,10 +142,28 @@ export function makeDefaultDisplayState({
       return { display: 'pending', pendingShownAt: prev.pendingShownAt ?? now }
     // Validating, still inside the show-delay window: hold whatever was on
     // screen before the run began (`prev.display`) rather than the in-flight
-    // verdict, which reads `valid: false` only because a check is running.
-    // A fast validation settles before `reviewAt` and the spinner never shows.
-    if (now - validatingSince < showDelay)
-      return { display: prev.display, reviewAt: validatingSince + showDelay }
+    // verdict, which reads `valid: false` only because a check is running. A
+    // fast validation settles before `reviewAt` and the spinner never shows; a
+    // slow one surfaces it at the window edge. The hold is uniform across every
+    // prior verdict — error, success, idle alike — so editing a field
+    // re-validates as [prior] -> pending -> [settled], never flashing idle in
+    // between. Holding a green check over a value mid-edit is the same
+    // anti-flash trade already accepted for a held error: the true verdict
+    // lands a moment later and replaces it, so a brief stale verdict beats a
+    // gratuitous idle flicker on every keystroke.
+    //
+    // Focus-out collapses the window to a brief settle grace (see
+    // {@link FOCUS_OUT_GRACE}). While the user is typing (`focused === true`) or
+    // there is no focus signal to act on (`focused === null`, a programmatic /
+    // cross-field run on an unbound field) the full `showDelay` holds. The
+    // instant the user focuses out, the window shrinks: a fast check settles
+    // inside the grace and resolves straight to its verdict (no spinner), while
+    // a validation still in flight past the grace surfaces `'pending'` promptly
+    // instead of waiting out a window meant for editing.
+    const window = field.focused === false ? Math.min(showDelay, FOCUS_OUT_GRACE) : showDelay
+    if (now - validatingSince < window) {
+      return { display: prev.display, reviewAt: validatingSince + window }
+    }
     // Window elapsed and still validating: the spinner has earned its place.
     return { display: 'pending', pendingShownAt: now, reviewAt: now + minVisible }
   }

--- a/src/runtime/core/display-state.ts
+++ b/src/runtime/core/display-state.ts
@@ -36,9 +36,12 @@ type Verdict = 'idle' | 'error' | 'success'
  * and, during a validation streak, for the verdict to hold under the
  * spinner once it lands.
  */
+function isGateOpen(field: DisplayCtx['field'], formMeta: DisplayCtx['formMeta']): boolean {
+  return formMeta.submissionAttempts > 0 || field.blurredAfterInteraction === true
+}
+
 function computeVerdict(field: DisplayCtx['field'], formMeta: DisplayCtx['formMeta']): Verdict {
-  const gateOpen = formMeta.submissionAttempts > 0 || field.blurredAfterInteraction === true
-  if (!gateOpen) return 'idle'
+  if (!isGateOpen(field, formMeta)) return 'idle'
   const hasOwnError = field.errors.some(
     (e) => e.path.length === field.path.length && e.path.every((s, i) => s === field.path[i])
   )
@@ -95,6 +98,11 @@ export function makeDefaultDisplayState({
 }: DisplayTimings): GetDisplayState {
   return (prev, { field, formMeta, validatingSince, now }) => {
     const verdict = computeVerdict(field, formMeta)
+    // The reveal gate governs the spinner too: until it opens, a field stays
+    // idle — no spinner mid-first-entry — exactly as errors and success are
+    // withheld. computeVerdict already returns idle for a closed gate; this
+    // short-circuit keeps a still-closed gate out of the timed-pending machine.
+    if (!isGateOpen(field, formMeta)) return { display: verdict }
     // Settled — nothing in flight. Show the true verdict, unless a spinner
     // is still inside its minimum-visible window: hold it so a validation
     // that landed just past the show-delay does not flash on and off.

--- a/src/runtime/core/field-state-api.ts
+++ b/src/runtime/core/field-state-api.ts
@@ -1,5 +1,7 @@
 import { computed, type ComputedRef } from 'vue'
 import type {
+  DisplayCtx,
+  DisplayMachine,
   FieldState,
   FieldStateDerivedKey,
   FormMeta,
@@ -238,7 +240,15 @@ function buildLeafFieldState<F extends GenericForm>(
   getDisplayState?: GetDisplayState
 ): FieldState<unknown> {
   const base = buildLeafFieldStateBase(state, segments, key, formInstanceId)
-  return decorateWithDerivedProps(base, state, getFormMetaBase, getDisplayState)
+  const validatingSince = state.fieldValidatingSince.get(key) ?? null
+  return decorateWithDerivedProps(
+    base,
+    state,
+    getFormMetaBase,
+    key,
+    validatingSince,
+    getDisplayState
+  )
 }
 
 /**
@@ -266,7 +276,7 @@ export function buildContainerFieldStateBase<F extends GenericForm>(
   segments: Path,
   key: PathKey,
   formInstanceId: string
-): FieldStateBase {
+): { readonly base: FieldStateBase; readonly validatingSince: number | null } {
   // Read live form value first so the access participates in dep
   // tracking; the discriminator key write that switches a DU variant
   // shows up here and re-runs the computed.
@@ -295,6 +305,7 @@ export function buildContainerFieldStateBase<F extends GenericForm>(
   let blurredAfterInteraction = false
   let connected = false
   let validating = false
+  let validatingSince: number | null = null
   let updatedAt: string | null = null
   let asyncPending = false
   for (const [leafKey, entry] of state.originals) {
@@ -317,7 +328,15 @@ export function buildContainerFieldStateBase<F extends GenericForm>(
     if (leafRecord?.interacted === true) interacted = true
     if (leafRecord?.blurredAfterInteraction === true) blurredAfterInteraction = true
     if (leafRecord?.connected === true) connected = true
-    if ((state.fieldValidationCounts.get(leafKey) ?? 0) > 0) validating = true
+    if ((state.fieldValidationCounts.get(leafKey) ?? 0) > 0) {
+      validating = true
+      // Anchor the container spinner at its earliest still-validating leaf,
+      // so a row's show-delay window measures from the first descendant to
+      // start rather than resetting each time another leaf joins the streak.
+      const since = state.fieldValidatingSince.get(leafKey)
+      if (since !== undefined && (validatingSince === null || since < validatingSince))
+        validatingSince = since
+    }
     if (state.pathHasAsyncValidationByKey(leafKey, entry.segments)) asyncPending = true
     const ts = leafRecord?.updatedAt
     if (ts !== undefined && ts !== null) {
@@ -357,30 +376,33 @@ export function buildContainerFieldStateBase<F extends GenericForm>(
   const lastSegment = segments.length === 0 ? '' : (segments[segments.length - 1] ?? '')
   const label = resolved.label || humanize(lastSegment)
   return {
-    value,
-    original,
-    pristine,
-    dirty,
-    focused,
-    blurred,
-    touched,
-    interacted,
-    blurredAfterInteraction,
-    connected,
-    element: null,
-    elements: EMPTY_ELEMENTS,
-    updatedAt,
-    errors,
-    validating,
-    valid,
-    path: segments,
-    ...computeFieldIdentity(formInstanceId, state.formKey, key),
-    key: state.arrayElementKey(segments),
-    blank,
-    label,
-    description: resolved.description,
-    placeholder: resolved.placeholder,
-    meta: resolved.meta,
+    base: {
+      value,
+      original,
+      pristine,
+      dirty,
+      focused,
+      blurred,
+      touched,
+      interacted,
+      blurredAfterInteraction,
+      connected,
+      element: null,
+      elements: EMPTY_ELEMENTS,
+      updatedAt,
+      errors,
+      validating,
+      valid,
+      path: segments,
+      ...computeFieldIdentity(formInstanceId, state.formKey, key),
+      key: state.arrayElementKey(segments),
+      blank,
+      label,
+      description: resolved.description,
+      placeholder: resolved.placeholder,
+      meta: resolved.meta,
+    },
+    validatingSince,
   }
 }
 
@@ -396,45 +418,68 @@ function buildContainerFieldState<F extends GenericForm>(
   getFormMetaBase: FormMetaBaseGetter,
   getDisplayState?: GetDisplayState
 ): FieldState<unknown> {
-  const base = buildContainerFieldStateBase(state, segments, key, formInstanceId)
-  return decorateWithDerivedProps(base, state, getFormMetaBase, getDisplayState)
+  const { base, validatingSince } = buildContainerFieldStateBase(
+    state,
+    segments,
+    key,
+    formInstanceId
+  )
+  return decorateWithDerivedProps(
+    base,
+    state,
+    getFormMetaBase,
+    key,
+    validatingSince,
+    getDisplayState
+  )
 }
 
 /**
  * Layer `displayState`, the four `show*` booleans, and `firstError`
  * onto a freshly-computed base. Shared by leaf and container paths so
- * the heuristic runs identically at every depth.
+ * the reducer runs identically at every depth.
  *
  * `firstError` is `errors[0]` — deterministic because errors are
  * already sorted by schema-declaration order (within a leaf: schema →
  * blank → user concat; across a container: `pathOrdinal` bucket sort).
  *
- * The predicate runs UNCONDITIONALLY: it resolves the full
- * idle/pending/error/success verdict, not just error visibility, so it
- * must see the no-error states (success, idle) too — short-circuiting on
- * `errors.length === 0` would starve those. The `show*` booleans are
- * pure projections of the single `displayState` result, so they can
- * never disagree with it.
+ * The reducer runs UNCONDITIONALLY through the per-form display engine,
+ * which threads the path's previous `DisplayMachine` and the injected
+ * clock so the timing policy (the anti-flash spinner) can compute the
+ * next verdict. It resolves the full idle/pending/error/success machine,
+ * not just error visibility, so it must see the no-error states too. The
+ * four `show*` booleans are pure projections of the single
+ * `machine.display`, so they can never disagree with it.
+ *
+ * A misbehaving custom reducer must not take down the reactive surface:
+ * its throw is caught, warned once per reference in dev, and the read is
+ * retried through the engine with `defaultDisplayState` so the fallback
+ * still participates in machine state. The reducer call happens before
+ * any engine mutation, so a throw leaves the machine map untouched and
+ * the retry sees the same `prev`.
  */
 function decorateWithDerivedProps<F extends GenericForm>(
   base: FieldStateBase,
   state: FormStore<F, GenericForm>,
   getFormMetaBase: FormMetaBaseGetter,
+  key: PathKey,
+  validatingSince: number | null,
   getDisplayState?: GetDisplayState
 ): FieldState<unknown> {
   const firstError = base.errors[0]
   const predicate = getDisplayState ?? state.getDisplayState
   const formMeta = getFormMetaBase()
-  // The predicate runs on every field-state read, so a misbehaving
-  // custom predicate must not take down the whole reactive surface.
-  // Fall back to the library default (total over well-formed base
-  // shapes) rather than propagating the throw out of the computed.
-  // Surface one dev-only warn per predicate reference so a
-  // consistently-broken consumer override is visible without spamming
-  // every read.
-  let displayState: ReturnType<GetDisplayState>
+  const ctx: DisplayCtx = {
+    field: base,
+    formMeta,
+    validatingSince,
+    // The engine's clock. Frozen to 0 under SSR (no clock, nothing in
+    // flight) so the reducer returns the plain verdict and hydration matches.
+    now: state.ssr ? 0 : Date.now(),
+  }
+  let machine: DisplayMachine
   try {
-    displayState = predicate(base, formMeta)
+    machine = state.displayEngine.resolve(key, ctx, predicate)
   } catch (err) {
     if (__DEV__ && !warnedDisplayStatePredicates.has(predicate)) {
       warnedDisplayStatePredicates.add(predicate)
@@ -444,8 +489,9 @@ function decorateWithDerivedProps<F extends GenericForm>(
         err
       )
     }
-    displayState = defaultDisplayState(base, formMeta)
+    machine = state.displayEngine.resolve(key, ctx, defaultDisplayState)
   }
+  const displayState = machine.display
   return {
     ...base,
     displayState,

--- a/src/runtime/core/field-state-api.ts
+++ b/src/runtime/core/field-state-api.ts
@@ -2,6 +2,7 @@ import { computed, type ComputedRef } from 'vue'
 import type {
   DisplayCtx,
   DisplayMachine,
+  DisplayState,
   FieldState,
   FieldStateDerivedKey,
   FormMeta,
@@ -11,7 +12,7 @@ import type {
 import type { GenericForm } from '../types/types-core'
 import type { FormStore } from './create-form-store'
 import { __DEV__ } from './dev'
-import { defaultDisplayState } from './display-state'
+import { defaultDisplayState, isDefaultDisplayState } from './display-state'
 import { computeFieldIdentity } from './field-ids'
 import { EMPTY_RESOLVED_FIELD_META } from './field-meta'
 import { humanize } from './humanize'
@@ -247,6 +248,7 @@ function buildLeafFieldState<F extends GenericForm>(
     getFormMetaBase,
     key,
     validatingSince,
+    false,
     getDisplayState
   )
 }
@@ -276,7 +278,11 @@ export function buildContainerFieldStateBase<F extends GenericForm>(
   segments: Path,
   key: PathKey,
   formInstanceId: string
-): { readonly base: FieldStateBase; readonly validatingSince: number | null } {
+): {
+  readonly base: FieldStateBase
+  readonly validatingSince: number | null
+  readonly revealedDescendantError: boolean
+} {
   // Read live form value first so the access participates in dep
   // tracking; the discriminator key write that switches a DU variant
   // shows up here and re-runs the computed.
@@ -308,6 +314,11 @@ export function buildContainerFieldStateBase<F extends GenericForm>(
   let validatingSince: number | null = null
   let updatedAt: string | null = null
   let asyncPending = false
+  // For the descendant display rollup: submit opens every gate at once;
+  // otherwise each error gates on whether a leaf at-or-under it has been
+  // blurred-after-interaction. Collected here from the one walk we already do.
+  const submissionAttempts = state.submissionAttempts.value
+  const blurredLeafSegments: Path[] = []
   for (const [leafKey, entry] of state.originals) {
     if (!isPathPrefix(segments, entry.segments)) continue
     if (segments.length === entry.segments.length) continue // self isn't a descendant
@@ -326,15 +337,26 @@ export function buildContainerFieldStateBase<F extends GenericForm>(
     if (leafRecord?.blurred === true) blurred = true
     if (leafRecord?.touched === true) touched = true
     if (leafRecord?.interacted === true) interacted = true
-    if (leafRecord?.blurredAfterInteraction === true) blurredAfterInteraction = true
+    if (leafRecord?.blurredAfterInteraction === true) {
+      blurredAfterInteraction = true
+      blurredLeafSegments.push(entry.segments)
+    }
     if (leafRecord?.connected === true) connected = true
     if ((state.fieldValidationCounts.get(leafKey) ?? 0) > 0) {
       validating = true
       // Anchor the container spinner at its earliest still-validating leaf,
       // so a row's show-delay window measures from the first descendant to
       // start rather than resetting each time another leaf joins the streak.
+      // Only a leaf whose own reveal gate is open contributes the anchor: a
+      // descendant validating on 'change' before it has been blurred would
+      // never show its own spinner, so the container must not show one for it.
+      const leafGateOpen = submissionAttempts > 0 || leafRecord?.blurredAfterInteraction === true
       const since = state.fieldValidatingSince.get(leafKey)
-      if (since !== undefined && (validatingSince === null || since < validatingSince))
+      if (
+        leafGateOpen &&
+        since !== undefined &&
+        (validatingSince === null || since < validatingSince)
+      )
         validatingSince = since
     }
     if (state.pathHasAsyncValidationByKey(leafKey, entry.segments)) asyncPending = true
@@ -361,6 +383,24 @@ export function buildContainerFieldStateBase<F extends GenericForm>(
   // `valid` derives from this single source so the two fields can
   // never disagree.
   const errors = aggregateErrorsAt(state, segments)
+  // Descendant display rollup: does any error UNDER this container have its
+  // owning field's reveal gate open? Iterates the aggregated errors (not just
+  // the leaf walk) so a cross-field error pinned at an intermediate object is
+  // included. The container's OWN-path error is left to the reducer's own-path
+  // rule; this adds only the descendant dimension the aggregate base hides.
+  const revealedDescendantError =
+    errors.length > 0 &&
+    errors.some((e) => {
+      const ePath = e.path
+      if (ePath.length === segments.length && ePath.every((s, i) => s === segments[i])) return false
+      if (submissionAttempts > 0) return true
+      // The form-errors bucket (path `['']`) belongs to the root container;
+      // gate it by the root's own aggregate blur rather than a leaf prefix.
+      if (ePath.length === 1 && ePath[0] === '') return blurredAfterInteraction
+      // A leaf error gates on that leaf's blur; an intermediate-container
+      // error gates on any blurred leaf beneath it.
+      return blurredLeafSegments.some((s) => isPathPrefix(ePath, s))
+    })
   // A container's own sub-schema can also declare async work — a
   // top-level `.refine(async ...)` on the root, or a cross-field
   // refine on a sub-object — and those don't show up in any per-
@@ -403,6 +443,7 @@ export function buildContainerFieldStateBase<F extends GenericForm>(
       meta: resolved.meta,
     },
     validatingSince,
+    revealedDescendantError,
   }
 }
 
@@ -418,7 +459,7 @@ function buildContainerFieldState<F extends GenericForm>(
   getFormMetaBase: FormMetaBaseGetter,
   getDisplayState?: GetDisplayState
 ): FieldState<unknown> {
-  const { base, validatingSince } = buildContainerFieldStateBase(
+  const { base, validatingSince, revealedDescendantError } = buildContainerFieldStateBase(
     state,
     segments,
     key,
@@ -430,6 +471,7 @@ function buildContainerFieldState<F extends GenericForm>(
     getFormMetaBase,
     key,
     validatingSince,
+    revealedDescendantError,
     getDisplayState
   )
 }
@@ -464,6 +506,7 @@ function decorateWithDerivedProps<F extends GenericForm>(
   getFormMetaBase: FormMetaBaseGetter,
   key: PathKey,
   validatingSince: number | null,
+  revealedDescendantError: boolean,
   getDisplayState?: GetDisplayState
 ): FieldState<unknown> {
   const firstError = base.errors[0]
@@ -478,6 +521,9 @@ function decorateWithDerivedProps<F extends GenericForm>(
     now: state.ssr ? 0 : Date.now(),
   }
   let machine: DisplayMachine
+  // The rollup is a library-default behavior; a fully custom reducer owns
+  // container verdicts. A throw falls back to the default, which restores it.
+  let rollupApplies = isDefaultDisplayState(predicate)
   try {
     machine = state.displayEngine.resolve(key, ctx, predicate)
   } catch (err) {
@@ -490,8 +536,19 @@ function decorateWithDerivedProps<F extends GenericForm>(
       )
     }
     machine = state.displayEngine.resolve(key, ctx, defaultDisplayState)
+    rollupApplies = true
   }
-  const displayState = machine.display
+  // Container rollup: surface a descendant's gated error (or a nested
+  // cross-field error) at the container, unless a validation is in flight
+  // (pending wins) or a custom reducer owns the verdict. The reducer already
+  // resolves the field's own-path error and the anti-flash timing; this only
+  // adds the descendant dimension it cannot see from the aggregate base. The
+  // four `show*` booleans below project from this single value, so the
+  // exactly-one-true invariant holds by construction.
+  const displayState: DisplayState =
+    rollupApplies && revealedDescendantError && machine.display !== 'pending'
+      ? 'error'
+      : machine.display
   return {
     ...base,
     displayState,

--- a/src/runtime/core/process-form.ts
+++ b/src/runtime/core/process-form.ts
@@ -414,6 +414,13 @@ export function buildProcessForm<F extends GenericForm, Out extends GenericForm 
         // writes can't clobber the authoritative submit result. Also
         // clears debounce timers that never fired.
         state.cancelFieldValidation()
+        // Drop the anti-flash display state too. An explicit submit is a
+        // "show me the verdict now" signal, so a leftover show-delay hold
+        // or a min-visible spinner timer from pre-submit typing must not
+        // outlive the submit and delay the reveal. `cancelFieldValidation`
+        // already cleared `fieldValidatingSince`, so the next read recomputes
+        // the settled verdict against the post-submit gate immediately.
+        state.displayEngine.clear()
         state.activeValidations.value += 1
         const refinement = await runRefinementValidation(state.form.value, undefined)
         const merged = composeWithDerivedBlank(refinement, undefined)

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -1477,29 +1477,31 @@ export type AttaformDefaults = {
    *   useForm({ getDisplayState })  >  AttaformDefaults  >  library default
    *
    * The library default opens one timing gate, then resolves by
-   * precedence: gate closed → `'idle'`; a run in flight → `'pending'`;
-   * an own-path error → `'error'`; otherwise `valid` → `'success'`, else
-   * `'idle'`. The gate opens after the first submit attempt OR once the
-   * field is touched and not currently focused:
+   * precedence: gate closed → `'idle'`; a run in flight → a delayed
+   * `'pending'` (held briefly to smooth fast validations, then held a
+   * minimum so it never flashes); an own-path error → `'error'`;
+   * otherwise earned `valid` → `'success'`, else `'idle'`. The gate opens
+   * after the first submit attempt OR once the field is edited and left:
    *
    * ```ts
-   * (field, formMeta) => {
+   * (prev, ctx) => {
    *   const gateOpen =
-   *     formMeta.submissionAttempts > 0 ||
-   *     (field.touched === true && field.focused !== true)
-   *   if (!gateOpen) return 'idle'
-   *   if (field.validating === true) return 'pending'
-   *   // ...own-path error → 'error'; valid → 'success'; else 'idle'
+   *     ctx.formMeta.submissionAttempts > 0 ||
+   *     ctx.field.blurredAfterInteraction === true
+   *   if (!gateOpen) return { display: 'idle' }
+   *   // ...timed 'pending' while validating; own-path error → 'error';
+   *   //    earned valid → 'success'; else 'idle'
    * }
    * ```
    *
    * Compose with the library default via the public `defaultDisplayState`
-   * export. The predicate runs on every field-state read, so it owns the
+   * export, or retune its timing via `makeDefaultDisplayState`. The
+   * reducer runs on every field-state read, so it owns the
    * idle / pending / error / success decision outright.
    *
-   * The predicate's args are `Omit`'d of the derived `displayState` /
-   * `show*` / `firstError` keys (see `FieldStateDerivedKey`) to prevent
-   * a self-referential predicate.
+   * The reducer's `ctx.field` / `ctx.formMeta` are `Omit`'d of the
+   * derived `displayState` / `show*` / `firstError` keys (see
+   * `FieldStateDerivedKey`) to prevent a self-referential reducer.
    */
   getDisplayState?: GetDisplayState
   /**
@@ -1673,16 +1675,60 @@ export type FieldStateDerivedKey =
   | 'firstError'
 
 /**
- * Predicate that resolves a path's `displayState`. Receives the field's
- * reactive state plus the form's reactive meta (both minus the derived
- * `displayState` / `show*` / `firstError` keys — see `FieldStateDerivedKey`)
- * and returns the single enum verdict; the `show*` booleans derive from
- * the result. Runs unconditionally on every field-state read, so the
- * idle / pending / error / success decision lives in exactly one place
- * and the whole app's validation-display behavior flows from it.
+ * One step of the display state machine: the verdict the field should
+ * render right now (`display`, projected to `displayState` and the
+ * `show*` booleans) plus two optional timing cells the engine reads.
  *
- * The library default — `defaultDisplayState` — is publicly exported so
- * a layered predicate can compose with it:
+ * - `reviewAt` — an absolute `Date.now()` millisecond stamp telling the
+ *   engine "re-evaluate this field no later than here." The engine keeps
+ *   a single timer per form aimed at the nearest `reviewAt` across all
+ *   active fields; when it fires, the dependent field computeds re-run
+ *   and call the reducer again. A machine with no `reviewAt` and a
+ *   non-pending `display` is terminal — the engine evicts it.
+ * - `pendingShownAt` — the stamp at which `'pending'` was first shown,
+ *   the memory the min-visible hold needs so a spinner that just appeared
+ *   is not yanked away the instant validation resolves. Opaque to the
+ *   engine; a custom reducer may carry its own extra memory fields too.
+ */
+export type DisplayMachine = {
+  readonly display: DisplayState
+  readonly reviewAt?: number
+  readonly pendingShownAt?: number
+}
+
+/**
+ * Inputs to a `getDisplayState` reducer. `field` and `formMeta` are the
+ * same reactive snapshots a predicate has always received (still minus
+ * the derived `displayState` / `show*` / `firstError` keys — see
+ * `FieldStateDerivedKey` — so a reducer can never read its own output and
+ * form a cycle), now joined by:
+ *
+ * - `validatingSince` — `Date.now()` at which the field's current
+ *   validation streak opened, or `null` when nothing is in flight. This,
+ *   not `field.validating`, is the timing anchor: the elapsed wait is
+ *   `now - validatingSince`. Pinned to the start of the streak, so
+ *   overlapping sub-runs do not reset it.
+ * - `now` — the engine's clock, injected so the reducer stays pure and
+ *   deterministic (and frozen to `0` under SSR, where there is no clock).
+ */
+export type DisplayCtx = {
+  readonly field: Omit<FieldState, FieldStateDerivedKey>
+  readonly formMeta: Omit<FormMeta, FieldStateDerivedKey>
+  readonly validatingSince: number | null
+  readonly now: number
+}
+
+/**
+ * Pure transition reducer that resolves a path's `displayState`. Given
+ * the field's previous `DisplayMachine` and the current `DisplayCtx`, it
+ * returns the next machine; the engine owns the clock and the timers, the
+ * reducer owns the timing policy. Runs on every field-state read (and
+ * again whenever a `reviewAt` deadline fires), so the whole app's
+ * validation-display behavior flows from this one function.
+ *
+ * The library default — `defaultDisplayState` — is publicly exported so a
+ * layered reducer can compose with it, and `makeDefaultDisplayState`
+ * builds a default with custom anti-flash timings:
  *
  * ```ts
  * import { defaultDisplayState } from 'attaform'
@@ -1690,17 +1736,16 @@ export type FieldStateDerivedKey =
  * useForm({
  *   schema,
  *   // Defer to the default everywhere, but never show a success check on `username`.
- *   getDisplayState: (field, formMeta) => {
- *     const state = defaultDisplayState(field, formMeta)
- *     return field.path[0] === 'username' && state === 'success' ? 'idle' : state
+ *   getDisplayState: (prev, ctx) => {
+ *     const next = defaultDisplayState(prev, ctx)
+ *     return next.display === 'success' && ctx.field.path[0] === 'username'
+ *       ? { display: 'idle' }
+ *       : next
  *   },
  * })
  * ```
  */
-export type GetDisplayState = (
-  field: Omit<FieldState, FieldStateDerivedKey>,
-  formMeta: Omit<FormMeta, FieldStateDerivedKey>
-) => DisplayState
+export type GetDisplayState = (prev: DisplayMachine, ctx: DisplayCtx) => DisplayMachine
 
 /**
  * Submit handler returned by `handleSubmit(onSubmit, onError)`. Bind

--- a/test/composables/aria.test.ts
+++ b/test/composables/aria.test.ts
@@ -59,8 +59,7 @@ afterEach(() => {
 
 const forceState =
   (state: 'idle' | 'pending' | 'error' | 'success'): GetDisplayState =>
-  () =>
-    state
+  () => ({ display: state })
 
 describe('auto-aria attribute mapping', () => {
   let mounted: Mounted | undefined

--- a/test/composables/display-reducer.test.ts
+++ b/test/composables/display-reducer.test.ts
@@ -169,6 +169,32 @@ describe('default reducer — settled verdict (validatingSince: null)', () => {
   })
 })
 
+describe('default reducer — the reveal gate governs the spinner', () => {
+  it('gate closed + validating past show-delay stays idle (no spinner mid-first-entry)', () => {
+    // No submit, not blurred-after-interaction: the gate is closed. Even a
+    // slow validation must not surface a spinner before the user engages,
+    // matching how errors and success are withheld.
+    const next = defaultDisplayState(
+      { display: 'idle' },
+      ctx({ field: field({ errors: [ownError] }), validatingSince: 0, now: showDelay + 50 })
+    )
+    expect(next.display).toBe('idle')
+    expect(next.reviewAt).toBeUndefined()
+  })
+
+  it('gate open + validating past show-delay does surface the spinner', () => {
+    const next = defaultDisplayState(
+      { display: 'idle' },
+      ctx({
+        field: field({ errors: [ownError], blurredAfterInteraction: true }),
+        validatingSince: 0,
+        now: showDelay,
+      })
+    )
+    expect(next.display).toBe('pending')
+  })
+})
+
 describe('default reducer — show-delay window', () => {
   const gatedError = field({ errors: [ownError], blurredAfterInteraction: true })
 

--- a/test/composables/display-reducer.test.ts
+++ b/test/composables/display-reducer.test.ts
@@ -1,0 +1,413 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DEFAULT_TIMINGS, defaultDisplayState, makeDefaultDisplayState } from '../../src'
+import type { DisplayCtx, DisplayMachine, ValidationError } from '../../src'
+import { createDisplayEngine } from '../../src/runtime/core/display-engine'
+import type { PathKey } from '../../src/runtime/core/paths'
+
+/**
+ * Pure-reducer lock for the anti-flash display timing.
+ *
+ * `makeDefaultDisplayState` returns a deterministic `(prev, ctx) => next`
+ * reducer: the engine injects `now`, threads the previous `DisplayMachine`,
+ * and supplies `validatingSince` (the streak anchor). Because every input
+ * is explicit, the show-delay / min-visible behaviour is testable without
+ * a clock or a mounted form — that is the backbone these tests pin down.
+ * Integration coverage (a real form, real timers) lives in
+ * `display-state.test.ts`.
+ */
+
+const { showDelay, minVisible } = DEFAULT_TIMINGS
+const IDLE: DisplayMachine = { display: 'idle' }
+const PENDING_AT = (shownAt: number): DisplayMachine => ({
+  display: 'pending',
+  pendingShownAt: shownAt,
+})
+
+const ownError: ValidationError = { path: ['x'], message: 'm', formKey: 'k', code: 'c' }
+const descendantError: ValidationError = { path: ['x', 'y'], message: 'm', formKey: 'k', code: 'c' }
+
+function field(over: Record<string, unknown> = {}): DisplayCtx['field'] {
+  return {
+    errors: [],
+    touched: false,
+    interacted: false,
+    blurredAfterInteraction: false,
+    focused: false,
+    validating: false,
+    valid: false,
+    blank: false,
+    dirty: false,
+    path: ['x'],
+    ...over,
+  } as unknown as DisplayCtx['field']
+}
+function meta(over: Record<string, unknown> = {}): DisplayCtx['formMeta'] {
+  return { submissionAttempts: 0, ...over } as unknown as DisplayCtx['formMeta']
+}
+function ctx(over: Partial<DisplayCtx> = {}): DisplayCtx {
+  return { field: field(), formMeta: meta(), validatingSince: null, now: 0, ...over }
+}
+
+describe('default reducer — settled verdict (validatingSince: null)', () => {
+  // The gate / error / earned-success / container matrix. With nothing in
+  // flight the reducer collapses to the documented heuristic, and `now`
+  // never changes the answer (the SSR-equivalence guarantee).
+  it('gate closed: idle even with an own error', () => {
+    expect(defaultDisplayState(IDLE, ctx({ field: field({ errors: [ownError] }) })).display).toBe(
+      'idle'
+    )
+  })
+
+  it('edited-and-left opens the gate: own error → error, regardless of dirty', () => {
+    expect(
+      defaultDisplayState(
+        IDLE,
+        ctx({ field: field({ errors: [ownError], blurredAfterInteraction: true }) })
+      ).display
+    ).toBe('error')
+  })
+
+  it('re-focused after engaging keeps the error (sticky bit, no not-focused term)', () => {
+    expect(
+      defaultDisplayState(
+        IDLE,
+        ctx({
+          field: field({ errors: [ownError], blurredAfterInteraction: true, focused: true }),
+        })
+      ).display
+    ).toBe('error')
+  })
+
+  it('clean tab-through (touched, never edited) stays idle', () => {
+    expect(
+      defaultDisplayState(IDLE, ctx({ field: field({ errors: [ownError], touched: true }) }))
+        .display
+    ).toBe('idle')
+  })
+
+  it('mid-first-entry (interacted + focused, not yet left) stays idle', () => {
+    expect(
+      defaultDisplayState(
+        IDLE,
+        ctx({
+          field: field({ errors: [ownError], interacted: true, touched: true, focused: true }),
+        })
+      ).display
+    ).toBe('idle')
+  })
+
+  it('after a submit attempt: own error → error regardless of focus/touch', () => {
+    expect(
+      defaultDisplayState(
+        IDLE,
+        ctx({
+          field: field({ errors: [ownError], focused: true }),
+          formMeta: meta({ submissionAttempts: 1 }),
+        })
+      ).display
+    ).toBe('error')
+  })
+
+  it('earned valid (dirty + non-blank) with the gate open → success', () => {
+    expect(
+      defaultDisplayState(
+        IDLE,
+        ctx({
+          field: field({ valid: true, blank: false, dirty: true, blurredAfterInteraction: true }),
+        })
+      ).display
+    ).toBe('success')
+  })
+
+  it('valid but unearned stays idle (blank, or not dirty, or post-submit flood)', () => {
+    const earned = { valid: true, blank: false, dirty: true, blurredAfterInteraction: true }
+    expect(
+      defaultDisplayState(IDLE, ctx({ field: field({ ...earned, valid: false }) })).display
+    ).toBe('idle')
+    expect(
+      defaultDisplayState(IDLE, ctx({ field: field({ ...earned, blank: true }) })).display
+    ).toBe('idle')
+    expect(
+      defaultDisplayState(IDLE, ctx({ field: field({ ...earned, dirty: false }) })).display
+    ).toBe('idle')
+    expect(
+      defaultDisplayState(
+        IDLE,
+        ctx({
+          field: field({ valid: true, blank: false, dirty: false }),
+          formMeta: meta({ submissionAttempts: 1 }),
+        })
+      ).display
+    ).toBe('idle')
+  })
+
+  it('container with ONLY descendant errors stays idle (own-path filter)', () => {
+    expect(
+      defaultDisplayState(
+        IDLE,
+        ctx({
+          field: field({ errors: [descendantError], path: ['x'] }),
+          formMeta: meta({ submissionAttempts: 1 }),
+        })
+      ).display
+    ).toBe('idle')
+  })
+
+  it('the verdict is independent of `now` (SSR-equivalence)', () => {
+    const settled = ctx({ field: field({ errors: [ownError], blurredAfterInteraction: true }) })
+    expect(defaultDisplayState(IDLE, { ...settled, now: 0 }).display).toBe('error')
+    expect(defaultDisplayState(IDLE, { ...settled, now: 9_999_999 }).display).toBe('error')
+  })
+
+  it('terminal settled machines carry no reviewAt', () => {
+    const next = defaultDisplayState(
+      IDLE,
+      ctx({ field: field({ errors: [ownError], blurredAfterInteraction: true }) })
+    )
+    expect(next.reviewAt).toBeUndefined()
+    expect(next.display).toBe('error')
+  })
+})
+
+describe('default reducer — show-delay window', () => {
+  const gatedError = field({ errors: [ownError], blurredAfterInteraction: true })
+
+  it('fast validation holds the prior verdict and schedules a review at the window edge', () => {
+    const prev: DisplayMachine = { display: 'error' }
+    const next = defaultDisplayState(
+      prev,
+      ctx({ field: gatedError, validatingSince: 1000, now: 1000 })
+    )
+    // Held — no spinner — and the engine is told to look again at +showDelay.
+    expect(next.display).toBe('error')
+    expect(next.reviewAt).toBe(1000 + showDelay)
+    expect(next.pendingShownAt).toBeUndefined()
+  })
+
+  it('holds a SUCCESS verdict through the window (no success → idle flicker)', () => {
+    // The in-flight field reads `valid: false` purely because a check is
+    // running; the reducer must hold the prior `success`, not recompute idle.
+    const prev: DisplayMachine = { display: 'success' }
+    const inFlight = field({ valid: false, blurredAfterInteraction: true })
+    const next = defaultDisplayState(
+      prev,
+      ctx({ field: inFlight, validatingSince: 1000, now: 1050 })
+    )
+    expect(next.display).toBe('success')
+    expect(next.reviewAt).toBe(1000 + showDelay)
+  })
+
+  it('settling inside the window returns the fresh verdict with no reviewAt', () => {
+    const prev: DisplayMachine = { display: 'error', reviewAt: 1000 + showDelay }
+    const next = defaultDisplayState(
+      prev,
+      ctx({ field: gatedError, validatingSince: null, now: 1050 })
+    )
+    expect(next.display).toBe('error')
+    expect(next.reviewAt).toBeUndefined()
+  })
+})
+
+describe('default reducer — slow validation surfaces pending', () => {
+  it('past the show-delay, still validating → pending, anchored now, held for min-visible', () => {
+    const prev: DisplayMachine = { display: 'error' }
+    const now = 1000 + showDelay
+    const next = defaultDisplayState(
+      prev,
+      ctx({
+        field: field({ errors: [ownError], blurredAfterInteraction: true }),
+        validatingSince: 1000,
+        now,
+      })
+    )
+    expect(next.display).toBe('pending')
+    expect(next.pendingShownAt).toBe(now)
+    expect(next.reviewAt).toBe(now + minVisible)
+  })
+
+  it('while the spinner is up and still validating: held, with no timer to wait on', () => {
+    const prev = PENDING_AT(2000)
+    const next = defaultDisplayState(
+      prev,
+      ctx({
+        field: field({ errors: [ownError], blurredAfterInteraction: true }),
+        validatingSince: 1900,
+        now: 2200,
+      })
+    )
+    expect(next.display).toBe('pending')
+    expect(next.pendingShownAt).toBe(2000)
+    // No reviewAt: the next move comes from the run settling (reactive),
+    // not from a timer — so the engine schedules nothing and can't busy-loop.
+    expect(next.reviewAt).toBeUndefined()
+  })
+})
+
+describe('default reducer — min-visible hold', () => {
+  it('settled but inside min-visible → still pending', () => {
+    const prev = PENDING_AT(2000)
+    const next = defaultDisplayState(
+      prev,
+      ctx({
+        field: field({ valid: true, dirty: true, blurredAfterInteraction: true }),
+        validatingSince: null,
+        now: 2000 + minVisible - 1,
+      })
+    )
+    expect(next.display).toBe('pending')
+    expect(next.pendingShownAt).toBe(2000)
+    expect(next.reviewAt).toBe(2000 + minVisible)
+  })
+
+  it('once min-visible elapses → the settled verdict is released', () => {
+    const prev = PENDING_AT(2000)
+    const next = defaultDisplayState(
+      prev,
+      ctx({
+        field: field({ valid: true, blank: false, dirty: true, blurredAfterInteraction: true }),
+        validatingSince: null,
+        now: 2000 + minVisible,
+      })
+    )
+    expect(next.display).toBe('success')
+    expect(next.reviewAt).toBeUndefined()
+  })
+})
+
+describe('default reducer — cross-episode continuity', () => {
+  it('a new validation starting mid-spinner keeps the spinner anchored (no flicker)', () => {
+    const prev = PENDING_AT(2000)
+    // A fresh streak opened at 2050, while the spinner from 2000 is still up.
+    const next = defaultDisplayState(
+      prev,
+      ctx({
+        field: field({ errors: [ownError], blurredAfterInteraction: true }),
+        validatingSince: 2050,
+        now: 2050,
+      })
+    )
+    expect(next.display).toBe('pending')
+    expect(next.pendingShownAt).toBe(2000)
+  })
+})
+
+describe('makeDefaultDisplayState — custom timings', () => {
+  it('{ showDelay: 0, minVisible: 0 } reproduces immediate, un-held pending (regression bridge)', () => {
+    const immediate = makeDefaultDisplayState({ showDelay: 0, minVisible: 0 })
+    const opened = immediate(
+      { display: 'error' },
+      ctx({
+        field: field({ errors: [ownError], blurredAfterInteraction: true }),
+        validatingSince: 500,
+        now: 500,
+      })
+    )
+    expect(opened.display).toBe('pending')
+    // min-visible 0 → released the instant validation settles.
+    const released = immediate(
+      PENDING_AT(500),
+      ctx({
+        field: field({ errors: [ownError], blurredAfterInteraction: true }),
+        validatingSince: null,
+        now: 500,
+      })
+    )
+    expect(released.display).toBe('error')
+  })
+
+  it('honours a tighter window than the default', () => {
+    const tight = makeDefaultDisplayState({ showDelay: 30, minVisible: 90 })
+    const gated = field({ errors: [ownError], blurredAfterInteraction: true })
+    // Held just before 30ms, pending at 30ms.
+    expect(
+      tight({ display: 'error' }, ctx({ field: gated, validatingSince: 0, now: 29 })).display
+    ).toBe('error')
+    const shown = tight({ display: 'error' }, ctx({ field: gated, validatingSince: 0, now: 30 }))
+    expect(shown.display).toBe('pending')
+    expect(shown.reviewAt).toBe(30 + 90)
+  })
+})
+
+describe('createDisplayEngine', () => {
+  const KEY = 'x' as PathKey
+
+  describe('client', () => {
+    beforeEach(() => vi.useFakeTimers())
+    afterEach(() => vi.useRealTimers())
+
+    it('evicts terminal idle machines but retains a verdict for the next streak', () => {
+      const engine = createDisplayEngine(false)
+      // idle → not retained.
+      engine.resolve(KEY, ctx({ field: field() }), defaultDisplayState)
+      expect(engine.has(KEY)).toBe(false)
+      expect(engine.size()).toBe(0)
+      // error → retained (so a later show-delay window can hold it).
+      engine.resolve(
+        KEY,
+        ctx({ field: field({ errors: [ownError], blurredAfterInteraction: true }) }),
+        defaultDisplayState
+      )
+      expect(engine.has(KEY)).toBe(true)
+      // back to idle → evicted again.
+      engine.resolve(KEY, ctx({ field: field() }), defaultDisplayState)
+      expect(engine.has(KEY)).toBe(false)
+      engine.dispose()
+    })
+
+    it('arms exactly one timer for a field inside the show-delay window', () => {
+      const engine = createDisplayEngine(false)
+      engine.resolve(
+        KEY,
+        ctx({
+          field: field({ errors: [ownError], blurredAfterInteraction: true }),
+          validatingSince: 0,
+          now: 0,
+        }),
+        defaultDisplayState
+      )
+      expect(engine.hasTimer()).toBe(true)
+      expect(vi.getTimerCount()).toBe(1)
+      engine.dispose()
+      expect(engine.hasTimer()).toBe(false)
+      expect(vi.getTimerCount()).toBe(0)
+    })
+
+    it('clear() drops machines and cancels the timer', () => {
+      const engine = createDisplayEngine(false)
+      engine.resolve(
+        KEY,
+        ctx({
+          field: field({ errors: [ownError], blurredAfterInteraction: true }),
+          validatingSince: 0,
+          now: 0,
+        }),
+        defaultDisplayState
+      )
+      expect(engine.size()).toBe(1)
+      expect(engine.hasTimer()).toBe(true)
+      engine.clear()
+      expect(engine.size()).toBe(0)
+      expect(engine.hasTimer()).toBe(false)
+    })
+  })
+
+  describe('ssr', () => {
+    it('never stores a machine or arms a timer', () => {
+      const engine = createDisplayEngine(true)
+      // Even a ctx the reducer would turn into a held spinner stores nothing.
+      const machine = engine.resolve(
+        KEY,
+        ctx({
+          field: field({ errors: [ownError], blurredAfterInteraction: true }),
+          validatingSince: 0,
+          now: showDelay,
+        }),
+        defaultDisplayState
+      )
+      expect(machine.display).toBe('pending') // the reducer still computes
+      expect(engine.size()).toBe(0) // but the engine persists nothing
+      expect(engine.has(KEY)).toBe(false)
+      expect(engine.hasTimer()).toBe(false)
+    })
+  })
+})

--- a/test/composables/display-reducer.test.ts
+++ b/test/composables/display-reducer.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope, watchEffect } from 'vue'
 import { DEFAULT_TIMINGS, defaultDisplayState, makeDefaultDisplayState } from '../../src'
-import type { DisplayCtx, DisplayMachine, ValidationError } from '../../src'
+import type { DisplayCtx, DisplayMachine, GetDisplayState, ValidationError } from '../../src'
 import { createDisplayEngine } from '../../src/runtime/core/display-engine'
+import { FOCUS_OUT_GRACE } from '../../src/runtime/core/display-state'
 import type { PathKey } from '../../src/runtime/core/paths'
 
 /**
@@ -32,7 +34,7 @@ function field(over: Record<string, unknown> = {}): DisplayCtx['field'] {
     touched: false,
     interacted: false,
     blurredAfterInteraction: false,
-    focused: false,
+    focused: null,
     validating: false,
     valid: false,
     blank: false,
@@ -193,6 +195,21 @@ describe('default reducer — the reveal gate governs the spinner', () => {
     )
     expect(next.display).toBe('pending')
   })
+
+  it('hydration-safe: a gate-closed validating field is idle for both SSR now=0 and a real client clock', () => {
+    // At first paint the gate is closed (submissionAttempts=0, not yet
+    // blurred-after-interaction), so a mid-validation field renders idle
+    // regardless of `now`. The server (now=0) and the client's first render
+    // (now=Date.now()) therefore agree — no hydration mismatch on the display
+    // projection. Locks the load-bearing constraint that the gate stays closed
+    // through SSR / first client render.
+    const validatingClosed = ctx({
+      field: field({ errors: [ownError], validating: true }),
+      validatingSince: 0,
+    })
+    expect(defaultDisplayState(IDLE, { ...validatingClosed, now: 0 }).display).toBe('idle')
+    expect(defaultDisplayState(IDLE, { ...validatingClosed, now: 9_999_999 }).display).toBe('idle')
+  })
 })
 
 describe('default reducer — show-delay window', () => {
@@ -210,17 +227,121 @@ describe('default reducer — show-delay window', () => {
     expect(next.pendingShownAt).toBeUndefined()
   })
 
-  it('holds a SUCCESS verdict through the window (no success → idle flicker)', () => {
-    // The in-flight field reads `valid: false` purely because a check is
-    // running; the reducer must hold the prior `success`, not recompute idle.
+  it('holds a headless (focused: null) success through the window (no blur signal)', () => {
+    // A re-validation with no focus to act on — a programmatic / cross-field run
+    // on a field with no bound element — keeps the full show-delay: the prior
+    // `success` is held (not recomputed to idle), exactly as for a focused edit.
     const prev: DisplayMachine = { display: 'success' }
-    const inFlight = field({ valid: false, blurredAfterInteraction: true })
+    const inFlight = field({ valid: false, blurredAfterInteraction: true, focused: null })
     const next = defaultDisplayState(
       prev,
       ctx({ field: inFlight, validatingSince: 1000, now: 1050 })
     )
     expect(next.display).toBe('success')
     expect(next.reviewAt).toBe(1000 + showDelay)
+  })
+
+  it('focus-out collapses the window to the settle grace (holds briefly, reviews at the grace edge)', () => {
+    // The instant the user focuses out, the show-delay (which exists to swallow
+    // the spinner during typing) collapses to a brief settle grace. The prior
+    // verdict is still held for that grace — a fast validation settling inside
+    // it resolves to its real verdict with no spinner — but the review is now
+    // scheduled at the grace edge, not the far show-delay edge.
+    const prev: DisplayMachine = { display: 'success' }
+    const blurred = field({ valid: false, blurredAfterInteraction: true, focused: false })
+    const next = defaultDisplayState(
+      prev,
+      ctx({ field: blurred, validatingSince: 1000, now: 1000 + FOCUS_OUT_GRACE - 1 })
+    )
+    expect(next.display).toBe('success')
+    expect(next.reviewAt).toBe(1000 + FOCUS_OUT_GRACE) // grace edge, not 1000 + showDelay
+  })
+
+  it('focus-out past the settle grace, still validating → pending at once', () => {
+    // The grace elapsed and the validation is still in flight: it outlived the
+    // grace, so it is genuinely async — surface the spinner now rather than
+    // waiting out the rest of a window the user has left.
+    const prev: DisplayMachine = { display: 'success' }
+    const blurred = field({ valid: false, blurredAfterInteraction: true, focused: false })
+    const next = defaultDisplayState(
+      prev,
+      ctx({ field: blurred, validatingSince: 1000, now: 1000 + FOCUS_OUT_GRACE })
+    )
+    expect(next.display).toBe('pending')
+    expect(next.pendingShownAt).toBe(1000 + FOCUS_OUT_GRACE)
+    expect(next.reviewAt).toBe(1000 + FOCUS_OUT_GRACE + minVisible)
+  })
+
+  it('holds a FOCUSED success through the window (no success → idle flicker while editing)', () => {
+    // Editing a valid field re-validates it; inside the show-delay window the
+    // in-flight field reads `valid: false` only because a check is running, so
+    // the reducer holds the prior `success` rather than recomputing idle. The
+    // window holds every prior verdict uniformly — focus is not special — so a
+    // value edited toward another still-valid value never flickers
+    // success → idle → success; it goes success → pending → success.
+    const prev: DisplayMachine = { display: 'success' }
+    const editing = field({ valid: false, blurredAfterInteraction: true, focused: true })
+    const next = defaultDisplayState(
+      prev,
+      ctx({ field: editing, validatingSince: 1000, now: 1050 })
+    )
+    expect(next.display).toBe('success')
+    expect(next.reviewAt).toBe(1000 + showDelay)
+  })
+
+  it('holds a FOCUSED error through the window (the window holds every prior verdict)', () => {
+    // The window holds whatever was on screen, focus included: a stale error
+    // while the user fixes the field is conservative (it was wrong, we are
+    // re-checking), exactly as a stale success is held while editing toward a
+    // still-valid value.
+    const prev: DisplayMachine = { display: 'error' }
+    const editing = field({ errors: [ownError], blurredAfterInteraction: true, focused: true })
+    const next = defaultDisplayState(
+      prev,
+      ctx({ field: editing, validatingSince: 1000, now: 1050 })
+    )
+    expect(next.display).toBe('error')
+    expect(next.reviewAt).toBe(1000 + showDelay)
+  })
+
+  it('regression: editing a valid value goes success → pending → success, never idle', () => {
+    // Live report: a filled, valid (success) field, re-focused and edited to
+    // another still-valid value, flashed `idle` before the spinner. The window
+    // must hold the prior `success`, so the only transitions a slow
+    // re-validation produces are success → pending → success — no idle frame.
+    const editing = field({
+      valid: false,
+      blurredAfterInteraction: true,
+      focused: true,
+      dirty: true,
+    })
+
+    // 1. Inside the show-delay window: the prior success is HELD (not idle).
+    const inWindow = defaultDisplayState(
+      { display: 'success' },
+      ctx({ field: editing, validatingSince: 1000, now: 1000 })
+    )
+    expect(inWindow.display).toBe('success')
+
+    // 2. Past the show-delay, still validating: the spinner earns its place.
+    const pastWindow = defaultDisplayState(
+      inWindow,
+      ctx({ field: editing, validatingSince: 1000, now: 1000 + showDelay })
+    )
+    expect(pastWindow.display).toBe('pending')
+
+    // 3. Settles valid past min-visible: success — never having shown idle.
+    const settled = field({
+      valid: true,
+      blurredAfterInteraction: true,
+      focused: true,
+      dirty: true,
+    })
+    const released = defaultDisplayState(
+      pastWindow,
+      ctx({ field: settled, validatingSince: null, now: 1000 + showDelay + minVisible })
+    )
+    expect(released.display).toBe('success')
   })
 
   it('settling inside the window returns the fresh verdict with no reviewAt', () => {
@@ -435,5 +556,85 @@ describe('createDisplayEngine', () => {
       expect(engine.has(KEY)).toBe(false)
       expect(engine.hasTimer()).toBe(false)
     })
+  })
+})
+
+describe('createDisplayEngine — untrusted reducer reviewAt (robustness)', () => {
+  // `getDisplayState` is consumer-overridable; a custom predicate can return a
+  // pathological `reviewAt` (bad arithmetic → NaN/Infinity, a unit slip → a
+  // huge value, a fixed/past timestamp). The try/catch in field-state-api only
+  // covers THROWS — a bad RETURN value must not reach setTimeout and spin the
+  // engine. None of these arise from the library default.
+  const KEY = 'x' as PathKey
+  const gated = () => field({ blurredAfterInteraction: true })
+
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('ignores a NaN reviewAt — never armed into setTimeout', () => {
+    const engine = createDisplayEngine(false)
+    const bad: GetDisplayState = () => ({ display: 'pending', reviewAt: NaN })
+    engine.resolve(KEY, ctx({ field: gated(), validatingSince: 0, now: 0 }), bad)
+    expect(engine.hasTimer()).toBe(false)
+    expect(vi.getTimerCount()).toBe(0)
+    engine.dispose()
+  })
+
+  it('ignores an Infinity reviewAt', () => {
+    const engine = createDisplayEngine(false)
+    const bad: GetDisplayState = () => ({ display: 'pending', reviewAt: Infinity })
+    engine.resolve(KEY, ctx({ field: gated(), validatingSince: 0, now: 0 }), bad)
+    expect(engine.hasTimer()).toBe(false)
+    engine.dispose()
+  })
+
+  it('drops an idle machine kept alive only by a non-finite reviewAt', () => {
+    const engine = createDisplayEngine(false)
+    const bad: GetDisplayState = () => ({ display: 'idle', reviewAt: NaN })
+    engine.resolve(KEY, ctx({ field: gated(), validatingSince: 0, now: 0 }), bad)
+    expect(engine.has(KEY)).toBe(false)
+    expect(engine.size()).toBe(0)
+    engine.dispose()
+  })
+
+  it('clamps an over-large finite reviewAt below the setTimeout overflow (no immediate fire)', () => {
+    const engine = createDisplayEngine(false)
+    const farFuture: GetDisplayState = (_p, c) => ({ display: 'pending', reviewAt: c.now + 1e15 })
+    engine.resolve(KEY, ctx({ field: gated(), validatingSince: 0, now: 0 }), farFuture)
+    expect(engine.hasTimer()).toBe(true)
+    // A normal advance must NOT fire it — an un-clamped 1e15 ms would overflow
+    // a 32-bit setTimeout and fire almost immediately, then re-arm and loop.
+    vi.advanceTimersByTime(10_000)
+    expect(engine.hasTimer()).toBe(true)
+    engine.dispose()
+  })
+
+  it('refuses to re-arm for the exact deadline it just fired — no fire loop', () => {
+    const engine = createDisplayEngine(false)
+    let calls = 0
+    // A misbehaving predicate that re-emits the same past deadline forever.
+    const stuck: GetDisplayState = () => {
+      calls++
+      return { display: 'pending', reviewAt: 500 }
+    }
+    const scope = effectScope()
+    scope.run(() => {
+      // A sync effect stands in for the field-state computed: a `tick` bump
+      // re-invokes `resolve`, which is exactly the loop vector in production.
+      watchEffect(
+        () => {
+          engine.resolve(KEY, ctx({ field: gated(), validatingSince: 0, now: 1000 }), stuck)
+        },
+        { flush: 'sync' }
+      )
+    })
+    // The first (0-delay) timer fires once; the forward-progress guard then
+    // refuses to re-arm for the same deadline. Without it this loops until
+    // vitest aborts at its 10k-timer ceiling.
+    vi.advanceTimersByTime(1000)
+    expect(calls).toBeLessThanOrEqual(3)
+    expect(engine.hasTimer()).toBe(false)
+    scope.stop()
+    engine.dispose()
   })
 })

--- a/test/composables/display-state.test.ts
+++ b/test/composables/display-state.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
 import { computed, createApp, defineComponent, h, nextTick, withDirectives, type App } from 'vue'
 import { z as zV4 } from 'zod'
 import { z as zV3 } from 'zod-v3'
@@ -7,26 +7,27 @@ import { useForm as useFormV4 } from '../../src/zod-v4'
 import { useForm as useFormV3 } from '../../src/zod-v3'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import { vRegister } from '../../src/runtime/core/directive'
-import { defaultDisplayState } from '../../src'
+import { DEFAULT_TIMINGS, defaultDisplayState, makeDefaultDisplayState } from '../../src'
 import type {
+  DisplayCtx,
+  DisplayMachine,
   DisplayState,
-  FieldState,
-  FormMeta,
   GetDisplayState,
   ValidationError,
 } from '../../src'
 
 /**
- * `field.displayState` + the `getDisplayState` predicate.
+ * `field.displayState` + the `getDisplayState` reducer.
  *
  * `field.displayState` is the single derived verdict on `FieldState`
- * (`'idle' | 'pending' | 'error' | 'success'`); the four `show*`
- * booleans are pure projections of it (`showErrors === (displayState ===
- * 'error')`, and so on). The heuristic `getDisplayState(field, formMeta)`
- * resolves through three tiers:
+ * (`'idle' | 'pending' | 'error' | 'success'`); the four `show*` booleans
+ * are pure projections of it (`showErrors === (displayState === 'error')`,
+ * and so on). The reducer `getDisplayState(prev, ctx)` returns the next
+ * `DisplayMachine` and resolves through three tiers:
  *   1. Library default: one timing gate
  *      (`submissionAttempts > 0 || blurredAfterInteraction`), then
- *      precedence — `validating` → pending; own-path error → error;
+ *      precedence — a validation in flight surfaces a delayed, then held,
+ *      `'pending'` (the anti-flash spinner); own-path error → error;
  *      earned (`valid && !blank && dirty`) → success; else idle.
  *      Containers (intermediate AND root) only resolve to error on their
  *      own-path errors; leaves always satisfy the own-path filter when
@@ -34,11 +35,13 @@ import type {
  *   2. `createAttaform({ defaults: { getDisplayState } })`.
  *   3. `useForm({ getDisplayState })`, wins over both above.
  *
- * The predicate runs unconditionally (it must see the no-error states to
- * resolve success / idle / pending). Its args (`field`, `formMeta`) are
+ * The reducer runs unconditionally (it must see the no-error states to
+ * resolve success / idle / pending). Its `ctx.field` / `ctx.formMeta` are
  * `Omit`'d of the derived `displayState` / `show*` / `firstError` keys at
- * BOTH the type and runtime level, so a self-referential predicate is
- * impossible regardless of language (TS or JS).
+ * BOTH the type and runtime level, so a self-referential reducer is
+ * impossible regardless of language (TS or JS). The pure timing matrix is
+ * locked in `display-reducer.test.ts`; this file covers the verdicts and
+ * the override tiers through a real mounted form.
  */
 
 const apps: App[] = []
@@ -297,14 +300,15 @@ function describeOverrideTier(
       ])
     }
 
-    // A predicate that surfaces errors purely on touch, ignoring the
+    // A reducer that surfaces errors purely on touch, ignoring the
     // submit arm of the default gate.
-    const touchOnly: GetDisplayState = (field) =>
-      field.errors.length > 0 && field.touched === true ? 'error' : 'idle'
-    // "Always show when errors exist" — the eager predicate.
-    const eager: GetDisplayState = (field) => (field.errors.length > 0 ? 'error' : 'idle')
+    const touchOnly: GetDisplayState = (_prev, { field }) =>
+      field.errors.length > 0 && field.touched === true ? { display: 'error' } : { display: 'idle' }
+    // "Always show when errors exist" — the eager reducer.
+    const eager: GetDisplayState = (_prev, { field }) =>
+      field.errors.length > 0 ? { display: 'error' } : { display: 'idle' }
     // "Never surface anything."
-    const silent: GetDisplayState = () => 'idle'
+    const silent: GetDisplayState = () => ({ display: 'idle' })
 
     it('plugin-level override: custom predicate ignores submissionAttempts', async () => {
       const form = makeForm(touchOnly, undefined)
@@ -470,12 +474,12 @@ describe('getDisplayState — cross-cutting', () => {
           key: `omit-runtime-${Math.random()}`,
           strict: false,
           defaultValues: v4Defaults,
-          getDisplayState: (field, formMeta) => {
+          getDisplayState: (_prev, { field, formMeta }) => {
             for (const k of derivedKeys) {
               if (k in (field as object)) probe.fieldPresent.push(k)
               if (k in (formMeta as object)) probe.formMetaPresent.push(k)
             }
-            return 'error'
+            return { display: 'error' }
           },
         })
       )
@@ -489,14 +493,14 @@ describe('getDisplayState — cross-cutting', () => {
     expect(probe.formMetaPresent).toEqual([])
   })
 
-  it('defaultDisplayState is publicly exported and arity-2', () => {
+  it('defaultDisplayState is publicly exported as a (prev, ctx) reducer', () => {
     expect(typeof defaultDisplayState).toBe('function')
     expect(defaultDisplayState.length).toBe(2)
   })
 
-  it('defaultDisplayState composes inside a layered predicate', async () => {
-    const layered: GetDisplayState = (field, formMeta) =>
-      field.path[0] === 'urgent' ? 'error' : defaultDisplayState(field, formMeta)
+  it('defaultDisplayState composes inside a layered reducer', async () => {
+    const layered: GetDisplayState = (prev, ctx) =>
+      ctx.field.path[0] === 'urgent' ? { display: 'error' } : defaultDisplayState(prev, ctx)
 
     const form = asForm(
       mountWithApp(() =>
@@ -520,140 +524,11 @@ describe('getDisplayState — cross-cutting', () => {
     expect(form.fields('email').displayState).toBe('error')
   })
 
-  it('defaultDisplayState tracks the documented heuristic on synthetic inputs', () => {
-    const ownErrorField = {
-      errors: [{ path: ['x'], message: 'm', formKey: 'k', code: 'c' }],
-      touched: false,
-      interacted: false,
-      blurredAfterInteraction: false,
-      focused: false,
-      validating: false,
-      valid: false,
-      path: ['x'],
-    } as unknown as Omit<FieldState, 'displayState' | 'showErrors' | 'firstError'>
-    const baseMeta = {
-      submissionAttempts: 0,
-    } as unknown as Omit<FormMeta, 'displayState' | 'showErrors' | 'firstError'>
-
-    // Gate closed (no submit, not touched): idle even with an own error.
-    expect(defaultDisplayState(ownErrorField, baseMeta)).toBe('idle')
-
-    // Edited and left (blurredAfterInteraction), own error → error,
-    // regardless of dirty.
-    expect(defaultDisplayState({ ...ownErrorField, blurredAfterInteraction: true }, baseMeta)).toBe(
-      'error'
-    )
-
-    // Re-focused after engaging (blurredAfterInteraction stays true while
-    // focused): the bit is sticky and carries no not-focused term, so the
-    // error persists through the re-focus instead of vanishing mid-fix.
-    expect(
-      defaultDisplayState(
-        { ...ownErrorField, blurredAfterInteraction: true, focused: true },
-        baseMeta
-      )
-    ).toBe('error')
-
-    // Tabbed through without editing (touched, but never edited so
-    // blurredAfterInteraction is false): a clean tab-through never engages
-    // the gate → idle.
-    expect(defaultDisplayState({ ...ownErrorField, touched: true }, baseMeta)).toBe('idle')
-
-    // First pass mid-entry: edited (interacted) and focused, and even
-    // tabbed through earlier (touched), but not yet left since the edit
-    // (blurredAfterInteraction false). The error stays quiet → idle. This
-    // is the case a bare `interacted && touched` gate got wrong.
-    expect(
-      defaultDisplayState(
-        { ...ownErrorField, interacted: true, touched: true, focused: true },
-        baseMeta
-      )
-    ).toBe('idle')
-
-    // Currently validating (gate open via blurredAfterInteraction): pending
-    // wins over the stale error verdict.
-    expect(
-      defaultDisplayState(
-        { ...ownErrorField, blurredAfterInteraction: true, validating: true },
-        baseMeta
-      )
-    ).toBe('pending')
-    expect(
-      defaultDisplayState({ ...ownErrorField, validating: true }, {
-        ...baseMeta,
-        submissionAttempts: 1,
-      } as typeof baseMeta)
-    ).toBe('pending')
-
-    // After first submit attempt: error regardless of touched/focused.
-    expect(
-      defaultDisplayState(ownErrorField, {
-        ...baseMeta,
-        submissionAttempts: 1,
-      } as typeof baseMeta)
-    ).toBe('error')
-
-    // Post-submit aggression: focused + untouched + own error still
-    // resolves to error. The user signalled they're done editing by
-    // hitting submit; transient mid-edit hiding no longer applies.
-    expect(
-      defaultDisplayState({ ...ownErrorField, touched: false, focused: true }, {
-        ...baseMeta,
-        submissionAttempts: 1,
-      } as typeof baseMeta)
-    ).toBe('error')
-
-    // No error + valid + earned (dirty + non-blank) + gate open → success.
-    const validField = {
-      errors: [],
-      touched: true,
-      interacted: true,
-      blurredAfterInteraction: true,
-      focused: false,
-      validating: false,
-      valid: true,
-      blank: false,
-      dirty: true,
-      path: ['x'],
-    } as unknown as Omit<FieldState, 'displayState' | 'showErrors' | 'firstError'>
-    expect(defaultDisplayState(validField, baseMeta)).toBe('success')
-
-    // No error + NOT yet valid (e.g. async first pass pending) + gate open → idle.
-    expect(defaultDisplayState({ ...validField, valid: false }, baseMeta)).toBe('idle')
-
-    // Valid but UNEARNED: success is withheld so the green check only ever
-    // means the user put valid content there themselves.
-    //   Blank (an empty optional field that happens to pass) → idle.
-    expect(defaultDisplayState({ ...validField, blank: true }, baseMeta)).toBe('idle')
-    //   Not dirty (a pre-filled field merely tabbed through) → idle.
-    expect(defaultDisplayState({ ...validField, dirty: false }, baseMeta)).toBe('idle')
-    //   The post-submit flood: a valid, non-blank, but untouched field
-    //   stays idle even with the gate forced open by a submit attempt.
-    expect(
-      defaultDisplayState({ ...validField, dirty: false }, {
-        ...baseMeta,
-        submissionAttempts: 1,
-      } as typeof baseMeta)
-    ).toBe('idle')
-
-    // Container with ONLY descendant errors: idle even after submit. The
-    // own-path filter blocks the container from resolving to error and
-    // duplicating leaf-rendered messages.
-    const containerOnlyDescendantErrors = {
-      errors: [{ path: ['x', 'y'], message: 'm', formKey: 'k', code: 'c' }],
-      touched: true,
-      focused: false,
-      validating: false,
-      valid: false,
-      path: ['x'],
-    } as unknown as Omit<FieldState, 'displayState' | 'showErrors' | 'firstError'>
-    expect(
-      defaultDisplayState(containerOnlyDescendantErrors, {
-        ...baseMeta,
-        submissionAttempts: 1,
-      } as typeof baseMeta)
-    ).toBe('idle')
-  })
+  // The full synthetic gate / error / earned-success / container matrix
+  // for the default reducer now lives in `display-reducer.test.ts`, where
+  // it can inject `now` / `validatingSince` / `prev` deterministically and
+  // also lock the anti-flash timing. Integration coverage of the same
+  // verdicts (through a real mounted form) stays in the adapter blocks above.
 
   // PASS2-11 — a consumer predicate that throws must not take the
   // reactive surface down. The catch was already there (correct, never
@@ -705,23 +580,22 @@ describe('getDisplayState — cross-cutting', () => {
   })
 })
 
-describe('getDisplayState — pending during validating', () => {
-  /**
-   * Pending contract: when a verdict is in flight, `field.errors`
-   * retains the stale entry (no flicker to empty) under stale-while-
-   * revalidate, but `field.displayState` resolves to `'pending'` because
-   * the application is recomputing and a spinner narrates the current
-   * state honestly. The error returns the moment validation completes if
-   * the new verdict still has issues.
-   */
-  it('async refine: pending during validation, error when verdict lands', async () => {
+describe('getDisplayState — anti-flash spinner timing (integration)', () => {
+  // Fake timers drive both the engine's deadline `setTimeout` and the
+  // injected `now` (vitest mocks `Date.now()`), so the show-delay /
+  // min-visible thresholds are exercised deterministically. The form's
+  // own validation runs on microtasks (not timers), which `await` and
+  // `advanceTimersByTimeAsync` flush.
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  function mountGatedRefine(): { form: FormLike; resolve: (ok: boolean) => void } {
     let resolveValidation: (ok: boolean) => void = () => {}
     const schema = zV4.object({
       email: zV4.string().refine(
         (val) => {
-          // Reject empty; for any non-empty value, await the
-          // externally-resolved gate so the test can observe the
-          // mid-validation window.
+          // Empty rejects synchronously; any non-empty value parks on the
+          // external gate so the test can sit inside the validating window.
           if (val.length === 0) return false
           return new Promise<boolean>((resolve) => {
             resolveValidation = resolve
@@ -730,46 +604,262 @@ describe('getDisplayState — pending during validating', () => {
         { error: 'invalid email' }
       ),
     })
-
     const form = asForm(
       mountWithApp(() =>
         useFormV4({
           schema,
-          key: `pending-validating-${Math.random()}`,
+          key: `pending-timing-${Math.random()}`,
           strict: false,
           defaultValues: { email: '' },
         } as never)
       )
     )
+    return { form, resolve: (ok) => resolveValidation(ok) }
+  }
 
-    // Touch + submit so the timing gate is open. Mount-time validation
-    // produces a verdict on the empty string ("invalid email").
+  it('holds the verdict through show-delay, shows a held spinner, then the landed verdict', async () => {
+    const { form, resolve } = mountGatedRefine()
+
+    // Gate open + a landed error on the empty string.
     form.touch('email')
     await form.handleSubmit(() => {})()
     await nextTick()
-    expect(form.fields('email').errors.length).toBeGreaterThan(0)
     expect(form.fields('email').displayState).toBe('error')
 
-    // Edit to a non-empty value. Change-mode validation schedules; the
-    // async refine pauses on the externally-resolved gate.
+    // Edit: change-mode validation starts and parks on the external gate.
     form.setValue('email', 'a@b.c')
     await nextTick()
     expect(form.fields('email').validating).toBe(true)
-    // SWR: the stale error stays in `errors`, so consumers reading the
-    // store directly still see something while the new verdict resolves.
-    expect(form.fields('email').errors.length).toBeGreaterThan(0)
-    // But displayState resolves to 'pending' during the recompute window.
-    expect(form.fields('email').displayState).toBe('pending')
-    expect(form.fields('email').showPending).toBe(true)
-    expect(form.fields('email').showErrors).toBe(false)
-
-    // Resolve the validation as STILL invalid. The new verdict lands,
-    // validating returns to false, displayState flips back to 'error'.
-    resolveValidation(false)
-    await new Promise((r) => setTimeout(r, 0))
-    expect(form.fields('email').validating).toBe(false)
+    // Inside the show-delay window: the prior verdict is HELD — no spinner
+    // flash even though a validation is genuinely in flight. SWR keeps the
+    // stale error in `errors` for direct readers.
     expect(form.fields('email').errors.length).toBeGreaterThan(0)
     expect(form.fields('email').displayState).toBe('error')
+    expectProjections(form.fields('email'))
+
+    // Cross the show-delay: now a long-running validation earns its spinner.
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.showDelay)
+    expect(form.fields('email').displayState).toBe('pending')
+    expectProjections(form.fields('email'))
+
+    // Resolve still-invalid. The spinner is held for its minimum-visible
+    // window even though validation has already settled.
+    resolve(false)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(form.fields('email').validating).toBe(false)
+    expect(form.fields('email').displayState).toBe('pending')
+
+    // Past min-visible: the landed error replaces the spinner.
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.minVisible)
+    expect(form.fields('email').displayState).toBe('error')
+    expect(form.fields('email').errors.length).toBeGreaterThan(0)
+    expectProjections(form.fields('email'))
+  })
+
+  it('fast validation never reveals the spinner (settles inside the show-delay)', async () => {
+    const { form, resolve } = mountGatedRefine()
+    form.touch('email')
+    await form.handleSubmit(() => {})()
+    await nextTick()
+    expect(form.fields('email').displayState).toBe('error')
+
+    form.setValue('email', 'a@b.c')
+    await nextTick()
+    expect(form.fields('email').validating).toBe(true)
+    expect(form.fields('email').displayState).toBe('error')
+
+    // Resolve valid BEFORE the show-delay elapses: no spinner is ever shown,
+    // and the verdict moves straight from the held error to success.
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.showDelay - 1)
+    resolve(true)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(form.fields('email').validating).toBe(false)
+    expect(form.fields('email').displayState).toBe('success')
+    expect(form.fields('email').showPending).toBe(false)
+    expectProjections(form.fields('email'))
+    // No orphaned engine timer once the field settled.
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('a custom factory drives the clock at its own thresholds', async () => {
+    let resolveValidation: (ok: boolean) => void = () => {}
+    const schema = zV4.object({
+      email: zV4.string().refine(
+        (val) =>
+          val.length === 0
+            ? false
+            : new Promise<boolean>((resolve) => {
+                resolveValidation = resolve
+              }),
+        { error: 'invalid email' }
+      ),
+    })
+    const form = asForm(
+      mountWithApp(() =>
+        useFormV4({
+          schema,
+          key: `custom-timing-${Math.random()}`,
+          strict: false,
+          defaultValues: { email: '' },
+          // Tighter than the default: spinner after 30ms, held for 90ms.
+          getDisplayState: makeDefaultDisplayState({ showDelay: 30, minVisible: 90 }),
+        } as never)
+      )
+    )
+
+    form.touch('email')
+    await form.handleSubmit(() => {})()
+    await nextTick()
+    expect(form.fields('email').displayState).toBe('error')
+
+    form.setValue('email', 'a@b.c')
+    await nextTick()
+    // Still held at the default's 100ms would be wrong — this factory shows
+    // the spinner at 30ms. Just before, it is still held.
+    await vi.advanceTimersByTimeAsync(29)
+    expect(form.fields('email').displayState).toBe('error')
+    await vi.advanceTimersByTimeAsync(1)
+    expect(form.fields('email').displayState).toBe('pending')
+
+    resolveValidation(false)
+    await vi.advanceTimersByTimeAsync(0)
+    // Held for the custom 90ms min-visible, not the default 120ms.
+    expect(form.fields('email').displayState).toBe('pending')
+    await vi.advanceTimersByTimeAsync(90)
+    expect(form.fields('email').displayState).toBe('error')
+  })
+
+  it('reset() mid-spinner clears the held state and leaves no orphaned timer', async () => {
+    const { form, resolve } = mountGatedRefine()
+    const api = form as unknown as { reset: () => void }
+    form.touch('email')
+    await form.handleSubmit(() => {})()
+    await nextTick()
+    form.setValue('email', 'a@b.c')
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.showDelay)
+    expect(form.fields('email').displayState).toBe('pending')
+
+    api.reset()
+    await nextTick()
+    // After reset the gate is closed again and nothing is in flight, so the
+    // verdict is idle — and the engine timer was cleared.
+    expect(form.fields('email').displayState).toBe('idle')
+    expect(vi.getTimerCount()).toBe(0)
+    // Settle the now-orphaned validation so it can't write post-reset.
+    resolve(false)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(form.fields('email').displayState).toBe('idle')
+  })
+
+  it('a second keystroke mid-spinner keeps the spinner continuous (no flash to a verdict)', async () => {
+    const { form } = mountGatedRefine()
+    form.touch('email')
+    await form.handleSubmit(() => {})()
+    await nextTick()
+
+    form.setValue('email', 'a@b.c')
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.showDelay)
+    expect(form.fields('email').displayState).toBe('pending')
+
+    // Type again while the spinner is up: a fresh validation streak opens
+    // before the first settled. The anchor carries over, so the spinner
+    // stays continuous rather than flashing back to the held verdict.
+    form.setValue('email', 'a@b.cd')
+    await nextTick()
+    expect(form.fields('email').displayState).toBe('pending')
+    // It stays pending while validation remains in flight — never a verdict
+    // frame between the two keystrokes.
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.showDelay + DEFAULT_TIMINGS.minVisible)
+    expect(form.fields('email').displayState).toBe('pending')
+  })
+
+  it('a container shows one continuous spinner while descendants validate on offset starts', async () => {
+    const resolvers: Array<(ok: boolean) => void> = []
+    const gate = (val: string): boolean | Promise<boolean> =>
+      val === '' ? false : new Promise<boolean>((r) => resolvers.push(r))
+    const schema = zV4.object({
+      profile: zV4.object({
+        a: zV4.string().refine(gate, { error: 'bad a' }),
+        b: zV4.string().refine(gate, { error: 'bad b' }),
+      }),
+    })
+    const form = asForm(
+      mountWithApp(() =>
+        useFormV4({
+          schema,
+          key: `container-spinner-${Math.random()}`,
+          strict: false,
+          defaultValues: { profile: { a: '', b: '' } },
+        } as never)
+      )
+    )
+    // Open the gate for every field (both empty leaves fail).
+    await form.handleSubmit(() => {})()
+    await nextTick()
+
+    // Leaf A starts; 30ms later leaf B joins the streak.
+    form.setValue('profile.a', 'x')
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(30)
+    form.setValue('profile.b', 'y')
+    await nextTick()
+
+    // Cross the show-delay (anchored at A, the earliest leaf): the container
+    // reads one spinner, and it stays continuous as B's own window passes.
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.showDelay)
+    expect(form.fields('profile').displayState).toBe('pending')
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.minVisible + 50)
+    expect(form.fields('profile').displayState).toBe('pending')
+
+    // Both resolve; after min-visible the container leaves pending. Its own
+    // path has no error (the leaves render theirs), so it settles to idle.
+    resolvers.forEach((r) => r(false))
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.minVisible)
+    expect(form.fields('profile').validating).toBe(false)
+    expect(form.fields('profile').displayState).not.toBe('pending')
+  })
+
+  it('100 fields, one validating: a single shared engine timer, the rest leave nothing', async () => {
+    const base = Object.fromEntries(Array.from({ length: 100 }, (_, i) => [`f${i}`, zV4.string()]))
+    let resolveF0: (ok: boolean) => void = () => {}
+    const schema = zV4.object({
+      ...base,
+      f0: zV4
+        .string()
+        .refine((v) => (v === '' ? false : new Promise<boolean>((r) => (resolveF0 = r))), {
+          error: 'bad',
+        }),
+    })
+    const defaults = Object.fromEntries(Array.from({ length: 100 }, (_, i) => [`f${i}`, '']))
+    const form = asForm(
+      mountWithApp(() =>
+        useFormV4({
+          schema,
+          key: `perf-${Math.random()}`,
+          strict: false,
+          defaultValues: defaults,
+        } as never)
+      )
+    )
+    await form.handleSubmit(() => {})()
+    await nextTick()
+    // Reading every field after submit leaves no timer: errors / idle are
+    // terminal, only an active validation arms one.
+    for (let i = 0; i < 100; i++) void form.fields(`f${i}`).displayState
+    expect(vi.getTimerCount()).toBe(0)
+
+    // Type into exactly one. The engine's single per-form timer is the only
+    // one armed, no matter how many fields are read.
+    form.setValue('f0', 'x')
+    await nextTick()
+    for (let i = 0; i < 100; i++) void form.fields(`f${i}`).displayState
+    expect(form.fields('f0').validating).toBe(true)
+    expect(vi.getTimerCount()).toBe(1)
+
+    resolveF0(false)
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.showDelay + DEFAULT_TIMINGS.minVisible)
   })
 })
 
@@ -915,21 +1005,21 @@ describe('getDisplayState — reward early, punish late (DOM gate)', () => {
 })
 
 describe('getDisplayState — type-level guards', () => {
-  it('predicate signature omits the derived display keys on field and formMeta args', () => {
-    type Field = Parameters<GetDisplayState>[0]
-    type Meta = Parameters<GetDisplayState>[1]
+  it('ctx.field / ctx.formMeta omit the derived display keys; reducer returns a DisplayMachine', () => {
+    type Field = DisplayCtx['field']
+    type Meta = DisplayCtx['formMeta']
 
-    // @ts-expect-error — `displayState` is omitted from the predicate's field arg
+    // @ts-expect-error — `displayState` is omitted from ctx.field
     expectTypeOf<Field['displayState']>()
-    // @ts-expect-error — `showErrors` is omitted from the predicate's field arg
+    // @ts-expect-error — `showErrors` is omitted from ctx.field
     expectTypeOf<Field['showErrors']>()
-    // @ts-expect-error — `showPending` is omitted from the predicate's field arg
+    // @ts-expect-error — `showPending` is omitted from ctx.field
     expectTypeOf<Field['showPending']>()
-    // @ts-expect-error — `firstError` is omitted from the predicate's field arg
+    // @ts-expect-error — `firstError` is omitted from ctx.field
     expectTypeOf<Field['firstError']>()
-    // @ts-expect-error — `displayState` is omitted from the predicate's formMeta arg
+    // @ts-expect-error — `displayState` is omitted from ctx.formMeta
     expectTypeOf<Meta['displayState']>()
-    // @ts-expect-error — `showSuccess` is omitted from the predicate's formMeta arg
+    // @ts-expect-error — `showSuccess` is omitted from ctx.formMeta
     expectTypeOf<Meta['showSuccess']>()
 
     // Every other FieldState key still reaches through, so authors keep
@@ -938,7 +1028,16 @@ describe('getDisplayState — type-level guards', () => {
     expectTypeOf<Field['valid']>().toEqualTypeOf<boolean>()
     expectTypeOf<Meta['submissionAttempts']>().toEqualTypeOf<number>()
 
-    // The predicate returns the DisplayState enum.
-    expectTypeOf<ReturnType<GetDisplayState>>().toEqualTypeOf<DisplayState>()
+    // The injected clock + episode anchor are on ctx, not on the field.
+    expectTypeOf<DisplayCtx['now']>().toEqualTypeOf<number>()
+    expectTypeOf<DisplayCtx['validatingSince']>().toEqualTypeOf<number | null>()
+
+    // The reducer's args are (prev: DisplayMachine, ctx: DisplayCtx) and it
+    // returns the next DisplayMachine.
+    expectTypeOf<Parameters<GetDisplayState>[0]>().toEqualTypeOf<DisplayMachine>()
+    expectTypeOf<Parameters<GetDisplayState>[1]>().toEqualTypeOf<DisplayCtx>()
+    expectTypeOf<ReturnType<GetDisplayState>>().toEqualTypeOf<DisplayMachine>()
+    // `display` carries the same enum the FieldState projection exposes.
+    expectTypeOf<DisplayMachine['display']>().toEqualTypeOf<DisplayState>()
   })
 })

--- a/test/composables/display-state.test.ts
+++ b/test/composables/display-state.test.ts
@@ -1,6 +1,15 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
-import { computed, createApp, defineComponent, h, nextTick, withDirectives, type App } from 'vue'
+import {
+  computed,
+  createApp,
+  defineComponent,
+  h,
+  nextTick,
+  watch,
+  withDirectives,
+  type App,
+} from 'vue'
 import { z as zV4 } from 'zod'
 import { z as zV3 } from 'zod-v3'
 import { useForm as useFormV4 } from '../../src/zod-v4'
@@ -9,6 +18,7 @@ import { createAttaform } from '../../src/runtime/core/plugin'
 import { vRegister } from '../../src/runtime/core/directive'
 import { useWizard } from '../../src/runtime/composables/use-wizard'
 import { DEFAULT_TIMINGS, defaultDisplayState, makeDefaultDisplayState } from '../../src'
+import { FOCUS_OUT_GRACE } from '../../src/runtime/core/display-state'
 import type {
   DisplayCtx,
   DisplayMachine,
@@ -682,6 +692,183 @@ describe('getDisplayState — anti-flash spinner timing (integration)', () => {
     expect(vi.getTimerCount()).toBe(0)
   })
 
+  it('a long-running client-side async check surfaces pending (async-ness drives it, not a network round-trip)', async () => {
+    // The UX story: `pending` reflects "validation is in flight across event-loop
+    // turns," NOT "a request is open to a server." A heavy on-device computation
+    // that yields — any non-blocking async work; here a timer stands in for it,
+    // no fetch anywhere — drives the spinner exactly as a remote check would, so
+    // the consumer never has to care whether validation runs on the client or
+    // the server. (A synchronous BLOCKING computation is the one case that can't
+    // show a spinner: it freezes the thread, so nothing renders until it returns.
+    // The remedy is to run it async — off the main thread or yielding — which
+    // earns pending for free.)
+    const schema = zV4.object({
+      email: zV4
+        .string()
+        .refine(
+          (val) =>
+            val.length === 0
+              ? false
+              : new Promise<boolean>((r) => setTimeout(() => r(val !== 'taken'), 5000)),
+          { error: 'taken' }
+        ),
+    })
+    const form = asForm(
+      mountWithApp(() =>
+        useFormV4({
+          schema,
+          key: `client-compute-${Math.random()}`,
+          strict: false,
+          defaultValues: { email: '' },
+        } as never)
+      )
+    )
+    // Open the gate. Empty rejects synchronously, so this submit doesn't await
+    // the 5s timer.
+    form.touch('email')
+    await form.handleSubmit(() => {})()
+    await nextTick()
+
+    // Kick off the slow on-device computation.
+    form.setValue('email', 'available')
+    await nextTick()
+    expect(form.fields('email').validating).toBe(true)
+    // Held through the show-delay — a fast result would never flash here.
+    expect(form.fields('email').displayState).not.toBe('pending')
+
+    // Past the show-delay, the LOCAL computation is still churning → spinner.
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.showDelay)
+    expect(form.fields('email').displayState).toBe('pending')
+    expectProjections(form.fields('email'))
+
+    // The 5s computation finishes on-device (no network) → the verdict lands.
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(form.fields('email').validating).toBe(false)
+    expect(form.fields('email').displayState).toBe('success')
+  })
+
+  it('a burst of keystrokes keeps re-arming the show-delay (no spinner mid-typing)', async () => {
+    // Regression for the live /demos/display-state report: typing showed the
+    // spinner with no perceptible delay. `validatingSince` re-anchors on every
+    // run start, not just the streak's 0 → 1 edge — with `debounceMs: 0` a fast
+    // burst keeps the validation count above 0 (the aborted run's decrement
+    // lands a microtask AFTER the next run's increment), so anchoring at the
+    // streak start would pin the show-delay to the FIRST keystroke and surface
+    // the spinner mid-typing. Re-anchoring suppresses it until the user pauses.
+    const { form, resolve } = mountGatedRefine()
+    form.touch('email')
+    await form.handleSubmit(() => {})()
+    await nextTick()
+    expect(form.fields('email').displayState).toBe('error')
+
+    // Type continuously: a fresh value every 40ms across 200ms — twice the
+    // 100ms show-delay — each edit aborting the prior parked validation and
+    // starting a new one. The spinner must stay suppressed the whole time.
+    for (const v of ['a@b.c', 'a@b.cc', 'a@b.ccc', 'a@b.cccc', 'a@b.ccccc']) {
+      form.setValue('email', v)
+      await vi.advanceTimersByTimeAsync(40)
+      expect(form.fields('email').validating).toBe(true)
+      expect(form.fields('email').showPending).toBe(false)
+    }
+
+    // Pause. Now a genuinely-still-running validation earns its spinner.
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.showDelay)
+    expect(form.fields('email').displayState).toBe('pending')
+    expectProjections(form.fields('email'))
+    // (The mid-burst parked validations are torn down by the afterEach
+    // unmount; `resolve` is unused here because after a burst the captured
+    // resolver may belong to an already-aborted run.)
+    void resolve
+  })
+
+  it('releases a held spinner when a long validation settles with an UNCHANGED verdict', async () => {
+    // Locks the continuity-branch release path: a validation longer than
+    // showDelay + minVisible holds `pending` with NO engine timer (it trusts
+    // the settle to be a reactive event), so the settle MUST re-run the display
+    // computed to release the spinner. Asserts the release happens on settle
+    // with no timer to advance — even when the verdict is unchanged (same
+    // error). (Note: this passes whether `fieldValidatingSince` is reactive or
+    // plain, because the field computed also depends on the reactive validation
+    // count; it guards the behaviour, not that specific mechanism.)
+    const { form, resolve } = mountGatedRefine()
+    form.touch('email')
+    await form.handleSubmit(() => {})()
+    await nextTick()
+    expect(form.fields('email').displayState).toBe('error') // landed error on ''
+
+    // Edit to another invalid value: the same 'invalid email' verdict lands.
+    form.setValue('email', 'still-bad')
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.showDelay)
+    expect(form.fields('email').displayState).toBe('pending')
+    // Past min-visible while STILL validating: the continuity branch drops the
+    // engine timer, so nothing is scheduled to release the spinner.
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.minVisible)
+    expect(form.fields('email').displayState).toBe('pending')
+    expect(vi.getTimerCount()).toBe(0)
+
+    // Settle with the SAME verdict. With no engine timer pending, only the
+    // reactive `validatingSince` delete can re-run the computed — flush
+    // microtasks only, advance no timers.
+    resolve(false)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(form.fields('email').validating).toBe(false)
+    expect(form.fields('email').displayState).toBe('error')
+    expectProjections(form.fields('email'))
+  })
+
+  it('re-validating a success field never flashes idle (validatingSince brackets the count)', async () => {
+    // Live report: a valid (success) field, edited to another valid value,
+    // flashed `idle` before the spinner. Root cause was a one-frame signal
+    // disagreement at the START of a run — `field.validating` flips true (the
+    // count increments) before `validatingSince` is stamped, so a synchronous
+    // reader catches (validating: true, validatingSince: null). Told it was
+    // "settled", the reducer returned the idle verdict (`valid` is clamped
+    // false mid-run, no error, no earned success), which then poisoned the
+    // held verdict for the rest of the window. The fix stamps `validatingSince`
+    // BEFORE the count, so the two signals never disagree.
+    const { form, resolve } = mountGatedRefine()
+
+    // Reach success: open the gate, edit to a valid value, resolve inside the
+    // show-delay so the spinner never shows and the verdict lands on success.
+    form.touch('email')
+    await form.handleSubmit(() => {})()
+    await nextTick()
+    form.setValue('email', 'a@b.c')
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.showDelay - 1)
+    resolve(true)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(form.fields('email').displayState).toBe('success')
+
+    // A synchronous subscriber records every display frame. The transient idle
+    // exists only for one synchronous re-eval between the two bookkeeping
+    // writes, so a flush:'pre' template smooths over it — a sync watch is what
+    // surfaces the defect (and what a consumer's own sync watch would hit).
+    const frames: DisplayState[] = []
+    const stop = watch(
+      () => form.fields('email').displayState,
+      (s) => frames.push(s),
+      {
+        flush: 'sync',
+      }
+    )
+
+    // Edit to another still-valid value and run the full spinner cycle.
+    form.setValue('email', 'a@b.cd')
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.showDelay)
+    expect(form.fields('email').displayState).toBe('pending')
+    resolve(true)
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.minVisible)
+    stop()
+
+    expect(form.fields('email').displayState).toBe('success')
+    // The crux: success → pending → success, with no idle frame in between.
+    expect(frames).toContain('pending')
+    expect(frames).not.toContain('idle')
+  })
+
   it('a custom factory drives the clock at its own thresholds', async () => {
     let resolveValidation: (ok: boolean) => void = () => {}
     const schema = zV4.object({
@@ -948,6 +1135,150 @@ describe('getDisplayState — anti-flash spinner timing (integration)', () => {
     await nextTick()
     expect(vi.getTimerCount()).toBe(0)
     expect(form.fields('email').displayState).toBe('error')
+  })
+})
+
+describe('resetField — in-flight validation teardown', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('cancels an in-flight run on the path (no orphaned validating, no stale error write-back)', async () => {
+    // Regression: resetField on a field mid-validation left the in-flight run
+    // orphaned. In blur mode (the restore write schedules no fresh run) the
+    // field kept `validating: true` after the reset, and when the orphan
+    // settled it committed its verdict back over the errors resetField had
+    // just cleared. resetField now cancels the subtree's runs first.
+    let resolveValidation: (ok: boolean) => void = () => {}
+    const schema = zV4.object({
+      email: zV4
+        .string()
+        .refine(
+          (val) =>
+            val.length === 0 ? false : new Promise<boolean>((r) => (resolveValidation = r)),
+          { error: 'invalid email' }
+        ),
+    })
+    let api!: FormLike
+    const Comp = defineComponent({
+      setup() {
+        api = asForm(
+          useFormV4({
+            schema,
+            key: `resetfield-teardown-${Math.random()}`,
+            strict: false,
+            validateOn: 'blur',
+            defaultValues: { email: '' },
+          } as never)
+        )
+        return () =>
+          withDirectives(h('input', { type: 'text' }), [
+            [vRegister, (api as unknown as { register: (p: string) => unknown }).register('email')],
+          ])
+      },
+    })
+    const app = createApp(Comp).use(createAttaform())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    apps.push(app)
+    const input = root.querySelector('input') as HTMLInputElement
+
+    // Edit + blur → a blur-mode validation run starts and parks on the gate.
+    input.value = 'a@b.c'
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    await nextTick()
+    input.dispatchEvent(new FocusEvent('focus'))
+    input.dispatchEvent(new FocusEvent('blur'))
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(api.fields('email').validating).toBe(true)
+
+    // Reset the field while validation is in flight.
+    ;(api as unknown as { resetField: (p: readonly (string | number)[]) => void }).resetField([
+      'email',
+    ])
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(0)
+    // The run is cancelled in lockstep: nothing left validating, errors clear,
+    // and the verdict rests at idle (the reset closed the gate).
+    expect(api.fields('email').validating).toBe(false)
+    expect(api.fields('email').errors.length).toBe(0)
+    expect(api.fields('email').displayState).toBe('idle')
+
+    // The orphaned run resolving must NOT write its verdict back post-reset.
+    resolveValidation(false)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(api.fields('email').validating).toBe(false)
+    expect(api.fields('email').errors.length).toBe(0)
+    expect(api.fields('email').displayState).toBe('idle')
+    // No orphaned engine timer left running either.
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})
+
+describe('getDisplayState — focus-out collapses the show-delay', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('blurring mid-validation surfaces the spinner within the settle grace (not the full window)', async () => {
+    // UX: the show-delay only swallows the spinner during active typing. Focus
+    // out while a slow check is in flight and the spinner appears within the
+    // brief settle grace — not after the rest of a window the user has already
+    // left. A fast check settles inside the grace and never flashes (the
+    // sync-field DOM-gate test above covers that no-flash path).
+    let resolveValidation: (ok: boolean) => void = () => {}
+    const schema = zV4.object({
+      email: zV4
+        .string()
+        .refine(
+          (val) =>
+            val.length === 0 ? false : new Promise<boolean>((r) => (resolveValidation = r)),
+          { error: 'invalid email' }
+        ),
+    })
+    let api!: FormLike
+    const Comp = defineComponent({
+      setup() {
+        api = asForm(
+          useFormV4({
+            schema,
+            key: `focusout-grace-${Math.random()}`,
+            strict: false,
+            validateOn: 'blur',
+            defaultValues: { email: '' },
+          } as never)
+        )
+        return () =>
+          withDirectives(h('input', { type: 'text' }), [
+            [vRegister, (api as unknown as { register: (p: string) => unknown }).register('email')],
+          ])
+      },
+    })
+    const app = createApp(Comp).use(createAttaform())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    apps.push(app)
+    const input = root.querySelector('input') as HTMLInputElement
+
+    // Type, then focus out — blur mode starts the (parked, slow) validation.
+    input.value = 'a@b.c'
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    await nextTick()
+    input.dispatchEvent(new FocusEvent('focus'))
+    input.dispatchEvent(new FocusEvent('blur'))
+    await nextTick()
+
+    // One settle grace later — far short of the show-delay — the spinner is up.
+    await vi.advanceTimersByTimeAsync(FOCUS_OUT_GRACE)
+    expect(api.fields('email').validating).toBe(true)
+    expect(api.fields('email').displayState).toBe('pending')
+    expectProjections(api.fields('email'))
+
+    // Then settles to the landed verdict (held for the min-visible window).
+    resolveValidation(false)
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.minVisible)
+    expect(api.fields('email').displayState).toBe('error')
   })
 })
 

--- a/test/composables/display-state.test.ts
+++ b/test/composables/display-state.test.ts
@@ -7,6 +7,7 @@ import { useForm as useFormV4 } from '../../src/zod-v4'
 import { useForm as useFormV3 } from '../../src/zod-v3'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import { vRegister } from '../../src/runtime/core/directive'
+import { useWizard } from '../../src/runtime/composables/use-wizard'
 import { DEFAULT_TIMINGS, defaultDisplayState, makeDefaultDisplayState } from '../../src'
 import type {
   DisplayCtx,
@@ -860,6 +861,93 @@ describe('getDisplayState — anti-flash spinner timing (integration)', () => {
 
     resolveF0(false)
     await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.showDelay + DEFAULT_TIMINGS.minVisible)
+  })
+
+  it('form submit cancels a held spinner timer and reveals the verdict at once', async () => {
+    const { form, resolve } = mountGatedRefine()
+    // Open the gate + land an error (empty value is synchronously invalid).
+    await form.handleSubmit(() => {})()
+    await nextTick()
+    expect(form.fields('email').displayState).toBe('error')
+
+    // Drive a spinner into its min-visible hold: shown, validation settled,
+    // hold timer still armed.
+    form.setValue('email', 'a@b.c')
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.showDelay)
+    expect(form.fields('email').displayState).toBe('pending')
+    resolve(false)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(form.fields('email').displayState).toBe('pending')
+    expect(vi.getTimerCount()).toBe(1)
+
+    // Submit. At submit entry (before its own validation even runs) the
+    // handler cancels field validation AND clears the display engine, so the
+    // leftover hold timer is gone and the verdict is no longer masked by it.
+    const submitting = form.handleSubmit(() => {})()
+    expect(vi.getTimerCount()).toBe(0)
+    expect(form.fields('email').displayState).not.toBe('pending')
+
+    // The submit re-validates (still invalid); the error shows, no spinner.
+    resolve(false)
+    await submitting
+    await nextTick()
+    expect(form.fields('email').displayState).toBe('error')
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('wizard submit cancels a held spinner timer on its forms', async () => {
+    let resolveValidation: (ok: boolean) => void = () => {}
+    const schema = zV4.object({
+      email: zV4.string().refine(
+        (val) =>
+          val.length === 0
+            ? false
+            : new Promise<boolean>((r) => {
+                resolveValidation = r
+              }),
+        { error: 'invalid email' }
+      ),
+    })
+    const { form, wizard } = mountWithApp(() => {
+      const f = useFormV4({
+        schema,
+        key: `wiz-timing-${Math.random()}`,
+        strict: false,
+        defaultValues: { email: '' },
+      } as never)
+      const w = useWizard({ steps: [f], restore: false, persist: false })
+      return { form: asForm(f), wizard: w }
+    })
+
+    // Clean first wizard submit opens the gate. The wizard validates via
+    // process(), which does not write per-field errors to the store, so the
+    // empty field reads idle (gate open, nothing surfaced yet) rather than
+    // error — that is fine; we only need the gate open to drive a spinner.
+    await wizard.handleSubmit(() => {})()
+    await nextTick()
+    expect(form.fields('email').displayState).toBe('idle')
+
+    // Drive a spinner into its min-visible hold (change validation DOES write
+    // the error, so the field carries a verdict under the spinner).
+    form.setValue('email', 'a@b.c')
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.showDelay)
+    expect(form.fields('email').displayState).toBe('pending')
+    resolveValidation(false)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(form.fields('email').displayState).toBe('pending')
+    expect(vi.getTimerCount()).toBe(1)
+
+    // Second wizard submit. processOne re-validates (parks on the gate); the
+    // per-form cancel runs once it resolves, dropping the held timer.
+    const submitting = wizard.handleSubmit(() => {})()
+    await vi.advanceTimersByTimeAsync(0)
+    resolveValidation(false)
+    await submitting
+    await nextTick()
+    expect(vi.getTimerCount()).toBe(0)
+    expect(form.fields('email').displayState).toBe('error')
   })
 })
 

--- a/test/composables/display-state.test.ts
+++ b/test/composables/display-state.test.ts
@@ -40,9 +40,11 @@ import type {
  *      precedence — a validation in flight surfaces a delayed, then held,
  *      `'pending'` (the anti-flash spinner); own-path error → error;
  *      earned (`valid && !blank && dirty`) → success; else idle.
- *      Containers (intermediate AND root) only resolve to error on their
- *      own-path errors; leaves always satisfy the own-path filter when
- *      they have errors.
+ *      Containers (intermediate AND root, including `form.meta`) roll up
+ *      their descendants' GATED verdicts: pending if any descendant is
+ *      pending, else error if any descendant (or own cross-field) error
+ *      has cleared its own reveal gate, else earned success, else idle.
+ *      An ungated sibling error never surfaces at the container.
  *   2. `createAttaform({ defaults: { getDisplayState } })`.
  *   3. `useForm({ getDisplayState })`, wins over both above.
  *
@@ -105,7 +107,15 @@ type FormLike = {
     onSubmit: (data: unknown) => void | Promise<void>,
     onError?: (errors: readonly ValidationError[]) => void
   ) => () => Promise<void>
-  meta: { submissionAttempts: number; submitting: boolean; displayState: DisplayState }
+  meta: {
+    submissionAttempts: number
+    submitting: boolean
+    displayState: DisplayState
+    showErrors: boolean
+    showPending: boolean
+    showSuccess: boolean
+    showIdle: boolean
+  }
   key: string
 }
 
@@ -206,34 +216,38 @@ function describeAdapter(label: string, makeForm: AdapterFactory): void {
       })
     })
 
-    describe('default heuristic — container', () => {
-      it('row-level container with ONLY descendant errors does not duplicate them (idle, not error)', async () => {
-        const form = makeForm()
-        injectError(form, ['users', 0, 'label'], 'label required')
-        form.touch(['users', 0, 'label'])
-        form.setValue('users.0.label', 'x')
-        await nextTick()
-        const row = form.fields('users.0')
-        expect(row.errors.length).toBeGreaterThan(0)
-        // Descendant errors are rendered by the descendant fields; the
-        // container's own-path filter keeps it out of 'error' to avoid
-        // UI duplication.
-        expect(row.displayState).not.toBe('error')
-        expect(row.showErrors).toBe(false)
-        expectProjections(row)
-      })
-
-      it('container shows nothing when descendants have errors and timing conditions unmet', async () => {
+    describe('default heuristic — container (descendant rollup)', () => {
+      it('an ungated descendant error keeps the container idle though invalid', async () => {
         const form = makeForm()
         injectError(form, ['users', 0, 'label'], 'label required')
         await nextTick()
         const row = form.fields('users.0')
         expect(row.errors.length).toBeGreaterThan(0)
+        // No submit and the leaf was never blurred-after-interaction, so the
+        // leaf withholds its own error (its gate is closed) and the container
+        // has nothing to surface. Validity still reflects the latent error.
+        expect(row.valid).toBe(false)
+        expect(row.displayState).toBe('idle')
         expect(row.showErrors).toBe(false)
         expectProjections(row)
       })
 
-      it('row-level container with its OWN error surfaces it after timing gate', async () => {
+      it('a gated descendant error rolls up to its container (row and array)', async () => {
+        const form = makeForm()
+        // Empty label fails min(1); submit opens every field's gate.
+        await form.handleSubmit(() => {})()
+        await nextTick()
+        expect(form.fields('users.0.label').displayState).toBe('error')
+        // The row container reflects the now-visible descendant error...
+        expect(form.fields('users.0').displayState).toBe('error')
+        expect(form.fields('users.0').showErrors).toBe(true)
+        expectProjections(form.fields('users.0'))
+        // ...and so does the array container above it.
+        expect(form.fields('users').displayState).toBe('error')
+        expectProjections(form.fields('users'))
+      })
+
+      it('a container surfaces its OWN (cross-field) error after the gate opens', async () => {
         const form = makeForm()
         // Error at the container path itself (e.g., an object-level refine
         // or a server-side cross-field error mapped to the row).
@@ -275,24 +289,30 @@ function describeAdapter(label: string, makeForm: AdapterFactory): void {
       })
     })
 
-    describe('form.meta.displayState', () => {
-      it('stays out of error when only descendant (leaf) errors exist (the leaves render their own)', async () => {
+    describe('form.meta.displayState (form-level rollup)', () => {
+      it('rolls up a gated descendant error to the form banner', async () => {
         const form = makeForm()
         injectError(form, ['email'], 'email required')
+        // Gate closed: nothing surfaced yet, at the leaf or the root.
         expect(form.meta.displayState).toBe('idle')
         await form.handleSubmit(() => {})()
         await nextTick()
-        // form.meta.displayState === rootFieldState.displayState with the
-        // own-path filter applied at root. Leaf errors don't surface here
-        // so the form banner can't duplicate them. Aggregate banners
-        // should bind to form.meta.errorCount > 0 instead.
-        expect(form.meta.displayState).not.toBe('error')
+        // Submit opens the gate; the now-visible leaf error rolls up to the
+        // form root, so form.meta.show* can drive a form-level banner.
+        expect(form.meta.displayState).toBe('error')
+        expect(form.meta.showErrors).toBe(true)
       })
 
-      // Affirmative "root-level error fires form.meta error" coverage
-      // lives in the cross-cutting synthetic test below; the integration
-      // path needs an object-level schema refine to land an error at the
-      // root path [], which isn't worth wiring per-adapter here.
+      it('greens once every field is valid and earned', async () => {
+        const form = makeForm()
+        form.setValue('email', 'a@b.c')
+        form.setValue('profile.name', 'Ada')
+        form.setValue('users.0.label', 'x')
+        await form.handleSubmit(() => {})()
+        await nextTick()
+        expect(form.meta.displayState).toBe('success')
+        expect(form.meta.showSuccess).toBe(true)
+      })
     })
   })
 }
@@ -1001,12 +1021,13 @@ describe('getDisplayState — anti-flash spinner timing (integration)', () => {
     await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.minVisible + 50)
     expect(form.fields('profile').displayState).toBe('pending')
 
-    // Both resolve; after min-visible the container leaves pending. Its own
-    // path has no error (the leaves render theirs), so it settles to idle.
+    // Both resolve invalid; after min-visible the container leaves pending.
+    // Each leaf now carries a gated error (submit opened the gate), so the
+    // container rolls them up and settles to error.
     resolvers.forEach((r) => r(false))
     await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.minVisible)
     expect(form.fields('profile').validating).toBe(false)
-    expect(form.fields('profile').displayState).not.toBe('pending')
+    expect(form.fields('profile').displayState).toBe('error')
   })
 
   it('100 fields, one validating: a single shared engine timer, the rest leave nothing', async () => {
@@ -1420,6 +1441,207 @@ describe('getDisplayState — reward early, punish late (DOM gate)', () => {
     await nextTick()
     expect(api.fields('email').interacted).toBe(true)
     expect(api.fields('email').displayState).toBe('idle')
+  })
+})
+
+describe('container & form.meta rollup — gated, DOM-driven', () => {
+  function mountRegistered(
+    schema: unknown,
+    paths: readonly string[],
+    formOpts: Record<string, unknown> = {}
+  ): {
+    api: FormLike & { register: (p: string) => unknown }
+    input: (p: string) => HTMLInputElement
+  } {
+    const handle: { api?: FormLike & { register: (p: string) => unknown } } = {}
+    const Comp = defineComponent({
+      setup() {
+        const api = useFormV4({
+          schema,
+          key: `rollup-dom-${Math.random()}`,
+          strict: false,
+          ...formOpts,
+        } as never) as unknown as FormLike & { register: (p: string) => unknown }
+        handle.api = api
+        return () =>
+          h(
+            'div',
+            paths.map((p) =>
+              withDirectives(h('input', { type: 'text', key: p }), [[vRegister, api.register(p)]])
+            )
+          )
+      },
+    })
+    const app = createApp(Comp).use(createAttaform())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    apps.push(app)
+    if (handle.api === undefined) throw new Error('mountRegistered: api never set')
+    const els = Array.from(root.querySelectorAll('input'))
+    const byPath = new Map<string, HTMLInputElement>()
+    paths.forEach((p, i) => {
+      const el = els[i]
+      if (!(el instanceof HTMLInputElement)) throw new Error(`mountRegistered: no input for ${p}`)
+      byPath.set(p, el)
+    })
+    const input = (p: string): HTMLInputElement => {
+      const el = byPath.get(p)
+      if (el === undefined) throw new Error(`mountRegistered: unknown path ${p}`)
+      return el
+    }
+    return { api: handle.api, input }
+  }
+
+  function editAndBlur(input: HTMLInputElement, value: string): void {
+    input.dispatchEvent(new FocusEvent('focus'))
+    input.value = value
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    input.dispatchEvent(new FocusEvent('blur'))
+  }
+
+  it('a blurred valid sibling does not surface an untouched sibling error (per-child gate)', async () => {
+    const schema = zV4.object({ a: zV4.string().min(1), b: zV4.string().min(1) })
+    const { api, input } = mountRegistered(schema, ['a', 'b'], {
+      defaultValues: { a: '', b: '' },
+      validateOn: 'blur',
+    })
+    // Edit A to a valid value and blur it: A earns success, its gate opens.
+    editAndBlur(input('a'), 'x')
+    await new Promise((r) => setTimeout(r, 0))
+    // B carries a committed error but was never touched (its gate is closed).
+    api.setFieldErrors([{ path: ['b'], message: 'b required', formKey: api.key, code: 'test' }])
+    await nextTick()
+    expect(api.fields('a').displayState).toBe('success')
+    expect(api.fields('b').displayState).toBe('idle')
+    // The root must NOT surface B's ungated error just because A opened its gate.
+    expect(api.meta.displayState).not.toBe('error')
+  })
+
+  it('an untouched optional sibling does not block container success', async () => {
+    const schema = zV4.object({
+      name: zV4.string().min(1),
+      nickname: zV4.string().optional(),
+    })
+    const { api, input } = mountRegistered(schema, ['name', 'nickname'], {
+      defaultValues: { name: '', nickname: '' },
+      validateOn: 'blur',
+    })
+    editAndBlur(input('name'), 'Ada')
+    await new Promise((r) => setTimeout(r, 0))
+    expect(api.fields('name').displayState).toBe('success')
+    expect(api.fields('nickname').displayState).toBe('idle')
+    // name is earned and nothing is wrong; the idle optional doesn't hold green back.
+    expect(api.meta.displayState).toBe('success')
+  })
+
+  it('an intermediate-container error rolls up to the form root once a descendant is blurred (no submit)', async () => {
+    const schema = zV4.object({
+      pw: zV4.object({ a: zV4.string(), b: zV4.string() }),
+    })
+    const { api, input } = mountRegistered(schema, ['pw.a', 'pw.b'], {
+      defaultValues: { pw: { a: '', b: '' } },
+      validateOn: 'blur',
+    })
+    // Open the intermediate object's gate by blurring one of its leaves...
+    editAndBlur(input('pw.a'), 'x')
+    await new Promise((r) => setTimeout(r, 0))
+    // ...then pin a cross-field error at the object path itself (a non-leaf).
+    api.setFieldErrors([{ path: ['pw'], message: 'must match', formKey: api.key, code: 'test' }])
+    await nextTick()
+    expect(api.fields('pw').displayState).toBe('error')
+    // It rolls up to the root even though no LEAF carries the error.
+    expect(api.meta.displayState).toBe('error')
+  })
+
+  it('a custom getDisplayState at a container is not overridden by the rollup', async () => {
+    const neverError: GetDisplayState = () => ({ display: 'idle' })
+    const schema = zV4.object({ profile: zV4.object({ name: zV4.string().min(1) }) })
+    const form = asForm(
+      mountWithApp(() =>
+        useFormV4({
+          schema,
+          key: `rollup-custom-${Math.random()}`,
+          strict: false,
+          defaultValues: { profile: { name: '' } },
+          getDisplayState: neverError,
+        } as never)
+      )
+    )
+    await form.handleSubmit(() => {})()
+    await nextTick()
+    // Empty name fails and the gate is open, but the consumer's reducer owns
+    // container verdicts: the default-only rollup override never fires.
+    expect(form.fields('profile').displayState).toBe('idle')
+    expect(form.fields('profile.name').displayState).toBe('idle')
+  })
+
+  describe('with fake timers', () => {
+    beforeEach(() => vi.useFakeTimers())
+    afterEach(() => vi.useRealTimers())
+
+    it('pending wins over a rolled-up error, then the error lands once validation settles', async () => {
+      let resolveB: (ok: boolean) => void = () => {}
+      const schema = zV4.object({
+        a: zV4.string().min(1),
+        b: zV4
+          .string()
+          .refine((v) => (v === '' ? true : new Promise<boolean>((r) => (resolveB = r))), {
+            error: 'bad b',
+          }),
+      })
+      const form = asForm(
+        mountWithApp(() =>
+          useFormV4({
+            schema,
+            key: `rollup-pending-${Math.random()}`,
+            strict: false,
+            defaultValues: { a: '', b: '' },
+          } as never)
+        )
+      )
+      // Submit opens every gate and lands a's min(1) error (b='' settles sync).
+      await form.handleSubmit(() => {})()
+      await nextTick()
+      // Park b's refine so the form has a validation in flight.
+      form.setValue('b', 'go')
+      await nextTick()
+      await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.showDelay)
+      // b is validating past the show-delay; pending wins over a's gated error.
+      expect(form.meta.displayState).toBe('pending')
+      // b settles valid; with nothing in flight, a's gated error rolls up.
+      resolveB(true)
+      await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.minVisible)
+      expect(form.meta.displayState).toBe('error')
+    })
+
+    it('an untouched descendant validating does not flash a container spinner', async () => {
+      let resolveB: (ok: boolean) => void = () => {}
+      const schema = zV4.object({
+        a: zV4.string().min(1),
+        b: zV4
+          .string()
+          .refine((v) => (v === '' ? true : new Promise<boolean>((r) => (resolveB = r))), {
+            error: 'bad b',
+          }),
+      })
+      const { api, input } = mountRegistered(schema, ['a', 'b'], {
+        defaultValues: { a: '', b: '' },
+      })
+      // Blur A (opens the container gate) without ever touching B.
+      editAndBlur(input('a'), 'x')
+      await vi.advanceTimersByTimeAsync(0)
+      // Kick B's async validation programmatically — no interaction, gate closed.
+      api.setValue('b', 'y')
+      await nextTick()
+      await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.showDelay + 50)
+      // B would never show its own spinner (gate closed); the container must
+      // not show one on its behalf, even though A opened the container gate.
+      expect(api.fields('b').displayState).not.toBe('pending')
+      expect(api.meta.displayState).not.toBe('pending')
+      resolveB(true)
+      await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.minVisible)
+    })
   })
 })
 

--- a/test/docs-demos/docs-demos-smoke.test.ts
+++ b/test/docs-demos/docs-demos-smoke.test.ts
@@ -801,6 +801,23 @@ const entries: SmokeEntry[] = [
     },
   },
   {
+    // Three side-by-side forms (change / blur / submit). Type a too-short
+    // value into the FIRST column (validateOn: 'change'): it validates on
+    // the keystroke, so its raw readout surfaces the message with no blur.
+    slug: 'validate-on-modes',
+    gesture: async (root) => {
+      const changeInput = root.querySelector<HTMLInputElement>('input')
+      if (!changeInput) throw new Error('validate-on-modes: change-mode input not found')
+      await dispatchInput(changeInput, 'a')
+      await waitUntil(() =>
+        root.textContent?.includes('At least 3 characters') === true ? true : null
+      )
+    },
+    assert: async (root) => {
+      expect(root.textContent ?? '').toContain('At least 3 characters')
+    },
+  },
+  {
     // No gesture — the blank-field-state demo shows blank
     // marking across four field shapes. Smoke verifies the table
     // mounts with all four rows.

--- a/test/docs-demos/docs-demos-smoke.test.ts
+++ b/test/docs-demos/docs-demos-smoke.test.ts
@@ -810,9 +810,18 @@ const entries: SmokeEntry[] = [
         throw new Error('container-display-state: password input (index 1) not found')
       await dispatchInput(password, 'short')
       await dispatchBlur(password)
-      await waitUntil(() =>
-        root.textContent?.includes('At least 8 characters') === true ? true : null
-      )
+      // Wait for the password error to surface AND the Account group to roll
+      // it up. The form's first async validation pass (the email availability
+      // refine, kicked off when the banner reads form.meta) can hold the group
+      // at 'pending' briefly, and longer under coverage instrumentation, so
+      // gate on the settled verdict rather than the first paint after blur.
+      await waitUntil(() => {
+        const legend = root.querySelectorAll('legend').item(0)
+        return root.textContent?.includes('At least 8 characters') === true &&
+          legend?.textContent?.includes('error') === true
+          ? true
+          : null
+      }, 3000)
     },
     assert: async (root) => {
       expect(root.textContent ?? '').toContain('At least 8 characters')

--- a/test/docs-demos/docs-demos-smoke.test.ts
+++ b/test/docs-demos/docs-demos-smoke.test.ts
@@ -801,6 +801,27 @@ const entries: SmokeEntry[] = [
     },
   },
   {
+    // Type a too-short password and blur: the password leaf errors, and the
+    // Account *group* badge rolls that up to 'error' (the container rollup).
+    slug: 'container-display-state',
+    gesture: async (root) => {
+      const password = root.querySelectorAll<HTMLInputElement>('input').item(1)
+      if (password === null)
+        throw new Error('container-display-state: password input (index 1) not found')
+      await dispatchInput(password, 'short')
+      await dispatchBlur(password)
+      await waitUntil(() =>
+        root.textContent?.includes('At least 8 characters') === true ? true : null
+      )
+    },
+    assert: async (root) => {
+      expect(root.textContent ?? '').toContain('At least 8 characters')
+      // The Account group legend badge reflects the rolled-up verdict.
+      const accountLegend = root.querySelectorAll('legend').item(0)
+      expect(accountLegend?.textContent ?? '').toContain('error')
+    },
+  },
+  {
     // Three side-by-side forms (change / blur / submit). Type a too-short
     // value into the FIRST column (validateOn: 'change'): it validates on
     // the keystroke, so its raw readout surfaces the message with no blur.

--- a/test/ssr-bare-vue/aria-ssr.test.ts
+++ b/test/ssr-bare-vue/aria-ssr.test.ts
@@ -21,8 +21,7 @@ type Api = UseFormReturn<typeof schema>
 
 const forceState =
   (state: 'idle' | 'pending' | 'error' | 'success'): GetDisplayState =>
-  () =>
-    state
+  () => ({ display: state })
 
 async function renderField(opts?: {
   getDisplayState?: GetDisplayState

--- a/test/types/use-form-typed-config-fields.test.ts
+++ b/test/types/use-form-typed-config-fields.test.ts
@@ -26,7 +26,7 @@ import type { GetDisplayState } from '../../src/runtime/types/types-api'
 const schemaV4 = z.object({ email: z.string() })
 const schemaV3 = zV3.object({ email: zV3.string() })
 
-const getDisplayState: GetDisplayState = () => 'idle'
+const getDisplayState: GetDisplayState = () => ({ display: 'idle' })
 
 describe('useForm — typed-config field surface (SF2)', () => {
   describe('attaform/zod-v3', () => {


### PR DESCRIPTION
## What

Bakes a polished **anti-flash** spinner into every form's display state. Today `form.fields.<path>.showPending` flips to a spinner on every keystroke and back: `field.validating` blips true→false for fast validations and the default mapped `validating` straight to `'pending'`. Now:

- a validation that settles fast never reveals a spinner (`showDelay`, default `100ms`), and
- once a spinner shows, it is held a minimum so it cannot blink off (`minVisible`, default `120ms`).

This shapes only the display projection. `errors`, `valid`, `validating`, and the underlying validation run exactly as before.

## Public API

`GetDisplayState` becomes a pure transition reducer `(prev, ctx) => DisplayMachine` (was `(field, formMeta) => DisplayState`). A per-form engine owns the clock and a single timer; the reducer owns timing policy. New exports: `makeDefaultDisplayState({ showDelay, minVisible })`, `DEFAULT_TIMINGS`, and the `DisplayMachine` / `DisplayCtx` / `DisplayTimings` types. Pre-1.0, no back-compat alias.

## Notable decisions (flag if you disagree)

- **Holds the prior verdict (`prev.display`) through the show-delay window** rather than the in-flight verdict (which reads `valid: false` only because a check is running), so a re-validated field never flickers through `idle`. The hold is now uniform across every prior verdict (see Hardening #4); the engine retains non-idle machines for it — memory only, they arm no timers.
- **Submit reveals immediately.** Form and wizard submit cancel any held anti-flash timer so an explicit submit is never masked by a leftover spinner.
- **Eager budget 45.00 kB gz** (currently **44.82**, 0.18 kB headroom). The engine + reducer are eager (`displayState` is read synchronously per field, no async seam), ~1 kB; rationale recorded in `check-eager-size.mjs`.
- **Demos:** stripped incidental `validateOn` from five demos and added a dedicated `validate-on-modes` demo. The anti-flash default keeps per-keystroke checks smooth; the URL-check doc's Tweaks point at blur/submit + debounce for real backends.

## Hardening (latent-bug fixes + UX polish since the initial feature)

Four follow-up commits, each independently reviewable, found by dogfooding the demo and probing edge cases:

1. **Engine robustness** (`5e6df6e`) — the per-form timer ignores a non-finite `reviewAt` from a custom reducer, clamps an over-large one below the 32-bit `setTimeout` overflow, and refuses to re-arm for the deadline it just fired (no busy-loop). A `visibilitychange` listener recovers from background-tab `setTimeout` throttling so an overdue min-visible hold resolves on return to the foreground.

2. **`validatingSince` is a reactive, re-anchored, bracketed signal** (`397a327`) — re-stamped on every run start (a keystroke burst keeps the spinner suppressed until you pause), and stamped **before** the validation count so `validatingSince` brackets `count > 0`. Without that ordering a synchronous reader caught `validating: true, validatingSince: null` for one frame and the reducer flashed **idle** at the start of every re-validation.

3. **`resetField` cancels in-flight validation** (`1429cbd`) — it used to leave an orphaned run that kept `validating: true` and committed its verdict back over the just-cleared errors. Now a path-scoped cancel tears down the subtree's runs (with a `released` flag so a run rescheduled at the same key isn't double-counted) and drops its blur-dedup snapshots.

4. **Reducer polish** (`6981025`) — the show-delay window holds the prior verdict **uniformly** (the focused-success exception that dropped a green check to idle while editing is gone), so editing a valid value goes `[prior] → pending → [settled]`, never idle. On **focus-out** the window collapses to a one-frame settle grace: leave a field mid-check and the spinner appears promptly instead of waiting out a window meant for typing, while a fast/synchronous check still settles inside the grace and never flashes.

**UX contract locked:** `pending` is driven by async-ness, not a network round-trip — a heavy *client-side* async check surfaces the spinner exactly like a server call (regression-tested). A synchronous *blocking* computation can't (it freezes the thread); the remedy is to run it async.

## Commits
- `feat(validation)` — reducer + per-form display engine + episode timing + field-state integration + exports + tests
- `docs(demos)` — strip incidental `validateOn`, add `validate-on-modes`
- `docs(validation)` — reducer shape, "Tune the timing" factory section, demo embed
- `fix(validation)` — cancel held display timers on submit (form + wizard); gate the spinner so none shows mid-first-entry
- `fix(validation)` — harden the display engine against untrusted `reviewAt` and background tabs
- `fix(validation)` — make `validatingSince` a reactive, re-anchored, bracketed signal
- `fix(validation)` — `resetField` cancels the field's in-flight validation
- `fix(validation)` — hold prior verdict on re-validation; collapse show-delay on focus-out

## Verification
- `pnpm test` — **3755 passed**, 0 failures (pure reducer matrix + engine unit/robustness tests + fake-timer integration + SSR-equivalence + the hardening regressions)
- `pnpm typecheck` + `pnpm lint` clean
- eager budget within (44.82 kB gz, 0.18 kB headroom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
