### PR TITLE
fix: docs-site demo bugs + v-register external-update reactivity

### DIFF
--- a/apps/site/components/docs/DocsSidebar.vue
+++ b/apps/site/components/docs/DocsSidebar.vue
@@ -6,6 +6,15 @@
   // the template (it doesn't see Nuxt's global auto-import declarations
   // through the template compiler at type time).
   const sections = docsNavigation
+
+  // Active-link state follows the same rule as the breadcrumb and pager:
+  // compare the current path to each `to` with the trailing slash
+  // normalized away, so a reader who landed on the canonical `/docs/foo/`
+  // URL (via search or a shared link) still lights up the right entry.
+  // `exact-active-class` can't do this — its comparison is verbatim, so
+  // the slash slips through and the sidebar deselects.
+  const route = useRoute()
+  const isActive = (to: string) => normalizePath(route.path) === normalizePath(to)
 </script>
 
 <template>
@@ -28,7 +37,8 @@
               {{ item.subheading }}
             </li>
             <li v-else :key="`link-${item.to}-${idx}`">
-              <!-- exact-active-class flips the link to the active state.
+              <!-- isActive flips the link to the active state (trailing
+                   slash normalized, unlike the verbatim exact-active-class).
                    The `.docs-nav-item` styles below replace the simple
                    `border-l` with a pseudo-element that scales in from
                    the center on activate — state changes feel intentional
@@ -36,8 +46,8 @@
                    so the link doesn't reflow when the indicator appears. -->
               <NuxtLink
                 :to="item.to"
-                exact-active-class="docs-nav-item--active"
                 class="docs-nav-item relative block py-1.5 pr-2 pl-4 text-sm text-fg-muted transition-colors duration-(--duration-fast) hover:text-fg"
+                :class="{ 'docs-nav-item--active': isActive(item.to) }"
               >
                 {{ item.title }}
               </NuxtLink>

