### PR TITLE
chore: add fallow code-intelligence (non-gating)

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
+
+  // Calibration for fallow's static analysis. The guiding rule mirrors
+  // scripts/check-eager-size.mjs: only suppress PROVEN false positives,
+  // and document why each one is noise. Anything fallow flags that is a
+  // genuine candidate (e.g. an actually-unreferenced devDep) is left
+  // visible on purpose so the signal stays honest.
+
+  // ── Dependencies ────────────────────────────────────────────────
+  // Only entries fallow cannot trace because the consumer is a config
+  // file / plugin-host auto-discovery, or the dep is deliberately
+  // peer / transitive / hoisted. The other 10 flagged devDeps
+  // (@typescript-eslint/*, @nuxt/eslint-config, eslint-config-prettier,
+  // @nuxt/module-builder, @vue/language-server, @vue/typescript-plugin,
+  // changelogen, immer, vite-plugin-dts) are NOT listed here: they have
+  // no code/config reference and are real "still needed?" candidates.
+  "ignoreDependencies": [
+    // Consumed by size-limit's preset auto-discovery; never imported by
+    // name, so fallow's module graph can't see the edge.
+    "@size-limit/preset-small-lib",
+    // Required peer of @fast-check/vitest. Property tests import `fc`
+    // from the wrapper, which re-exports fast-check.
+    "fast-check",
+    // Type-only import in .size-limit.js (`import('esbuild').BuildOptions`)
+    // plus transitive runtime use by size-limit and check-eager-size.mjs.
+    // Deliberately not a root direct dep (zero-runtime-deps posture).
+    "esbuild",
+    // apps/site demos + nuxt.config.ts import `zod` through the
+    // root-hoisted copy rather than declaring it in apps/site/package.json.
+    // Arguably real workspace hygiene; suppressed as a deliberate hoist.
+    "zod",
+    // apps/site/nuxt.config.ts; `npm:zod@^3.24` alias fallow doesn't
+    // decode, same root-hoist story as `zod`.
+    "zod-v3"
+  ],
+
+  // ── Unresolved imports ──────────────────────────────────────────
+  // The lone unresolved import is a Docker-absolute path string
+  // (`/app/src/<entry>.ts`) that fallow's tokenizer lifts out of a
+  // docstring in test/docs-site-source-alias-symmetry.test.ts (the
+  // jiti-shim staleness explanation). No real import; never resolvable
+  // on the host.
+  "ignoreUnresolvedImports": ["/app/**"],
+
+  // ── Duplication ─────────────────────────────────────────────────
+  // Duplication is a source-DRY signal, so scope it to the shipped
+  // library. The bulk of the raw 18.6% is DELIBERATE: the zod v3/v4
+  // parity test batteries (mirrored by design) and the parallel
+  // teaching demos. Excluding test/bench/scripts/apps leaves real src/
+  // duplication, which still surfaces the intentional v3<->v4 adapter
+  // twin for inspection.
+  "duplicates": {
+    "ignore": ["test/**", "bench/**", "scripts/**", "apps/site/**"],
+    // Strip import blocks from clone detection — sorted import lists
+    // look alike everywhere and aren't copy-paste worth refactoring.
+    "ignoreImports": true
+  },
+
+  // ── Complexity / hotspots ───────────────────────────────────────
+  // Measure product code (src/ library + apps/site docs site). Drop
+  // test trees (a 600-line `describe` arrow is not a "large function")
+  // and one-off build/release scripts.
+  "health": {
+    "ignore": ["test/**", "bench/**", "scripts/**"]
+  }
+}

