### PR TITLE
fix(zod): keep the unified entry's v3 read shape from collapsing to never

### DIFF
--- a/scripts/check-bundled-types.mjs
+++ b/scripts/check-bundled-types.mjs
@@ -18,12 +18,20 @@
  *     `wizard.allErrors`, `wizard.forms.<key>`) must compile against the
  *     bundled `.d.ts` without surface-shape drift between src and dist.
  *
+ * A second fixture project, `tests/fixtures/bundled-types-v3/`, compiles
+ * the unified `attaform/zod` entry with `zod` remapped (via tsconfig
+ * `paths`) to a single v3 install — recreating the one-Zod-major
+ * consumer the repo itself can't represent (it installs both majors).
+ * It guards the read-slot regression where the unified entry's v4
+ * overload greedily matched a v3 schema and collapsed `form.values` /
+ * `form.fields` to `never`.
+ *
  * Usage:
  *   pnpm check:bundled-types
  *
  * Side effects:
  *   - Builds `dist/` if missing (calls `pnpm prepack`).
- *   - Runs `tsc --project tests/fixtures/bundled-types/tsconfig.json`.
+ *   - Runs `tsc --project <fixture>/tsconfig.json` for each fixture set.
  *   - Exits non-zero on any compile error.
  */
 import { execSync } from 'node:child_process'
@@ -34,7 +42,16 @@ import { dirname, resolve } from 'node:path'
 const here = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(here, '..')
 const distDir = resolve(repoRoot, 'dist')