--- a/apps/site/composables/useDocsNavigation.ts
+++ b/apps/site/composables/useDocsNavigation.ts
@@ -187,6 +187,20 @@ export const docsLinksFlat: ReadonlyArray<DocsLink> = docsNavigation.flatMap((se
   section.links.filter(isDocsLink)
 )
 
+// Normalize a route path before matching it against a nav `to`. Docs
+// pages render to `foo/index.html`, so the canonical URL (and every
+// Pagefind result link) carries a trailing slash (`/docs/foo/`), while
+// the `to` values above do not (`/docs/foo`). A bare `=== route.path`
+// then misses the moment a reader arrives via search or a shared
+// canonical link: the breadcrumb collapses to "Docs", the sidebar
+// deselects, and the pager loses prev/next. Dropping the trailing slash
+// on both sides (root "/" preserved) makes the match resilient to
+// however the reader reached the page. Exported so DocsSidebar derives
+// its active state through the same rule.
+export function normalizePath(path: string): string {
+  return path.length > 1 ? path.replace(/\/+$/, '') : path
+}
+
 // Returns the prev/next link for the current route. Composables that
 // rely on `useRoute` only work inside Nuxt's reactivity scope — so
 // pager components import and call this directly. Returns nulls at
@@ -194,7 +208,8 @@ export const docsLinksFlat: ReadonlyArray<DocsLink> = docsNavigation.flatMap((se
 export function useDocsPagination() {
   const route = useRoute()
   return computed(() => {
-    const idx = docsLinksFlat.findIndex((l) => l.to === route.path)
+    const current = normalizePath(route.path)
+    const idx = docsLinksFlat.findIndex((l) => normalizePath(l.to) === current)
     return {
       prev: idx > 0 ? docsLinksFlat[idx - 1] : null,
       next: idx >= 0 && idx < docsLinksFlat.length - 1 ? docsLinksFlat[idx + 1] : null,
@@ -212,9 +227,10 @@ export function useDocsBreadcrumb() {
   const route = useRoute()
   return computed(() => {
     const segments: Array<{ label: string; to?: string }> = [{ label: 'Docs', to: '/docs' }]
+    const current = normalizePath(route.path)
     for (const section of docsNavigation) {
       const link = section.links.find(
-        (item): item is DocsLink => isDocsLink(item) && item.to === route.path
+        (item): item is DocsLink => isDocsLink(item) && normalizePath(item.to) === current
       )
       if (link) {
         segments.push({ label: section.heading })

--- a/apps/site/docs-demos/fields.vue
+++ b/apps/site/docs-demos/fields.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
   import { useForm, withMeta } from 'attaform/zod'
   import { z } from 'zod'
+  import { ref, onMounted } from 'vue'
 
   const schema = z.object({
     email: withMeta(
@@ -21,9 +22,21 @@
     toast.success(`Submitted as ${values.email}`, { description: values })
   })
 
+  // toLocaleTimeString() is locale/timezone dependent and updatedAt is
+  // wall-clock state, so the time can't match between the SSR pass and
+  // the client — hold a placeholder until mounted to keep hydration in
+  // agreement, then fill in the live time on the client.
+  const mounted = ref(false)
+  onMounted(() => {
+    mounted.value = true
+  })
+
   const formatPath = (path: ReadonlyArray<string | number>) => JSON.stringify(path)
-  const formatTime = (iso: string | null) =>
-    iso === null ? 'null' : new Date(iso).toLocaleTimeString()
+  const formatTime = (iso: string | null) => {
+    if (iso === null) return 'null'
+    if (!mounted.value) return '…'
+    return new Date(iso).toLocaleTimeString()
+  }
 </script>
 
 <template>

--- a/apps/site/docs-demos/multi-tab-sync.vue
+++ b/apps/site/docs-demos/multi-tab-sync.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
   import { useForm } from 'attaform/zod'
   import { z } from 'zod'
-  import { ref, onMounted } from 'vue'
 
   const form = useForm({
     schema: z.object({
@@ -12,27 +11,11 @@
     key: 'docs-demo-multi-tab-sync',
     multiTab: true,
   })
-
-  // The standalone playground renders this demo inside a sandboxed
-  // <iframe>, where cross-tab sync can't establish. Detect the embed so
-  // the instructions point readers at the docs page (top-level, where
-  // sync works) rather than asking them to duplicate a tab that won't
-  // converge.
-  const embedded = ref(false)
-  onMounted(() => {
-    embedded.value = window.self !== window.top
-  })
 </script>
 
 <template>
   <form @submit.prevent>
-    <p v-if="embedded" class="hint open">
-      This standalone playground runs in a sandboxed frame, so cross-tab sync stays local to it.
-      Open the <code>multi-tab-sync</code> demo on the docs page in two browser tabs to watch them
-      converge. The form still opts in here with <code>multiTab: true</code> on a keyed
-      <code>useForm</code>.
-    </p>
-    <p v-else class="hint open">
+    <p class="hint open">
       Open this page in a <strong>second tab</strong> (right-click the title and pick
       &quot;Duplicate&quot;), then type in either one. The other tab converges within a microtask.
       The demo opts in with <code>multiTab: true</code> on a keyed <code>useForm</code>; the rest is

--- a/apps/site/docs-demos/multi-tab-sync.vue
+++ b/apps/site/docs-demos/multi-tab-sync.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
   import { useForm } from 'attaform/zod'
   import { z } from 'zod'
+  import { ref, onMounted } from 'vue'
 
   const form = useForm({
     schema: z.object({
@@ -11,11 +12,27 @@
     key: 'docs-demo-multi-tab-sync',
     multiTab: true,
   })
+
+  // The standalone playground renders this demo inside a sandboxed
+  // <iframe>, where cross-tab sync can't establish. Detect the embed so
+  // the instructions point readers at the docs page (top-level, where
+  // sync works) rather than asking them to duplicate a tab that won't
+  // converge.
+  const embedded = ref(false)
+  onMounted(() => {
+    embedded.value = window.self !== window.top
+  })
 </script>
 
 <template>
   <form @submit.prevent>
-    <p class="hint open">
+    <p v-if="embedded" class="hint open">
+      This standalone playground runs in a sandboxed frame, so cross-tab sync stays local to it.
+      Open the <code>multi-tab-sync</code> demo on the docs page in two browser tabs to watch them
+      converge. The form still opts in here with <code>multiTab: true</code> on a keyed
+      <code>useForm</code>.
+    </p>
+    <p v-else class="hint open">
       Open this page in a <strong>second tab</strong> (right-click the title and pick
       &quot;Duplicate&quot;), then type in either one. The other tab converges within a microtask.
       The demo opts in with <code>multiTab: true</code> on a keyed <code>useForm</code>; the rest is

--- a/apps/site/scripts/index-search-dev.mjs
+++ b/apps/site/scripts/index-search-dev.mjs
@@ -21,7 +21,7 @@
  */
 
 import { createIndex } from 'pagefind'
-import { readFile, readdir } from 'node:fs/promises'
+import { readFile, readdir, rm } from 'node:fs/promises'
 import { resolve, dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Marked } from 'marked'
@@ -130,6 +130,13 @@ async function indexAll() {
     meta: { title: 'Documentation' },
   })
 
+  // Pagefind's writeFiles doesn't purge the output directory first, so
+  // pages that were removed or renamed leave orphaned content-hashed
+  // fragments behind. They aren't referenced by the freshly-written
+  // index (so they don't surface in search), but they accumulate across
+  // dev runs. Clear the directory so the index is an exact mirror of the
+  // current docs/ source.
+  await rm(outDir, { recursive: true, force: true })
   const { errors: writeErrors } = await index.writeFiles({ outputPath: outDir })
   if (writeErrors.length) {
     console.error('[index:search:dev] writeFiles errors:', writeErrors)

--- a/src/runtime/core/directive-value-sync.ts
+++ b/src/runtime/core/directive-value-sync.ts
@@ -1,0 +1,79 @@
+import { effectScope, watch } from 'vue'
+import type { RegisterValue } from '../types/types-api'
+
+/**
+ * Per-element teardown slot for the value-sync watch. `Symbol.for(...)`
+ * so duplicate copies of attaform agree on the slot across bundles.
+ */
+const valueSyncScopeKey: unique symbol = Symbol.for('attaform:value-sync-scope')
+type ValueSyncCarrier = HTMLElement & {
+  [valueSyncScopeKey]?: () => void
+}
+
+/**
+ * ShadowRoot-aware "is this element the focused one" check. A
+ * v-register'd input mounted inside a shadow tree reports its focus on
+ * the rootNode, not on `document` — mirrors the activeElement lookup in
+ * the directive's `beforeUpdate` and `register-api`'s focus probe.
+ */
+function isElementFocused(el: HTMLElement): boolean {
+  const rootNode = el.getRootNode()
+  const activeElement =
+    rootNode instanceof Document || rootNode instanceof ShadowRoot ? rootNode.activeElement : null
+  return activeElement === el
+}
+
+/**
+ * Reactively mirror a text / number input's `displayValue` onto the DOM.
+ *
+ * The directive's `beforeUpdate` hook only re-syncs `el.value` when the
+ * host component re-renders. A form mutation that originates OUTSIDE the
+ * component never triggers that re-render on its own:
+ *
+ *   - cross-tab sync (`applyFormReplacement` from the multi-tab module),
+ *   - a sibling component's `setValue` / `reset` / `clear`,
+ *   - any imperative store write while the bound component's template
+ *     reads no field state (a display-only form never re-renders).
+ *
+ * In all of these the store and `displayValue` update correctly, but the
+ * `<input>` would stay stale. Watching `displayValue` in its own effect
+ * scope closes the gap — the same way the aria and file directives watch
+ * their reactive sources for ticks that don't ride a parent re-render.
+ *
+ * Skipped while the element is focused or mid-IME-composition so the
+ * watch never overwrites the user's in-flight edit or moves their caret;
+ * the keystroke path and `beforeUpdate` own the focused case. The
+ * `el.value !== next` guard keeps the write idempotent, and a
+ * programmatic `el.value` assignment doesn't dispatch `input`, so there's
+ * no write-back echo loop.
+ */
+export function setupValueSync(
+  el: HTMLInputElement | HTMLTextAreaElement,
+  rv: RegisterValue
+): void {
+  const scope = effectScope(true)
+  scope.run(() => {
+    watch(
+      rv.displayValue,
+      (next) => {
+        if ((el as { composing?: boolean }).composing === true) return
+        if (isElementFocused(el)) return
+        if (el.value !== next) el.value = next
+      },
+      { flush: 'post' }
+    )
+  })
+  ;(el as ValueSyncCarrier)[valueSyncScopeKey] = (): void => scope.stop()
+}
+
+/**
+ * Stop the value-sync watch. Gated on an active scope so an element that
+ * never set one up (checkbox / radio / select / file) is a no-op.
+ */
+export function teardownValueSync(el: HTMLElement): void {
+  const carrier = el as ValueSyncCarrier
+  const stop = carrier[valueSyncScopeKey]
+  if (stop === undefined) return
+  stop()
+  delete carrier[valueSyncScopeKey]
+}

--- a/src/runtime/core/directive-value-sync.ts
+++ b/src/runtime/core/directive-value-sync.ts
@@ -1,5 +1,4 @@
-import { effectScope, watch } from 'vue'
-import type { RegisterValue } from '../types/types-api'
+import { effectScope, watch, type WatchSource } from 'vue'
 
 /**
  * Per-element teardown slot for the value-sync watch. `Symbol.for(...)`
@@ -12,7 +11,7 @@ type ValueSyncCarrier = HTMLElement & {
 
 /**
  * ShadowRoot-aware "is this element the focused one" check. A
- * v-register'd input mounted inside a shadow tree reports its focus on
+ * v-register'd control mounted inside a shadow tree reports its focus on
  * the rootNode, not on `document` — mirrors the activeElement lookup in
  * the directive's `beforeUpdate` and `register-api`'s focus probe.
  */
@@ -23,42 +22,56 @@ function isElementFocused(el: HTMLElement): boolean {
   return activeElement === el
 }
 
+export interface ValueSyncOptions {
+  /**
+   * Skip the write while the element is focused. Set for text / textarea
+   * so the watch never overwrites the user's in-flight edit or moves
+   * their caret — the keystroke path and `beforeUpdate` own the focused
+   * case. Left off for checkbox / radio / select: their DOM writes are
+   * atomic and idempotent, so an external change must reflect even on a
+   * focused control (that's the failure surface this closes), and the
+   * in-flight-interaction window is guarded by `apply` itself (the
+   * select's `_assigning` flag).
+   */
+  skipWhileFocused?: boolean
+}
+
 /**
- * Reactively mirror a text / number input's `displayValue` onto the DOM.
- *
- * The directive's `beforeUpdate` hook only re-syncs `el.value` when the
- * host component re-renders. A form mutation that originates OUTSIDE the
- * component never triggers that re-render on its own:
+ * Reactively mirror a register binding's reactive source onto the DOM for
+ * changes that DON'T ride a host re-render:
  *
  *   - cross-tab sync (`applyFormReplacement` from the multi-tab module),
  *   - a sibling component's `setValue` / `reset` / `clear`,
  *   - any imperative store write while the bound component's template
  *     reads no field state (a display-only form never re-renders).
  *
- * In all of these the store and `displayValue` update correctly, but the
- * `<input>` would stay stale. Watching `displayValue` in its own effect
- * scope closes the gap — the same way the aria and file directives watch
- * their reactive sources for ticks that don't ride a parent re-render.
+ * The directive's `beforeUpdate` / `updated` hooks only fire on a host
+ * re-render, so without this the store updates but the control stays
+ * stale. `apply` performs the type-specific DOM write — `el.value` for
+ * text, `el.checked` for checkbox / radio, `<option>.selected` for select
+ * — and is the SAME write the re-render path runs, so both stay in
+ * lockstep. Runs in its own effect scope, torn down by
+ * `teardownValueSync` from the dispatcher's `beforeUnmount`.
  *
- * Skipped while the element is focused or mid-IME-composition so the
- * watch never overwrites the user's in-flight edit or moves their caret;
- * the keystroke path and `beforeUpdate` own the focused case. The
- * `el.value !== next` guard keeps the write idempotent, and a
- * programmatic `el.value` assignment doesn't dispatch `input`, so there's
- * no write-back echo loop.
+ * Mid-IME-composition writes are always skipped (text only; inert
+ * elsewhere). A programmatic DOM write doesn't dispatch `input` / `change`,
+ * so there's no write-back echo loop.
  */
 export function setupValueSync(
-  el: HTMLInputElement | HTMLTextAreaElement,
-  rv: RegisterValue
+  el: HTMLElement,
+  source: WatchSource,
+  apply: () => void,
+  options: ValueSyncOptions = {}
 ): void {
+  const skipWhileFocused = options.skipWhileFocused === true
   const scope = effectScope(true)
   scope.run(() => {
     watch(
-      rv.displayValue,
-      (next) => {
+      source,
+      () => {
         if ((el as { composing?: boolean }).composing === true) return
-        if (isElementFocused(el)) return
-        if (el.value !== next) el.value = next
+        if (skipWhileFocused && isElementFocused(el)) return
+        apply()
       },
       { flush: 'post' }
     )
@@ -68,7 +81,7 @@ export function setupValueSync(
 
 /**
  * Stop the value-sync watch. Gated on an active scope so an element that
- * never set one up (checkbox / radio / select / file) is a no-op.
+ * never set one up is a no-op.
  */
 export function teardownValueSync(el: HTMLElement): void {
   const carrier = el as ValueSyncCarrier

--- a/src/runtime/core/directive.ts
+++ b/src/runtime/core/directive.ts
@@ -43,6 +43,7 @@ import {
   syncPersistOptIn,
 } from './directive-lifecycle'
 import { addTrackedListener, noteInteraction, removeTrackedListeners } from './directive-listeners'
+import { setupValueSync, teardownValueSync } from './directive-value-sync'
 import { INTERACTIVE_TAG_NAMES } from './interactive-tags'
 import type {
   CustomDirectiveRegisterAssignerFn,
@@ -810,6 +811,15 @@ const vRegisterText: RegisterTextCustomDirective = {
     // the assigner — wiping the blank flag and locking the user
     // out of the empty display state.
     el.value = value.displayValue.value
+
+    // Reactive value sync: `beforeUpdate` only repaints the DOM when the
+    // host component re-renders, so a form mutation that originates
+    // outside this component (cross-tab sync, a sibling's setValue /
+    // reset / clear, any imperative write while the template reads no
+    // field state) wouldn't reach the input. Watch `displayValue` in its
+    // own scope to close that gap — torn down via `teardownValueSync` in
+    // the dispatcher's `beforeUnmount`.
+    setupValueSync(el, value)
   },
   beforeUpdate(el, { value, oldValue, modifiers: { lazy, trim } }, vnode) {
     setAssignFunction(el, vnode, value)
@@ -1430,6 +1440,10 @@ const vRegisterDynamic: RegisterModelDynamicCustomDirective = {
     // Stop the aria watch and clear the attributes we set. A reused
     // element (KeepAlive / v-show) starts clean on its next activation.
     teardownAria(el as AriaCarrier)
+
+    // Stop the reactive value-sync watch (text / textarea bindings). A
+    // no-op for variants that never set one up.
+    teardownValueSync(el)
 
     // Drop every opt-in this element ever held — `removeAllFor` sweeps
     // by elementId rather than (id, path), which covers the case where

--- a/src/runtime/core/directive.ts
+++ b/src/runtime/core/directive.ts
@@ -818,8 +818,17 @@ const vRegisterText: RegisterTextCustomDirective = {
     // reset / clear, any imperative write while the template reads no
     // field state) wouldn't reach the input. Watch `displayValue` in its
     // own scope to close that gap — torn down via `teardownValueSync` in
-    // the dispatcher's `beforeUnmount`.
-    setupValueSync(el, value)
+    // the dispatcher's `beforeUnmount`. Focus-gated so it never disturbs
+    // an in-flight edit; `beforeUpdate` writes the same target value.
+    setupValueSync(
+      el,
+      value.displayValue,
+      () => {
+        const next = value.displayValue.value
+        if (el.value !== next) el.value = next
+      },
+      { skipWhileFocused: true }
+    )
   },
   beforeUpdate(el, { value, oldValue, modifiers: { lazy, trim } }, vnode) {
     setAssignFunction(el, vnode, value)
@@ -954,7 +963,17 @@ const vRegisterCheckbox: RegisterCheckboxCustomDirective = {
   // set initial checked on mount to wait for true-value/false-value
   mounted(el, { value }) {
     setChecked(el, value)
-    if (isRegisterValue(value)) el._lastAppliedModel = value.innerRef.value
+    if (!isRegisterValue(value)) return
+    el._lastAppliedModel = value.innerRef.value
+    // External model changes that don't trigger a host re-render
+    // (cross-tab sync, a sibling's setValue / reset / clear) re-run the
+    // same `setChecked` the `beforeUpdate` path uses. Not focus-gated:
+    // an external change must reflect even on a focused checkbox, and the
+    // write is idempotent (`setChecked` skips when `el.checked` matches).
+    setupValueSync(el, value.innerRef, () => {
+      setChecked(el, value)
+      el._lastAppliedModel = value.innerRef.value
+    })
   },
   // Skip the DOM sync when the model is identity-unchanged from the
   // last application. Pre-fix the scalar branch in `setChecked`
@@ -1064,6 +1083,14 @@ const vRegisterRadio: RegisterRadioCustomDirective = {
     // the comparison stays symmetric — see setChecked's note.
     el.checked = looseEqual(value.innerRef.value, applyCoerce(getValue(el), value))
     el._lastAppliedModel = value.innerRef.value
+    // External model changes that don't trigger a host re-render re-run
+    // the same checked computation the `beforeUpdate` path uses. Not
+    // focus-gated: an external change must reflect even on a focused
+    // radio, and writing `el.checked` is atomic.
+    setupValueSync(el, value.innerRef, () => {
+      el.checked = looseEqual(value.innerRef.value, applyCoerce(getValue(el), value))
+      el._lastAppliedModel = value.innerRef.value
+    })
   },
   // Skip the DOM sync when the model is identity-unchanged from the
   // last application. Pre-fix the guard read `value.innerRef.value
@@ -1139,7 +1166,17 @@ const vRegisterSelect: RegisterSelectCustomDirective = {
   // <option>s.
   mounted(el, { value }) {
     setSelected(el, value)
-    if (isRegisterValue(value)) el._lastAppliedModel = value.innerRef.value
+    if (!isRegisterValue(value)) return
+    el._lastAppliedModel = value.innerRef.value
+    // External model changes that don't trigger a host re-render re-run
+    // the same `setSelected` the `updated` path uses. The `_assigning`
+    // guard short-circuits the mid-click window (mousedown → change) so
+    // an in-progress multi-select isn't clobbered, matching `updated`.
+    setupValueSync(el, value.innerRef, () => {
+      if (el._assigning === true) return
+      setSelected(el, value)
+      el._lastAppliedModel = value.innerRef.value
+    })
   },
   beforeUpdate(el, binding, vnode) {
     setAssignFunction(el, vnode, binding.value)

--- a/test/core/directive-external-update.test.ts
+++ b/test/core/directive-external-update.test.ts
@@ -1,0 +1,138 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Regression: a `v-register` text input must reflect form changes that
+ * originate OUTSIDE the host component — cross-tab sync
+ * (`applyFormReplacement`), a sibling component's `setValue` / `reset` /
+ * `clear`, or any imperative store write while the bound component's
+ * template reads no field state (a display-only form never re-renders).
+ *
+ * The directive's `beforeUpdate` hook only re-syncs `el.value` on a host
+ * re-render. The value-sync watch (`setupValueSync`, run from `mounted`)
+ * is what catches the no-re-render case. Without it the store updates but
+ * the `<input>` stays stale — the multi-tab demo's exact failure, where a
+ * patch received from another tab landed in the store yet never repainted
+ * the input.
+ *
+ * These exercise the directive hooks directly (no Vue render cycle) so the
+ * only thing under test is the reactive DOM sync. The mock RegisterValue
+ * mirrors the one in directive-prop-reactivity.test.ts.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { computed, nextTick, ref, type Ref } from 'vue'
+import type { DirectiveBinding } from 'vue'
+import { vRegister } from '../../src/runtime/core/directive'
+import { createPersistOptInRegistry } from '../../src/runtime/core/persistence/opt-in-registry'
+import type { PathKey } from '../../src/runtime/core/paths'
+import type { InternalRegisterValue, RegisterValue } from '../../src/runtime/types/types-api'
+
+type MutableMockRv<T> = {
+  -readonly [K in keyof InternalRegisterValue<T>]: InternalRegisterValue<T>[K]
+}
+
+function makeRegisterValue<T>(initial: T): MutableMockRv<T> {
+  const innerRef = ref(initial)
+  return {
+    innerRef: innerRef as InternalRegisterValue<T>['innerRef'],
+    displayValue: computed(() => {
+      const v = innerRef.value
+      return v == null ? '' : String(v)
+    }) as Readonly<Ref<string>>,
+    markBlank: () => true,
+    markInteracted: () => undefined,
+    lastTypedForm: ref<string | null>(null),
+    registerElement: vi.fn(),
+    deregisterElement: vi.fn(),
+    setValueWithInternalPath: vi.fn(() => true),
+    markConnectedOptimistically: () => undefined,
+    path: 'mock' as PathKey,
+    segments: Object.freeze(['mock']),
+    formKey: 'mock-form',
+    formInstanceId: 'mock-inst',
+    persist: false,
+    acknowledgeSensitive: false,
+    persistOptIns: createPersistOptInRegistry(),
+    isSensitivePath: () => false,
+    multiTab: true,
+    acceptsUndefined: false,
+    acceptsString: true,
+  }
+}
+
+function makeBinding<T>(rv: RegisterValue<T>): DirectiveBinding {
+  return {
+    value: rv,
+    oldValue: null,
+    modifiers: {},
+    arg: undefined,
+    dir: {},
+    instance: null,
+  } as unknown as DirectiveBinding
+}
+
+type FakeVNode = { props: Record<string, unknown> }
+type DirectiveHook = (el: Element, binding: DirectiveBinding, vnode: FakeVNode, prev: null) => void
+const hooks = vRegister as unknown as {
+  created?: DirectiveHook
+  mounted?: DirectiveHook
+  beforeUnmount?: DirectiveHook
+}
+
+// Set the store-side value the way an external writer would — straight
+// onto `innerRef`, with no directive hook and no component render.
+function writeExternally<T>(rv: MutableMockRv<T>, next: T): void {
+  ;(rv.innerRef as { value: T }).value = next
+}
+
+async function mountInput(
+  initial: string
+): Promise<{ input: HTMLInputElement; rv: MutableMockRv<unknown> }> {
+  const input = document.createElement('input')
+  input.type = 'text'
+  document.body.appendChild(input)
+  const rv = makeRegisterValue<unknown>(initial)
+  const vnode: FakeVNode = { props: { type: 'text' } }
+  hooks.created?.(input, makeBinding(rv), vnode, null)
+  hooks.mounted?.(input, makeBinding(rv), vnode, null)
+  await nextTick()
+  return { input, rv }
+}
+
+describe('v-register — external store updates reach the DOM without a re-render', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('repaints the input when the value changes outside the component', async () => {
+    const { input, rv } = await mountInput('')
+    expect(input.value).toBe('')
+
+    writeExternally(rv, 'from-another-tab')
+    await nextTick()
+
+    expect(input.value).toBe('from-another-tab')
+  })
+
+  it('leaves the input alone while it is focused (caret safety)', async () => {
+    const { input, rv } = await mountInput('')
+    input.focus()
+    expect(document.activeElement).toBe(input)
+
+    writeExternally(rv, 'remote-edit')
+    await nextTick()
+
+    // The keystroke path + beforeUpdate own the focused case; the watch
+    // must not yank the user's caret mid-edit.
+    expect(input.value).toBe('')
+  })
+
+  it('stops mirroring after beforeUnmount', async () => {
+    const { input, rv } = await mountInput('')
+    hooks.beforeUnmount?.(input, makeBinding(rv), { props: { type: 'text' } }, null)
+
+    writeExternally(rv, 'after-unmount')
+    await nextTick()
+
+    expect(input.value).toBe('')
+  })
+})

--- a/test/core/directive-external-update.test.ts
+++ b/test/core/directive-external-update.test.ts
@@ -98,6 +98,82 @@ async function mountInput(
   return { input, rv }
 }
 
+async function mountTextarea(
+  initial: string
+): Promise<{ el: HTMLTextAreaElement; rv: MutableMockRv<unknown> }> {
+  const el = document.createElement('textarea')
+  document.body.appendChild(el)
+  const rv = makeRegisterValue<unknown>(initial)
+  const vnode: FakeVNode = { props: {} }
+  hooks.created?.(el, makeBinding(rv), vnode, null)
+  hooks.mounted?.(el, makeBinding(rv), vnode, null)
+  await nextTick()
+  return { el, rv }
+}
+
+async function mountCheckbox(
+  initial: unknown
+): Promise<{ el: HTMLInputElement; rv: MutableMockRv<unknown> }> {
+  const el = document.createElement('input')
+  el.type = 'checkbox'
+  document.body.appendChild(el)
+  const rv = makeRegisterValue<unknown>(initial)
+  const vnode: FakeVNode = { props: { type: 'checkbox' } }
+  hooks.created?.(el, makeBinding(rv), vnode, null)
+  hooks.mounted?.(el, makeBinding(rv), vnode, null)
+  await nextTick()
+  return { el, rv }
+}
+
+async function mountRadio(
+  optionValue: string,
+  initial: unknown
+): Promise<{ el: HTMLInputElement; rv: MutableMockRv<unknown> }> {
+  const el = document.createElement('input')
+  el.type = 'radio'
+  el.value = optionValue
+  document.body.appendChild(el)
+  const rv = makeRegisterValue<unknown>(initial)
+  const vnode: FakeVNode = { props: { type: 'radio' } }
+  hooks.created?.(el, makeBinding(rv), vnode, null)
+  hooks.mounted?.(el, makeBinding(rv), vnode, null)
+  await nextTick()
+  return { el, rv }
+}
+
+function makeSelect(options: string[], multiple: boolean): HTMLSelectElement {
+  const select = document.createElement('select')
+  if (multiple) select.multiple = true
+  for (const v of options) {
+    const opt = document.createElement('option')
+    opt.value = v
+    opt.text = v
+    select.appendChild(opt)
+  }
+  return select
+}
+
+async function mountSelect(
+  options: string[],
+  initial: unknown,
+  multiple = false
+): Promise<{ select: HTMLSelectElement; rv: MutableMockRv<unknown> }> {
+  const select = makeSelect(options, multiple)
+  document.body.appendChild(select)
+  const rv = makeRegisterValue<unknown>(initial)
+  const vnode: FakeVNode = { props: {} }
+  hooks.created?.(select, makeBinding(rv), vnode, null)
+  hooks.mounted?.(select, makeBinding(rv), vnode, null)
+  await nextTick()
+  return { select, rv }
+}
+
+function selectedValues(select: HTMLSelectElement): string[] {
+  return Array.prototype.filter
+    .call(select.options, (o: HTMLOptionElement) => o.selected)
+    .map((o: HTMLOptionElement) => o.value)
+}
+
 describe('v-register — external store updates reach the DOM without a re-render', () => {
   beforeEach(() => {
     document.body.innerHTML = ''
@@ -134,5 +210,117 @@ describe('v-register — external store updates reach the DOM without a re-rende
     await nextTick()
 
     expect(input.value).toBe('')
+  })
+
+  it('repaints a textarea on an external change', async () => {
+    const { el, rv } = await mountTextarea('')
+    expect(el.value).toBe('')
+
+    writeExternally(rv, 'multi\nline')
+    await nextTick()
+
+    expect(el.value).toBe('multi\nline')
+  })
+})
+
+describe('v-register checkbox — external updates without a re-render', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('reflects an external boolean change', async () => {
+    const { el, rv } = await mountCheckbox(false)
+    expect(el.checked).toBe(false)
+
+    writeExternally(rv, true)
+    await nextTick()
+
+    expect(el.checked).toBe(true)
+  })
+
+  it('reflects even while focused (checkboxes are not focus-gated, unlike text)', async () => {
+    const { el, rv } = await mountCheckbox(false)
+    el.focus()
+    expect(document.activeElement).toBe(el)
+
+    writeExternally(rv, true)
+    await nextTick()
+
+    expect(el.checked).toBe(true)
+  })
+
+  it('stops mirroring after beforeUnmount', async () => {
+    const { el, rv } = await mountCheckbox(false)
+    hooks.beforeUnmount?.(el, makeBinding(rv), { props: { type: 'checkbox' } }, null)
+
+    writeExternally(rv, true)
+    await nextTick()
+
+    expect(el.checked).toBe(false)
+  })
+})
+
+describe('v-register radio — external updates without a re-render', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('checks and unchecks as the external model moves on / off its value', async () => {
+    const { el, rv } = await mountRadio('a', '')
+    expect(el.checked).toBe(false)
+
+    writeExternally(rv, 'a')
+    await nextTick()
+    expect(el.checked).toBe(true)
+
+    writeExternally(rv, 'b')
+    await nextTick()
+    expect(el.checked).toBe(false)
+  })
+
+  it('stops mirroring after beforeUnmount', async () => {
+    const { el, rv } = await mountRadio('a', '')
+    hooks.beforeUnmount?.(el, makeBinding(rv), { props: { type: 'radio' } }, null)
+
+    writeExternally(rv, 'a')
+    await nextTick()
+
+    expect(el.checked).toBe(false)
+  })
+})
+
+describe('v-register select — external updates without a re-render', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('reflects an external change on a single select', async () => {
+    const { select, rv } = await mountSelect(['a', 'b', 'c'], 'a')
+    expect(select.value).toBe('a')
+
+    writeExternally(rv, 'b')
+    await nextTick()
+
+    expect(select.value).toBe('b')
+  })
+
+  it('reflects an external change on a multi-select', async () => {
+    const { select, rv } = await mountSelect(['a', 'b', 'c'], ['a'], true)
+    expect(selectedValues(select)).toEqual(['a'])
+
+    writeExternally(rv, ['a', 'c'])
+    await nextTick()
+
+    expect(selectedValues(select).sort()).toEqual(['a', 'c'])
+  })
+
+  it('stops mirroring after beforeUnmount', async () => {
+    const { select, rv } = await mountSelect(['a', 'b', 'c'], 'a')
+    hooks.beforeUnmount?.(select, makeBinding(rv), { props: {} }, null)
+
+    writeExternally(rv, 'b')
+    await nextTick()
+
+    expect(select.value).toBe('a')
   })
 })

--- a/test/core/multi-tab-sync-no-plugin.test.ts
+++ b/test/core/multi-tab-sync-no-plugin.test.ts
@@ -47,6 +47,9 @@ type SyncForm = {
     readonly password: string
     readonly comment: string
   }
+  readonly fields: {
+    readonly username: { readonly connected: boolean }
+  }
   setValue: (path: string, value: unknown) => boolean
 }
 
@@ -225,5 +228,58 @@ describe('multi-tab sync — no-plugin lazy-install path', () => {
     // Local-side state still carries the password (the sensitive
     // filter is an outbound/inbound gate, not a local write block).
     expect(formA.values.password).toBe('hunter2')
+  })
+})
+
+describe('multi-tab sync — state crosses tabs with no registered components', () => {
+  it('a programmatic setValue in tab A syncs to tab B though neither tab binds an input', async () => {
+    const captureA: { form?: SyncForm } = {}
+    const captureB: { form?: SyncForm } = {}
+
+    // Both apps render an empty <div> via `mountBareApp` — no v-register,
+    // so `register()` is never called and no field is ever connected to a
+    // DOM element. This isolates the cross-tab contract from the DOM.
+    const appA = mountBareApp(() => {
+      captureA.form = useForm({
+        schema,
+        key: 'multitab-headless',
+        multiTab: true,
+        defaultValues: { username: '', password: '', comment: '' },
+      }) as unknown as SyncForm
+    })
+    const appB = mountBareApp(() => {
+      captureB.form = useForm({
+        schema,
+        key: 'multitab-headless',
+        multiTab: true,
+        defaultValues: { username: '', password: '', comment: '' },
+      }) as unknown as SyncForm
+    })
+
+    const formA = captureA.form
+    const formB = captureB.form
+    if (formA === undefined || formB === undefined) throw new Error('setup did not capture form')
+
+    await waitForEstablished([appA, appB])
+
+    // Precondition: with no input bound, the field reports unconnected in
+    // both tabs — there is genuinely no registered component in play.
+    expect(formA.fields.username.connected).toBe(false)
+    expect(formB.fields.username.connected).toBe(false)
+
+    // Tab A writes purely through the store API — no DOM, no v-register.
+    expect(formA.setValue('username', 'alice')).toBe(true)
+
+    // Tab B's form STATE converges anyway. Cross-tab sync rides the
+    // store's `onFormChange` (which `setValue` fires), independent of any
+    // binding; the value-sync directive only matters for mirroring
+    // received state onto an input WHEN one is bound.
+    const synced = await waitFor(() =>
+      formB.values.username === 'alice' ? formB.values.username : undefined
+    )
+    expect(synced).toBe('alice')
+    // Still no component anywhere, and untouched fields keep their default.
+    expect(formB.fields.username.connected).toBe(false)
+    expect(formB.values.comment).toBe('')
   })
 })


### PR DESCRIPTION
## What

Three docs-site demo bugs surfaced through dogfooding, plus the core `v-register` reactivity defect they led to.

### Docs-site fixes
- **Breadcrumb + sidebar on trailing-slash URLs** (`cd398a2`) — pages render to `foo/index.html`, so Pagefind / canonical links carry a trailing slash while the nav `to` values don't; the exact `=== route.path` match missed. Normalized via one shared `normalizePath`.
- **Fields demo SSR hydration mismatch** (`06b2431`) — `toLocaleTimeString()` of a creation-stamped `updatedAt` can't match server vs client; gated behind a mounted ref.
- **Dev search index hygiene** (`b490c7b`) — `index-search-dev.mjs` never purged its output dir, so removed routes left orphaned Pagefind fragments (490 for 83 live pages). Clear the dir before writing.

### The real multi-tab fix (core)
Multi-tab sync in the playground "didn't work", but the transport was fine. Root cause: the `v-register` directive wrote the DOM only in `mounted` / `beforeUpdate` / `updated`, which fire on a host re-render. A form change from *outside* the component (cross-tab sync, a sibling's `setValue` / `reset` / `clear`) updated the store but never repainted the control when nothing re-rendered.

- **`dfa2ad8`** — reactive value-sync watch for text / textarea (`directive-value-sync.ts`).
- **`4b79faf`** — extended to checkbox, radio, select, reusing each variant's existing DOM-write.
- **`e745adc`** — test pinning that state crosses tabs from `setValue` with no registered components.
- `a9695c6` (a "frame-local" band-aid) is reverted by `1ff42eb` once the real fix landed.

## Verification
Full suite green (3778 tests); Playwright two-tab sync confirmed end to end; lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)