### PR TITLE
feat(validation): roll up descendant display verdict to containers

### DIFF
--- a/apps/site/docs-demos/container-display-state.vue
+++ b/apps/site/docs-demos/container-display-state.vue
@@ -1,0 +1,264 @@
+<script setup lang="ts">
+  import { useForm } from 'attaform/zod'
+  import { z } from 'zod'
+
+  const wait = (ms: number) => new Promise((r) => setTimeout(r, ms))
+  const takenEmails = new Set(['ada@team.dev', 'champ@team.dev'])
+
+  async function isAvailable(email: string): Promise<boolean> {
+    await wait(700)
+    return !takenEmails.has(email.toLowerCase())
+  }
+
+  const schema = z.object({
+    account: z.object({
+      email: z
+        .string()
+        .email('Enter a valid email')
+        .refine(async (v) => isAvailable(v), { message: 'That email is taken' }),
+      password: z.string().min(8, 'At least 8 characters'),
+    }),
+    profile: z.object({
+      name: z.string().min(1, 'Tell us your name'),
+      nickname: z.string().optional(),
+    }),
+  })
+
+  const form = useForm({
+    schema,
+    key: 'docs-demo-container-display-state',
+  })
+
+  const bannerText = {
+    idle: 'Fill in your details',
+    pending: 'Checking…',
+    error: 'A few fields need attention',
+    success: 'Looking good, ready to submit',
+  }
+
+  const onSubmit = form.handleSubmit(() => {})
+</script>
+
+<template>
+  <form @submit.prevent="onSubmit">
+    <div class="banner" :class="form.meta.displayState">
+      <span class="badge" :class="form.meta.displayState">{{ form.meta.displayState }}</span>
+      <span class="banner-text">{{ bannerText[form.meta.displayState] }}</span>
+      <span class="chips">
+        <span class="chip" :class="{ on: form.meta.showIdle }">showIdle</span>
+        <span class="chip" :class="{ on: form.meta.showPending }">showPending</span>
+        <span class="chip" :class="{ on: form.meta.showErrors }">showErrors</span>
+        <span class="chip" :class="{ on: form.meta.showSuccess }">showSuccess</span>
+      </span>
+    </div>
+
+    <fieldset>
+      <legend>
+        Account
+        <span class="badge" :class="form.fields('account').displayState">{{
+          form.fields('account').displayState
+        }}</span>
+      </legend>
+
+      <label>
+        <span>Email (taken: ada@team.dev, champ@team.dev)</span>
+        <input v-register="form.register('account.email')" />
+        <small v-if="form.fields.account.email.showErrors" class="msg msg--error">{{
+          form.fields.account.email.firstError?.message
+        }}</small>
+        <small v-else-if="form.fields.account.email.showPending" class="msg msg--pending"
+          >Checking availability…</small
+        >
+      </label>
+
+      <label>
+        <span>Password</span>
+        <input type="password" v-register="form.register('account.password')" />
+        <small v-if="form.fields.account.password.showErrors" class="msg msg--error">{{
+          form.fields.account.password.firstError?.message
+        }}</small>
+      </label>
+    </fieldset>
+
+    <fieldset>
+      <legend>
+        Profile
+        <span class="badge" :class="form.fields('profile').displayState">{{
+          form.fields('profile').displayState
+        }}</span>
+      </legend>
+
+      <label>
+        <span>Name</span>
+        <input v-register="form.register('profile.name')" />
+        <small v-if="form.fields.profile.name.showErrors" class="msg msg--error">{{
+          form.fields.profile.name.firstError?.message
+        }}</small>
+      </label>
+
+      <label>
+        <span>Nickname (optional)</span>
+        <input v-register="form.register('profile.nickname')" />
+      </label>
+    </fieldset>
+
+    <button type="submit">Create account</button>
+
+    <p class="hint">
+      Every group carries the same <code>displayState</code> as a leaf, rolled up from its fields. A
+      group rests at <code>idle</code> until one of its fields earns a verdict, shows
+      <code>pending</code> while any child is checking, flips to <code>error</code> the moment a
+      child's error becomes visible, and greens only once every child is earned. An untouched
+      optional like Nickname never holds the group back, and a field you have not engaged with yet
+      never drags the group into <code>error</code>. <code>form.meta</code> is the same rollup at
+      the root, so the banner reflects the whole form.
+    </p>
+  </form>
+</template>
+
+<style scoped>
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    max-width: 32rem;
+  }
+  .banner {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem 0.75rem;
+    padding: 0.65rem 0.85rem;
+    border-radius: 0.5rem;
+    border: 1px solid #e5e7eb;
+    background: #f9fafb;
+  }
+  .banner.error {
+    border-color: #fecaca;
+    background: #fef2f2;
+  }
+  .banner.pending {
+    border-color: #bfdbfe;
+    background: #eff6ff;
+  }
+  .banner.success {
+    border-color: #bbf7d0;
+    background: #f0fdf4;
+  }
+  .banner-text {
+    font-size: 0.875rem;
+    font-weight: 500;
+  }
+  fieldset {
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    padding: 1rem 1rem 1.15rem;
+  }
+  legend {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0 0.4rem;
+    font-size: 0.875rem;
+    font-weight: 600;
+  }
+  label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+  }
+  input {
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.375rem;
+    border: 1px solid #d1d5db;
+    font-size: 0.875rem;
+  }
+  input:focus {
+    outline: 2px solid #2563eb;
+    outline-offset: -1px;
+  }
+  .badge {
+    min-width: 4.25rem;
+    text-align: center;
+    padding: 0.15rem 0.55rem;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    font-family: ui-monospace, monospace;
+  }
+  .badge.idle {
+    background: #f3f4f6;
+    color: #6b7280;
+  }
+  .badge.pending {
+    background: #dbeafe;
+    color: #1d4ed8;
+  }
+  .badge.error {
+    background: #fee2e2;
+    color: #dc2626;
+  }
+  .badge.success {
+    background: #dcfce7;
+    color: #16a34a;
+  }
+  .chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+    margin-left: auto;
+  }
+  .chip {
+    padding: 0.1rem 0.4rem;
+    border-radius: 0.25rem;
+    border: 1px solid #e5e7eb;
+    font-size: 0.6875rem;
+    font-family: ui-monospace, monospace;
+    color: #9ca3af;
+  }
+  .chip.on {
+    border-color: #2563eb;
+    color: #1d4ed8;
+    font-weight: 600;
+  }
+  .msg {
+    font-size: 0.8125rem;
+    line-height: 1.2rem;
+  }
+  .msg--error {
+    color: #dc2626;
+  }
+  .msg--pending {
+    color: #2563eb;
+  }
+  button {
+    align-self: flex-start;
+    padding: 0.5rem 1rem;
+    border-radius: 0.375rem;
+    border: 1px solid #2563eb;
+    background: #2563eb;
+    color: #fff;
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+  }
+  button:hover {
+    background: #1d4ed8;
+  }
+  .hint {
+    font-size: 0.8rem;
+    color: #6b7280;
+    margin: 0;
+    line-height: 1.5;
+  }
+  .hint code {
+    font-family: ui-monospace, monospace;
+    font-size: 0.75rem;
+    color: #374151;
+  }
+</style>

