### PR TITLE
ci(codeql): emit single-language check name to match required context

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -76,7 +76,15 @@ concurrency:
 
 jobs:
   analyze:
-    name: Analyze (javascript-typescript)
+    # Interpolate the matrix language into the job name. A matrixed job
+    # whose name does not itself reference `${{ matrix.language }}` gets
+    # the matrix value appended by GitHub for disambiguation, which would
+    # double the reported check context to
+    # `Analyze (javascript-typescript) (javascript-typescript)`. The
+    # single-suffix `Analyze (javascript-typescript)` is the exact context
+    # required by the `main protection` ruleset, so this name must stay in
+    # the interpolated form to satisfy the merge requirement.
+    name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     timeout-minutes: 30 # CodeQL JS/TS on a ~38k LOC repo finishes in ~6-10min; a 30min ceiling catches a runaway analysis without flagging healthy runs.
     permissions:


### PR DESCRIPTION
## What

The CodeQL `analyze` job hardcoded `name: Analyze (javascript-typescript)` while also carrying a single-entry `language` matrix. GitHub appends the matrix value to any matrixed job name that does not itself reference `${{ matrix.language }}`, so the reported check context doubled to:

```
Analyze (javascript-typescript) (javascript-typescript)
```

## Why it matters

The `main protection` ruleset requires the **single-suffix** context `Analyze (javascript-typescript)`. Nothing ever reported that name, so the merge box sat at *"Expected — Waiting for status to be reported"* on every PR to `main`. It surfaced on #351 (a dependabot dev-deps bump) but was stuck on all PRs, not just that one.

## The fix

Interpolate the matrix into the job name (`name: Analyze (${{ matrix.language }})`), matching the upstream CodeQL template. The run now reports `Analyze (javascript-typescript)`, satisfying the ruleset with **no ruleset change**. A comment on the job documents the coupling so it is not "simplified" back into the doubled form.

This PR's own CodeQL run uses the corrected workflow from its head branch, so it reports the single-suffix name and satisfies its own required check.

## Follow-up

After this merges, #351 needs `@dependabot rebase` so it re-runs the corrected workflow (PR runs use the workflow file from the PR's head branch, so fixing `main` alone does not retroactively rename #351's check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)