--- a/.github/workflows/fallow.yml
+++ b/.github/workflows/fallow.yml
@@ -1,0 +1,94 @@
+name: Fallow
+
+# Non-gating code-intelligence pass: unused code, dependency hygiene,
+# duplication, circular dependencies, and complexity hotspots. This job
+# NEVER blocks a merge — every step is best-effort and the job is marked
+# continue-on-error, so a finding (or a fallow crash) can't fail CI. The
+# report lands in the run's Step Summary for a reviewer to glance at.
+#
+# Calibrated by .fallowrc.jsonc (only proven false positives suppressed),
+# so the findings here mirror a local `make fallow` / `pnpm fallow` run.
+# CRAP/complexity is ESTIMATED here (no coverage in this lightweight job);
+# for coverage-accurate CRAP, run fallow locally against a coverage file.
+#
+# Dependency-free by design: fallow is fetched with a pinned
+# `npx fallow@<version>` rather than added to the lockfile, matching the
+# project's zero-runtime-deps posture. Bump FALLOW_VERSION to adopt a new
+# release (mirror the pin in package.json's `fallow` script).
+#
+# Telemetry is hard-disabled via env (DO_NOT_TRACK + FALLOW_TELEMETRY).
+# fallow's telemetry is opt-in / off-by-default anyway; this pins it off
+# regardless of any machine-local config.
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    branches: ['main']
+  workflow_dispatch:
+
+# Cancel superseded runs on the same ref (mirrors the test-suite workflow).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Single source of truth for the pinned fallow release in CI. Keep in
+  # lockstep with the `fallow` script in package.json.
+  FALLOW_VERSION: '2.88.3'
+  DO_NOT_TRACK: '1'
+  FALLOW_TELEMETRY: '0'
+  NO_COLOR: '1'
+
+jobs:
+  analyze:
+    name: Code intelligence (non-gating)
+    runs-on: ubuntu-latest
+    # Belt-and-suspenders non-gating: even an infra/step failure is
+    # reported neutral and never blocks a PR.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # fallow reads git history for churn / hotspot trends; a shallow
+          # clone would empty them out.
+          fetch-depth: 0
+          # CI-only job; no git push needs the token on the working tree.
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 'lts/*'
+
+      # No pnpm install: fallow analyzes the source tree + package.json +
+      # git directly. Skipping the install keeps this job light and the
+      # cache surface zero. Import-resolution findings (unresolved /
+      # unlisted) are best read from a local run with node_modules present;
+      # .fallowrc.jsonc already settles the known ones.
+      - name: Run fallow (dead code, duplication, complexity)
+        run: |
+          npx --yes "fallow@${FALLOW_VERSION}" --score --format markdown \
+            > fallow-report.md 2> fallow-stderr.txt || true
+
+      - name: Publish report to job summary
+        if: always()
+        run: |
+          {
+            echo "## 🌱 Fallow — code intelligence (non-gating)"
+            echo
+            echo "Calibrated by \`.fallowrc.jsonc\`. CRAP/complexity is **estimated** (no coverage in this job). Informational only — never gates a merge."
+            echo
+            if [ -s fallow-report.md ]; then
+              cat fallow-report.md
+            else
+              echo '> fallow produced no report. stderr:'
+              echo
+              echo '```'
+              cat fallow-stderr.txt 2>/dev/null || echo '(no stderr captured)'
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build up down clean clean-orphans restart logs shell install test test-watch lint format check prepare typecheck bundle-repl publish-prep watch watch-bg unwatch
+.PHONY: help build up down clean clean-orphans restart logs shell install test test-watch lint format check fallow prepare typecheck bundle-repl publish-prep watch watch-bg unwatch
 .DEFAULT_GOAL := help
 
 CONTAINER := attaform-dev
@@ -72,6 +72,17 @@ format:  ## Format
 
 check:  ## Lint + format check + typecheck
 	docker compose exec attaform pnpm check
+
+# Non-gating code-intelligence pass (unused code, dependency hygiene,
+# duplication, circular deps, complexity). Reads the calibrated
+# .fallowrc.jsonc; telemetry hard-disabled via the `fallow` script env.
+# fallow is fetched with a pinned `npx fallow@<version>` (see the `fallow`
+# script in package.json) rather than added to the lockfile, keeping the
+# zero-runtime-deps posture intact. Runs in-container like the rest, so it
+# shares the dev env (and a future coverage variant path-matches without
+# a host/container remap).
+fallow:  ## Run fallow code-intelligence (unused code, dupes, complexity) — non-gating
+	docker compose exec attaform pnpm fallow
 
 typecheck:  ## TypeScript check
 	docker compose exec attaform pnpm typecheck

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "check:bench": "node scripts/check-bench.mjs",
     "check:bundled-types": "node scripts/check-bundled-types.mjs",
     "check:site": "pnpm dev:prepare && pnpm --filter attaform-site typecheck",
+    "fallow": "DO_NOT_TRACK=1 FALLOW_TELEMETRY=0 npx --yes fallow@2.88.3 --score",
     "version": "node scripts/promote-changelog.mjs && (node scripts/generate-release-notes.mjs || echo '[version] release-notes step failed; continuing') && git add CHANGELOG.md RELEASES.md",
     "prepare": "husky"
   },


### PR DESCRIPTION
## What

Wires [fallow](https://github.com/fallow-rs/fallow) (a Rust static analyzer for TS/JS: unused code, dependency hygiene, duplication, circular dependencies, complexity hotspots) as **non-gating** code-intelligence, both locally and in CI.

## Why

Attaform had no standing dead-code / dependency-hygiene / duplication signal. This adds one as a recurring, evidence-backed pass that complements the existing byte/correctness gates (size, eager, bench, CodeQL, scorecard) without ever blocking a merge.

## How to use

- **Local:** `make fallow` (in-container) or `pnpm fallow` (host).
- **CI:** the `Fallow` workflow runs on PRs/pushes to `main` and on manual dispatch, posting the full report to the run's **Step Summary**. Informational only.

## Design

- **Never gates.** The analysis step ends in `|| true` and the job is `continue-on-error: true`, so a finding (or a fallow crash) can't red a PR.
- **Zero new deps.** fallow is fetched via pinned `npx fallow@2.88.3` (the `fallow` script + the workflow's `FALLOW_VERSION`); nothing enters the lockfile. Bump both pins together.
- **Telemetry hard-off** via `DO_NOT_TRACK` + `FALLOW_TELEMETRY` (it's opt-in / off-by-default upstream regardless).
- **Calibrated** by `.fallowrc.jsonc`, which suppresses only proven false positives and documents each. Duplication 18.6% → 2.4% (scoped to `src/`, excluding the deliberate v3/v4 parity test mirrors); large-function noise 607 → 113 (test `describe` trees excluded).

## What it surfaces (not fixed here)

Instrumentation only. The calibrated run flags, for later triage:

- 4 circular dependencies in the directive/register layer (real value imports).
- 10 devDependencies with no code/config reference (e.g. `@typescript-eslint/*` superseded by the `typescript-eslint` meta-package, `changelogen`, `immer`, `vite-plugin-dts`).
- 2 unused prod deps (`better-sqlite3`, `satori`) and 2 unreferenced scripts.
- One genuine coverage hotspot: `src/runtime/adapters/zod-v4/strip.ts` `recurse` (52 cyclomatic at 51% coverage).

CRAP/complexity in the CI job is estimated (no coverage there); a local run against a coverage file de-inflates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
