### PR TITLE
fix(ssr): emit v-register value/checked in server render (no first-paint flash)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@
 
 ### Fixed
 
+- **Server-rendered fields paint with their value, no first-frame flash.** A
+  `v-register` field with a seeded or restored value now carries that value (and
+  `checked` for checkbox / radio) in the server-rendered HTML, so it shows
+  filled on the very first paint instead of flashing empty and filling in once
+  the client mounts. This closes the two render paths that previously dropped
+  it: a wrapper component whose inner input binds a dynamic `:type` (the
+  compile-time transform no longer bails on a type it cannot prove is
+  non-`file`, and instead excludes the file case at runtime), and a render
+  function built with `h()` + `withDirectives` (the directive's `getSSRProps`
+  now emits value / checked alongside the aria attributes it already carried).
+  File inputs still emit no `value` (browsers reject it), and compiled
+  `<select>` keeps its template-driven `selected`. Tested against both the Zod
+  v3 and v4 adapters. (#374)
+
 - **No false `v-register` no-op warning during SSR hydration.** A custom field
   wrapper that follows the recommended pattern (a non-input root that calls
   `useRegister()` and re-binds `v-register` onto an inner native input) stayed

--- a/src/runtime/core/directive.ts
+++ b/src/runtime/core/directive.ts
@@ -1201,7 +1201,23 @@ const vRegisterDynamic: RegisterModelDynamicCustomDirective = {
     // lockout is therefore only available client-side and on the runtime
     // SSR path; under compiled SSR an authored aria attribute can't be
     // detected here, and the client directive reconciles it on hydration.
-    return getSSRAriaProps(rv, (vnode as VNode | null) ?? null)
+    const realVnode = (vnode as VNode | null) ?? null
+    const ariaProps = getSSRAriaProps(rv, realVnode)
+
+    // Form-state (`value` / `checked`) is the runtime path's analogue of
+    // the compile-time transform's injected binding. Compiled SSR passes a
+    // `null` vnode (the transform already emitted the binding there), so
+    // this only fires for `h()` / `withDirectives` renders — the two
+    // mechanisms own disjoint paths and never double-emit. Without it, a
+    // render-function field rendered server-side carries its aria attrs
+    // but no value, painting empty for one frame before the client
+    // directive fills it in on mount.
+    const formStateProps = realVnode !== null ? getSSRFormStateProps(rv, realVnode) : undefined
+
+    if (ariaProps === undefined && formStateProps === undefined) return undefined
+    // Disjoint key spaces (`aria-*` vs `value` / `checked`), so the merge
+    // order is immaterial; spreading `undefined` is a no-op.
+    return { ...ariaProps, ...formStateProps }
   },
 }
 