-const fixtureTsConfig = resolve(repoRoot, 'tests/fixtures/bundled-types/tsconfig.json')
+const fixtureProjects = [
+  {
+    label: 'v4 / default consumer',
+    tsconfig: resolve(repoRoot, 'tests/fixtures/bundled-types/tsconfig.json'),
+  },
+  {
+    label: 'v3-only consumer (zod remapped to a single v3 install)',
+    tsconfig: resolve(repoRoot, 'tests/fixtures/bundled-types-v3/tsconfig.json'),
+  },
+]
 const sentinelDts = resolve(distDir, 'zod-v4.d.ts')
 
 function run(cmd, opts = {}) {
@@ -57,20 +74,27 @@ if (!distIsRealBundle()) {
   run('pnpm prepack')
 }
 
-console.log('[check-bundled-types] typechecking bundled-types fixtures against bundled .d.ts')
-try {
-  run(`pnpm exec tsc --project "${fixtureTsConfig}"`)
-  console.log('[check-bundled-types] ok — bundled-types fixtures compile cleanly')
-} catch {
+let failed = false
+for (const { label, tsconfig } of fixtureProjects) {
+  console.log(`[check-bundled-types] typechecking ${label} against bundled .d.ts`)
+  try {
+    run(`pnpm exec tsc --project "${tsconfig}"`)
+    console.log(`[check-bundled-types] ok — ${label}`)
+  } catch {
+    failed = true
+    console.error(`[check-bundled-types] FAILED — ${label} did not compile.`)
+  }
+}
+
+if (failed) {
   console.error('[check-bundled-types] FAILED — a bundled-types fixture did not compile.')
-  console.error(
-    '  Depth-efficiency regression suspects: DefaultValuesInput, LeafWalker,'
-  )
-  console.error(
-    '  internal-helper exports, WriteShape. Surface-shape drift suspects: any'
-  )
-  console.error(
-    '  recent change to public types that did not propagate through unbuild to dist.'
-  )
+  console.error('  Depth-efficiency regression suspects: DefaultValuesInput, LeafWalker,')
+  console.error('  internal-helper exports, WriteShape. Surface-shape drift suspects: any')
+  console.error('  recent change to public types that did not propagate through unbuild to dist.')
+  console.error('  v3-only consumer regression suspects: the unified entry v4 overload')
+  console.error('  matching a v3 schema (read slot collapses to `never`); see')
+  console.error('  src/runtime/adapters/unified/ and the ZodV4 structural marker.')
   process.exit(1)
 }
+
+console.log('[check-bundled-types] ok — all bundled-types fixtures compile cleanly')

--- a/src/runtime/adapters/unified/types-unified.ts
+++ b/src/runtime/adapters/unified/types-unified.ts
@@ -18,6 +18,7 @@
  */
 import type { z } from 'zod'
 import type { z as zV3 } from 'zod-v3'
+import type { ZodV4Internals } from './types-zod-major'
 import type { StorageShape as StorageShapeV4 } from '../zod-v4/types-storage-shape'
 import type { StorageShape as StorageShapeV3 } from '../zod-v3/types-storage-shape'
 import type { UnwrapZodObject } from '../zod-v3/types-zod-adapter'
@@ -108,7 +109,10 @@ export type UseFormConfigV3<
  * this helper stays deferred and TS can't prove return-type
  * compatibility.
  */
-export type UseFormReturn<Schema, K extends FormKey = FormKey> = Schema extends z.ZodObject
+export type UseFormReturn<
+  Schema,
+  K extends FormKey = FormKey,
+> = Schema extends z.ZodObject<z.ZodRawShape> & ZodV4Internals
   ? UseFormReturnType<V4FormOf<Schema>, V4OutOf<Schema>, V4ReadOf<Schema>, K>
   : Schema extends zV3.ZodObject<zV3.ZodRawShape>
     ? UseFormReturnType<V3FormOf<Schema>, V3OutOf<Schema>, V3ReadOf<Schema>, K>
@@ -119,7 +123,10 @@ export type UseFormReturn<Schema, K extends FormKey = FormKey> = Schema extends 
  * schema. Mirrors `UseFormReturn`'s dispatch — replaces
  * `Parameters<typeof useForm<Schema, K>>[0]` in test code.
  */
-export type UseFormConfig<Schema, K extends FormKey = FormKey> = Schema extends z.ZodObject
+export type UseFormConfig<
+  Schema,
+  K extends FormKey = FormKey,
+> = Schema extends z.ZodObject<z.ZodRawShape> & ZodV4Internals
   ? Omit<
       UseFormConfiguration<
         V4FormOf<Schema>,

--- a/src/runtime/adapters/unified/types-zod-major.ts
+++ b/src/runtime/adapters/unified/types-zod-major.ts
@@ -1,0 +1,35 @@
+/**
+ * Type-level Zod-major discriminator for the unified `attaform/zod`
+ * entry. The runtime dispatch (`use-form.ts`'s impl) already routes on
+ * the schema's shape via `isZodV4SchemaShape`; this is the type-level
+ * mirror so the overloads and projection helpers discriminate the same
+ * way.
+ *
+ * Why a structural marker instead of `z.ZodObject`: the unified entry's
+ * overloads constrain on `z.ZodObject`, but the published `.d.mts`
+ * resolves `z` against whichever single Zod major the consumer
+ * installed. In a v3-only install `z.ZodObject` is v3's `ZodObject`
+ * (and, lacking its required type arguments, degrades to an `any`-like
+ * error type under `skipLibCheck`), so a v3 schema satisfies the v4
+ * overload's constraint and binds it — collapsing the read slot to
+ * `never`. A Zod v4 schema carries the `_zod` internals brand; a v3
+ * schema never does.
+ * Intersecting a v4-only constraint or conditional branch with this
+ * marker keeps it unreachable for a v3 schema regardless of how `zod`
+ * resolves, so v3 schemas fall through to the v3 overload.
+ *
+ * Distinct from `core/zod-shape.ts`'s runtime `ZodV4Shape` (which reads
+ * the public `def` getter): at the type level the stable v4 brand is
+ * `_zod.def`, the same internals `StorageShape` (v4) already reads.
+ *
+ * Pairing requirement: a v4 overload/branch must constrain on
+ * `z.ZodObject<z.ZodRawShape> & ZodV4Internals`, NOT bare
+ * `z.ZodObject & ZodV4Internals`. In a v3-only install `z.ZodObject`
+ * with no type argument is `ZodObject<T, ...>` missing its required
+ * arguments — an error type that behaves like `any` under
+ * `skipLibCheck`, so `any & ZodV4Internals` collapses back to `any` and
+ * the marker stops excluding v3 schemas. Supplying `z.ZodRawShape`
+ * keeps it a concrete object type in both majors, so the intersection
+ * stays meaningful.
+ */
+export type ZodV4Internals = { _zod: { def: unknown } }

--- a/src/runtime/adapters/unified/use-form.ts
+++ b/src/runtime/adapters/unified/use-form.ts
@@ -35,6 +35,7 @@ import type { z } from 'zod'
 import type { z as zV3 } from 'zod-v3'
 import { InvalidUseFormConfigError } from '../../core/errors'
 import { isZodV4SchemaShape } from '../../core/zod-shape'
+import type { ZodV4Internals } from './types-zod-major'
 import { useForm as useFormV3 } from '../../composables/use-form'
 import { useForm as useFormV4 } from '../zod-v4'
 import type { StorageShape as StorageShapeV4 } from '../zod-v4/types-storage-shape'
@@ -85,10 +86,15 @@ type V3ReadOf<S extends zV3.ZodObject<zV3.ZodRawShape>> =
  * })
  * ```
  *
- * v4 schemas match this overload first via their structural `def`
- * field. v3 schemas fall through to the v3 overload below.
+ * The constraint intersects `ZodV4Internals` (the v4-only `_zod`
+ * brand) so a v3 schema can't bind this overload even when `z`
+ * resolves to v3 in a single-major consumer install; v3 schemas fall
+ * through to the v3 overload below. See `types-zod-major.ts`.
  */
-export function useForm<Schema extends z.ZodObject, K extends FormKey = FormKey>(
+export function useForm<
+  Schema extends z.ZodObject<z.ZodRawShape> & ZodV4Internals,
+  K extends FormKey = FormKey,
+>(
   configuration: Omit<
     UseFormConfiguration<
       V4FormOf<Schema>,

--- a/tests/fixtures/bundled-types-v3/consumer.ts
+++ b/tests/fixtures/bundled-types-v3/consumer.ts
@@ -1,0 +1,55 @@
+/**
+ * Bundled-types regression fixture — Zod v3 consumer (single-major
+ * install). Compiled with `zod` remapped to a v3 install via the
+ * sibling tsconfig's `paths`, recreating what a consumer who installs
+ * only `zod@3` sees through the unified `attaform/zod` entry's bundled
+ * `.d.mts`.
+ *
+ * Standing guard for the read-slot regression: with one Zod major
+ * installed, the bundled `import { z } from 'zod'` inside
+ * `dist/zod.d.mts` collapses to that major, so the unified entry's v4
+ * overload must NOT greedily match a v3 schema. When it does, the read
+ * slot (`form.values` / `form.fields`) projects through the v4
+ * `StorageShape` (structural on the v4-only `_zod` brand, which a v3
+ * schema lacks) and collapses to `never`, while the input/output slots
+ * keep resolving — so `register` / `handleSubmit` compile but every
+ * read is poisoned.
+ *
+ * In-repo type tests can't catch this: the repo installs both majors,
+ * so `zod` and `zod-v3` stay distinct and the v4-vs-v3 discrimination
+ * always works. The collapse only happens in a one-major consumer —
+ * which is exactly what the `paths` remap recreates here.
+ */
+import { z } from 'zod' // remapped to a v3 install via tsconfig `paths`
+import { useForm } from '../../../dist/zod'
+
+// Strict type equality — distinguishes `never` and `any` from the real
+// type, so a fix can't regress the read slot to either.
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false
+type Expect<T extends true> = T
+
+const schema = z.object({
+  urls: z.array(z.string()).min(1),
+  name: z.string(),
+})
+
+const form = useForm({ schema, key: 'signup-v3' })
+
+// Read slot — the regression. These were `never` for a v3 consumer.
+type _ValuesUrls = Expect<Equal<typeof form.values.urls, string[]>>
+type _ValuesName = Expect<Equal<typeof form.values.name, string>>
+
+// Field handles must descend to a real FieldState, not collapse.
+type _FieldValue = Expect<Equal<typeof form.fields.name.value, string>>
+
+// Input / submit slots stayed correct even under the bug — pin them so
+// the fix can't regress them in the other direction.
+form.register('name')
+form.handleSubmit((data) => {
+  type _SubmitUrls = Expect<Equal<typeof data.urls, string[]>>
+  type _SubmitName = Expect<Equal<typeof data.name, string>>
+  void data
+})
+
+export { form }

--- a/tests/fixtures/bundled-types-v3/tsconfig.json
+++ b/tests/fixtures/bundled-types-v3/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "lib": ["es2020", "es2022.error", "dom"],
+    "types": [],
+    "paths": {
+      "zod": ["../../../node_modules/zod-v3"]
+    }
+  },
+  "include": ["./*.ts"]
+}


### PR DESCRIPTION
## What

The unified `attaform/zod` entry's v4 `useForm` overload constrained on bare `z.ZodObject`. The published `.d.mts` resolves `z` against whichever single Zod major a consumer installed, so in a **v3-only install** `z.ZodObject` is v3's `ZodObject` and (missing its required type arguments) degrades to an `any`-like error type under `skipLibCheck`. A v3 schema therefore bound the v4 overload, and `form.values` / `form.fields` projected through the v4 `StorageShape` (structural on the v4-only `_zod` brand, absent on v3) and collapsed to `never`, while `register` / `handleSubmit` kept compiling. The app *runs* (the Vite plugin rewrites the entry at build) but fails `vue-tsc`.

Surfaced via DX feedback from a Zod-v3 consumer dogfooding the library; reproduced end-to-end in a single-`zod@3.25.76` project.

## Why it escaped CI

The repo installs **both** Zod majors (`zod` + the `zod-v3` alias), so `zod` and `zod-v3` stay distinct and the v4-vs-v3 discrimination always works. The collapse only happens in a one-major consumer.

## Fix

- New structural `ZodV4Internals` marker (`{ _zod: { def: unknown } }`), the type-level mirror of the runtime `isZodV4SchemaShape` discriminator.
- Gate the v4 overload and the `UseFormReturn` / `UseFormConfig` dispatch helpers on it.
- Constrain on `z.ZodObject<z.ZodRawShape>` (not bare `z.ZodObject`) so the type stays concrete in a v3 install and the marker intersection actually excludes v3 schemas; bare `z.ZodObject` collapses to `any` and defeats it. v3 schemas now fall through to the v3 overload.

No public API change; v4 behavior is identical (v4 schemas carry `_zod`).

## Regression gate

`tests/fixtures/bundled-types-v3/` compiles the **built** `.d.mts` with `zod` remapped to a single v3 install, recreating the one-major consumer the repo can't otherwise represent. Wired into `check:bundled-types` (CI). Verified red on pre-fix dist, green after.

## Verification

- v3 fixture ✅, v4 fixtures ✅ (no regression)
- in-repo `tsc --noEmit` ✅
- lint + format ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)