--- a/docs/validation/showing-errors.md
+++ b/docs/validation/showing-errors.md
@@ -71,18 +71,23 @@ Until the gate opens, `displayState` is `'idle'` no matter what is in the store.
 Once the gate is open, the default resolves in order:
 
 1. **Pending (timed).** While a per-field validation runs, the field is heading for a spinner, but Attaform holds the prior verdict for a short window first. A fast check that settles inside that window never shows `'pending'` at all; a slow one flips to the spinner and is then held a minimum so it cannot blink off. This anti-flash timing is tunable, see [Tune the timing](#tune-the-timing).
-2. **Error.** An own-path error resolves to `'error'`.
+2. **Error.** An error at the field resolves to `'error'` (containers roll up their descendants, see below).
 3. **Success.** No error, `field.valid`, and the green check is earned: the field is non-blank and `dirty`, so the user put valid content there themselves. An empty field that happens to pass, a pre-filled field merely tabbed through, and the post-submit flood of every valid field all stay `'idle'` rather than greening for free. `valid` already waits on the form-wide first validation pass for async schemas, so success never fires before the first real verdict lands.
 4. **Idle.** Anything else, including a valid-but-unearned field (blank or unchanged), stays `'idle'`.
 
-### The own-path filter
+### Rollup at containers and the form
 
-The error arm fires only on an error whose path equals the field's own path.
+A container resolves over the gated verdicts of everything beneath it, so one verdict reflects the whole subtree.
 
-- **Leaves** always satisfy this when they have errors (a leaf's errors are at its own path).
-- **Containers** (intermediate AND root) resolve to `'error'` only for errors that point directly at them. Descendant errors are rendered by the descendant fields, so binding `field.showErrors` at a container never duplicates them.
+- **Leaves** resolve on their own error.
+- **Containers** (an object, an array row, the array itself, and the root `form.meta`) resolve to `'error'` when any descendant is showing an error, or when a cross-field error is pinned at the container itself. Each descendant counts only once its own gate has opened, so a sibling that has been blurred never drags an untouched field's error up to the group.
 
-That means `form.meta.displayState` only reaches `'error'` for root-level (cross-field or object-level) errors. Aggregate "fix the errors below" banners should bind to `form.meta.errorCount > 0` paired with whatever timing signal fits, not to `form.meta.showErrors`.
+Precedence rolls up too: a container shows `'pending'` while any descendant is still checking, `'error'` if a gated descendant (or the container's own cross-field check) failed, `'success'` once every field is valid and at least one is earned, and `'idle'` otherwise. An untouched optional sibling sits `'idle'` without holding the group's success back.
+
+That makes `form.meta.showErrors` the natural binding for a form-level "fix the errors below" banner: it turns on the moment a field's error becomes visible and off when the last one clears.
+
+::docs-demo{slug="container-display-state" label="Container rollup demo"}
+::
 
 ## Override per form
 

--- a/src/runtime/core/display-state.ts
+++ b/src/runtime/core/display-state.ts
@@ -88,6 +88,21 @@ export const DEFAULT_TIMINGS: DisplayTimings = { showDelay: 100, minVisible: 120
 export const FOCUS_OUT_GRACE = 16
 
 /**
+ * The reducers produced by {@link makeDefaultDisplayState} — the exported
+ * {@link defaultDisplayState} and every custom-timing variant. The container
+ * `displayState` rollup (surfacing a descendant's gated error at its container
+ * and at `form.meta`) is a behavior of the library default, applied around the
+ * reducer rather than inside it, so a fully custom `getDisplayState` owns
+ * container verdicts outright. WeakSet so it never pins a reducer against GC.
+ */
+const defaultFamily = new WeakSet<GetDisplayState>()
+
+/** True for any reducer built by {@link makeDefaultDisplayState}. */
+export function isDefaultDisplayState(fn: GetDisplayState): boolean {
+  return defaultFamily.has(fn)
+}
+
+/**
  * Build a default `getDisplayState` reducer with custom anti-flash timing.
  * Power users who want a tighter or looser spinner than {@link DEFAULT_TIMINGS}
  * pass their own `{ showDelay, minVisible }`:
@@ -110,7 +125,7 @@ export function makeDefaultDisplayState({
   showDelay,
   minVisible,
 }: DisplayTimings): GetDisplayState {
-  return (prev, { field, formMeta, validatingSince, now }) => {
+  const reducer: GetDisplayState = (prev, { field, formMeta, validatingSince, now }) => {
     const verdict = computeVerdict(field, formMeta)
     // The reveal gate governs the spinner too: until it opens, a field stays
     // idle — no spinner mid-first-entry — exactly as errors and success are
@@ -167,6 +182,8 @@ export function makeDefaultDisplayState({
     // Window elapsed and still validating: the spinner has earned its place.
     return { display: 'pending', pendingShownAt: now, reviewAt: now + minVisible }
   }
+  defaultFamily.add(reducer)
+  return reducer
 }
 
 /**

--- a/src/runtime/core/field-state-api.ts
+++ b/src/runtime/core/field-state-api.ts
@@ -2,6 +2,7 @@ import { computed, type ComputedRef } from 'vue'
 import type {
   DisplayCtx,
   DisplayMachine,
+  DisplayState,
   FieldState,
   FieldStateDerivedKey,
   FormMeta,
@@ -11,7 +12,7 @@ import type {
 import type { GenericForm } from '../types/types-core'
 import type { FormStore } from './create-form-store'
 import { __DEV__ } from './dev'
-import { defaultDisplayState } from './display-state'
+import { defaultDisplayState, isDefaultDisplayState } from './display-state'
 import { computeFieldIdentity } from './field-ids'
 import { EMPTY_RESOLVED_FIELD_META } from './field-meta'
 import { humanize } from './humanize'
@@ -247,6 +248,7 @@ function buildLeafFieldState<F extends GenericForm>(
     getFormMetaBase,
     key,
     validatingSince,
+    false,
     getDisplayState
   )
 }
@@ -276,7 +278,11 @@ export function buildContainerFieldStateBase<F extends GenericForm>(
   segments: Path,
   key: PathKey,
   formInstanceId: string
-): { readonly base: FieldStateBase; readonly validatingSince: number | null } {
+): {
+  readonly base: FieldStateBase
+  readonly validatingSince: number | null
+  readonly revealedDescendantError: boolean
+} {
   // Read live form value first so the access participates in dep
   // tracking; the discriminator key write that switches a DU variant
   // shows up here and re-runs the computed.
@@ -308,6 +314,11 @@ export function buildContainerFieldStateBase<F extends GenericForm>(
   let validatingSince: number | null = null
   let updatedAt: string | null = null
   let asyncPending = false
+  // For the descendant display rollup: submit opens every gate at once;
+  // otherwise each error gates on whether a leaf at-or-under it has been
+  // blurred-after-interaction. Collected here from the one walk we already do.
+  const submissionAttempts = state.submissionAttempts.value
+  const blurredLeafSegments: Path[] = []
   for (const [leafKey, entry] of state.originals) {
     if (!isPathPrefix(segments, entry.segments)) continue
     if (segments.length === entry.segments.length) continue // self isn't a descendant
@@ -326,15 +337,26 @@ export function buildContainerFieldStateBase<F extends GenericForm>(
     if (leafRecord?.blurred === true) blurred = true
     if (leafRecord?.touched === true) touched = true
     if (leafRecord?.interacted === true) interacted = true
-    if (leafRecord?.blurredAfterInteraction === true) blurredAfterInteraction = true
+    if (leafRecord?.blurredAfterInteraction === true) {
+      blurredAfterInteraction = true
+      blurredLeafSegments.push(entry.segments)
+    }
     if (leafRecord?.connected === true) connected = true
     if ((state.fieldValidationCounts.get(leafKey) ?? 0) > 0) {
       validating = true
       // Anchor the container spinner at its earliest still-validating leaf,
       // so a row's show-delay window measures from the first descendant to
       // start rather than resetting each time another leaf joins the streak.
+      // Only a leaf whose own reveal gate is open contributes the anchor: a
+      // descendant validating on 'change' before it has been blurred would
+      // never show its own spinner, so the container must not show one for it.
+      const leafGateOpen = submissionAttempts > 0 || leafRecord?.blurredAfterInteraction === true
       const since = state.fieldValidatingSince.get(leafKey)
-      if (since !== undefined && (validatingSince === null || since < validatingSince))
+      if (
+        leafGateOpen &&
+        since !== undefined &&
+        (validatingSince === null || since < validatingSince)
+      )
         validatingSince = since
     }
     if (state.pathHasAsyncValidationByKey(leafKey, entry.segments)) asyncPending = true
@@ -361,6 +383,24 @@ export function buildContainerFieldStateBase<F extends GenericForm>(
   // `valid` derives from this single source so the two fields can
   // never disagree.
   const errors = aggregateErrorsAt(state, segments)
+  // Descendant display rollup: does any error UNDER this container have its
+  // owning field's reveal gate open? Iterates the aggregated errors (not just
+  // the leaf walk) so a cross-field error pinned at an intermediate object is
+  // included. The container's OWN-path error is left to the reducer's own-path
+  // rule; this adds only the descendant dimension the aggregate base hides.
+  const revealedDescendantError =
+    errors.length > 0 &&
+    errors.some((e) => {
+      const ePath = e.path
+      if (ePath.length === segments.length && ePath.every((s, i) => s === segments[i])) return false
+      if (submissionAttempts > 0) return true
+      // The form-errors bucket (path `['']`) belongs to the root container;
+      // gate it by the root's own aggregate blur rather than a leaf prefix.
+      if (ePath.length === 1 && ePath[0] === '') return blurredAfterInteraction
+      // A leaf error gates on that leaf's blur; an intermediate-container
+      // error gates on any blurred leaf beneath it.
+      return blurredLeafSegments.some((s) => isPathPrefix(ePath, s))
+    })
   // A container's own sub-schema can also declare async work — a
   // top-level `.refine(async ...)` on the root, or a cross-field
   // refine on a sub-object — and those don't show up in any per-
@@ -403,6 +443,7 @@ export function buildContainerFieldStateBase<F extends GenericForm>(
       meta: resolved.meta,
     },
     validatingSince,
+    revealedDescendantError,
   }
 }
 
@@ -418,7 +459,7 @@ function buildContainerFieldState<F extends GenericForm>(
   getFormMetaBase: FormMetaBaseGetter,
   getDisplayState?: GetDisplayState
 ): FieldState<unknown> {
-  const { base, validatingSince } = buildContainerFieldStateBase(
+  const { base, validatingSince, revealedDescendantError } = buildContainerFieldStateBase(
     state,
     segments,
     key,
@@ -430,6 +471,7 @@ function buildContainerFieldState<F extends GenericForm>(
     getFormMetaBase,
     key,
     validatingSince,
+    revealedDescendantError,
     getDisplayState
   )
 }
@@ -464,6 +506,7 @@ function decorateWithDerivedProps<F extends GenericForm>(
   getFormMetaBase: FormMetaBaseGetter,
   key: PathKey,
   validatingSince: number | null,
+  revealedDescendantError: boolean,
   getDisplayState?: GetDisplayState
 ): FieldState<unknown> {
   const firstError = base.errors[0]
@@ -478,6 +521,9 @@ function decorateWithDerivedProps<F extends GenericForm>(
     now: state.ssr ? 0 : Date.now(),
   }
   let machine: DisplayMachine
+  // The rollup is a library-default behavior; a fully custom reducer owns
+  // container verdicts. A throw falls back to the default, which restores it.
+  let rollupApplies = isDefaultDisplayState(predicate)
   try {
     machine = state.displayEngine.resolve(key, ctx, predicate)
   } catch (err) {
@@ -490,8 +536,19 @@ function decorateWithDerivedProps<F extends GenericForm>(
       )
     }
     machine = state.displayEngine.resolve(key, ctx, defaultDisplayState)
+    rollupApplies = true
   }
-  const displayState = machine.display
+  // Container rollup: surface a descendant's gated error (or a nested
+  // cross-field error) at the container, unless a validation is in flight
+  // (pending wins) or a custom reducer owns the verdict. The reducer already
+  // resolves the field's own-path error and the anti-flash timing; this only
+  // adds the descendant dimension it cannot see from the aggregate base. The
+  // four `show*` booleans below project from this single value, so the
+  // exactly-one-true invariant holds by construction.
+  const displayState: DisplayState =
+    rollupApplies && revealedDescendantError && machine.display !== 'pending'
+      ? 'error'
+      : machine.display
   return {
     ...base,
     displayState,

--- a/test/composables/display-state.test.ts
+++ b/test/composables/display-state.test.ts
@@ -40,9 +40,11 @@ import type {
  *      precedence — a validation in flight surfaces a delayed, then held,
  *      `'pending'` (the anti-flash spinner); own-path error → error;
  *      earned (`valid && !blank && dirty`) → success; else idle.
- *      Containers (intermediate AND root) only resolve to error on their
- *      own-path errors; leaves always satisfy the own-path filter when
- *      they have errors.
+ *      Containers (intermediate AND root, including `form.meta`) roll up
+ *      their descendants' GATED verdicts: pending if any descendant is
+ *      pending, else error if any descendant (or own cross-field) error
+ *      has cleared its own reveal gate, else earned success, else idle.
+ *      An ungated sibling error never surfaces at the container.
  *   2. `createAttaform({ defaults: { getDisplayState } })`.
  *   3. `useForm({ getDisplayState })`, wins over both above.
  *
@@ -105,7 +107,15 @@ type FormLike = {
     onSubmit: (data: unknown) => void | Promise<void>,
     onError?: (errors: readonly ValidationError[]) => void
   ) => () => Promise<void>
-  meta: { submissionAttempts: number; submitting: boolean; displayState: DisplayState }
+  meta: {
+    submissionAttempts: number
+    submitting: boolean
+    displayState: DisplayState
+    showErrors: boolean
+    showPending: boolean
+    showSuccess: boolean
+    showIdle: boolean
+  }
   key: string
 }
 
@@ -206,34 +216,38 @@ function describeAdapter(label: string, makeForm: AdapterFactory): void {
       })
     })
 
-    describe('default heuristic — container', () => {
-      it('row-level container with ONLY descendant errors does not duplicate them (idle, not error)', async () => {
-        const form = makeForm()
-        injectError(form, ['users', 0, 'label'], 'label required')
-        form.touch(['users', 0, 'label'])
-        form.setValue('users.0.label', 'x')
-        await nextTick()
-        const row = form.fields('users.0')
-        expect(row.errors.length).toBeGreaterThan(0)
-        // Descendant errors are rendered by the descendant fields; the
-        // container's own-path filter keeps it out of 'error' to avoid
-        // UI duplication.
-        expect(row.displayState).not.toBe('error')
-        expect(row.showErrors).toBe(false)
-        expectProjections(row)
-      })
-
-      it('container shows nothing when descendants have errors and timing conditions unmet', async () => {
+    describe('default heuristic — container (descendant rollup)', () => {
+      it('an ungated descendant error keeps the container idle though invalid', async () => {
         const form = makeForm()
         injectError(form, ['users', 0, 'label'], 'label required')
         await nextTick()
         const row = form.fields('users.0')
         expect(row.errors.length).toBeGreaterThan(0)
+        // No submit and the leaf was never blurred-after-interaction, so the
+        // leaf withholds its own error (its gate is closed) and the container
+        // has nothing to surface. Validity still reflects the latent error.
+        expect(row.valid).toBe(false)
+        expect(row.displayState).toBe('idle')
         expect(row.showErrors).toBe(false)
         expectProjections(row)
       })
 
-      it('row-level container with its OWN error surfaces it after timing gate', async () => {
+      it('a gated descendant error rolls up to its container (row and array)', async () => {
+        const form = makeForm()
+        // Empty label fails min(1); submit opens every field's gate.
+        await form.handleSubmit(() => {})()
+        await nextTick()
+        expect(form.fields('users.0.label').displayState).toBe('error')
+        // The row container reflects the now-visible descendant error...
+        expect(form.fields('users.0').displayState).toBe('error')
+        expect(form.fields('users.0').showErrors).toBe(true)
+        expectProjections(form.fields('users.0'))
+        // ...and so does the array container above it.
+        expect(form.fields('users').displayState).toBe('error')
+        expectProjections(form.fields('users'))
+      })
+
+      it('a container surfaces its OWN (cross-field) error after the gate opens', async () => {
         const form = makeForm()
         // Error at the container path itself (e.g., an object-level refine
         // or a server-side cross-field error mapped to the row).
@@ -275,24 +289,30 @@ function describeAdapter(label: string, makeForm: AdapterFactory): void {
       })
     })
 
-    describe('form.meta.displayState', () => {
-      it('stays out of error when only descendant (leaf) errors exist (the leaves render their own)', async () => {
+    describe('form.meta.displayState (form-level rollup)', () => {
+      it('rolls up a gated descendant error to the form banner', async () => {
         const form = makeForm()
         injectError(form, ['email'], 'email required')
+        // Gate closed: nothing surfaced yet, at the leaf or the root.
         expect(form.meta.displayState).toBe('idle')
         await form.handleSubmit(() => {})()
         await nextTick()
-        // form.meta.displayState === rootFieldState.displayState with the
-        // own-path filter applied at root. Leaf errors don't surface here
-        // so the form banner can't duplicate them. Aggregate banners
-        // should bind to form.meta.errorCount > 0 instead.
-        expect(form.meta.displayState).not.toBe('error')
+        // Submit opens the gate; the now-visible leaf error rolls up to the
+        // form root, so form.meta.show* can drive a form-level banner.
+        expect(form.meta.displayState).toBe('error')
+        expect(form.meta.showErrors).toBe(true)
       })
 
-      // Affirmative "root-level error fires form.meta error" coverage
-      // lives in the cross-cutting synthetic test below; the integration
-      // path needs an object-level schema refine to land an error at the
-      // root path [], which isn't worth wiring per-adapter here.
+      it('greens once every field is valid and earned', async () => {
+        const form = makeForm()
+        form.setValue('email', 'a@b.c')
+        form.setValue('profile.name', 'Ada')
+        form.setValue('users.0.label', 'x')
+        await form.handleSubmit(() => {})()
+        await nextTick()
+        expect(form.meta.displayState).toBe('success')
+        expect(form.meta.showSuccess).toBe(true)
+      })
     })
   })
 }
@@ -1001,12 +1021,13 @@ describe('getDisplayState — anti-flash spinner timing (integration)', () => {
     await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.minVisible + 50)
     expect(form.fields('profile').displayState).toBe('pending')
 
-    // Both resolve; after min-visible the container leaves pending. Its own
-    // path has no error (the leaves render theirs), so it settles to idle.
+    // Both resolve invalid; after min-visible the container leaves pending.
+    // Each leaf now carries a gated error (submit opened the gate), so the
+    // container rolls them up and settles to error.
     resolvers.forEach((r) => r(false))
     await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.minVisible)
     expect(form.fields('profile').validating).toBe(false)
-    expect(form.fields('profile').displayState).not.toBe('pending')
+    expect(form.fields('profile').displayState).toBe('error')
   })
 
   it('100 fields, one validating: a single shared engine timer, the rest leave nothing', async () => {
@@ -1420,6 +1441,207 @@ describe('getDisplayState — reward early, punish late (DOM gate)', () => {
     await nextTick()
     expect(api.fields('email').interacted).toBe(true)
     expect(api.fields('email').displayState).toBe('idle')
+  })
+})
+
+describe('container & form.meta rollup — gated, DOM-driven', () => {
+  function mountRegistered(
+    schema: unknown,
+    paths: readonly string[],
+    formOpts: Record<string, unknown> = {}
+  ): {
+    api: FormLike & { register: (p: string) => unknown }
+    input: (p: string) => HTMLInputElement
+  } {
+    const handle: { api?: FormLike & { register: (p: string) => unknown } } = {}
+    const Comp = defineComponent({
+      setup() {
+        const api = useFormV4({
+          schema,
+          key: `rollup-dom-${Math.random()}`,
+          strict: false,
+          ...formOpts,
+        } as never) as unknown as FormLike & { register: (p: string) => unknown }
+        handle.api = api
+        return () =>
+          h(
+            'div',
+            paths.map((p) =>
+              withDirectives(h('input', { type: 'text', key: p }), [[vRegister, api.register(p)]])
+            )
+          )
+      },
+    })
+    const app = createApp(Comp).use(createAttaform())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    apps.push(app)
+    if (handle.api === undefined) throw new Error('mountRegistered: api never set')
+    const els = Array.from(root.querySelectorAll('input'))
+    const byPath = new Map<string, HTMLInputElement>()
+    paths.forEach((p, i) => {
+      const el = els[i]
+      if (!(el instanceof HTMLInputElement)) throw new Error(`mountRegistered: no input for ${p}`)
+      byPath.set(p, el)
+    })
+    const input = (p: string): HTMLInputElement => {
+      const el = byPath.get(p)
+      if (el === undefined) throw new Error(`mountRegistered: unknown path ${p}`)
+      return el
+    }
+    return { api: handle.api, input }
+  }
+
+  function editAndBlur(input: HTMLInputElement, value: string): void {
+    input.dispatchEvent(new FocusEvent('focus'))
+    input.value = value
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    input.dispatchEvent(new FocusEvent('blur'))
+  }
+
+  it('a blurred valid sibling does not surface an untouched sibling error (per-child gate)', async () => {
+    const schema = zV4.object({ a: zV4.string().min(1), b: zV4.string().min(1) })
+    const { api, input } = mountRegistered(schema, ['a', 'b'], {
+      defaultValues: { a: '', b: '' },
+      validateOn: 'blur',
+    })
+    // Edit A to a valid value and blur it: A earns success, its gate opens.
+    editAndBlur(input('a'), 'x')
+    await new Promise((r) => setTimeout(r, 0))
+    // B carries a committed error but was never touched (its gate is closed).
+    api.setFieldErrors([{ path: ['b'], message: 'b required', formKey: api.key, code: 'test' }])
+    await nextTick()
+    expect(api.fields('a').displayState).toBe('success')
+    expect(api.fields('b').displayState).toBe('idle')
+    // The root must NOT surface B's ungated error just because A opened its gate.
+    expect(api.meta.displayState).not.toBe('error')
+  })
+
+  it('an untouched optional sibling does not block container success', async () => {
+    const schema = zV4.object({
+      name: zV4.string().min(1),
+      nickname: zV4.string().optional(),
+    })
+    const { api, input } = mountRegistered(schema, ['name', 'nickname'], {
+      defaultValues: { name: '', nickname: '' },
+      validateOn: 'blur',
+    })
+    editAndBlur(input('name'), 'Ada')
+    await new Promise((r) => setTimeout(r, 0))
+    expect(api.fields('name').displayState).toBe('success')
+    expect(api.fields('nickname').displayState).toBe('idle')
+    // name is earned and nothing is wrong; the idle optional doesn't hold green back.
+    expect(api.meta.displayState).toBe('success')
+  })
+
+  it('an intermediate-container error rolls up to the form root once a descendant is blurred (no submit)', async () => {
+    const schema = zV4.object({
+      pw: zV4.object({ a: zV4.string(), b: zV4.string() }),
+    })
+    const { api, input } = mountRegistered(schema, ['pw.a', 'pw.b'], {
+      defaultValues: { pw: { a: '', b: '' } },
+      validateOn: 'blur',
+    })
+    // Open the intermediate object's gate by blurring one of its leaves...
+    editAndBlur(input('pw.a'), 'x')
+    await new Promise((r) => setTimeout(r, 0))
+    // ...then pin a cross-field error at the object path itself (a non-leaf).
+    api.setFieldErrors([{ path: ['pw'], message: 'must match', formKey: api.key, code: 'test' }])
+    await nextTick()
+    expect(api.fields('pw').displayState).toBe('error')
+    // It rolls up to the root even though no LEAF carries the error.
+    expect(api.meta.displayState).toBe('error')
+  })
+
+  it('a custom getDisplayState at a container is not overridden by the rollup', async () => {
+    const neverError: GetDisplayState = () => ({ display: 'idle' })
+    const schema = zV4.object({ profile: zV4.object({ name: zV4.string().min(1) }) })
+    const form = asForm(
+      mountWithApp(() =>
+        useFormV4({
+          schema,
+          key: `rollup-custom-${Math.random()}`,
+          strict: false,
+          defaultValues: { profile: { name: '' } },
+          getDisplayState: neverError,
+        } as never)
+      )
+    )
+    await form.handleSubmit(() => {})()
+    await nextTick()
+    // Empty name fails and the gate is open, but the consumer's reducer owns
+    // container verdicts: the default-only rollup override never fires.
+    expect(form.fields('profile').displayState).toBe('idle')
+    expect(form.fields('profile.name').displayState).toBe('idle')
+  })
+
+  describe('with fake timers', () => {
+    beforeEach(() => vi.useFakeTimers())
+    afterEach(() => vi.useRealTimers())
+
+    it('pending wins over a rolled-up error, then the error lands once validation settles', async () => {
+      let resolveB: (ok: boolean) => void = () => {}
+      const schema = zV4.object({
+        a: zV4.string().min(1),
+        b: zV4
+          .string()
+          .refine((v) => (v === '' ? true : new Promise<boolean>((r) => (resolveB = r))), {
+            error: 'bad b',
+          }),
+      })
+      const form = asForm(
+        mountWithApp(() =>
+          useFormV4({
+            schema,
+            key: `rollup-pending-${Math.random()}`,
+            strict: false,
+            defaultValues: { a: '', b: '' },
+          } as never)
+        )
+      )
+      // Submit opens every gate and lands a's min(1) error (b='' settles sync).
+      await form.handleSubmit(() => {})()
+      await nextTick()
+      // Park b's refine so the form has a validation in flight.
+      form.setValue('b', 'go')
+      await nextTick()
+      await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.showDelay)
+      // b is validating past the show-delay; pending wins over a's gated error.
+      expect(form.meta.displayState).toBe('pending')
+      // b settles valid; with nothing in flight, a's gated error rolls up.
+      resolveB(true)
+      await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.minVisible)
+      expect(form.meta.displayState).toBe('error')
+    })
+
+    it('an untouched descendant validating does not flash a container spinner', async () => {
+      let resolveB: (ok: boolean) => void = () => {}
+      const schema = zV4.object({
+        a: zV4.string().min(1),
+        b: zV4
+          .string()
+          .refine((v) => (v === '' ? true : new Promise<boolean>((r) => (resolveB = r))), {
+            error: 'bad b',
+          }),
+      })
+      const { api, input } = mountRegistered(schema, ['a', 'b'], {
+        defaultValues: { a: '', b: '' },
+      })
+      // Blur A (opens the container gate) without ever touching B.
+      editAndBlur(input('a'), 'x')
+      await vi.advanceTimersByTimeAsync(0)
+      // Kick B's async validation programmatically — no interaction, gate closed.
+      api.setValue('b', 'y')
+      await nextTick()
+      await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.showDelay + 50)
+      // B would never show its own spinner (gate closed); the container must
+      // not show one on its behalf, even though A opened the container gate.
+      expect(api.fields('b').displayState).not.toBe('pending')
+      expect(api.meta.displayState).not.toBe('pending')
+      resolveB(true)
+      await vi.advanceTimersByTimeAsync(DEFAULT_TIMINGS.minVisible)
+    })
   })
 })
 

--- a/test/docs-demos/docs-demos-smoke.test.ts
+++ b/test/docs-demos/docs-demos-smoke.test.ts
@@ -801,6 +801,27 @@ const entries: SmokeEntry[] = [
     },
   },
   {
+    // Type a too-short password and blur: the password leaf errors, and the
+    // Account *group* badge rolls that up to 'error' (the container rollup).
+    slug: 'container-display-state',
+    gesture: async (root) => {
+      const password = root.querySelectorAll<HTMLInputElement>('input').item(1)
+      if (password === null)
+        throw new Error('container-display-state: password input (index 1) not found')
+      await dispatchInput(password, 'short')
+      await dispatchBlur(password)
+      await waitUntil(() =>
+        root.textContent?.includes('At least 8 characters') === true ? true : null
+      )
+    },
+    assert: async (root) => {
+      expect(root.textContent ?? '').toContain('At least 8 characters')
+      // The Account group legend badge reflects the rolled-up verdict.
+      const accountLegend = root.querySelectorAll('legend').item(0)
+      expect(accountLegend?.textContent ?? '').toContain('error')
+    },
+  },
+  {
     // Three side-by-side forms (change / blur / submit). Type a too-short
     // value into the FIRST column (validateOn: 'change'): it validates on
     // the keystroke, so its raw readout surfaces the message with no blur.


### PR DESCRIPTION
Stacked on #343 (`feat/timed-display-state`).

## What

A container's `displayState` (and `form.meta`, the root container) now reflects its descendants' gated verdicts instead of only its own-path error:

- `pending` while any descendant is checking
- `error` when any descendant's error has cleared its own reveal gate, so a blurred sibling never leaks an untouched field's error up to the group
- `success` once every field is valid and at least one is earned
- `idle` otherwise

It is computed in `buildContainerFieldStateBase` over the aggregated errors (so a cross-field error pinned at an intermediate object counts too) and applied as a post-reducer override in `decorateWithDerivedProps`. The pure reducer and the public `DisplayCtx` stay frozen; a fully custom `getDisplayState` still owns container verdicts, gated by a default-family marker. The pending anchor is gated per child so an untouched descendant never flashes a container spinner.

## Docs

Adds a registration-form demo (`container-display-state`) and rewrites the "own-path filter" section of `showing-errors.md` to the rollup contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
