### PR TITLE
chore(engines): relax the supported-runtime declaration

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -25,8 +25,10 @@ concurrency:
 #     They have no Node-version sensitivity — running them on a matrix
 #     would 3× the compute for no signal.
 #   - Cross-Node coverage lives in the `test` matrix: it runs ONLY
-#     `pnpm test`, on the load-bearing Node majors (20.x as the
-#     engines minimum, 22.x as the current LTS).
+#     `pnpm test`, on `lts/*` (the auto-rotating current LTS, 22.x
+#     today). The `engines.node` floor is >=22 (Node 20 is EOL) with
+#     no upper bound, so newer Node majors stay supported without a
+#     workflow edit.
 #
 # Wall-clock time = max(slowest single-Node job, slowest matrix
 # shard). The previous `pnpm check` matrix had each Node version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Changed
+
+- **Relaxed the supported-runtime declaration.** `engines.node` drops its upper
+  bound (was `>=22.0.0 <27`), so Attaform installs without an engine warning on
+  current and future Node majors; the floor stays at Node 22, the lowest release
+  still receiving security support. `engines.pnpm` is removed entirely: the
+  published package is pre-built and installs under any package manager, so
+  pinning a pnpm version only warned pnpm users for no runtime reason (the pnpm
+  11 requirement is dev-only, kept in `packageManager`). (#372)
+
 ### Fixed
 
 - **No false `v-register` no-op warning during SSR hydration.** A custom field

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   ],
   "sideEffects": false,
   "engines": {
-    "node": ">=22.0.0 <27",
-    "pnpm": ">=11.0.0"
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
Relaxes the `engines` field, which had been over-tightened. The result is fewer needless install-time warnings for consumers, with the security floor held where it belongs.

## Changes

`package.json` `engines`:

```jsonc
// before
"engines": { "node": ">=22.0.0 <27", "pnpm": ">=11.0.0" }
// after
"engines": { "node": ">=22.0.0" }
```

**Dropped the `<27` upper bound on `node`.** Capping a library's Node major is an anti-pattern: it preemptively breaks installs on future, still-secure Node releases (27+, ~2027) for no reason.

**Kept the `>=22` floor.** "As low as we can go *securely*" lands at 22: Node 20 reached EOL on 2026-04-30, so claiming support below 22 would officially endorse an unpatched runtime. The build output is `es2020` and would *execute* far lower, but "supported" is not "happens to run." The CI test matrix runs `lts/*` (22.x today), so the floor stays honest.

**Removed `engines.pnpm` entirely.** The published package is pre-built `dist/` and installs under any package manager; `engines.pnpm` only nagged pnpm consumers (npm/yarn/bun ignore it) and carries no security dimension for a consumer. The genuine pnpm 11 requirement is dev-only (the v11 `pnpm-workspace.yaml` syntax) and stays enforced via `packageManager: pnpm@11.3.0`.

Also refreshes a stale `matrix.yml` header comment that still described Node 20 as the engines minimum.

Note: `engines` is not an OpenSSF Scorecard metric, so this relaxation does not affect the Scorecard rating.

## Verification

`engines` parses to `{"node":">=22.0.0"}` · prettier clean · `pnpm install --frozen-lockfile` accepts the manifest (lockfile unchanged; `engines` isn't tracked there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)