### PR TITLE
docs(demos): give every faux submit button toast feedback

### DIFF
--- a/apps/site/docs-demos/container-display-state.vue
+++ b/apps/site/docs-demos/container-display-state.vue
@@ -36,7 +36,9 @@
     success: 'Looking good, ready to submit',
   }
 
-  const onSubmit = form.handleSubmit(() => {})
+  const onSubmit = form.handleSubmit((values) => {
+    toast.success('Account created', { description: values })
+  })
 </script>
 
 <template>

--- a/apps/site/docs-demos/display-state.vue
+++ b/apps/site/docs-demos/display-state.vue
@@ -22,7 +22,9 @@
     key: 'docs-demo-display-state',
   })
 
-  const onSubmit = form.handleSubmit(() => {})
+  const onSubmit = form.handleSubmit((values) => {
+    toast.success(`Welcome, ${values.username}`, { description: values })
+  })
 </script>
 
 <template>

--- a/apps/site/docs-demos/fields.vue
+++ b/apps/site/docs-demos/fields.vue
@@ -17,7 +17,9 @@
     key: 'docs-demo-form.fields',
   })
 
-  const onSubmit = form.handleSubmit(() => {})
+  const onSubmit = form.handleSubmit((values) => {
+    toast.success(`Submitted as ${values.email}`, { description: values })
+  })
 
   const formatPath = (path: ReadonlyArray<string | number>) => JSON.stringify(path)
   const formatTime = (iso: string | null) =>

--- a/apps/site/docs-demos/focus-scroll.vue
+++ b/apps/site/docs-demos/focus-scroll.vue
@@ -13,8 +13,8 @@
     key: 'docs-demo-focus-scroll',
   })
 
-  const onSubmit = form.handleSubmit(() => {
-    /* success path not relevant for this demo */
+  const onSubmit = form.handleSubmit((values) => {
+    toast.success(`Thanks, ${values.name}`, { description: values })
   })
 </script>
 

--- a/apps/site/docs-demos/the-form.vue
+++ b/apps/site/docs-demos/the-form.vue
@@ -13,8 +13,9 @@
     key: 'docs-demo-the-form',
   })
 
-  const onSubmit = form.handleSubmit(async () => {
+  const onSubmit = form.handleSubmit(async (values) => {
     await new Promise((r) => setTimeout(r, 500))
+    toast.success('Saved', { description: values })
   })
 </script>
 

--- a/apps/site/docs-demos/validate-on-modes.vue
+++ b/apps/site/docs-demos/validate-on-modes.vue
@@ -29,19 +29,25 @@
     {
       mode: 'change',
       form: changeForm,
-      onSubmit: changeForm.handleSubmit(() => {}),
+      onSubmit: changeForm.handleSubmit((values) =>
+        toast.success('Submitted', { description: values })
+      ),
       caption: 'Checks on every keystroke.',
     },
     {
       mode: 'blur',
       form: blurForm,
-      onSubmit: blurForm.handleSubmit(() => {}),
+      onSubmit: blurForm.handleSubmit((values) =>
+        toast.success('Submitted', { description: values })
+      ),
       caption: 'Checks when the field loses focus.',
     },
     {
       mode: 'submit',
       form: submitForm,
-      onSubmit: submitForm.handleSubmit(() => {}),
+      onSubmit: submitForm.handleSubmit((values) =>
+        toast.success('Submitted', { description: values })
+      ),
       caption: 'Checks only when you submit.',
     },
   ]


### PR DESCRIPTION
Stacked on `feat/container-display-rollup`.

## What

Six demos had a no-op submit handler (an empty body, a placeholder comment, or an await that resolved to nothing), so submitting did nothing visible. Each now runs `toast.success` with a short title and the validated `values` as the description, matching the idiom the other demos already use:

`container-display-state`, `display-state`, `fields`, `focus-scroll`, `the-form`, and `validate-on-modes` (x3).

The payload-panel demos (`preprocess`, `storage-shape`, `url-availability-check`, `defaults-sync-factory`, `type-safety`) are left alone: their submit already renders the parsed values into a panel that is the feedback.

## Verification

Smoke suite (61 passed / 3 skipped), eslint, and the site typecheck are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
