### PR TITLE
ci: stabilize the Peer-Dep Matrix (smoke timing flake + pnpm 11 overrides)

### DIFF
--- a/.github/workflows/peer-matrix.yml
+++ b/.github/workflows/peer-matrix.yml
@@ -88,7 +88,7 @@ jobs:
         with:
           node-version: 22.x
 
-      - name: Inject pnpm.overrides for this matrix cell
+      - name: Inject pnpm-workspace.yaml overrides for this matrix cell
         env:
           # Bind matrix values into env vars so the `node -e` script
           # below reads them via `process.env` rather than YAML
@@ -101,18 +101,30 @@ jobs:
           MATRIX_VITE: ${{ matrix.vite }}
           MATRIX_NUXT: ${{ matrix.nuxt }}
         run: |
+          # pnpm 11 no longer reads the `pnpm` field in package.json, so
+          # the per-cell pins go into pnpm-workspace.yaml — the new home
+          # for `overrides` (https://pnpm.io/settings). Injecting into
+          # package.json instead would be silently ignored, leaving the
+          # matrix testing default-resolved versions rather than the
+          # pinned cell. The pins merge into the committed `overrides`
+          # block (whose `@nuxt/*: $nuxt` aliases then follow the `nuxt`
+          # pin injected here). No YAML library is installed at this
+          # step, so insert the three keys with a built-in text edit
+          # rather than a parse/serialize round-trip.
           node -e '
           const fs = require("fs");
-          const pkg = JSON.parse(fs.readFileSync("./package.json", "utf8"));
-          pkg.pnpm = pkg.pnpm ?? {};
-          pkg.pnpm.overrides = {
-            ...(pkg.pnpm.overrides ?? {}),
-            vue: process.env.MATRIX_VUE,
-            vite: process.env.MATRIX_VITE,
-            nuxt: process.env.MATRIX_NUXT,
-          };
-          fs.writeFileSync("./package.json", JSON.stringify(pkg, null, 2) + "\n");
-          console.log("applied overrides:", pkg.pnpm.overrides);
+          const file = "./pnpm-workspace.yaml";
+          const lines = fs.readFileSync(file, "utf8").split("\n");
+          const at = lines.findIndex((l) => /^overrides:[ \t]*$/.test(l));
+          if (at === -1) throw new Error("no overrides: block found in pnpm-workspace.yaml");
+          const pins = [
+            "  vue: " + process.env.MATRIX_VUE,
+            "  vite: " + process.env.MATRIX_VITE,
+            "  nuxt: " + process.env.MATRIX_NUXT,
+          ];
+          lines.splice(at + 1, 0, ...pins);
+          fs.writeFileSync(file, lines.join("\n"));
+          console.log("applied overrides:", pins.join(", "));
           '
 
       - name: Install with overrides

--- a/test/docs-demos/docs-demos-smoke.test.ts
+++ b/test/docs-demos/docs-demos-smoke.test.ts
@@ -1,10 +1,20 @@
 // @vitest-environment jsdom
 // eslint-disable-next-line spaced-comment
 /// <reference types="vite/client" />
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, h, nextTick, type App } from 'vue'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import { waitForPersistence, waitUntil } from '../utils/form-harness'
+
+// Every smoke case drives a real demo SFC with real timers (the
+// async-refinements demo alone simulates ~700ms of server latency).
+// Vitest's 5s default per-test budget is too tight for that under
+// full-suite load on a contended CI runner, where event-loop pressure
+// can push a real-timer resolution past a case's internal waitUntil
+// ceiling. Raise the file-wide budget so the waits settle on their own
+// terms; each gesture/assert still returns the moment state settles, so
+// this only lifts the ceiling, never the normal-case runtime.
+vi.setConfig({ testTimeout: 15_000 })
 
 /**
  * Smoke harness for the docs demos at `apps/site/docs-demos/**`. Each
@@ -1010,7 +1020,15 @@ const entries: SmokeEntry[] = [
   },
   {
     // Type "ada" (in the "taken" set), blur; the async refine
-    // resolves to a "taken" message after ~700ms.
+    // resolves to a "taken" message after ~700ms. The poll budget is
+    // deliberately generous (well above that 700ms): this case drives a
+    // real timer end-to-end, and on a contended CI runner under
+    // full-suite load the event loop can push the resolution past a
+    // tight ceiling. A 2000ms budget flaked on the Peer-Dep Matrix
+    // (the assertion ran against an empty <em> when the wait gave up at
+    // 2000ms) even though the pipeline resolved correctly. waitUntil
+    // returns the moment the message lands, so this only raises the
+    // ceiling, never the normal-case runtime (~720ms).
     slug: 'async-refinements',
     gesture: async (root) => {
       const username = root.querySelector<HTMLInputElement>('input')
@@ -1020,7 +1038,7 @@ const entries: SmokeEntry[] = [
       await dispatchBlur(username)
       await waitUntil(
         () => (root.querySelector('em')?.textContent?.includes('taken') === true ? true : null),
-        2000
+        5000
       )
     },
     assert: async (root) => {


### PR DESCRIPTION
Stabilizes the weekly Peer-Dep Matrix canary, which surfaced a failing `async-refinements` smoke test on the `Vue 3.5 latest / Vite 6 / Nuxt 3 latest` cell ([failed run](https://github.com/attaform/Attaform/actions/runs/27131118993)). Two independent issues, one commit each.

## 1. Smoke-timing flake (the reported failure)

`test(docs-demos)`. The `async-refinements` demo drives a real ~700ms server-latency timer; the smoke case polled only 2000ms for the resolved error. Under full-suite load on a contended 2-core runner the event loop pushed that resolution past 2000ms, so the assertion ran against an empty `<em>`. Confirmed a flake, not a bug:

- Passes deterministically locally on the same Vue 3.5.x, both isolated (~1.2s) and in the full 65-demo file (~720ms).
- A CI re-run on a fresh runner went green on all four cells.

Widened that case's poll budget to 5000ms and raised the file-wide per-test timeout to 15s (`vi.setConfig`). `waitUntil` returns the moment state settles, so this only lifts the ceiling, never the normal-case runtime.

## 2. pnpm 11 override injection (the CI warning)

`ci(peer-matrix)`. pnpm 11 no longer reads the `pnpm` field in package.json (the repo's own settings already moved to `pnpm-workspace.yaml`). But the matrix still injected its per-cell vue/vite/nuxt pins into `package.json#pnpm.overrides`, which pnpm 11 silently ignores with a warning. So **every cell was installing default-resolved versions instead of the pinned ones**, and the matrix had quietly stopped testing the peer-dep surface it claims to cover.

Now injects into the `pnpm-workspace.yaml` `overrides` block (the v11 home), merging above the committed overrides so the `@nuxt/*: $nuxt` aliases follow the injected `nuxt` pin. Verified locally that the injection produces valid YAML with all three pins applied and the committed overrides preserved.

Out of scope: the `Detected a pnpm v10 installation layout at PNPM_HOME` warning is environmental (the runner's `pnpm/action-setup` layout) and self-corrects, not a repo syntax change.

## Verification

`typecheck` clean · smoke file green (async-refinements ~715ms) · `lint` + prettier clean on both files · injection dry-run produces valid merged YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)