@@ -1216,6 +1232,77 @@ function resolveDynamicModel(tagName: string, type: unknown) {
   if (type === 'checkbox') return vRegisterCheckbox
   if (type === 'radio') return vRegisterRadio
   return vRegisterText
+}
+
+/**
+ * SSR `checked` verdict for a checkbox, mirroring `setChecked`'s
+ * Array→`looseIndexOf` / Set→`.has` / scalar→`looseEqual(trueValue)`
+ * ladder — but reading the option-value and true-value from `vnode.props`
+ * rather than the DOM element (there's no element server-side). Returns
+ * the props bag (`{ checked: '' }`) when the box should render checked,
+ * else `undefined` so no attribute is emitted.
+ */
+function ssrCheckboxProps(
+  rv: RegisterValue,
+  props: Record<string, unknown> | null
+): Record<string, string> | undefined {
+  const model = rv.innerRef.value
+  const optionValue = props?.['value']
+  let checked: boolean
+  if (isArray(model)) {
+    checked = looseIndexOf(model, applyElementCoerce(optionValue, rv)) > -1
+  } else if (isSet(model)) {
+    checked = model.has(applyElementCoerce(optionValue, rv))
+  } else {
+    // `getCheckboxValue(el, true)` returns `_trueValue` (the `:true-value`
+    // binding) when present, else `true`. On the server we read the
+    // `true-value` prop directly.
+    const trueValue = props !== null && 'true-value' in props ? props['true-value'] : true
+    checked = looseEqual(model, applyCoerce(trueValue, rv))
+  }
+  return checked ? { checked: '' } : undefined
+}
+
+/**
+ * Compute the form-state props (`value` / `checked`) the directive would
+ * apply on mount, for SSR emission on the RUNTIME render-function path.
+ * Mirrors each variant's mount logic — `vRegisterText`'s
+ * `el.value = displayValue.value`, `setChecked`, the radio `looseEqual` —
+ * but sources the element-side option-value from `vnode.props` since
+ * there's no DOM element server-side.
+ *
+ * Returns `undefined` for the variants whose initial state can't be
+ * expressed at the element level here:
+ *  - file: browsers reject `value` on file inputs; `vRegisterFile` owns
+ *    the DOM contract.
+ *  - select: option `selected` is option-level, not expressible from the
+ *    `<select>` element's props (compiled templates carry it via
+ *    `componentBridgeTransform`; documented limitation for runtime
+ *    render functions).
+ *
+ * Only reached on the runtime path — compiled SSR passes a `null` vnode,
+ * where the compile-time transform already injected the binding — so the
+ * two mechanisms never double-emit.
+ */
+function getSSRFormStateProps(rv: RegisterValue, vnode: VNode): Record<string, string> | undefined {
+  // Component vnodes (`h(MyComp, ...)` with a v-register binding) have no
+  // element-level form state — the inner native input the component
+  // re-binds owns it. Only real HTML tags dispatch here.
+  if (typeof vnode.type !== 'string') return undefined
+  const props = (vnode.props as Record<string, unknown> | null) ?? null
+  const variant = resolveDynamicModel(vnode.type.toUpperCase(), props?.['type'])
+
+  if (variant === vRegisterFile || variant === vRegisterSelect) return undefined
+  if (variant === vRegisterCheckbox) return ssrCheckboxProps(rv, props)
+  if (variant === vRegisterRadio) {
+    const matches = looseEqual(rv.innerRef.value, applyCoerce(props?.['value'], rv))
+    return matches ? { checked: '' } : undefined
+  }
+  // text / textarea / number / email — mirror `el.value = displayValue`.
+  // `displayValue` already folds blank/unset to `''`; omit the attribute
+  // for an empty field so SSR matches the no-value initial paint.
+  const value = rv.displayValue.value
+  return value === '' ? undefined : { value }
 }
 
 function callModelHook(

--- a/src/runtime/lib/core/transforms/_shared-props.ts
+++ b/src/runtime/lib/core/transforms/_shared-props.ts
@@ -11,10 +11,11 @@ import { NodeTypes } from '@vue/compiler-core'
 
 /**
  * Shared prop-summarization toolkit for the compile-time node
- * transforms. `input-text-area-transform.ts` and `select-transform.ts`
- * both summarize their host element's props into a uniform
- * `{ key, value }` shape before deciding which directive to inject,
- * which props to strip, and how to construct the synthesized binding.
+ * transforms. `input-text-area-transform.ts` and
+ * `component-bridge-transform.ts` both summarize their host element's
+ * props into a uniform `{ key, value }` shape before deciding which
+ * directive to inject, which props to strip, and how to construct the
+ * synthesized binding.
  * The summarization rules are byte-identical across both transforms;
  * keeping two copies risked silent drift — particularly on key-shape
  * decisions (`isExactKey`) and quoting (`renderAsStatic`).
@@ -137,11 +138,11 @@ export function isExactKey(summarizedKey: string, name: string): boolean {
  * nodes carry a list of strings interleaved with nested expression
  * nodes — concatenate the textual content to reconstruct the source.
  *
- * Single source of truth for the select transform's per-`<option>`
- * processExpression input AND the v-register preamble transform's
- * pre-wrap binding capture. Both call sites built equivalent inline
- * helpers; the consolidation prevents drift in how a future Vue node-
- * type addition gets handled.
+ * Single source of truth for the component-bridge transform's
+ * per-`<option>` processExpression input AND the v-register preamble
+ * transform's pre-wrap binding capture. Both call sites built equivalent
+ * inline helpers; the consolidation prevents drift in how a future Vue
+ * node-type addition gets handled.
  *
  * Children that aren't string / SIMPLE / COMPOUND (symbols from the
  * codegen helper indices; node types added in a future Vue) are

--- a/src/runtime/lib/core/transforms/input-text-area-transform.ts
+++ b/src/runtime/lib/core/transforms/input-text-area-transform.ts
@@ -111,28 +111,24 @@ function isStaticTypeOneOf(value: SummarizedProp['value'], names: readonly strin
 }
 
 /**
- * Returns true if the type prop's value MIGHT resolve to "file" at runtime.
- * Conservative — anything not provably non-"file" returns true so the caller
- * skips the transform.
+ * True when the `type` prop is a DYNAMIC binding whose value can't be
+ * read as a static string literal at compile time. A static attribute
+ * (`type="text"`) or a literal bound expression (`:type="'text'"`) is
+ * NOT dynamic — its type is settled at compile time, so the transform
+ * classifies it directly (and can skip the runtime file guard).
  *
- * Concretely:
- *   - `type="text"`   → value is `'"text"'`         → false (static literal != "file")
- *   - `type="file"`   → value is `'"file"'`         → true  (static "file")
- *   - `:type="'text'"`→ value is `"'text'"`         → false
- *   - `:type="'file'"`→ value is `"'file'"`         → true
- *   - `:type="kind"`  → value is `'kind'`           → true  (dynamic identifier)
- *   - `:type="`a-${x}`"` → array or template lit    → true  (compound expression)
+ *   - `type="text"`      → value is `'"text"'`      → false (static attr literal)
+ *   - `:type="'text'"`   → value is `"'text'"`      → false (literal expression)
+ *   - `:type="kind"`     → value is `'kind'`        → true  (dynamic identifier)
+ *   - `:type="`a-${x}`"` → array (compound exp)     → true  (interpolated)
+ *
+ * Dynamic-typed inputs keep their static `value=` attribute (it may be a
+ * checkbox/radio option discriminator at runtime) AND get the runtime
+ * file-exclusion guard on the injected binding.
  */
-function couldResolveToFileType(value: SummarizedProp['value']): boolean {
-  if (Array.isArray(value)) return true
-  const parsed = parseStaticStringLiteral(value)
-  if (parsed === null) return true // dynamic expression — can't prove safe
-  // Template literals with interpolations resolve at runtime.
-  if (parsed.quote === '`' && parsed.inner.includes('${')) return true
-  // The HTML spec matches `type` ASCII case-insensitively, so
-  // `<input type="FILE">` behaves identically to `<input type="file">`.
-  // Compare lower-cased so we catch both.
-  return parsed.inner.toLowerCase() === 'file'
+function isDynamicTypeValue(value: SummarizedProp['value']): boolean {
+  if (Array.isArray(value)) return true // compound / interpolated expression
+  return parseStaticStringLiteral(value) === null // dynamic identifier / expression
 }
 
 /**
@@ -159,18 +155,19 @@ export const inputTextAreaNodeTransform: NodeTransform = (node) => {
     const registerSummarizedProp = elementProps[registerIndex]
     if (!registerSummarizedProp) return // no v-register directive; nothing to transform
 
-    // <input type="file" v-register="..."> bypasses the value-binding
-    // injection — the runtime `vRegisterFile` variant owns the DOM
-    // contract for file inputs (read `el.files` on change; clear via
-    // `el.value = ''` only). Skipping at compile-time avoids the
-    // `:value=""` binding browsers would otherwise reject on a file
-    // input. We must skip not just the static `type="file"` case but any
-    // dynamic binding (`:type="x"`, template-literal expressions, etc.)
-    // that COULD resolve to "file" at runtime — `couldResolveToFileType`
-    // errs on the conservative side.
+    // A provably-static `type="file"` (or `:type="'file'"`) bypasses the
+    // value-binding injection entirely — the runtime `vRegisterFile`
+    // variant owns the DOM contract for file inputs (read `el.files` on
+    // change; clear via `el.value = ''` only), and browsers reject a
+    // `value=` attribute on a file input. A DYNAMIC `:type` that could
+    // only SOMETIMES resolve to "file" does NOT bail here: it proceeds to
+    // inject, and the synthesized expression below excludes the file case
+    // at runtime (`type === 'file' ? undefined : …`) so a wrapper input
+    // that resolves to "text" still gets its SSR value. This is what fixes
+    // the first-paint flash on every dynamically-typed wrapper field.
     const typeIndex = elementProps.findIndex((p) => isExactKey(p.key, 'type'))
     const typeProp = elementProps[typeIndex]
-    if (typeProp !== undefined && couldResolveToFileType(typeProp.value)) return
+    if (typeProp !== undefined && isStaticTypeOneOf(typeProp.value, ['file'])) return
 
     const valueIndex = elementProps.findIndex((p) => isExactKey(p.key, 'value'))
     const elementValueSummarizedProp = elementProps?.[valueIndex] ?? {
@@ -243,7 +240,14 @@ export const inputTextAreaNodeTransform: NodeTransform = (node) => {
       const isStaticCheckbox =
         typeProp !== undefined && isStaticTypeOneOf(typeProp.value, ['checkbox'])
       const isStaticRadio = typeProp !== undefined && isStaticTypeOneOf(typeProp.value, ['radio'])
-      const keepStaticValue = isStaticCheckbox || isStaticRadio
+      // A dynamic `:type` could resolve to checkbox/radio at runtime,
+      // where the static `value=` is the option discriminator the runtime
+      // directive matches against the model — so it must survive the
+      // strip. If the runtime type turns out to be text instead, the
+      // injected `:value` binding harmlessly overrides the static
+      // attribute (dynamic binds win over static attrs in mergeProps).
+      const isDynamicType = typeProp !== undefined && isDynamicTypeValue(typeProp.value)
+      const keepStaticValue = isStaticCheckbox || isStaticRadio || isDynamicType
       removePropsByName(props, keepStaticValue ? ['checked'] : ['checked', 'value'])
       const registerValueArr = Array.isArray(registerSummarizedProp.value)
         ? registerSummarizedProp.value
@@ -282,24 +286,48 @@ export const inputTextAreaNodeTransform: NodeTransform = (node) => {
           : 'true'
         : elementValueSummarizedProp.value
 
+      // The core binding: a boolean for the `checked` branch (checkbox /
+      // radio), the register's `displayValue` for the `value` branch
+      // (text / textarea). The arg (`elementSelectionLabelExpression`)
+      // picks which attribute key this binds to at runtime.
+      const coreExpression = [
+        '(',
+        ...elementSelectionLabelExpression.children,
+        ") === 'checked' ? (",
+        // resolves to a boolean
+        ...generateEqualityExpression(
+          registerSummarizedProp.value,
+          elementValueSummarizedProp.value,
+          scalarTarget
+        ),
+        ') : (',
+        // resolves to the provided register value
+        ...valueExpression.children,
+        ')',
+      ]
+
+      // Runtime file-exclusion guard, dynamic `:type` only: when the type
+      // resolves to "file" at runtime the binding yields `undefined`, so
+      // Vue omits the attribute (browsers reject `value` on a file input,
+      // and the runtime `vRegisterFile` variant owns that DOM contract).
+      // A provably-static non-file type skips the guard — its file-ness is
+      // already settled at compile time, so the runtime check would be
+      // dead weight on the SSR-correct common path (static `type="file"`
+      // bailed out far above and never reaches here).
+      const exp = isDynamicType
+        ? createCompoundExpression([
+            'String((',
+            ...inputTypeExpressionArray,
+            ")).toLowerCase() === 'file' ? undefined : (",
+            ...coreExpression,
+            ')',
+          ])
+        : createCompoundExpression(coreExpression)
+
       const valueOrCheckedProp: DirectiveNode = {
         // reconstruct the `value` attribute based on the provided v-registerer, now that the computation is complete
         arg: elementSelectionLabelExpression,
-        exp: createCompoundExpression([
-          '(',
-          ...elementSelectionLabelExpression.children,
-          ") === 'checked' ? (",
-          // resolves to a boolean
-          ...generateEqualityExpression(
-            registerSummarizedProp.value,
-            elementValueSummarizedProp.value,
-            scalarTarget
-          ),
-          ') : (',
-          // resolves to the provided register value
-          ...valueExpression.children,
-          ')',
-        ]),
+        exp,
         name: 'bind',
         modifiers: [],
         type: NodeTypes.DIRECTIVE,

--- a/test/composables/ssr-value-hydration.test.ts
+++ b/test/composables/ssr-value-hydration.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+//
+// The no-flash proof. The SSR value/checked fix is only worth anything
+// if the seeded value is in the markup the browser parses BEFORE any
+// client JS runs (so there's no empty-then-fills-in flash) AND the
+// client hydrates that markup without a mismatch warning (a mismatch
+// forces Vue to re-render the subtree — its own kind of flash).
+//
+// Covers both render paths that drop the value pre-fix:
+//   - runtime `h()` + `withDirectives` (getSSRProps — Fix B)
+//   - compiled template with a dynamic `:type` (nodeTransform — Fix A)
+// across both zod adapters (first-class v3/v4 parity).
+import { baseCompile } from '@vue/compiler-core'
+import { renderToString } from '@vue/server-renderer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as Vue from 'vue'
+import { createSSRApp, defineComponent, h, withDirectives, type App } from 'vue'
+import { z as zV4 } from 'zod'
+import { z as zV3 } from 'zod-v3'
+import { vRegister } from '../../src/runtime/core/directive'
+import { useForm as useFormV4 } from '../../src/zod-v4'
+import { useForm as useFormV3 } from '../../src/zod-v3'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import { inputTextAreaNodeTransform } from '../../src/runtime/lib/core/transforms/input-text-area-transform'
+import { waitUntil } from '../utils/form-harness'
+
+// zV3 / useFormV3 are cast to their v4 static types so the shared
+// describe.each loop type-checks (the two adapters' static types don't
+// unify, but their runtime surface used here is identical). The real v3
+// instances run at runtime; this only satisfies the compiler.
+const ADAPTERS = [
+  { name: 'zod-v4', z: zV4, useForm: useFormV4 },
+  {
+    name: 'zod-v3',
+    z: zV3 as unknown as typeof zV4,
+    useForm: useFormV3 as unknown as typeof useFormV4,
+  },
+] as const
+
+function compileRender(template: string): (this: unknown, ctx: unknown) => unknown {
+  const result = baseCompile(template, {
+    nodeTransforms: [inputTextAreaNodeTransform],
+    mode: 'function',
+    prefixIdentifiers: true,
+    hoistStatic: false,
+  })
+  const fn = new Function('Vue', `${result.code}\nreturn render`)
+  return fn(Vue) as (this: unknown, ctx: unknown) => unknown
+}
+
+describe.each(ADAPTERS)(
+  'SSR value hydration, no flash/mismatch ($name)',
+  ({ name, z, useForm }) => {
+    let app: App | undefined
+    let warnings: string[]
+    let warnSpy: ReturnType<typeof vi.spyOn>
+    let errorSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+      warnings = []
+      const capture = (...args: unknown[]): void => {
+        warnings.push(args.map((a) => String(a)).join(' '))
+      }
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(capture)
+      errorSpy = vi.spyOn(console, 'error').mockImplementation(capture)
+    })
+
+    afterEach(() => {
+      app?.unmount()
+      app = undefined
+      warnSpy.mockRestore()
+      errorSpy.mockRestore()
+      document.body.innerHTML = ''
+    })
+
+    function hydrationMismatchWarnings(): string[] {
+      return warnings.filter((w) => /hydrat|mismatch/i.test(w))
+    }
+
+    function makeRuntimeComponent(key: string): Vue.Component {
+      return defineComponent({
+        setup() {
+          const form = useForm({
+            schema: z.object({ orgName: z.string() }),
+            defaultValues: { orgName: 'Acme PHA' },
+            key,
+          })
+          const rv = form.register('orgName')
+          return () => withDirectives(h('input', { type: 'text' }), [[vRegister, rv]])
+        },
+      })
+    }
+
+    function makeCompiledComponent(key: string): Vue.Component {
+      return defineComponent({
+        setup() {
+          const form = useForm({
+            schema: z.object({ orgName: z.string() }),
+            defaultValues: { orgName: 'Acme PHA' },
+            key,
+          })
+          return { form, t: 'text' }
+        },
+        render: compileRender(`<input :type="t" v-register="form.register('orgName')" />`),
+      })
+    }
+
+    async function assertNoFlashNoMismatch(Component: Vue.Component): Promise<void> {
+      // SSR pass.
+      const html = await renderToString(createSSRApp(Component).use(createAttaform()))
+      // The value is in the markup the browser parses — no empty first paint.
+      expect(html).toContain('value="Acme PHA"')
+
+      // Plant the SSR markup and confirm the parsed DOM carries the value
+      // before any client JS touches it.
+      const root = document.createElement('div')
+      document.body.appendChild(root)
+      root.innerHTML = html
+      const inputPre = root.querySelector('input') as HTMLInputElement | null
+      if (inputPre === null) throw new Error('input missing from SSR HTML')
+      expect(inputPre.getAttribute('value')).toBe('Acme PHA')
+
+      // Client hydration over the populated container.
+      app = createSSRApp(Component).use(createAttaform())
+      app.mount(root)
+      await waitUntil(() => (root.querySelector('input')?.value === 'Acme PHA' ? true : null))
+
+      // No hydration-mismatch warning — the SSR markup and the client's
+      // first render agree, so there's no corrective re-render flash.
+      expect(hydrationMismatchWarnings()).toEqual([])
+      // Value survives hydration.
+      expect((root.querySelector('input') as HTMLInputElement).value).toBe('Acme PHA')
+    }
+
+    it('runtime h() + withDirectives: value present pre-hydration, hydrates clean', async () => {
+      await assertNoFlashNoMismatch(makeRuntimeComponent(`ssr-hydrate-runtime-${name}`))
+    })
+
+    it('compiled dynamic :type: value present pre-hydration, hydrates clean', async () => {
+      await assertNoFlashNoMismatch(makeCompiledComponent(`ssr-hydrate-compiled-${name}`))
+    })
+  }
+)

--- a/test/ssr-bare-vue/runtime-form-state-ssr.test.ts
+++ b/test/ssr-bare-vue/runtime-form-state-ssr.test.ts
@@ -1,0 +1,159 @@
+import { renderToString } from '@vue/server-renderer'
+import { describe, expect, it } from 'vitest'
+import { createSSRApp, defineComponent, h, withDirectives } from 'vue'
+import { z as zV4 } from 'zod'
+import { z as zV3 } from 'zod-v3'
+import { vRegister } from '../../src'
+import { useForm as useFormV4 } from '../../src/zod-v4'
+import { useForm as useFormV3 } from '../../src/zod-v3'
+import { createAttaform } from '../../src/runtime/core/plugin'
+
+/**
+ * SSR value/checked emission on the RUNTIME render-function path
+ * (`h()` + `withDirectives`, no compile-time transform). The bug
+ * report's literal repro: a seeded text input rendered through a
+ * render function came out with `aria-*` (from `getSSRProps`) but no
+ * `value`, so the field painted empty for one frame and filled in on
+ * client mount.
+ *
+ * `getSSRProps` receives a real vnode on this path (compiled SSR passes
+ * `null`), so it can dispatch by tag/type and emit the same form-state
+ * the client directive applies on mount. Both zod adapters per
+ * first-class v3/v4 parity.
+ */
+
+// zV3 / useFormV3 are cast to their v4 static types so the shared
+// describe.each loop type-checks (the two adapters' static types don't
+// unify, but their runtime surface used here is identical). The real v3
+// instances run at runtime; this only satisfies the compiler.
+const ADAPTERS = [
+  { name: 'zod-v4', z: zV4, useForm: useFormV4 },
+  {
+    name: 'zod-v3',
+    z: zV3 as unknown as typeof zV4,
+    useForm: useFormV3 as unknown as typeof useFormV4,
+  },
+] as const
+
+describe.each(ADAPTERS)('runtime getSSRProps form-state ($name)', ({ z, useForm }) => {
+  function ssr(setup: () => () => unknown): Promise<string> {
+    const app = createSSRApp(defineComponent({ setup }))
+    app.use(createAttaform())
+    return renderToString(app)
+  }
+
+  it('text input emits the seeded value (the report repro)', async () => {
+    const html = await ssr(() => {
+      const form = useForm({
+        schema: z.object({ orgName: z.string() }),
+        defaultValues: { orgName: 'Acme PHA' },
+      })
+      return () =>
+        withDirectives(h('input', { type: 'text' }), [[vRegister, form.register('orgName')]])
+    })
+    expect(html).toContain('value="Acme PHA"')
+  })
+
+  it('textarea emits the seeded value', async () => {
+    const html = await ssr(() => {
+      const form = useForm({
+        schema: z.object({ bio: z.string() }),
+        defaultValues: { bio: 'hello world' },
+      })
+      return () => withDirectives(h('textarea'), [[vRegister, form.register('bio')]])
+    })
+    // Vue's server renderer routes a `value` prop on a <textarea> to its
+    // text content (the spec'd way to seed a textarea), not a `value=`
+    // attribute — so the seeded value rides along as content, no flash.
+    expect(html).toContain('hello world</textarea>')
+  })
+
+  it('checkbox (boolean scalar model) emits `checked` when true', async () => {
+    const html = await ssr(() => {
+      const form = useForm({
+        schema: z.object({ agree: z.boolean() }),
+        defaultValues: { agree: true },
+      })
+      return () =>
+        withDirectives(h('input', { type: 'checkbox' }), [[vRegister, form.register('agree')]])
+    })
+    expect(html).toMatch(/\bchecked\b/)
+  })
+
+  it('checkbox (array model) emits `checked` for a member option', async () => {
+    const html = await ssr(() => {
+      const form = useForm({
+        schema: z.object({ picks: z.array(z.string()) }),
+        defaultValues: { picks: ['apple'] },
+      })
+      return () =>
+        withDirectives(h('input', { type: 'checkbox', value: 'apple' }), [
+          [vRegister, form.register('picks')],
+        ])
+    })
+    expect(html).toMatch(/\bchecked\b/)
+  })
+
+  it('radio emits `checked` when the model matches the option value', async () => {
+    const html = await ssr(() => {
+      const form = useForm({
+        schema: z.object({ size: z.string() }),
+        defaultValues: { size: 'b' },
+      })
+      return () =>
+        withDirectives(h('input', { type: 'radio', value: 'b' }), [
+          [vRegister, form.register('size')],
+        ])
+    })
+    expect(html).toMatch(/\bchecked\b/)
+  })
+
+  it('radio emits NO `checked` when the model does not match', async () => {
+    const html = await ssr(() => {
+      const form = useForm({
+        schema: z.object({ size: z.string() }),
+        defaultValues: { size: 'a' },
+      })
+      return () =>
+        withDirectives(h('input', { type: 'radio', value: 'b' }), [
+          [vRegister, form.register('size')],
+        ])
+    })
+    expect(html).not.toMatch(/\bchecked\b/)
+  })
+
+  it('file input emits NO value (browsers reject value on file inputs)', async () => {
+    const html = await ssr(() => {
+      const form = useForm({
+        schema: z.object({ doc: z.string() }),
+        defaultValues: { doc: 'should-not-leak' },
+      })
+      return () => withDirectives(h('input', { type: 'file' }), [[vRegister, form.register('doc')]])
+    })
+    expect(html).not.toContain('value=')
+    expect(html).not.toContain('should-not-leak')
+  })
+
+  it('runtime <select> is a documented no-op (option-level state is not element-expressible)', async () => {
+    const html = await ssr(() => {
+      const form = useForm({
+        schema: z.object({ country: z.string() }),
+        defaultValues: { country: 'uk' },
+      })
+      return () =>
+        withDirectives(
+          h('select', null, [
+            h('option', { value: 'us' }, 'US'),
+            h('option', { value: 'uk' }, 'UK'),
+          ]),
+          [[vRegister, form.register('country')]]
+        )
+    })
+    // The select renders without crashing; option-level `selected` is
+    // intentionally NOT emitted from the element-level getSSRProps
+    // (compiled templates carry it via componentBridgeTransform). Pin
+    // the limitation so a future change to it is a deliberate edit.
+    expect(html).toContain('<select')
+    expect(html).not.toContain('selected')
+  })
+})

--- a/test/transforms/input-text-area.test.ts
+++ b/test/transforms/input-text-area.test.ts
@@ -64,17 +64,23 @@ describe('inputTextAreaNodeTransform', () => {
       expect(code).toContain('innerRef')
     })
 
-    // Conservative skip on dynamic / template-literal type bindings — they
-    // could resolve to "file" at runtime and trigger DOMException on
-    // el.value assignment.
-    it('skips <input :type="userKind" v-register> (dynamic identifier)', () => {
+    // Dynamic / template-literal type bindings can't be classified at
+    // compile time, so the transform no longer bails on them (that left
+    // every dynamically-typed wrapper input without an SSR value — a
+    // first-paint flash). Instead it injects the binding AND guards it
+    // with a runtime file-exclusion (`type === 'file' ? undefined`) so a
+    // type that resolves to "file" still emits no value (browsers reject
+    // it; the runtime `vRegisterFile` variant owns the DOM contract).
+    it('injects with a runtime file guard for <input :type="userKind" v-register> (dynamic identifier)', () => {
       const code = compileWithTransform(`<input :type="userKind" v-register="x" />`)
-      expect(code).not.toContain('innerRef')
+      expect(code).toContain('innerRef')
+      expect(code).toContain("=== 'file' ? undefined")
     })
 
-    it('skips <input :type="`prefix-${suffix}`" v-register> (template literal with interpolation)', () => {
+    it('injects with a runtime file guard for <input :type="`prefix-${suffix}`" v-register> (template literal)', () => {
       const code = compileWithTransform('<input :type="`prefix-${suffix}`" v-register="x" />')
-      expect(code).not.toContain('innerRef')
+      expect(code).toContain('innerRef')
+      expect(code).toContain("=== 'file' ? undefined")
     })
 
     it('skips <input :type="\'file\'" v-register> (literal expression form)', () => {

--- a/test/transforms/ssr-dynamic-type-value.test.ts
+++ b/test/transforms/ssr-dynamic-type-value.test.ts
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+import { baseCompile } from '@vue/compiler-core'
+import { renderToString } from '@vue/server-renderer'
+import { describe, expect, it } from 'vitest'
+import * as Vue from 'vue'
+import { createSSRApp, defineComponent, ref } from 'vue'
+import { z as zV4 } from 'zod'
+import { z as zV3 } from 'zod-v3'
+import { useRegister } from '../../src'
+import { useForm as useFormV4 } from '../../src/zod-v4'
+import { useForm as useFormV3 } from '../../src/zod-v3'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import { componentBridgeTransform } from '../../src/runtime/lib/core/transforms/component-bridge-transform'
+import { inputTextAreaNodeTransform } from '../../src/runtime/lib/core/transforms/input-text-area-transform'
+import { vRegisterHintTransform } from '../../src/runtime/lib/core/transforms/v-register-hint-transform'
+import { vRegisterPreambleTransform } from '../../src/runtime/lib/core/transforms/v-register-preamble-transform'
+
+/**
+ * SSR value/checked emission for `<input>` / `<textarea>` carrying a
+ * DYNAMIC `:type` binding — the wrapper-component shape (e.g. a
+ * `UiTextField` re-binding its inner `<input v-register :type="type">`).
+ *
+ * Pre-fix, `inputTextAreaNodeTransform` bailed on any non-provably-
+ * static `type` (couldn't prove it wasn't `file`), so the value binding
+ * was never injected and the field painted empty for one frame, then
+ * filled in on client mount — a visible first-paint flash on every
+ * SSR'd wrapper field. Static `type="text"` already worked; this pins
+ * the dynamic-type parity AND the file-input safety (a runtime
+ * `type="file"` must NEVER receive a `value` binding — browsers reject
+ * it).
+ *
+ * Both zod adapters per first-class v3/v4 parity.
+ */
+
+// zV3 / useFormV3 are cast to their v4 static types so the shared
+// describe.each loop type-checks (the two adapters' static types don't
+// unify, but their runtime surface used here is identical). The real v3
+// instances run at runtime; this only satisfies the compiler.
+const ADAPTERS = [
+  { name: 'zod-v4', z: zV4, useForm: useFormV4 },
+  {
+    name: 'zod-v3',
+    z: zV3 as unknown as typeof zV4,
+    useForm: useFormV3 as unknown as typeof useFormV4,
+  },
+] as const
+
+const TRANSFORMS = [
+  componentBridgeTransform,
+  inputTextAreaNodeTransform,
+  vRegisterPreambleTransform,
+  vRegisterHintTransform,
+]
+
+function compileRender(template: string): (this: unknown, ctx: unknown) => unknown {
+  const result = baseCompile(template, {
+    nodeTransforms: TRANSFORMS,
+    mode: 'function',
+    prefixIdentifiers: true,
+    hoistStatic: false,
+  })
+  const fn = new Function('Vue', `${result.code}\nreturn render`)
+  return fn(Vue) as (this: unknown, ctx: unknown) => unknown
+}
+
+describe.each(ADAPTERS)('SSR dynamic :type value/checked emission ($name)', ({ z, useForm }) => {
+  function ssr(
+    template: string,
+    schema: unknown,
+    defaultValues: Record<string, unknown>,
+    extraSetup: Record<string, unknown> = {}
+  ): Promise<string> {
+    const Component = defineComponent({
+      setup() {
+        // The schema is statically `unknown` here (the helper is generic
+        // over every case's shape); useForm needs a concrete type, so the
+        // single cast lives here rather than at every call site.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const form = useForm({ schema: schema as any, defaultValues })
+        return { form, ...extraSetup }
+      },
+      render: compileRender(template),
+    })
+    const app = createSSRApp(Component)
+    app.use(createAttaform())
+    return renderToString(app)
+  }
+
+  it('dynamic :type resolving to text emits the seeded value (the wrapper bug)', async () => {
+    const html = await ssr(
+      `<input :type="t" v-register="form.register('orgName')" />`,
+      z.object({ orgName: z.string() }),
+      { orgName: 'Acme PHA' },
+      { t: 'text' }
+    )
+    expect(html).toContain('value="Acme PHA"')
+  })
+
+  it('dynamic :type resolving to checkbox emits `checked` and keeps the static value discriminator', async () => {
+    const html = await ssr(
+      `<input :type="t" v-register="form.register('picks')" value="apple" />`,
+      z.object({ picks: z.array(z.string()) }),
+      { picks: ['apple'] },
+      { t: 'checkbox' }
+    )
+    expect(html).toMatch(/\bchecked\b/)
+    expect(html).toContain('value="apple"')
+  })
+
+  it('dynamic :type resolving to radio emits `checked` and keeps the static value', async () => {
+    const html = await ssr(
+      `<input :type="t" v-register="form.register('size')" value="b" />`,
+      z.object({ size: z.string() }),
+      { size: 'b' },
+      { t: 'radio' }
+    )
+    expect(html).toMatch(/\bchecked\b/)
+    expect(html).toContain('value="b"')
+  })
+
+  it('dynamic :type resolving to file emits NO value (browsers reject value on file inputs)', async () => {
+    const html = await ssr(
+      `<input :type="t" v-register="form.register('doc')" />`,
+      z.object({ doc: z.string() }),
+      { doc: 'should-not-leak' },
+      { t: 'file' }
+    )
+    expect(html).not.toContain('value=')
+    expect(html).not.toContain('should-not-leak')
+  })
+
+  it('regression: static type="text" still emits the value', async () => {
+    const html = await ssr(
+      `<input type="text" v-register="form.register('orgName')" />`,
+      z.object({ orgName: z.string() }),
+      { orgName: 'Acme PHA' }
+    )
+    expect(html).toContain('value="Acme PHA"')
+  })
+
+  it('regression: static type="file" still emits no value', async () => {
+    const html = await ssr(
+      `<input type="file" v-register="form.register('doc')" />`,
+      z.object({ doc: z.string() }),
+      { doc: 'should-not-leak' }
+    )
+    expect(html).not.toContain('value=')
+  })
+
+  it('wrapper component (useRegister + inner <input v-register :type>) emits the value through SSR', async () => {
+    const UiTextField = defineComponent({
+      name: 'UiTextField',
+      inheritAttrs: false,
+      setup() {
+        const register = useRegister()
+        const type = ref('text')
+        return { register, type }
+      },
+      render: compileRender(`<input v-register="register" :type="type" />`),
+    })
+
+    const Parent = defineComponent({
+      name: 'WrapperParent',
+      components: { UiTextField },
+      setup() {
+        const form = useForm({
+          schema: z.object({ orgName: z.string() }),
+          defaultValues: { orgName: 'Acme PHA' },
+        })
+        return { form }
+      },
+      render: compileRender(`<div><UiTextField v-register="form.register('orgName')" /></div>`),
+    })
+    const app = createSSRApp(Parent)
+    app.use(createAttaform())
+    const html = await renderToString(app)
+    expect(html).toContain('value="Acme PHA"')
+  })
+})


### PR DESCRIPTION
## What

A `v-register` field with a seeded or restored value rendered **empty server-side and filled in on client mount** — a visible first-paint flash on every SSR'd form, worst on refresh / deep-link. Reported against 0.21.1 (surfaced in the Cubic Housing frontend).

The value (generalized: `value` for text, `checked` for checkbox/radio) was dropped on **two render paths**, both fixed here for full parity:

### Fix A — compiled templates with a dynamic `:type` (the wrapper-component shape)
`inputTextAreaNodeTransform` bailed on any `type` it couldn't prove was non-`file`, so a wrapper like `UiTextField` re-binding `<input v-register :type="type">` got no SSR value. It now:
- bails only on a **provably-static** `type="file"` / `:type="'file'"`,
- injects for dynamic types and **excludes the file case at runtime** (`String(type).toLowerCase() === 'file' ? undefined : …`), so a type that resolves to `text` still emits its value while a runtime `file` emits nothing (browsers reject `value` on file inputs),
- keeps the static `value=` for dynamic types (it may be a checkbox/radio option discriminator at runtime).

### Fix B — runtime render functions (`h()` + `withDirectives`)
The directive's `getSSRProps` emitted aria-only. It now also emits `value` / `checked`, dispatched by tag/type via the existing `resolveDynamicModel`, mirroring each variant's mount logic (`displayValue` for text/textarea, `setChecked`'s Array→`looseIndexOf` / Set→`.has` / scalar→`looseEqual` ladder for checkbox, `looseEqual` for radio). File and runtime `<select>` emit nothing (documented limitations; compiled `<select>` already carries `selected` via `componentBridgeTransform`).

Compiled SSR passes a `null` vnode, so `getSSRProps` stays inert there — the two mechanisms own **disjoint paths and never double-emit**.

## Tests (TDD, RED → GREEN, both Zod v3 + v4 adapters)
- `test/transforms/ssr-dynamic-type-value.test.ts` — compiled dynamic-`:type` matrix (text value, checkbox/radio checked + discriminator, file safety, static-type regression guards, the real wrapper-component shape).
- `test/ssr-bare-vue/runtime-form-state-ssr.test.ts` — the report's literal `h()` repro + checkbox/radio/textarea/file/select on the runtime path.
- `test/composables/ssr-value-hydration.test.ts` — the no-flash proof: value present in the parsed DOM **pre-hydration**, and hydration is **mismatch-free** (no corrective re-render), both render paths.
- Updated two `input-text-area.test.ts` cases that pinned the old "bail on any could-be-`file` `:type`" contract to the new inject-with-runtime-guard behavior.

Also retires the now-dead `couldResolveToFileType` helper and fixes two stale `select-transform.ts` doc references (renamed to `component-bridge-transform.ts`).

## Gate
- ✅ Full suite: **4114 passed, 0 failed** (+34 new across the 3 suites)
- ✅ `typecheck` · `lint` · `format:check`
- ✅ `check:bench` (within 3× floor — SSR path is off the keystroke hot path)
- ✅ `check:eager` (47.14 / 47.25 kB gz) · `check:size` (all budgets; `transforms.mjs` 3.22 / 6 kB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)