### PR TITLE
fix(directive): silence false v-register no-op warn during async SSR hydration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,18 @@
 
 ## Unreleased
 
-_No unreleased changes yet._
+### Fixed
+
+- **No false `v-register` no-op warning during SSR hydration.** A custom field
+  wrapper that follows the recommended pattern (a non-input root that calls
+  `useRegister()` and re-binds `v-register` onto an inner native input) stayed
+  silent on a fresh client mount but warned on every server-rendered page,
+  because its suppression marker landed a tick after the directive's deferred
+  no-op check on the async-hydration path. The check now runs from the
+  directive's `mounted` hook, which always settles after the wrapper's own
+  mount, so the marker is in place before the check reads it. The warning still
+  fires for a genuinely unsupported root, on both fresh mount and hydration.
+  (#370)
 
 ## v0.21.1
 ### Added

--- a/src/runtime/core/directive.ts
+++ b/src/runtime/core/directive.ts
@@ -1019,9 +1019,18 @@ function getCheckboxValue(
 // `assignKey` / `@update:registerValue` shapes flow through.
 //
 // The dev-warn for the "no escape hatch" case is deferred to the
-// next tick after `created`, so `useRegister`'s `onMounted` marker
-// has a chance to set `REGISTER_OWNER_MARKER` on the rendered root
-// before the warn check runs. Without the deferral, deeply-nested
+// next tick after the directive's `mounted` hook, so `useRegister`'s
+// `onMounted` marker has a chance to set `REGISTER_OWNER_MARKER` on
+// the rendered root before the warn check runs. The anchor is
+// `mounted`, NOT `created`, on purpose: `mounted` always runs inside
+// a real scheduler post-flush (fresh mount AND the Suspense/async-
+// hydration path), so the `nextTick` chained from it reliably
+// resolves after the owning child's post-flush `onMounted`. Anchoring
+// from `created` races during async hydration — the directive hook
+// then runs inside a bare `Promise.then` (registerDep / Suspense)
+// with no active flush, so a `created`-scheduled `nextTick` is a bare
+// microtask that fires before the marker is set, warning falsely on
+// every SSR'd wrapper. Without any deferral, deeply-nested
 // `useRegister` children would always warn (the directive can't
 // reach the child instance via `binding.instance` — that's the
 // page/parent component, whose `subTree` is the outer element tree,
@@ -1053,13 +1062,22 @@ const vRegisterDynamic: RegisterModelDynamicCustomDirective = {
     // the gated display state for async ticks. No-op when the binding
     // disabled aria or carries no display-state accessor.
     if (isRegisterValue(binding.value)) setupAria(el as AriaCarrier, binding.value, vnode)
+  },
+  mounted(el, binding, vnode) {
+    callModelHook(el, binding, vnode, null, 'mounted')
 
-    // Defer the unsupported-element warn to nextTick. By then:
+    // Defer the unsupported-element warn one tick past `mounted`. By the
+    // time this resolves:
     //  - useRegister's onMounted has run, setting REGISTER_OWNER_MARKER
     //    on the el if the child component called useRegister()
     //  - any post-install assignKey override (via onMounted /
     //    ref-callback) is in place, so the assigner isn't default
     // anymore. The warn fires only when neither escape hatch was used.
+    // Anchoring on `mounted` rather than `created` is what makes this
+    // hold on the async-hydration path (see the directive-level note
+    // above the dedupe set): `mounted` always runs inside a real
+    // post-flush, so this `nextTick` resolves after the owning child's
+    // `onMounted`, never before it.
     if (
       __DEV__ &&
       warnedUnsupportedElements !== null &&
@@ -1084,9 +1102,6 @@ const vRegisterDynamic: RegisterModelDynamicCustomDirective = {
         )
       })
     }
-  },
-  mounted(el, binding, vnode) {
-    callModelHook(el, binding, vnode, null, 'mounted')
   },
   beforeUpdate(el, binding, vnode, prevVNode) {
     // Reactive opt-in toggling: `register('foo', { persist: rememberMe })`

--- a/test/composables/v-register-component-runtime.test.ts
+++ b/test/composables/v-register-component-runtime.test.ts
@@ -8,7 +8,7 @@ import { assignKey, vRegister } from '../../src/runtime/core/directive'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import { useRegister } from '../../src/runtime/composables/use-register'
 import type { RegisterValue } from '../../src/runtime/types/types-api'
-import { waitUntil } from '../utils/form-harness'
+import { awaitSettle, waitUntil } from '../utils/form-harness'
 
 /**
  * Runtime contract for `<MyComponent v-register="register(...)" />`.
@@ -100,13 +100,14 @@ async function mountWithChild(
   const root = document.createElement('div')
   document.body.appendChild(root)
   app.mount(root)
-  // The directive's "is a no-op" warn is deferred via `nextTick` so
-  // that `useRegister`'s `onMounted` marker (and any post-install
-  // assignKey) has a chance to land before the warn check runs.
-  // Wait until the api is captured AND the rendered root has been
-  // committed; that gives the deferred-warn microtask time to settle
-  // before the spy is restored.
+  // The directive's "is a no-op" warn is deferred a tick past its
+  // `mounted` hook so that `useRegister`'s `onMounted` marker (and any
+  // post-install assignKey) has a chance to land before the warn check
+  // runs. Wait until the api is captured AND the rendered root has been
+  // committed, then settle the microtask queue so the post-mount warn
+  // tick has fired before the spy is restored.
   await waitUntil(() => (handle.api !== undefined && root.firstElementChild !== null ? true : null))
+  await awaitSettle()
   warnSpy.mockRestore()
 
   const rootEl = root.firstElementChild as HTMLElement | null

--- a/test/composables/v-register-hydration-warn.test.ts
+++ b/test/composables/v-register-hydration-warn.test.ts
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+//
+// Regression for the false `v-register` "no-op on <div>" warning that
+// fires during SSR async hydration even when the consumer follows the
+// prescribed delegation pattern (a custom field-wrapper whose <div> root
+// calls useRegister() and re-binds v-register onto an inner native
+// <input>). Surfaced from the Cubic Housing app: every SSR'd form page
+// emitted one warning per field, and the message prescribes the exact
+// fix that was already applied, so it actively misdirects.
+//
+// Root cause is a marker-timing race. useRegister() sets
+// REGISTER_OWNER_MARKER on the wrapper's root element in its onMounted;
+// the vRegister directive defers its unsupported-root warn-check and
+// skips when the marker is present. On a fresh client mount the
+// directive's deferral resolves after the post-flush onMounted (marker
+// set first → silent). Under async hydration the directive hook runs
+// inside a deferred Promise.then (registerDep / Suspense) with no active
+// scheduler flush, so a bare-microtask deferral fires BEFORE the
+// component's post-flush onMounted sets the marker → false warning.
+//
+// The async-setup ancestor under <Suspense> is what forces the
+// async-hydration path (registerDep + hydrateSuspense), reproducing
+// Nuxt's lazy page/layout hydration. A plain sync mount will NOT
+// reproduce it — the existing fresh-mount coverage in
+// v-register-component-runtime.test.ts (pattern 2) stays green either
+// way.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  Suspense,
+  createSSRApp,
+  defineComponent,
+  h,
+  nextTick,
+  withDirectives,
+  type App,
+  type Component,
+} from 'vue'
+import { renderToString } from '@vue/server-renderer'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { useRegister } from '../../src'
+import { vRegister } from '../../src/runtime/core/directive'
+import { createAttaform } from '../../src/runtime/core/plugin'
+
+const schema = z.object({ email: z.string() })
+
+// Correctly-implemented field wrapper: <div> root, useRegister(), and
+// the captured register re-bound onto an inner native <input>. Exactly
+// what the warning prescribes — so it must NOT warn.
+const Field = defineComponent({
+  name: 'Field',
+  inheritAttrs: false,
+  setup() {
+    const rv = useRegister()
+    return () =>
+      h('div', { class: 'field' }, [
+        withDirectives(h('input', { type: 'text' }), [[vRegister, rv]]),
+      ])
+  },
+})
+
+// A genuinely unsupported wrapper: a <div> root with NO useRegister and
+// no custom assigner. This is the case the warn EXISTS for — the fix
+// must keep warning here, including under hydration, or it would have
+// blanket-suppressed a real diagnostic instead of fixing the race.
+const BareDiv = defineComponent({
+  name: 'BareDiv',
+  inheritAttrs: false,
+  setup() {
+    return () => h('div', { class: 'bare' }, 'no useRegister here')
+  },
+})
+
+// Parent owns the form and applies v-register to the wrapper COMPONENT
+// (the directive lands on the wrapper's root <div>). Passing the same
+// RegisterValue as the `registerValue` attr mirrors what
+// componentBridgeTransform injects in real templates, so the child's
+// useRegister() binds for real (no collateral no-parent-RV warn).
+function makeParent(Wrapper: Component, key: string, bridge: boolean): Component {
+  return defineComponent({
+    name: 'Parent',
+    setup() {
+      const form = useForm({ schema, key, defaultValues: { email: '' } })
+      return () => {
+        const rv = form.register('email')
+        const props = bridge ? { registerValue: rv } : {}
+        return withDirectives(h(Wrapper, props), [[vRegister, rv]])
+      }
+    },
+  })
+}
+
+// The async-setup ancestor under <Suspense> forces the async-hydration
+// path (registerDep + hydrateSuspense), reproducing Nuxt's lazy
+// page/layout hydration.
+function asyncHydrationApp(Inner: Component): Component {
+  const AsyncBoundary = defineComponent({
+    name: 'AsyncBoundary',
+    async setup() {
+      await Promise.resolve()
+      return () => h(Inner)
+    },
+  })
+  return defineComponent({
+    name: 'App',
+    setup() {
+      return () => h(Suspense, null, { default: () => h(AsyncBoundary) })
+    },
+  })
+}
+
+// Async hydration completes over several microtasks (registerDep's
+// Promise.then + Suspense resolution) and the directive's deferred
+// warn-check is itself a post-flush nextTick, so drain both the micro-
+// and macro-task queues to make the warn assertion conclusive either
+// way (absence for the correct pattern, presence for genuine misuse).
+async function settle(): Promise<void> {
+  await nextTick()
+  await new Promise((resolve) => setTimeout(resolve, 10))
+  await nextTick()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+async function hydrate(AppComponent: Component): Promise<App> {
+  const html = await renderToString(createSSRApp(AppComponent).use(createAttaform()))
+  const container = document.createElement('div')
+  container.innerHTML = html
+  document.body.appendChild(container)
+  const app = createSSRApp(AppComponent).use(createAttaform())
+  app.mount(container)
+  await settle()
+  return app
+}
+
+describe('v-register no-op warn — SSR async hydration (marker-timing race)', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+  let warnings: string[]
+  let app: App | undefined
+
+  beforeEach(() => {
+    warnings = []
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+      warnings.push(args.map((a) => String(a)).join(' '))
+    })
+  })
+
+  afterEach(() => {
+    app?.unmount()
+    app = undefined
+    warnSpy.mockRestore()
+    document.body.innerHTML = ''
+  })
+
+  it('does NOT emit the no-op warning during async hydration of the prescribed useRegister wrapper', async () => {
+    app = await hydrate(asyncHydrationApp(makeParent(Field, 'hydration-warn-correct', true)))
+
+    const noop = warnings.filter((w) => w.includes('is a no-op'))
+    expect(noop).toEqual([])
+  })
+
+  it('STILL warns for a genuinely unsupported <div> root under the same async-hydration path', async () => {
+    app = await hydrate(asyncHydrationApp(makeParent(BareDiv, 'hydration-warn-misuse', false)))
+
+    const noop = warnings.filter((w) => w.includes('is a no-op'))
+    expect(noop.length).toBe(1)
+    expect(noop[0]).toContain('v-register on <div> is a no-op')
+  })
+})

--- a/test/core/directive-cleanup.test.ts
+++ b/test/core/directive-cleanup.test.ts
@@ -291,10 +291,12 @@ describe('v-register directive — D2 unsupported-element warning', () => {
     const binding = makeBinding(value)
     const vnode = makeVNode({})
     hooks.created?.(div, binding, vnode, null)
-    // Same element re-fires created (KeepAlive case); warn must not
-    // double-fire — WeakSet dedupe.
-    hooks.created?.(div, binding, vnode, null)
-    // The warn is deferred via `nextTick` so `useRegister`'s
+    hooks.mounted?.(div, binding, vnode, null)
+    // Same element re-fires the lifecycle (KeepAlive case); the warn
+    // must not double-fire — WeakSet dedupe. The warn-check lives in
+    // `mounted` (not `created`), so re-fire that hook.
+    hooks.mounted?.(div, binding, vnode, null)
+    // The warn is deferred a tick past `mounted` so `useRegister`'s
     // `onMounted` marker has a chance to land first. Flush before
     // asserting on the spy.
     await nextTick()
@@ -313,6 +315,7 @@ describe('v-register directive — D2 unsupported-element warning', () => {
     const binding = makeBinding(value)
     const vnode = makeVNode({})
     hooks.created?.(div, binding, vnode, null)
+    hooks.mounted?.(div, binding, vnode, null)
     await nextTick()
     const matched = warnSpy.mock.calls.filter((c: unknown[]) => String(c[0]).includes('is a no-op'))
     expect(matched.length).toBe(0)
@@ -327,6 +330,7 @@ describe('v-register directive — D2 unsupported-element warning', () => {
       const binding = makeBinding(value)
       const vnode = makeVNode({})
       hooks.created?.(el, binding, vnode, null)
+      hooks.mounted?.(el, binding, vnode, null)
     }
     await nextTick()
     const matched = warnSpy.mock.calls.filter((c: unknown[]) => String(c[0]).includes('is a no-op'))


### PR DESCRIPTION
## Summary

A false-positive `[attaform] v-register on <div> is a no-op …` dev-warning fired on every SSR'd form page that uses the prescribed `useRegister` delegation pattern (a custom field-wrapper whose `<div>` root calls `useRegister()` and re-binds `v-register` onto an inner native `<input>`). The warning prescribes the exact fix that was already applied, so it actively misdirected. Surfaced from the Cubic Housing app.

## Root cause

A marker-timing race. `useRegister` sets `REGISTER_OWNER_MARKER` in its post-flush `onMounted`; the directive's warn-check skips when that marker is present, deferring a tick to let it land. The deferral was anchored on the directive's `created` hook:

- **Fresh mount:** `created` runs inside a scheduler flush, so its `nextTick` chains onto the active flush and resolves *after* the post-flush `onMounted` (marker set → silent ✅).
- **Async hydration** (`registerDep` / `<Suspense>`): `created` runs inside a bare `Promise.then` with *no active flush*, so `nextTick` degrades to a bare microtask that fires *before* the child's later post-flush `onMounted` (marker absent → false warn ❌).

## Fix

Anchor the deferred warn-check on the directive's **`mounted`** hook instead of `created`. `mounted` always runs inside a real post-flush (fresh mount and Suspense hydration alike), so the chained `nextTick` reliably resolves after the owning child's `onMounted`, never before it.

Chosen over `queuePostFlushCb` (Vue `@internal`, fragile across versions) and a fixed second-tick (depends on an unstable microtask-hop count): `mounted` is a public, stable lifecycle anchor that structurally sits in a real post-flush.

## Tests

New `test/composables/v-register-hydration-warn.test.ts` asserts both directions under the async-hydration path:
- **The bug:** correct `useRegister` delegation → no warn.
- **The guard:** genuine `<div>` misuse (no `useRegister`, no assigner) → *still warns* under the same path (proves the race is fixed, not the warning muted).

Two timing-coupled existing tests aligned to the `mounted`-anchored deferral (no assertions weakened; the genuine-misuse warn still fires on fresh mount too).

## Verification

`typecheck` · full suite (4080 pass) · `lint` + prettier · `bench` (7.86× / 13.33× vs 3× floor, off the hot path) · `size` · `eager` (within budget) · `coverage` (above thresholds). `check:site` skipped (no site/docs changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)