### PR TITLE
feat(bench-arena): fair, reproducible cross-library Vue form benchmark

### DIFF
--- a/.github/workflows/bench-arena.yml
+++ b/.github/workflows/bench-arena.yml
@@ -1,0 +1,260 @@
+name: bench-arena refresh
+
+# Monthly refresh of the cross-library benchmark numbers the docs render.
+#
+# STRICTLY NON-GATING. This workflow runs only on a monthly schedule and on
+# manual dispatch, never on `pull_request`, and is never added to the branch
+# protection ruleset's required checks. It cannot block a merge. The
+# `check:bench` job in matrix.yml remains the real, gating performance check;
+# this one only republishes the public comparison numbers. `continue-on-error`
+# is belt-and-suspenders on top of that: a flaky arena run reports neutral
+# rather than red.
+#
+# What it does: builds the real Attaform dist, drives the whole cohort through
+# the arena in a real Chromium (the same orchestrator a developer runs locally),
+# and writes a provenance-stamped results.json with source=ci. It then opens a
+# reviewer PR with that single file changed. Merging it republishes the
+# authoritative numbers; the committed copy the docs render is therefore always
+# from a clean CI runner, never a developer machine. Closing it is a no-op, for
+# a month whose numbers are not worth landing.
+#
+# Bot-PR topology mirrors release-pr.yml exactly, for the same reason: a PR
+# opened with the default GITHUB_TOKEN does not cascade main's required status
+# checks, so it could never be merged. The results.json commit is created via
+# the createCommitOnBranch GraphQL mutation (signed by github-actions[bot]'s
+# server-side web-flow key, which main's required-signatures rule accepts), and
+# the PR is opened with a per-run, pull-requests:write-only installation token
+# from the shared `Production (Release PR)` GitHub App, minted and revoked
+# within the job. Reusing that App rather than standing up a second one keeps
+# the privileged surface to a single, already-audited credential.
+#
+# Network note: the arena makes one best-effort outbound call per library to the
+# OpenSSF Scorecard API. GitHub-hosted runners have egress, so it resolves live
+# scores; were the network blocked, those rows degrade to "unavailable" (never
+# "not published", which would misreport an opted-out project) and the run still
+# succeeds.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 07:00 UTC on the 1st of each month. Clear of the repo's other crons.
+    - cron: '0 7 1 * *'
+
+# Workflow-level default: read-only. The refresh job below upgrades to
+# contents: write + pull-requests: write for the signed commit + PR open.
+permissions:
+  contents: read
+
+# Never run two refreshes at once, and never cancel an in-flight one: the arena
+# sweep is long, and a cancelled run leaves no useful state behind.
+concurrency:
+  group: bench-arena
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    name: Refresh benchmark results (non-gating)
+    runs-on: ubuntu-latest
+    # Belt-and-suspenders non-gating: this job already cannot fail a PR (it has
+    # no pull_request trigger and is not a required check); continue-on-error
+    # additionally reports a flaky monthly run as neutral rather than red.
+    continue-on-error: true
+    # The full sweep across the cohort is long-running; the monthly cadence
+    # keeps the compute a non-issue.
+    timeout-minutes: 60
+    # Scope the shared release-PR App credentials to this workflow, exactly as
+    # release-pr.yml does (zizmor secrets-outside-env). The environment's
+    # selected-branches policy (main, hotfix/v*) is already satisfied: both the
+    # schedule and a manual dispatch run on main.
+    environment: Production (Release PR)
+    permissions:
+      contents: write # createCommitOnBranch: the refresh branch ref + signed results.json commit. Never writes to main directly.
+      pull-requests: write # gh pr create, via the App installation token.
+    steps:
+      - name: Validate release-PR app credentials
+        # The PR open below MUST use a GitHub App installation token, not
+        # GITHUB_TOKEN: a PR opened by GITHUB_TOKEN does not cascade main's
+        # required status checks, so it could never be merged. Fail here, before
+        # the long arena sweep, if the shared App secrets are absent, so a
+        # misconfiguration costs seconds rather than the better part of an hour.
+        env:
+          APP_CLIENT_ID: ${{ secrets.RELEASE_PR_APP_CLIENT_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.RELEASE_PR_APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${APP_CLIENT_ID:-}" ] || [ -z "${APP_PRIVATE_KEY:-}" ]; then
+            echo "::error title=Release-PR app credentials missing::bench-arena.yml reuses the Production (Release PR) GitHub App to open its refresh PR. Configure RELEASE_PR_APP_CLIENT_ID and RELEASE_PR_APP_PRIVATE_KEY on that environment (see release-pr.yml for the one-time setup)."
+            exit 1
+          fi
+
+      - name: Checkout main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # The refresh branch + signed commit are written via gh api
+          # (createCommitOnBranch), not git push, so the working tree never
+          # needs an attached credential (zizmor artipacked).
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 'lts/*'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Attaform dist
+        # The arena consumes the real published build, the same artifact an
+        # installer gets, never the src alias or the unbuild --stub shim. The
+        # Playwright webServer's build step fails loudly if dist is absent.
+        run: pnpm prepack
+
+      - name: Install Playwright Chromium
+        run: pnpm --filter attaform-bench-arena exec playwright install --with-deps chromium
+
+      - name: Run the arena
+        # Drives the cohort through every scenario and writes
+        # apps/bench-arena/results.json with provenance source=ci (the default
+        # GITHUB_* env vars supply the run id, commit, and run URL). One
+        # best-effort outbound call per library hits the OpenSSF Scorecard API;
+        # a blocked network degrades those rows to "unavailable" without failing
+        # the run. A red spec run writes nothing, so this step simply fails and
+        # no stale numbers are committed.
+        run: pnpm --filter attaform-bench-arena run arena
+
+      - name: Prepare commit metadata
+        id: meta
+        env:
+          GH_RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          echo "branch=bench-arena/refresh-$(date -u +%Y-%m-%d)-${GH_RUN_ID}" >> "$GITHUB_OUTPUT"
+          echo "base_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Create signed results commit
+        # createCommitOnBranch produces a commit signed by github-actions[bot]'s
+        # server-side web-flow key (Verified in the UI), satisfying main's
+        # required-signatures rule on merge with no GPG key in this workflow. The
+        # branch ref is created first (the mutation requires it to exist), then
+        # results.json is overlaid onto the base tree as a single base64
+        # addition. Runs on the default GITHUB_TOKEN (job contents: write); only
+        # the PR open needs the App identity. execFileSync keeps every argument
+        # its own argv element, so the call is shell-free end to end.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPOSITORY: ${{ github.repository }}
+          BRANCH: ${{ steps.meta.outputs.branch }}
+          BASE_SHA: ${{ steps.meta.outputs.base_sha }}
+        run: |
+          set -euo pipefail
+          node -e '
+            const fs = require("node:fs");
+            const { execFileSync } = require("node:child_process");
+            const repo = process.env.GH_REPOSITORY;
+            const branch = process.env.BRANCH;
+            const baseSha = process.env.BASE_SHA;
+            const file = "apps/bench-arena/results.json";
+
+            // Create the refresh branch ref on origin, pointing at the
+            // main tip captured by the Prepare step.
+            execFileSync(
+              "gh",
+              [
+                "api",
+                "-X", "POST",
+                `repos/${repo}/git/refs`,
+                "-f", `ref=refs/heads/${branch}`,
+                "-f", `sha=${baseSha}`,
+              ],
+              { stdio: "inherit" }
+            );
+
+            const requestBody = JSON.stringify({
+              query: `mutation($input: CreateCommitOnBranchInput!) {
+                createCommitOnBranch(input: $input) { commit { oid url } }
+              }`,
+              variables: {
+                input: {
+                  branch: { repositoryNameWithOwner: repo, branchName: branch },
+                  message: {
+                    headline: "chore(bench-arena): refresh benchmark results.json",
+                    body: "Monthly cross-library benchmark refresh from a clean CI run. Supersedes the committed results.json with a fresh source=ci snapshot.",
+                  },
+                  expectedHeadOid: baseSha,
+                  fileChanges: {
+                    additions: [
+                      { path: file, contents: fs.readFileSync(file).toString("base64") },
+                    ],
+                  },
+                },
+              },
+            });
+            const requestPath = `${process.env.RUNNER_TEMP}/createCommitOnBranch.json`;
+            fs.writeFileSync(requestPath, requestBody);
+            execFileSync("gh", ["api", "graphql", "--input", requestPath], { stdio: "inherit" });
+          '
+
+      - name: Build PR body
+        # Built to a file via Node (no shell interpolation of dispatch context)
+        # and read by gh pr create --body-file below. Reads the just-written
+        # results.json so the body summarizes the run it is about to publish.
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          node -e '
+            const fs = require("node:fs");
+            const path = require("node:path");
+            const r = JSON.parse(fs.readFileSync("apps/bench-arena/results.json", "utf8"));
+            const p = r.provenance;
+            const published = r.capabilities.filter((c) => c.scorecardStatus === "published").length;
+            const body = [
+              "## Monthly benchmark refresh",
+              "",
+              "Mechanical refresh opened by `bench-arena.yml`. It rebuilds the real Attaform dist, drives the whole cohort through the arena in a real Chromium, and rewrites `apps/bench-arena/results.json` with `source=ci`. The Benchmarks docs page renders this file directly, so merging republishes the authoritative numbers.",
+              "",
+              "This PR is non-gating: nothing depends on it. Squash-merge to publish, or close it if a given month is not worth landing.",
+              "",
+              "| Detail | Value |",
+              "|---|---|",
+              "| Source | CI run [" + p.ciRunId + "](" + process.env.RUN_URL + ") |",
+              "| Ran against | `" + (p.commit || "").slice(0, 12) + "` |",
+              "| Runner | " + p.runner.cpuModel + " |",
+              "| Node | " + p.node + " |",
+              "| Published Scorecards | " + published + " of " + r.capabilities.length + " |",
+              "",
+            ].join("\n");
+            fs.writeFileSync(path.join(process.env.RUNNER_TEMP, "pr-body.md"), body);
+          '
+          echo "PR_BODY_PATH=$RUNNER_TEMP/pr-body.md" >> "$GITHUB_ENV"
+
+      - name: Mint release-PR app token
+        id: app_token
+        # Minted per run, scoped to pull-requests: write only (the App on
+        # install may hold more; this slice does not inherit it), and revoked by
+        # the action's post-job step. The App identity, not github-actions[bot],
+        # is what lets the PR cascade main's required checks.
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.RELEASE_PR_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_PR_APP_PRIVATE_KEY }}
+          permission-pull-requests: write
+
+      - name: Open refresh PR
+        # GH_TOKEN is the App installation token, NOT secrets.GITHUB_TOKEN, so
+        # the pull_request: opened event cascades the required checks. Everything
+        # above (branch ref, signed commit) ran on the lower-privilege default
+        # token.
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          BRANCH: ${{ steps.meta.outputs.branch }}
+        run: |
+          set -euo pipefail
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore(bench-arena): refresh benchmark results.json" \
+            --body-file "$PR_BODY_PATH"

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,11 @@ pnpm-lock.yaml
 CHANGELOG.md
 RELEASES.md
 test/perf-lock/__golden__/
+
+# Bench-arena tooling output (mirrors apps/bench-arena/.gitignore; prettier
+# does not read .gitignore). The committed results.json is hand-checked; these
+# are smoke runs and Playwright artifacts.
+**/test-results/
+**/playwright-report/
+**/.playwright/
+**/results.smoke.json

--- a/apps/bench-arena/.gitignore
+++ b/apps/bench-arena/.gitignore
@@ -1,0 +1,5 @@
+# Build + tooling output (the real Attaform dist lives at the repo root).
+dist/
+test-results/
+playwright-report/
+.playwright/

--- a/apps/bench-arena/.gitignore
+++ b/apps/bench-arena/.gitignore
@@ -3,3 +3,5 @@ dist/
 test-results/
 playwright-report/
 .playwright/
+# Smoke output from `run-arena.mjs --grep`; only a full run's results.json ships.
+results.smoke.json

--- a/apps/bench-arena/README.md
+++ b/apps/bench-arena/README.md
@@ -1,0 +1,57 @@
+# bench-arena
+
+A fair, reproducible, cross-library benchmark for Vue form libraries. It
+measures Attaform against the current Vue form-library field in a real browser
+(Playwright) across a suite of practical form shapes, and emits a
+provenance-stamped `results.json` that the documentation renders directly.
+
+The goal is credibility, not a victory lap. The harness holds the rendered DOM
+constant, normalizes triggers, pins one validator version across every entry
+that can take it, and reports where Attaform is heavier as plainly as where it
+is faster. Every number on the docs page links back to the exact CI run that
+produced it.
+
+## The committed numbers come from CI
+
+`results.json` is committed to the repository so the docs can render without a
+network call, but **the authoritative copy is always written by CI** on a clean
+Ubuntu runner. A local run is for development and sanity-checking; its numbers
+should never be committed as the published set. The provenance block in
+`results.json` records which run produced it (commit, CI run URL, runner, Node
+version, resolved library versions).
+
+## Running it locally
+
+The arena consumes the real published Attaform build, so build it first from
+the repo root:
+
+```sh
+pnpm prepack                                   # build dist/*.mjs
+pnpm --filter attaform-bench-arena exec playwright install chromium
+pnpm --filter attaform-bench-arena run arena   # build + drive + write results.json
+```
+
+To probe a single cell by hand, run the harness app and open a parameterized
+URL:
+
+```sh
+pnpm --filter attaform-bench-arena dev
+# then open, e.g.:
+#   http://localhost:4173/?adapter=attaform&scenario=flat&params=F50&trigger=input&dim=keystroke
+```
+
+## The cohort
+
+Attaform is measured against libraries grouped by what layer they own, because
+that is the only fair way to compare them. The harness owns the inputs for the
+headless libraries so the DOM is identical; libraries that render their own
+inputs are measured in their idiomatic mode and labeled as such.
+
+See the documentation's Benchmarks page for the full methodology, the
+capability matrix, and the live results.
+
+## Found a fairer setup?
+
+The adapters live in `src/adapters/`. If you can express a library more
+idiomatically, or more fairly, open a PR against its adapter. The whole point
+is a benchmark the community trusts.

--- a/apps/bench-arena/README.md
+++ b/apps/bench-arena/README.md
@@ -20,6 +20,11 @@ should never be committed as the published set. The provenance block in
 `results.json` records which run produced it (commit, CI run URL, runner, Node
 version, resolved library versions).
 
+The monthly `bench-arena.yml` workflow (also dispatchable by hand) runs that
+clean-runner sweep and opens a non-gating PR with the refreshed `results.json`.
+Merging it republishes the numbers; it never blocks anything, and a month not
+worth landing can simply be closed.
+
 ## Running it locally
 
 The arena consumes the real published Attaform build, so build it first from
@@ -30,6 +35,18 @@ pnpm prepack                                   # build dist/*.mjs
 pnpm --filter attaform-bench-arena exec playwright install chromium
 pnpm --filter attaform-bench-arena run arena   # build + drive + write results.json
 ```
+
+Supply-chain scores move on a different cadence than runtime performance, so
+they can be refreshed on their own, with no browser run:
+
+```sh
+pnpm --filter attaform-bench-arena exec node scripts/run-arena.mjs --scorecards-only
+```
+
+This re-polls each library's OpenSSF Scorecard and rewrites only those fields of
+`results.json`, leaving the runtime numbers untouched. If every lookup comes
+back unavailable (the network is down), it writes nothing rather than blanking
+good scores.
 
 To probe a single cell by hand, run the harness app and open a parameterized
 URL:

--- a/apps/bench-arena/entries/attaform.form.ts
+++ b/apps/bench-arena/entries/attaform.form.ts
@@ -1,0 +1,56 @@
+import { createAttaform } from 'attaform'
+import { useForm } from 'attaform/zod-v3'
+import { type App, createApp, defineComponent, h } from 'vue'
+import { z } from 'zod'
+
+/**
+ * The minimal real Attaform form weighed by the bundle dimension: a Zod schema,
+ * `useForm`, two registered fields, and a submit handler, mounted with the
+ * Attaform plugin so `register` and the value funnel resolve exactly as a
+ * consumer's app wires them. Every cohort entry is this same two-field form in
+ * its own idiomatic API, so esbuild (Vue external) weighs like against like.
+ */
+const schema = z.object({
+  name: z.string().min(2),
+  email: z.string().email(),
+})
+
+/**
+ * `useForm`'s schema generic derives the static `FlatPath` set; calling it
+ * through a loose signature erases that derivation while leaving the runtime
+ * call identical (the path the typed API resolves to). It also side-steps the
+ * monorepo-only type skew where Attaform's published `.d.ts` resolves the repo
+ * root's zod (v4) while this entry imports the arena's zod (v3); a real
+ * single-zod consumer never sees it. The adapters take the same loose route.
+ */
+type RegisterBinding = { displayValue: { value: string } }
+type BundleForm = {
+  register: (path: string) => RegisterBinding
+  setValue: (path: string, value: string) => void
+  handleSubmit: (onValid: (values: unknown) => void) => (event?: Event) => Promise<void>
+}
+const useFormLoose = useForm as unknown as (config: { schema: unknown }) => BundleForm
+
+const Form = defineComponent({
+  name: 'AttaformBundleForm',
+  setup() {
+    const form = useFormLoose({ schema })
+    const onSubmit = form.handleSubmit(() => {})
+    const name = form.register('name')
+    const email = form.register('email')
+    const write = (path: 'name' | 'email', event: Event): void => {
+      form.setValue(path, (event.target as HTMLInputElement).value)
+    }
+    return () =>
+      h('form', { onSubmit }, [
+        h('input', { value: name.displayValue.value, onInput: (e: Event) => write('name', e) }),
+        h('input', { value: email.displayValue.value, onInput: (e: Event) => write('email', e) }),
+      ])
+  },
+})
+
+export function mount(el: HTMLElement): App {
+  const app = createApp(Form).use(createAttaform())
+  app.mount(el)
+  return app
+}

--- a/apps/bench-arena/entries/formisch.form.ts
+++ b/apps/bench-arena/entries/formisch.form.ts
@@ -1,0 +1,54 @@
+import { useField, useForm } from '@formisch/vue'
+import { type App, createApp, defineComponent, h } from 'vue'
+import { email, minLength, object, pipe, string } from 'valibot'
+
+/**
+ * The minimal real @formisch/vue form: `useForm` over a valibot schema (the
+ * validator formisch is built on) and two fields through the `useField`
+ * composable. formisch's functional generics collapse under introspection, so
+ * the store and field handles are cast through; the runtime calls are the real
+ * ones a consumer ships.
+ */
+const schema = object({
+  name: pipe(string(), minLength(2)),
+  email: pipe(string(), email()),
+})
+
+type FormStore = object
+type FieldHandle = { input: string; props: { onBlur: (event?: FocusEvent) => void } }
+
+const Field = defineComponent({
+  name: 'FormischBundleField',
+  props: {
+    form: { type: Object, required: true },
+    name: { type: String, required: true },
+  },
+  setup(props) {
+    const field = useField(
+      props.form as never,
+      { path: [props.name] } as never
+    ) as unknown as FieldHandle
+    return () =>
+      h('input', {
+        value: field.input,
+        onInput: (e: Event) => {
+          field.input = (e.target as HTMLInputElement).value
+        },
+        onBlur: () => field.props.onBlur(),
+      })
+  },
+})
+
+const Form = defineComponent({
+  name: 'FormischBundleForm',
+  setup() {
+    const form = useForm({ schema, initialInput: { name: '', email: '' } } as never) as FormStore
+    return () => h('form', [h(Field, { form, name: 'name' }), h(Field, { form, name: 'email' })])
+  },
+})
+
+export function mount(el: HTMLElement): App {
+  const app = createApp(Form)
+  app.mount(el)
+  return app
+}

--- a/apps/bench-arena/entries/formkit.form.ts
+++ b/apps/bench-arena/entries/formkit.form.ts
@@ -1,0 +1,36 @@
+import { FormKit, defaultConfig, plugin } from '@formkit/vue'
+import { createZodPlugin } from '@formkit/zod'
+import { type App, type Component, createApp, defineComponent, h } from 'vue'
+import { z } from 'zod'
+
+/**
+ * The minimal real FormKit form, the batteries-included entry: FormKit renders
+ * its own inputs, so this weighs its component runtime plus the default config
+ * and the Zod plugin, the cost a consumer pays to ship a FormKit form. FormKit
+ * accepts attributes its typed surface does not enumerate, so it is bound
+ * through a loose Component, exactly as the adapter does.
+ */
+const schema = z.object({
+  name: z.string().min(2),
+  email: z.string().email(),
+})
+
+const FormKitC = FormKit as unknown as Component
+
+const Form = defineComponent({
+  name: 'FormKitBundleForm',
+  setup() {
+    const [zodPlugin, submitHandler] = createZodPlugin(schema as never, () => {})
+    return () =>
+      h(FormKitC, { type: 'form', plugins: [zodPlugin], onSubmit: submitHandler }, () => [
+        h(FormKitC, { type: 'text', name: 'name' }),
+        h(FormKitC, { type: 'email', name: 'email' }),
+      ])
+  },
+})
+
+export function mount(el: HTMLElement): App {
+  const app = createApp(Form).use(plugin, defaultConfig())
+  app.mount(el)
+  return app
+}

--- a/apps/bench-arena/entries/regle.form.ts
+++ b/apps/bench-arena/entries/regle.form.ts
@@ -1,0 +1,46 @@
+import { useRegleSchema } from '@regle/schemas'
+import { type App, createApp, defineComponent, h, reactive } from 'vue'
+import { z } from 'zod'
+
+/**
+ * The minimal real Regle form (schema mode, the Zod comparison): `useRegleSchema`
+ * validating a reactive state object against a Zod schema, with two fields bound
+ * to their granular `$value` and a submit that runs the root validation. Regle
+ * is validation-only, so the form owns its own reactive state; its deep generic
+ * tree is cast to the slice this form reads.
+ */
+const schema = z.object({
+  name: z.string().min(2),
+  email: z.string().email(),
+})
+
+type RegleField = { $value: string; $validate: () => Promise<unknown> }
+type RegleRoot = { $validate: () => Promise<unknown>; $fields: Record<string, RegleField> }
+
+const Form = defineComponent({
+  name: 'RegleBundleForm',
+  setup() {
+    const state = reactive({ name: '', email: '' })
+    const { r$ } = useRegleSchema(state as never, schema as never) as unknown as { r$: RegleRoot }
+    const field = (key: 'name' | 'email') =>
+      h('input', {
+        value: r$.$fields[key]?.$value,
+        onInput: (e: Event) => {
+          const f = r$.$fields[key]
+          if (f) f.$value = (e.target as HTMLInputElement).value
+        },
+        onBlur: () => void r$.$fields[key]?.$validate(),
+      })
+    const onSubmit = (event: Event): void => {
+      event.preventDefault()
+      void r$.$validate()
+    }
+    return () => h('form', { onSubmit }, [field('name'), field('email')])
+  },
+})
+
+export function mount(el: HTMLElement): App {
+  const app = createApp(Form)
+  app.mount(el)
+  return app
+}

--- a/apps/bench-arena/entries/tanstack.form.ts
+++ b/apps/bench-arena/entries/tanstack.form.ts
@@ -1,0 +1,47 @@
+import { useForm } from '@tanstack/vue-form'
+import { type App, createApp, defineComponent, h } from 'vue'
+import { z } from 'zod'
+
+/**
+ * The minimal real @tanstack/vue-form form: `useForm` with the schema attached
+ * as a Standard Schema `onChange` validator (its recommended setup), two fields
+ * through the `form.Field` render-prop component, and `handleSubmit`. The
+ * dynamic-free static schema still leaves TanStack's field generics heavy, so
+ * the `Field` props and slot are cast through; the runtime calls are the real
+ * ones a consumer ships.
+ */
+const schema = z.object({
+  name: z.string().min(2),
+  email: z.string().email(),
+})
+
+type FieldSlot = { field: { state: { value: string }; handleChange: (value: string) => void } }
+
+const Form = defineComponent({
+  name: 'TanstackBundleForm',
+  setup() {
+    const form = useForm({
+      defaultValues: { name: '', email: '' },
+      validators: { onChange: schema },
+    })
+    const field = (name: 'name' | 'email') =>
+      h(form.Field, { name } as never, {
+        default: (slot: FieldSlot) =>
+          h('input', {
+            value: slot.field.state.value,
+            onInput: (e: Event) => slot.field.handleChange((e.target as HTMLInputElement).value),
+          }),
+      })
+    const onSubmit = (event: Event): void => {
+      event.preventDefault()
+      void form.handleSubmit()
+    }
+    return () => h('form', { onSubmit }, [field('name'), field('email')])
+  },
+})
+
+export function mount(el: HTMLElement): App {
+  const app = createApp(Form)
+  app.mount(el)
+  return app
+}

--- a/apps/bench-arena/entries/vee-validate.form.ts
+++ b/apps/bench-arena/entries/vee-validate.form.ts
@@ -1,0 +1,43 @@
+import { toTypedSchema } from '@vee-validate/zod'
+import { useField, useForm } from 'vee-validate'
+import { type App, createApp, defineComponent, h } from 'vue'
+import { z } from 'zod'
+
+/**
+ * The minimal real vee-validate form: `useForm` over a typed Zod schema, two
+ * fields through the `useField` composition API, and `handleSubmit`. This is
+ * the headless composition-API shape (no `<Form>`/`<Field>` components), the
+ * fastest-correct setup the keystroke dimension also drives.
+ */
+const schema = z.object({
+  name: z.string().min(2),
+  email: z.string().email(),
+})
+
+const Field = defineComponent({
+  name: 'VeeBundleField',
+  props: { name: { type: String, required: true } },
+  setup(props) {
+    const { value, handleChange } = useField<string>(() => props.name)
+    return () =>
+      h('input', {
+        value: value.value,
+        onInput: (e: Event) => handleChange((e.target as HTMLInputElement).value),
+      })
+  },
+})
+
+const Form = defineComponent({
+  name: 'VeeBundleForm',
+  setup() {
+    const form = useForm({ validationSchema: toTypedSchema(schema) })
+    const onSubmit = form.handleSubmit(() => {})
+    return () => h('form', { onSubmit }, [h(Field, { name: 'name' }), h(Field, { name: 'email' })])
+  },
+})
+
+export function mount(el: HTMLElement): App {
+  const app = createApp(Form)
+  app.mount(el)
+  return app
+}

--- a/apps/bench-arena/entries/vuelidate.form.ts
+++ b/apps/bench-arena/entries/vuelidate.form.ts
@@ -1,0 +1,44 @@
+import { useVuelidate } from '@vuelidate/core'
+import { email, minLength, required } from '@vuelidate/validators'
+import { type App, createApp, defineComponent, h, reactive } from 'vue'
+
+/**
+ * The minimal real Vuelidate form: model-based native validators (`required`,
+ * `minLength`, `email`) over a reactive state object, with `useVuelidate`
+ * deriving the validation tree and a submit that runs `$validate`. Vuelidate
+ * ships no schema mode, so this weighs its core plus the native validators, the
+ * honest cost of its idiomatic form. The validation tree is cast to the slice
+ * this form reads.
+ */
+const Form = defineComponent({
+  name: 'VuelidateBundleForm',
+  setup() {
+    const state = reactive({ name: '', email: '' })
+    const rules = {
+      name: { required, minLength: minLength(2) },
+      email: { required, email },
+    }
+    const v$ = useVuelidate(rules, state) as unknown as {
+      value: { $validate: () => Promise<boolean> } & Record<string, { $touch: () => void }>
+    }
+    const field = (key: 'name' | 'email') =>
+      h('input', {
+        value: state[key],
+        onInput: (e: Event) => {
+          state[key] = (e.target as HTMLInputElement).value
+        },
+        onBlur: () => v$.value[key]?.$touch(),
+      })
+    const onSubmit = (event: Event): void => {
+      event.preventDefault()
+      void v$.value.$validate()
+    }
+    return () => h('form', { onSubmit }, [field('name'), field('email')])
+  },
+})
+
+export function mount(el: HTMLElement): App {
+  const app = createApp(Form)
+  app.mount(el)
+  return app
+}

--- a/apps/bench-arena/index.html
+++ b/apps/bench-arena/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Attaform bench-arena</title>
+  </head>
+  <body>
+    <!--
+      The arena mounts exactly one adapter per page load, selected by query
+      param (?adapter&scenario&params&trigger&dim). The driver navigates to a
+      fresh URL for every cell so no library shares a heap with another.
+    -->
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/apps/bench-arena/package.json
+++ b/apps/bench-arena/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "attaform-bench-arena",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Fair, reproducible cross-library Vue form benchmark. Measures Attaform against the Vue form-library cohort in a real browser and emits a provenance-stamped results.json consumed by the docs.",
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "exports": {
+    "./results.json": "./results.json"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 4174",
+    "typecheck": "vue-tsc --noEmit",
+    "arena": "node scripts/run-arena.mjs",
+    "bench:bundles": "node scripts/measure-bundles.mjs",
+    "test:arena": "playwright test"
+  },
+  "dependencies": {
+    "attaform": "workspace:*"
+  },
+  "devDependencies": {
+    "@formisch/vue": "^0.8.0",
+    "@formkit/vue": "^2.0.0",
+    "@formkit/zod": "^2.0.0",
+    "@playwright/test": "^1.60.0",
+    "@regle/core": "^1.26.1",
+    "@regle/rules": "^1.26.1",
+    "@regle/schemas": "^1.26.1",
+    "@tanstack/vue-form": "^1.33.0",
+    "@vee-validate/zod": "^4.15.1",
+    "@vitejs/plugin-vue": "^6.0.7",
+    "@vuelidate/core": "^2.0.3",
+    "@vuelidate/validators": "^2.0.4",
+    "pinia": "^3.0.4",
+    "valibot": "^1.4.1",
+    "vee-validate": "^4.15.1",
+    "vite": "^8.0.10",
+    "vue": "^3.5.33",
+    "vue-tsc": "^3.2.7",
+    "zod": "^3.25.76"
+  }
+}

--- a/apps/bench-arena/playwright.config.ts
+++ b/apps/bench-arena/playwright.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * Drives the arena against a production `build` + `preview` (stable code,
+ * representative of what a consumer ships), one worker for CPU isolation. The
+ * preview server consumes the real Attaform `dist`, so run `pnpm prepack` at the
+ * repo root first (the webServer build will fail loudly otherwise). `gc()` is
+ * exposed so the driver can collect between cells and keep one library's
+ * garbage from skewing the next.
+ */
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  reporter: process.env.CI ? 'github' : 'list',
+  timeout: 90_000,
+  use: {
+    baseURL: 'http://localhost:4174',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        launchOptions: { args: ['--js-flags=--expose-gc'] },
+      },
+    },
+  ],
+  webServer: {
+    command: 'pnpm build && pnpm preview',
+    url: 'http://localhost:4174',
+    reuseExistingServer: !process.env.CI,
+    timeout: 240_000,
+  },
+})

--- a/apps/bench-arena/results.json
+++ b/apps/bench-arena/results.json
@@ -43,6 +43,7 @@
       "repo": "github.com/attaform/Attaform",
       "repoUrl": "https://github.com/attaform/Attaform",
       "scorecardUrl": "https://scorecard.dev/viewer/?uri=github.com/attaform/Attaform",
+      "scorecardStatus": "published",
       "scorecard": {
         "score": 7.9,
         "date": "2026-06-10T05:33:32Z"
@@ -64,6 +65,7 @@
       "repo": "github.com/logaretm/vee-validate",
       "repoUrl": "https://github.com/logaretm/vee-validate",
       "scorecardUrl": "https://scorecard.dev/viewer/?uri=github.com/logaretm/vee-validate",
+      "scorecardStatus": "published",
       "scorecard": {
         "score": 3.6,
         "date": "2026-06-08"
@@ -85,6 +87,7 @@
       "repo": "github.com/TanStack/form",
       "repoUrl": "https://github.com/TanStack/form",
       "scorecardUrl": "https://scorecard.dev/viewer/?uri=github.com/TanStack/form",
+      "scorecardStatus": "not-published",
       "scorecard": null
     },
     {
@@ -103,6 +106,7 @@
       "repo": "github.com/open-circle/formisch",
       "repoUrl": "https://github.com/open-circle/formisch",
       "scorecardUrl": "https://scorecard.dev/viewer/?uri=github.com/open-circle/formisch",
+      "scorecardStatus": "not-published",
       "scorecard": null
     },
     {
@@ -121,6 +125,7 @@
       "repo": "github.com/victorgarciaesgi/regle",
       "repoUrl": "https://github.com/victorgarciaesgi/regle",
       "scorecardUrl": "https://scorecard.dev/viewer/?uri=github.com/victorgarciaesgi/regle",
+      "scorecardStatus": "not-published",
       "scorecard": null
     },
     {
@@ -139,6 +144,7 @@
       "repo": "github.com/victorgarciaesgi/regle",
       "repoUrl": "https://github.com/victorgarciaesgi/regle",
       "scorecardUrl": "https://scorecard.dev/viewer/?uri=github.com/victorgarciaesgi/regle",
+      "scorecardStatus": "not-published",
       "scorecard": null
     },
     {
@@ -157,6 +163,7 @@
       "repo": "github.com/formkit/formkit",
       "repoUrl": "https://github.com/formkit/formkit",
       "scorecardUrl": "https://scorecard.dev/viewer/?uri=github.com/formkit/formkit",
+      "scorecardStatus": "not-published",
       "scorecard": null
     },
     {
@@ -175,6 +182,7 @@
       "repo": "github.com/vuelidate/vuelidate",
       "repoUrl": "https://github.com/vuelidate/vuelidate",
       "scorecardUrl": "https://scorecard.dev/viewer/?uri=github.com/vuelidate/vuelidate",
+      "scorecardStatus": "published",
       "scorecard": {
         "score": 4.4,
         "date": "2026-06-01"

--- a/apps/bench-arena/results.json
+++ b/apps/bench-arena/results.json
@@ -1,0 +1,9112 @@
+{
+  "schemaVersion": 1,
+  "provenance": {
+    "source": "local",
+    "commit": null,
+    "ciRunId": null,
+    "ciRunUrl": null,
+    "runner": {
+      "os": "darwin",
+      "arch": "arm64",
+      "cpuModel": "Apple M4 Pro",
+      "cpuCount": 14
+    },
+    "node": "v25.6.1",
+    "timestamp": "2026-06-10T19:56:16.031Z",
+    "libVersions": {
+      "attaform": "0.21.2",
+      "vee-validate": "4.15.1",
+      "@tanstack/vue-form": "1.33.0",
+      "@formisch/vue": "0.8.0",
+      "@regle/core": "1.26.1",
+      "@formkit/vue": "2.0.0",
+      "@vuelidate/core": "2.0.3",
+      "zod": "3.25.76",
+      "valibot": "1.4.1"
+    }
+  },
+  "baseline": "attaform",
+  "capabilities": [
+    {
+      "lib": "attaform",
+      "displayName": "Attaform",
+      "layer": "headless-form-state",
+      "schemaLib": "zod3",
+      "ownsInputs": false,
+      "flat": "native",
+      "nested": "native",
+      "arrays": "native",
+      "grid": "native",
+      "discriminated-union": "native",
+      "massive": "native",
+      "wizard": "native"
+    },
+    {
+      "lib": "vee-validate",
+      "displayName": "vee-validate",
+      "layer": "headless-form-state",
+      "schemaLib": "zod3",
+      "ownsInputs": false,
+      "flat": "native",
+      "nested": "native",
+      "arrays": "native",
+      "grid": "native",
+      "discriminated-union": "hand-rolled",
+      "massive": "native",
+      "wizard": "hand-rolled"
+    },
+    {
+      "lib": "tanstack",
+      "displayName": "@tanstack/vue-form",
+      "layer": "headless-form-state",
+      "schemaLib": "zod3",
+      "ownsInputs": false,
+      "flat": "native",
+      "nested": "native",
+      "arrays": "native",
+      "grid": "native",
+      "discriminated-union": "hand-rolled",
+      "massive": "native",
+      "wizard": "hand-rolled"
+    },
+    {
+      "lib": "formisch",
+      "displayName": "@formisch/vue",
+      "layer": "headless-form-state",
+      "schemaLib": "valibot",
+      "ownsInputs": false,
+      "flat": "native",
+      "nested": "native",
+      "arrays": "native",
+      "grid": "native",
+      "discriminated-union": "hand-rolled",
+      "massive": "native",
+      "wizard": "hand-rolled"
+    },
+    {
+      "lib": "regle-schema",
+      "displayName": "Regle (schema)",
+      "layer": "headless-validation-only",
+      "schemaLib": "zod3",
+      "ownsInputs": false,
+      "flat": "native",
+      "nested": "native",
+      "arrays": "native",
+      "grid": "native",
+      "discriminated-union": "native",
+      "massive": "native",
+      "wizard": "hand-rolled"
+    },
+    {
+      "lib": "regle-rules",
+      "displayName": "Regle (rules)",
+      "layer": "headless-validation-only",
+      "schemaLib": "native",
+      "ownsInputs": false,
+      "flat": "native",
+      "nested": "native",
+      "arrays": "native",
+      "grid": "native",
+      "discriminated-union": "hand-rolled",
+      "massive": "native",
+      "wizard": "hand-rolled"
+    },
+    {
+      "lib": "formkit",
+      "displayName": "FormKit",
+      "layer": "batteries-included",
+      "schemaLib": "zod3",
+      "ownsInputs": true,
+      "flat": "native",
+      "nested": "native",
+      "arrays": "native",
+      "grid": "native",
+      "discriminated-union": "hand-rolled",
+      "massive": "native",
+      "wizard": "hand-rolled"
+    },
+    {
+      "lib": "vuelidate",
+      "displayName": "Vuelidate",
+      "layer": "headless-validation-only",
+      "schemaLib": "native",
+      "ownsInputs": false,
+      "flat": "native",
+      "nested": "native",
+      "arrays": "hand-rolled",
+      "grid": "hand-rolled",
+      "discriminated-union": "hand-rolled",
+      "massive": "native",
+      "wizard": "hand-rolled"
+    }
+  ],
+  "bundle": [
+    {
+      "id": "attaform",
+      "lib": "Attaform",
+      "version": "0.21.2",
+      "validator": "zod 3.25.76",
+      "gzBytes": 69810,
+      "ratio": 1
+    },
+    {
+      "id": "vee-validate",
+      "lib": "vee-validate",
+      "version": "4.15.1",
+      "validator": "zod 3.25.76",
+      "gzBytes": 25199,
+      "ratio": 0.36
+    },
+    {
+      "id": "tanstack",
+      "lib": "@tanstack/vue-form",
+      "version": "1.33.0",
+      "validator": "zod 3.25.76",
+      "gzBytes": 30685,
+      "ratio": 0.44
+    },
+    {
+      "id": "formisch",
+      "lib": "@formisch/vue",
+      "version": "0.8.0",
+      "validator": "valibot 1.4.1",
+      "gzBytes": 3689,
+      "ratio": 0.05
+    },
+    {
+      "id": "regle",
+      "lib": "Regle",
+      "version": "1.26.1",
+      "validator": "zod 3.25.76",
+      "gzBytes": 32245,
+      "ratio": 0.46
+    },
+    {
+      "id": "formkit",
+      "lib": "FormKit",
+      "version": "2.0.0",
+      "validator": "zod 3.25.76",
+      "gzBytes": 44233,
+      "ratio": 0.63
+    },
+    {
+      "id": "vuelidate",
+      "lib": "Vuelidate",
+      "version": "2.0.3",
+      "validator": "native validators",
+      "gzBytes": 5086,
+      "ratio": 0.07
+    }
+  ],
+  "runtime": {
+    "flat": {
+      "keystroke": {
+        "unit": "ms",
+        "byParam": {
+          "F10": [
+            {
+              "lib": "attaform",
+              "median": 0.6000000238418579,
+              "p95": 1.2999999523162842,
+              "iqr": 0.42500007152557373,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 0.2999999523162842,
+              "p95": 1,
+              "iqr": 0.39999985694885254,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.5,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 0.8000000715255737,
+              "p95": 1.399999976158142,
+              "iqr": 0.39999985694885254,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.33,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.8000000715255737,
+              "p95": 1.1999999284744263,
+              "iqr": 0.29999998211860657,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.33,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 0.8000000715255737,
+              "p95": 1.3000000715255737,
+              "iqr": 0.4500000476837158,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.33,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 0.7999999523162842,
+              "p95": 1.299999964237213,
+              "iqr": 0.5,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.33,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 0.9000000953674316,
+              "p95": 1.399999976158142,
+              "iqr": 0.5,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.5,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.6000000238418579,
+              "p95": 1,
+              "iqr": 0.39999985694885254,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            }
+          ],
+          "F50": [
+            {
+              "lib": "attaform",
+              "median": 0.7999999523162842,
+              "p95": 1.710000038146972,
+              "iqr": 0.7999999523162842,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1.33
+            },
+            {
+              "lib": "vee-validate",
+              "median": 0.7999999523162842,
+              "p95": 1.399999976158142,
+              "iqr": 0.5999999344348907,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 2.67
+            },
+            {
+              "lib": "tanstack",
+              "median": 1.5,
+              "p95": 2.1999999403953554,
+              "iqr": 0.5999999046325684,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.88,
+              "slope": 1.87
+            },
+            {
+              "lib": "formisch",
+              "median": 1.1999999284744263,
+              "p95": 1.600000023841858,
+              "iqr": 0.3999999761581421,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.5,
+              "slope": 1.5
+            },
+            {
+              "lib": "regle-schema",
+              "median": 1.5,
+              "p95": 2.200000047683716,
+              "iqr": 0.5999999344348907,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.88,
+              "slope": 1.87
+            },
+            {
+              "lib": "regle-rules",
+              "median": 1.100000023841858,
+              "p95": 1.5,
+              "iqr": 0.5000001192092896,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.38,
+              "slope": 1.38
+            },
+            {
+              "lib": "formkit",
+              "median": 1.399999976158142,
+              "p95": 2.0999999046325684,
+              "iqr": 0.5999999046325684,
+              "count": 198,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.75,
+              "slope": 1.56
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.7999999523162842,
+              "p95": 1.4099999785423274,
+              "iqr": 0.5,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1.33
+            }
+          ]
+        }
+      },
+      "mount": {
+        "unit": "ms",
+        "byParam": {
+          "F10": [
+            {
+              "lib": "attaform",
+              "median": 0.8999999761581421,
+              "p95": 1.0350000083446502,
+              "iqr": 0.15000009536743164,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 0.6499999761581421,
+              "p95": 1.0050000011920928,
+              "iqr": 0.2000001072883606,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.72,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 0.7999999523162842,
+              "p95": 0.9699999928474425,
+              "iqr": 0.10000002384185791,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.89,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.6000000238418579,
+              "p95": 0.8000000715255737,
+              "iqr": 0.20000004768371582,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.67,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 0.7999999523162842,
+              "p95": 1.1799999952316282,
+              "iqr": 0.34999996423721313,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.89,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 0.7999999523162842,
+              "p95": 1.0799999713897703,
+              "iqr": 0.2999999523162842,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.89,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 5.650000035762787,
+              "p95": 8.235000008344649,
+              "iqr": 1.7499999403953552,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 6.28,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.7500000596046448,
+              "p95": 1.0050000011920928,
+              "iqr": 0.19999998807907104,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.83,
+              "slope": 1
+            }
+          ],
+          "F50": [
+            {
+              "lib": "attaform",
+              "median": 1.899999976158142,
+              "p95": 2.380000042915344,
+              "iqr": 0.6500000953674316,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 2.11
+            },
+            {
+              "lib": "vee-validate",
+              "median": 1.9000000357627869,
+              "p95": 2.7349999368190767,
+              "iqr": 0.6500000357627869,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 2.92
+            },
+            {
+              "lib": "tanstack",
+              "median": 2.8000000715255737,
+              "p95": 3.7200000286102277,
+              "iqr": 0.5500000715255737,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.47,
+              "slope": 3.5
+            },
+            {
+              "lib": "formisch",
+              "median": 1.1999999284744263,
+              "p95": 1.520000028610229,
+              "iqr": 0.4500000476837158,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.63,
+              "slope": 2
+            },
+            {
+              "lib": "regle-schema",
+              "median": 2.350000023841858,
+              "p95": 3.2350000143051147,
+              "iqr": 0.9500000476837158,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.24,
+              "slope": 2.94
+            },
+            {
+              "lib": "regle-rules",
+              "median": 2.5,
+              "p95": 2.740000009536743,
+              "iqr": 0.3999999761581421,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.32,
+              "slope": 3.13
+            },
+            {
+              "lib": "formkit",
+              "median": 24.80000001192093,
+              "p95": 31.065000039339065,
+              "iqr": 3.549999952316284,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 13.05,
+              "slope": 4.39
+            },
+            {
+              "lib": "vuelidate",
+              "median": 1.8000000715255737,
+              "p95": 2.6599999904632563,
+              "iqr": 0.5500000715255737,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.95,
+              "slope": 2.4
+            }
+          ]
+        }
+      },
+      "validate": {
+        "unit": "ms",
+        "byParam": {
+          "F10": [
+            {
+              "lib": "attaform",
+              "median": 0.19999992847442627,
+              "p95": 0.40000009536743164,
+              "iqr": 0.19999992847442627,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 6,
+              "p95": 6.299999964237213,
+              "iqr": 0.20000004768371582,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 30,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 0.19999992847442627,
+              "p95": 0.30000007152557373,
+              "iqr": 0.10000002384185791,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.19999992847442627,
+              "p95": 0.30000007152557373,
+              "iqr": 0.10000002384185791,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 0.3999999761581421,
+              "p95": 0.7999999523162842,
+              "iqr": 0.3999999761581421,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 2,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 0.2999999523162842,
+              "p95": 0.5,
+              "iqr": 0.20000004768371582,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.5,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 1.3000000715255737,
+              "p95": 2.799999952316284,
+              "iqr": 0.9000000953674316,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 6.5,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.10000002384185791,
+              "p95": 0.20000004768371582,
+              "iqr": 0.10000002384185791,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.5,
+              "slope": 1
+            }
+          ],
+          "F50": [
+            {
+              "lib": "attaform",
+              "median": 0.20000004768371582,
+              "p95": 0.41500008106231606,
+              "iqr": 0.19999992847442627,
+              "count": 98,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 6.299999952316284,
+              "p95": 6.799999964237213,
+              "iqr": 0.5,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 31.5,
+              "slope": 1.05
+            },
+            {
+              "lib": "tanstack",
+              "median": 0.3999999761581421,
+              "p95": 0.6000000238418579,
+              "iqr": 0.2999999523162842,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 2,
+              "slope": 2
+            },
+            {
+              "lib": "formisch",
+              "median": 0.10000002384185791,
+              "p95": 0.2100000381469721,
+              "iqr": 0.10000002384185791,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.5,
+              "slope": 0.5
+            },
+            {
+              "lib": "regle-schema",
+              "median": 1,
+              "p95": 1.8000000715255737,
+              "iqr": 0.8999999761581421,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 5,
+              "slope": 2.5
+            },
+            {
+              "lib": "regle-rules",
+              "median": 0.3999999761581421,
+              "p95": 1,
+              "iqr": 0.3250000476837158,
+              "count": 97,
+              "trimmed": 3,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 2,
+              "slope": 1.33
+            },
+            {
+              "lib": "formkit",
+              "median": 2.8000000715255737,
+              "p95": 3.2500000298023224,
+              "iqr": 0.2999999523162842,
+              "count": 96,
+              "trimmed": 4,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 14,
+              "slope": 2.15
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.10000002384185791,
+              "p95": 0.20000004768371582,
+              "iqr": 0.10000002384185791,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.5,
+              "slope": 1
+            }
+          ]
+        }
+      },
+      "rerender": {
+        "unit": "renders",
+        "byParam": {
+          "F10": [
+            {
+              "lib": "attaform",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 1,
+              "p95": 3,
+              "iqr": 2,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "dom-mutations",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            }
+          ],
+          "F50": [
+            {
+              "lib": "attaform",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 3,
+              "p95": 3,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "dom-mutations",
+              "supported": true,
+              "ratio": 3,
+              "slope": 3
+            },
+            {
+              "lib": "vuelidate",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            }
+          ]
+        }
+      },
+      "memory": {
+        "unit": "bytes",
+        "byParam": {
+          "F10": [
+            {
+              "lib": "attaform",
+              "retained": {
+                "median": 128372,
+                "p95": 311988,
+                "count": 12
+              },
+              "churn": {
+                "median": 457660,
+                "p95": 485236,
+                "count": 12
+              },
+              "leak": {
+                "median": 28324,
+                "p95": 226216,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  732276, 144032, 125128, 129740, 128372, 115500, 129244, 115976, 311988, 109972,
+                  131880, 98668
+                ],
+                "churn": [
+                  708476, 451940, 466876, 457660, 457664, 462060, 455172, 452540, 464916, 447192,
+                  485236, 433312
+                ],
+                "leak": [
+                  891596, 42296, 40980, 32180, 28324, 26748, 18948, 19912, 226216, 2576, 52348, 3540
+                ]
+              },
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "retained": {
+                "median": 131844,
+                "p95": 172892,
+                "count": 12
+              },
+              "churn": {
+                "median": 234232,
+                "p95": 244596,
+                "count": 12
+              },
+              "leak": {
+                "median": 17040,
+                "p95": 129588,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  594188, 131844, 156036, 145372, 135672, 140808, 125076, 130988, 172892, 126404,
+                  127272, 120948
+                ],
+                "churn": [
+                  726896, 243548, 211036, 244596, 238988, 239476, 232704, 234232, 222572, 241372,
+                  230948, 221956
+                ],
+                "leak": [
+                  639772, 34212, 36268, 25512, 19488, 17040, 2896, 13188, 129588, 3740, 13452, 1112
+                ]
+              },
+              "supported": true,
+              "ratio": 1.03,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "retained": {
+                "median": 142156,
+                "p95": 187104,
+                "count": 12
+              },
+              "churn": {
+                "median": 770308,
+                "p95": 829812,
+                "count": 12
+              },
+              "leak": {
+                "median": 47780,
+                "p95": 79224,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  601800, 149320, 139152, 136940, 155448, 142156, 134012, 152728, 187104, 140828,
+                  143384, 141048
+                ],
+                "churn": [
+                  1076456, 829812, 793584, 789340, 773608, 764788, 749784, 757804, 770308, 766012,
+                  771616, 749100
+                ],
+                "leak": [
+                  810752, 52780, 51280, 59384, 45528, 47780, 29084, 49052, 79224, 30840, 39072,
+                  20568
+                ]
+              },
+              "supported": true,
+              "ratio": 1.11,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "retained": {
+                "median": 81132,
+                "p95": 108348,
+                "count": 12
+              },
+              "churn": {
+                "median": 244944,
+                "p95": 254832,
+                "count": 12
+              },
+              "leak": {
+                "median": 9120,
+                "p95": 40828,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  368608, 86544, 73240, 74732, 79168, 91860, 81132, 84944, 108348, 79636, 82232,
+                  74680
+                ],
+                "churn": [
+                  365656, 241668, 245364, 247420, 241820, 245148, 244944, 241844, 254832, 253124,
+                  238976, 235784
+                ],
+                "leak": [429016, 16296, 2940, 6760, 9120, 25868, 4768, 12976, 40828, 4252, 9336, 0]
+              },
+              "supported": true,
+              "ratio": 0.63,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "retained": {
+                "median": 208768,
+                "p95": 302440,
+                "count": 12
+              },
+              "churn": {
+                "median": 622428,
+                "p95": 647544,
+                "count": 12
+              },
+              "leak": {
+                "median": 15552,
+                "p95": 121872,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  749872, 226800, 217036, 204964, 209840, 206376, 204520, 208768, 302440, 206488,
+                  215184, 200752
+                ],
+                "churn": [
+                  306560, 721440, 634608, 603296, 628024, 608420, 622748, 623912, 647544, 622428,
+                  602648, 604196
+                ],
+                "leak": [
+                  700804, 18572, 21004, 17284, 6508, 15552, 2592, 11488, 121872, 960, 19404, 0
+                ]
+              },
+              "supported": true,
+              "ratio": 1.63,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "retained": {
+                "median": 238060,
+                "p95": 333048,
+                "count": 12
+              },
+              "churn": {
+                "median": 466384,
+                "p95": 507232,
+                "count": 12
+              },
+              "leak": {
+                "median": 13804,
+                "p95": 119620,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  774660, 250416, 259256, 234048, 241912, 234712, 232952, 238060, 333048, 234532,
+                  238288, 229880
+                ],
+                "churn": [
+                  595604, 466656, 467588, 463612, 464824, 466512, 460044, 466384, 507232, 477448,
+                  463908, 449328
+                ],
+                "leak": [
+                  649232, 13184, 30468, 4524, 16208, 16708, 5468, 14248, 119620, 3092, 13804, 0
+                ]
+              },
+              "supported": true,
+              "ratio": 1.85,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "retained": {
+                "median": 2315688,
+                "p95": 2375788,
+                "count": 12
+              },
+              "churn": {
+                "median": 743064,
+                "p95": 767152,
+                "count": 12
+              },
+              "leak": {
+                "median": 52512,
+                "p95": 139788,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  3384884, 2371752, 2315688, 2340828, 2349292, 2299772, 2312364, 2304692, 2375788,
+                  2372388, 2282900, 2296488
+                ],
+                "churn": [
+                  426084, 833584, 767152, 755344, 755988, 741936, 736856, 764564, 755120, 743064,
+                  736128, 737360
+                ],
+                "leak": [
+                  1682108, 139788, 61020, 52512, 84744, 34532, 21908, 47400, 116140, 76676, 4364,
+                  19592
+                ]
+              },
+              "supported": true,
+              "ratio": 18.04,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "retained": {
+                "median": 137140,
+                "p95": 182392,
+                "count": 12
+              },
+              "churn": {
+                "median": 229256,
+                "p95": 237884,
+                "count": 12
+              },
+              "leak": {
+                "median": 13032,
+                "p95": 66784,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  501556, 137140, 149844, 130704, 142176, 133320, 129040, 138752, 182392, 130744,
+                  132076, 138560
+                ],
+                "churn": [
+                  347056, 223328, 224556, 229784, 234924, 216364, 237884, 229256, 237532, 211376,
+                  232744, 208224
+                ],
+                "leak": [
+                  492916, 25148, 31648, 12472, 31676, 17152, 9128, 11428, 66784, 1808, 13032, 10036
+                ]
+              },
+              "supported": true,
+              "ratio": 1.07,
+              "slope": 1
+            }
+          ],
+          "F50": [
+            {
+              "lib": "attaform",
+              "retained": {
+                "median": 376796,
+                "p95": 559144,
+                "count": 12
+              },
+              "churn": {
+                "median": 473720,
+                "p95": 525092,
+                "count": 12
+              },
+              "leak": {
+                "median": 34088,
+                "p95": 227936,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  1042196, 353056, 393876, 376796, 396452, 382116, 344376, 350444, 559144, 367496,
+                  387020, 339372
+                ],
+                "churn": [
+                  704764, 477500, 483000, 475684, 473720, 466760, 458980, 463612, 474388, 454748,
+                  525092, 455600
+                ],
+                "leak": [
+                  946100, 27748, 51144, 34088, 57224, 41164, 13092, 11376, 227936, 3116, 72728, 2788
+                ]
+              },
+              "supported": true,
+              "ratio": 1,
+              "slope": 2.94
+            },
+            {
+              "lib": "vee-validate",
+              "retained": {
+                "median": 517472,
+                "p95": 554096,
+                "count": 12
+              },
+              "churn": {
+                "median": 307260,
+                "p95": 329964,
+                "count": 12
+              },
+              "leak": {
+                "median": 22520,
+                "p95": 324352,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  1044356, 499292, 504992, 517472, 525304, 536100, 512504, 517504, 554096, 508832,
+                  537260, 504676
+                ],
+                "churn": [
+                  389096, 307260, 325404, 308120, 329964, 300404, 305352, 295100, 319972, 293492,
+                  309284, 296656
+                ],
+                "leak": [
+                  704664, 16124, 37888, 22520, 36892, 34812, 8736, 18012, 66092, 0, 324352, 0
+                ]
+              },
+              "supported": true,
+              "ratio": 1.37,
+              "slope": 3.92
+            },
+            {
+              "lib": "tanstack",
+              "retained": {
+                "median": 632148,
+                "p95": 686328,
+                "count": 12
+              },
+              "churn": {
+                "median": 118828,
+                "p95": 163012,
+                "count": 12
+              },
+              "leak": {
+                "median": 107340,
+                "p95": 136500,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  1179140, 644712, 632148, 621876, 649420, 686328, 626012, 628176, 673100, 631760,
+                  654764, 624492
+                ],
+                "churn": [
+                  463860, 153792, 142912, 115948, 104508, 123768, 109284, 117244, 122620, 115792,
+                  163012, 118828
+                ],
+                "leak": [
+                  910048, 134048, 136500, 98300, 107340, 133348, 85652, 82412, 122212, 79764,
+                  117404, 75308
+                ]
+              },
+              "supported": true,
+              "ratio": 1.68,
+              "slope": 4.45
+            },
+            {
+              "lib": "formisch",
+              "retained": {
+                "median": 328432,
+                "p95": 350532,
+                "count": 12
+              },
+              "churn": {
+                "median": 734752,
+                "p95": 740952,
+                "count": 12
+              },
+              "leak": {
+                "median": 15912,
+                "p95": 40476,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  630272, 336912, 326620, 328432, 345360, 341064, 322424, 327316, 349116, 324152,
+                  350532, 321780
+                ],
+                "churn": [
+                  847264, 729988, 737672, 734776, 727852, 740952, 734752, 717556, 738616, 726168,
+                  736112, 722476
+                ],
+                "leak": [
+                  447704, 16912, 15912, 12980, 25928, 17620, 6752, 13724, 40476, 3304, 31132, 1636
+                ]
+              },
+              "supported": true,
+              "ratio": 0.87,
+              "slope": 4.05
+            },
+            {
+              "lib": "regle-schema",
+              "retained": {
+                "median": 873608,
+                "p95": 962972,
+                "count": 12
+              },
+              "churn": {
+                "median": 443340,
+                "p95": 463132,
+                "count": 12
+              },
+              "leak": {
+                "median": 13736,
+                "p95": 114472,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  1473812, 882608, 863088, 873608, 869348, 907132, 864864, 874196, 962972, 863660,
+                  906336, 857800
+                ],
+                "churn": [
+                  1861296, 443340, 415260, 451868, 423908, 448732, 463132, 432080, 445892, 439572,
+                  460084, 438780
+                ],
+                "leak": [
+                  737008, 20308, 13736, 25668, 7560, 44060, 10700, 13148, 114472, 5196, 31144, 2216
+                ]
+              },
+              "supported": true,
+              "ratio": 2.32,
+              "slope": 4.18
+            },
+            {
+              "lib": "regle-rules",
+              "retained": {
+                "median": 1061368,
+                "p95": 1167944,
+                "count": 12
+              },
+              "churn": {
+                "median": 623800,
+                "p95": 640404,
+                "count": 12
+              },
+              "leak": {
+                "median": 18312,
+                "p95": 110820,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  1666920, 1064096, 1058036, 1059568, 1073880, 1097632, 1056172, 1061368, 1167944,
+                  1055436, 1103152, 1050612
+                ],
+                "churn": [
+                  728812, 623888, 617952, 640404, 617912, 630384, 613396, 623800, 629860, 609900,
+                  630040, 608652
+                ],
+                "leak": [
+                  696284, 16112, 9588, 21560, 19836, 48288, 8244, 18312, 110820, 5900, 36148, 4880
+                ]
+              },
+              "supported": true,
+              "ratio": 2.82,
+              "slope": 4.46
+            },
+            {
+              "lib": "formkit",
+              "retained": {
+                "median": 9845720,
+                "p95": 9999892,
+                "count": 12
+              },
+              "churn": {
+                "median": 372548,
+                "p95": 464040,
+                "count": 12
+              },
+              "leak": {
+                "median": 80484,
+                "p95": 313960,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  11040304, 9999892, 9902416, 9851776, 9826104, 9846560, 9795060, 9796908, 9768660,
+                  9845720, 9966384, 9683416
+                ],
+                "churn": [
+                  517644, 464040, 415088, 427064, 372548, 372044, 348840, 354356, 390276, 392820,
+                  355132, 352592
+                ],
+                "leak": [
+                  3418580, 313960, 171252, 90460, 50664, 129344, 15496, 24656, 80484, 78608, 180192,
+                  4912
+                ]
+              },
+              "supported": true,
+              "ratio": 26.13,
+              "slope": 4.25
+            },
+            {
+              "lib": "vuelidate",
+              "retained": {
+                "median": 563584,
+                "p95": 608516,
+                "count": 12
+              },
+              "churn": {
+                "median": 289448,
+                "p95": 448916,
+                "count": 12
+              },
+              "leak": {
+                "median": 22404,
+                "p95": 76516,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  968072, 570440, 563584, 546056, 571872, 576512, 559784, 547704, 608516, 544788,
+                  587432, 548820
+                ],
+                "churn": [
+                  1336444, 438144, 441996, 448916, 432336, 318808, 236500, 289448, 270228, 266640,
+                  271988, 258808
+                ],
+                "leak": [569256, 31376, 26032, 1296, 22404, 26856, 8860, 1544, 76516, 0, 41124, 0]
+              },
+              "supported": true,
+              "ratio": 1.5,
+              "slope": 4.11
+            }
+          ]
+        }
+      }
+    },
+    "nested": {
+      "keystroke": {
+        "unit": "ms",
+        "byParam": {
+          "D4": [
+            {
+              "lib": "attaform",
+              "median": 0.3999999761581421,
+              "p95": 1.0999999165534973,
+              "iqr": 0.30000007152557373,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 0.3999999761581421,
+              "p95": 0.899999988079071,
+              "iqr": 0.30000007152557373,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 0.3999999761581421,
+              "p95": 1,
+              "iqr": 0.40000009536743164,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.2999999523162842,
+              "p95": 0.81000006198883,
+              "iqr": 0.30000007152557373,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.75,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 0.5,
+              "p95": 1.2000000476837158,
+              "iqr": 0.40000009536743164,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.25,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 0.5,
+              "p95": 1.2000000476837158,
+              "iqr": 0.42500007152557373,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.25,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 0.7000000476837158,
+              "p95": 1.5999999046325684,
+              "iqr": 0.7000000476837158,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.75,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.3999999761581421,
+              "p95": 0.8999999761581421,
+              "iqr": 0.2999999523162842,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            }
+          ],
+          "D8": [
+            {
+              "lib": "attaform",
+              "median": 0.30000007152557373,
+              "p95": 0.7150000333786016,
+              "iqr": 0.20000004768371582,
+              "count": 178,
+              "trimmed": 22,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 0.75
+            },
+            {
+              "lib": "vee-validate",
+              "median": 0.30000001192092896,
+              "p95": 0.8999999761581421,
+              "iqr": 0.2999999523162842,
+              "count": 198,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 0.75
+            },
+            {
+              "lib": "tanstack",
+              "median": 0.2999999523162842,
+              "p95": 1,
+              "iqr": 0.2999999523162842,
+              "count": 195,
+              "trimmed": 5,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 0.75
+            },
+            {
+              "lib": "formisch",
+              "median": 0.2999999523162842,
+              "p95": 0.7999999642372131,
+              "iqr": 0.30000007152557373,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 0.5,
+              "p95": 1.2000000476837158,
+              "iqr": 0.3999999761581421,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.67,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 0.6999999284744263,
+              "p95": 1.100000023841858,
+              "iqr": 0.4249999523162842,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 2.33,
+              "slope": 1.4
+            },
+            {
+              "lib": "formkit",
+              "median": 1,
+              "p95": 1.7000000476837158,
+              "iqr": 0.5,
+              "count": 198,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 3.33,
+              "slope": 1.43
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.5,
+              "p95": 1,
+              "iqr": 0.3999999761581421,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.67,
+              "slope": 1.25
+            }
+          ],
+          "D16": [
+            {
+              "lib": "attaform",
+              "median": 0.40000009536743164,
+              "p95": 1.210000038146972,
+              "iqr": 0.42500007152557373,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 0.30000007152557373,
+              "p95": 0.9100000858306879,
+              "iqr": 0.2999999523162842,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.75,
+              "slope": 0.75
+            },
+            {
+              "lib": "tanstack",
+              "median": 0.30000007152557373,
+              "p95": 0.7999999523162842,
+              "iqr": 0.20000004768371582,
+              "count": 190,
+              "trimmed": 10,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.75,
+              "slope": 0.75
+            },
+            {
+              "lib": "formisch",
+              "median": 0.2999999523162842,
+              "p95": 0.8999999761581421,
+              "iqr": 0.29999998211860657,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.75,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 0.3999999761581421,
+              "p95": 1,
+              "iqr": 0.2999998927116394,
+              "count": 191,
+              "trimmed": 9,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 0.8
+            },
+            {
+              "lib": "regle-rules",
+              "median": 0.3999999761581421,
+              "p95": 1,
+              "iqr": 0.40000009536743164,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 0.8
+            },
+            {
+              "lib": "formkit",
+              "median": 1.3000000715255737,
+              "p95": 2.399999976158142,
+              "iqr": 0.9000000059604645,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 3.25,
+              "slope": 1.86
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.5,
+              "p95": 1,
+              "iqr": 0.3999999761581421,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.25,
+              "slope": 1.25
+            }
+          ]
+        }
+      },
+      "mount": {
+        "unit": "ms",
+        "byParam": {
+          "D4": [
+            {
+              "lib": "attaform",
+              "median": 0.699999988079071,
+              "p95": 0.9349999845027923,
+              "iqr": 0.20000004768371582,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 0.3999999761581421,
+              "p95": 0.6349999904632568,
+              "iqr": 0.10000002384185791,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.57,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 0.3999999761581421,
+              "p95": 0.6349999904632568,
+              "iqr": 0.25,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.57,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.3500000238418579,
+              "p95": 0.6000000238418579,
+              "iqr": 0.20000004768371582,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.5,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 0.7999999523162842,
+              "p95": 1.0700000166893004,
+              "iqr": 0.25,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.14,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 0.5,
+              "p95": 0.8350000023841857,
+              "iqr": 0.2999999523162842,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.71,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 3.699999988079071,
+              "p95": 5.06000000834465,
+              "iqr": 1.25,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 5.29,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.5499999523162842,
+              "p95": 0.770000022649765,
+              "iqr": 0.30000007152557373,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.79,
+              "slope": 1
+            }
+          ],
+          "D8": [
+            {
+              "lib": "attaform",
+              "median": 0.6999999284744263,
+              "p95": 0.9349999845027923,
+              "iqr": 0.2999999523162842,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 0.40000009536743164,
+              "p95": 0.7000000476837158,
+              "iqr": 0.2500000596046448,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.57,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 0.3999999761581421,
+              "p95": 0.6999999701976776,
+              "iqr": 0.20000004768371582,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.57,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.30000007152557373,
+              "p95": 0.5,
+              "iqr": 0.15000009536743164,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.43,
+              "slope": 0.86
+            },
+            {
+              "lib": "regle-schema",
+              "median": 0.7999999523162842,
+              "p95": 0.9699999511241912,
+              "iqr": 0.1499999761581421,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.14,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 0.699999988079071,
+              "p95": 1.3000000715255737,
+              "iqr": 0.2999999523162842,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1.4
+            },
+            {
+              "lib": "formkit",
+              "median": 4.900000035762787,
+              "p95": 6.63000002503395,
+              "iqr": 1.25,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 7,
+              "slope": 1.32
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.40000009536743164,
+              "p95": 0.6399999618530272,
+              "iqr": 0.1499999761581421,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.57,
+              "slope": 0.73
+            }
+          ],
+          "D16": [
+            {
+              "lib": "attaform",
+              "median": 0.75,
+              "p95": 1.3450000405311582,
+              "iqr": 0.3500000834465027,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1.07
+            },
+            {
+              "lib": "vee-validate",
+              "median": 0.5,
+              "p95": 0.780000019073486,
+              "iqr": 0.25,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.67,
+              "slope": 1.25
+            },
+            {
+              "lib": "tanstack",
+              "median": 0.40000003576278687,
+              "p95": 0.770000022649765,
+              "iqr": 0.20000004768371582,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.53,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.30000001192092896,
+              "p95": 0.7000000476837158,
+              "iqr": 0.3999999761581421,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.4,
+              "slope": 0.86
+            },
+            {
+              "lib": "regle-schema",
+              "median": 0.8999999761581421,
+              "p95": 1.1999999761581421,
+              "iqr": 0.25,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.2,
+              "slope": 1.13
+            },
+            {
+              "lib": "regle-rules",
+              "median": 0.8999999761581421,
+              "p95": 1.3699999690055846,
+              "iqr": 0.30000007152557373,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.2,
+              "slope": 1.8
+            },
+            {
+              "lib": "formkit",
+              "median": 8,
+              "p95": 8.7,
+              "iqr": 0.75,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 10.67,
+              "slope": 2.16
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.6000000238418579,
+              "p95": 0.7400000572204588,
+              "iqr": 0.10000002384185791,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.8,
+              "slope": 1.09
+            }
+          ]
+        }
+      },
+      "validate": {
+        "unit": "ms",
+        "byParam": {
+          "D4": [
+            {
+              "lib": "attaform",
+              "median": 0.19999992847442627,
+              "p95": 0.3999999761581421,
+              "iqr": 0.19999992847442627,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 5.800000071525574,
+              "p95": 6.110000026226043,
+              "iqr": 0.2999999523162842,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 29,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 0.10000002384185791,
+              "p95": 0.30000007152557373,
+              "iqr": 0.1000000536441803,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.5,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.10000002384185791,
+              "p95": 0.20000004768371582,
+              "iqr": 0.10000002384185791,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.5,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 0.10000002384185791,
+              "p95": 0.40000001788139344,
+              "iqr": 0.125,
+              "count": 94,
+              "trimmed": 6,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.5,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 0.20000004768371582,
+              "p95": 0.3999999761581421,
+              "iqr": 0.19999992847442627,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 0.6000000238418579,
+              "p95": 1.399999976158142,
+              "iqr": 0.30000007152557373,
+              "count": 91,
+              "trimmed": 9,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 3,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.10000002384185791,
+              "p95": 0.10000002384185791,
+              "iqr": 1.1920928955078125e-7,
+              "count": 76,
+              "trimmed": 24,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.5,
+              "slope": 1
+            }
+          ],
+          "D8": [
+            {
+              "lib": "attaform",
+              "median": 0.10000002384185791,
+              "p95": 0.2999999523162842,
+              "iqr": 0.10000014305114746,
+              "count": 97,
+              "trimmed": 3,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 0.5
+            },
+            {
+              "lib": "vee-validate",
+              "median": 5.800000071525574,
+              "p95": 6.100000023841858,
+              "iqr": 0.20000004768371582,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 58,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 0.10000002384185791,
+              "p95": 0.2100000381469721,
+              "iqr": 0.10000002384185791,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.10000002384185791,
+              "p95": 0.30000007152557373,
+              "iqr": 0.10000002384185791,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 0.20000004768371582,
+              "p95": 0.5,
+              "iqr": 0.15000009536743164,
+              "count": 97,
+              "trimmed": 3,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 2,
+              "slope": 2
+            },
+            {
+              "lib": "regle-rules",
+              "median": 0.3999999761581421,
+              "p95": 0.7000000476837158,
+              "iqr": 0.3999999761581421,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 4,
+              "slope": 2
+            },
+            {
+              "lib": "formkit",
+              "median": 1.2000000476837158,
+              "p95": 2.399999976158142,
+              "iqr": 0.8999998867511749,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 12,
+              "slope": 2
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.10000002384185791,
+              "p95": 0.20000004768371582,
+              "iqr": 0.10000002384185791,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            }
+          ],
+          "D16": [
+            {
+              "lib": "attaform",
+              "median": 0.19999992847442627,
+              "p95": 0.3999999761581421,
+              "iqr": 0.125,
+              "count": 98,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 5.800000071525574,
+              "p95": 6,
+              "iqr": 0.10000002384185791,
+              "count": 91,
+              "trimmed": 9,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 29,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 0.10000002384185791,
+              "p95": 0.2999999523162842,
+              "iqr": 0.10000002384185791,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.5,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.10000002384185791,
+              "p95": 0.10000002384185791,
+              "iqr": 0.02500009536743164,
+              "count": 80,
+              "trimmed": 20,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.5,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 0.20000004768371582,
+              "p95": 0.5,
+              "iqr": 0.19999992847442627,
+              "count": 97,
+              "trimmed": 3,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 2
+            },
+            {
+              "lib": "regle-rules",
+              "median": 0.6000000238418579,
+              "p95": 1.5099999904632562,
+              "iqr": 0.5,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 3,
+              "slope": 3
+            },
+            {
+              "lib": "formkit",
+              "median": 1.4000000953674316,
+              "p95": 2.060000014305114,
+              "iqr": 0.5,
+              "count": 89,
+              "trimmed": 11,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 7,
+              "slope": 2.33
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.10000002384185791,
+              "p95": 0.2100000381469721,
+              "iqr": 0.10000002384185791,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.5,
+              "slope": 1
+            }
+          ]
+        }
+      },
+      "rerender": {
+        "unit": "renders",
+        "byParam": {
+          "D4": [
+            {
+              "lib": "attaform",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 29,
+              "trimmed": 1,
+              "unit": "dom-mutations",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            }
+          ],
+          "D8": [
+            {
+              "lib": "attaform",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 29,
+              "trimmed": 1,
+              "unit": "dom-mutations",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            }
+          ],
+          "D16": [
+            {
+              "lib": "attaform",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 29,
+              "trimmed": 1,
+              "unit": "dom-mutations",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            }
+          ]
+        }
+      },
+      "memory": {
+        "unit": "bytes",
+        "byParam": {
+          "D4": [
+            {
+              "lib": "attaform",
+              "retained": {
+                "median": 97520,
+                "p95": 293312,
+                "count": 12
+              },
+              "churn": {
+                "median": 670188,
+                "p95": 706848,
+                "count": 12
+              },
+              "leak": {
+                "median": 45832,
+                "p95": 241688,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  479284, 140516, 122364, 109516, 142432, 82248, 74076, 75796, 293312, 75712, 97520,
+                  62100
+                ],
+                "churn": [
+                  1021984, 688892, 683692, 669876, 665664, 670188, 656868, 677060, 684188, 662120,
+                  706848, 664944
+                ],
+                "leak": [
+                  733088, 90184, 80500, 45832, 75500, 19916, 4704, 10388, 241688, 10740, 65408, 0
+                ]
+              },
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "retained": {
+                "median": 71132,
+                "p95": 136680,
+                "count": 12
+              },
+              "churn": {
+                "median": 250136,
+                "p95": 384004,
+                "count": 12
+              },
+              "leak": {
+                "median": 16588,
+                "p95": 132520,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  308892, 84372, 105220, 78228, 127044, 48824, 47372, 63336, 136680, 71132, 70764,
+                  51708
+                ],
+                "churn": [
+                  384004, 260264, 419360, 261404, 234860, 250136, 251368, 241460, 265436, 249856,
+                  234024, 242552
+                ],
+                "leak": [
+                  425028, 49172, 70188, 48220, 73112, 14828, 2676, 4228, 132520, 7856, 16588, 8848
+                ]
+              },
+              "supported": true,
+              "ratio": 0.73,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "retained": {
+                "median": 46140,
+                "p95": 116448,
+                "count": 12
+              },
+              "churn": {
+                "median": 118984,
+                "p95": 172212,
+                "count": 12
+              },
+              "leak": {
+                "median": 36364,
+                "p95": 124940,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  283264, 46140, 69688, 52876, 90228, 38516, 36368, 36548, 116448, 42532, 56608,
+                  40520
+                ],
+                "churn": [
+                  497716, 136476, 131740, 120352, 172212, 112896, 94740, 103368, 118984, 107896,
+                  131540, 97296
+                ],
+                "leak": [
+                  642200, 42212, 82024, 29496, 124940, 36364, 18640, 19620, 113192, 20076, 55068,
+                  17028
+                ]
+              },
+              "supported": true,
+              "ratio": 0.47,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "retained": {
+                "median": 40844,
+                "p95": 75160,
+                "count": 12
+              },
+              "churn": {
+                "median": 196340,
+                "p95": 206640,
+                "count": 12
+              },
+              "leak": {
+                "median": 14884,
+                "p95": 62692,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  166568, 40844, 56016, 41572, 75160, 24780, 23348, 23472, 67308, 30664, 42400,
+                  26660
+                ],
+                "churn": [
+                  363124, 193396, 195848, 197856, 196340, 195484, 197648, 205496, 206640, 194404,
+                  197872, 184752
+                ],
+                "leak": [
+                  312704, 14884, 41192, 17156, 62692, 11780, 4884, 4532, 52400, 6260, 23516, 24
+                ]
+              },
+              "supported": true,
+              "ratio": 0.42,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "retained": {
+                "median": 123896,
+                "p95": 215788,
+                "count": 12
+              },
+              "churn": {
+                "median": 681704,
+                "p95": 740784,
+                "count": 12
+              },
+              "leak": {
+                "median": 28976,
+                "p95": 142916,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  399416, 157760, 142960, 123896, 156816, 107028, 101016, 102932, 215788, 102392,
+                  123956, 97168
+                ],
+                "churn": [
+                  446752, 813808, 740784, 705448, 700108, 670572, 681704, 675112, 702960, 691740,
+                  663376, 644376
+                ],
+                "leak": [
+                  535980, 59188, 43236, 28976, 59312, 13028, 0, 5000, 142916, 10968, 33576, 544
+                ]
+              },
+              "supported": true,
+              "ratio": 1.27,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "retained": {
+                "median": 108668,
+                "p95": 214288,
+                "count": 12
+              },
+              "churn": {
+                "median": 430892,
+                "p95": 447940,
+                "count": 12
+              },
+              "leak": {
+                "median": 25812,
+                "p95": 147172,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  360164, 146480, 126776, 110452, 146868, 101756, 89764, 88960, 214288, 90024,
+                  108668, 84680
+                ],
+                "churn": [
+                  640888, 438420, 429112, 430892, 424588, 427512, 427356, 432208, 437736, 431056,
+                  447940, 415700
+                ],
+                "leak": [
+                  455116, 61928, 44156, 22848, 61680, 25812, 1888, 10656, 147172, 11344, 29304, 664
+                ]
+              },
+              "supported": true,
+              "ratio": 1.11,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "retained": {
+                "median": 926480,
+                "p95": 1058760,
+                "count": 12
+              },
+              "churn": {
+                "median": 589668,
+                "p95": 762064,
+                "count": 12
+              },
+              "leak": {
+                "median": 49920,
+                "p95": 230892,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  1720272, 1058760, 927572, 955652, 926480, 907036, 918644, 898652, 970764, 981720,
+                  902928, 906384
+                ],
+                "churn": [
+                  1548536, 762064, 703952, 659452, 589668, 627724, 595668, 556820, 557612, 551348,
+                  544048, 543932
+                ],
+                "leak": [
+                  1266032, 230892, 74952, 49920, 35716, 57988, 15084, 9456, 106056, 81180, 21128,
+                  21416
+                ]
+              },
+              "supported": true,
+              "ratio": 9.5,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "retained": {
+                "median": 68868,
+                "p95": 122128,
+                "count": 12
+              },
+              "churn": {
+                "median": 119024,
+                "p95": 139716,
+                "count": 12
+              },
+              "leak": {
+                "median": 22964,
+                "p95": 82864,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  245992, 91944, 74968, 68868, 106700, 56516, 63424, 59500, 122128, 59184, 71588,
+                  56600
+                ],
+                "churn": [
+                  286200, 125096, 113276, 119024, 116132, 116288, 116472, 133452, 139716, 127404,
+                  132836, 107616
+                ],
+                "leak": [
+                  331500, 50848, 31984, 25048, 66848, 13256, 10228, 16592, 82864, 11536, 22964, 84
+                ]
+              },
+              "supported": true,
+              "ratio": 0.71,
+              "slope": 1
+            }
+          ],
+          "D8": [
+            {
+              "lib": "attaform",
+              "retained": {
+                "median": 110156,
+                "p95": 308576,
+                "count": 12
+              },
+              "churn": {
+                "median": 180424,
+                "p95": 214100,
+                "count": 12
+              },
+              "leak": {
+                "median": 34724,
+                "p95": 239840,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  560188, 131040, 124752, 110156, 155220, 97308, 103232, 89424, 308576, 92348,
+                  120828, 78296
+                ],
+                "churn": [
+                  541008, 191752, 171560, 188204, 160988, 180424, 153180, 192380, 191316, 167400,
+                  214100, 164340
+                ],
+                "leak": [
+                  798484, 67908, 50468, 34724, 74736, 23804, 1596, 10472, 239840, 7912, 67948, 7072
+                ]
+              },
+              "supported": true,
+              "ratio": 1,
+              "slope": 1.13
+            },
+            {
+              "lib": "vee-validate",
+              "retained": {
+                "median": 83008,
+                "p95": 172844,
+                "count": 12
+              },
+              "churn": {
+                "median": 294660,
+                "p95": 426576,
+                "count": 12
+              },
+              "leak": {
+                "median": 17432,
+                "p95": 130500,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  328456, 91508, 96736, 83008, 118496, 58060, 56812, 83976, 172844, 64756, 63064,
+                  54808
+                ],
+                "churn": [
+                  426576, 264596, 491920, 302308, 266920, 297012, 274200, 314028, 276260, 302584,
+                  270716, 294660
+                ],
+                "leak": [
+                  500184, 95596, 78548, 40508, 66092, 15552, 0, 15600, 130500, 8052, 17432, 7732
+                ]
+              },
+              "supported": true,
+              "ratio": 0.75,
+              "slope": 1.17
+            },
+            {
+              "lib": "tanstack",
+              "retained": {
+                "median": 53144,
+                "p95": 123232,
+                "count": 12
+              },
+              "churn": {
+                "median": 312120,
+                "p95": 368680,
+                "count": 12
+              },
+              "leak": {
+                "median": 43316,
+                "p95": 131100,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  292604, 53144, 79552, 54276, 96192, 45212, 43152, 43332, 123232, 49316, 56952,
+                  47304
+                ],
+                "churn": [
+                  681236, 317348, 333692, 315844, 368680, 306148, 288220, 296904, 312120, 308032,
+                  322412, 289200
+                ],
+                "leak": [
+                  653412, 45832, 92468, 34776, 131100, 43316, 25744, 26688, 121888, 33964, 55612,
+                  24152
+                ]
+              },
+              "supported": true,
+              "ratio": 0.48,
+              "slope": 1.15
+            },
+            {
+              "lib": "formisch",
+              "retained": {
+                "median": 40136,
+                "p95": 79428,
+                "count": 12
+              },
+              "churn": {
+                "median": 224328,
+                "p95": 233336,
+                "count": 12
+              },
+              "leak": {
+                "median": 12516,
+                "p95": 62584,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  184532, 40136, 59948, 41356, 79428, 29068, 35784, 27964, 71800, 33596, 40432,
+                  31152
+                ],
+                "churn": [
+                  399332, 220752, 219800, 225808, 224328, 219376, 225528, 233336, 230972, 222092,
+                  225860, 208752
+                ],
+                "leak": [
+                  325736, 9004, 39272, 12516, 62584, 11540, 12792, 4444, 52492, 4596, 17056, 24
+                ]
+              },
+              "supported": true,
+              "ratio": 0.36,
+              "slope": 0.98
+            },
+            {
+              "lib": "regle-schema",
+              "retained": {
+                "median": 162492,
+                "p95": 261216,
+                "count": 12
+              },
+              "churn": {
+                "median": 756728,
+                "p95": 882280,
+                "count": 12
+              },
+              "leak": {
+                "median": 21248,
+                "p95": 151972,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  520320, 166880, 170972, 169088, 197120, 144268, 142992, 143772, 261216, 145060,
+                  162492, 138600
+                ],
+                "churn": [
+                  516832, 882280, 751128, 754760, 753100, 758984, 756728, 1510632, 799636, 764820,
+                  757224, 744068
+                ],
+                "leak": [
+                  588936, 22256, 36236, 21248, 57784, 14224, 56, 5812, 151972, 7132, 30040, 0
+                ]
+              },
+              "supported": true,
+              "ratio": 1.48,
+              "slope": 1.31
+            },
+            {
+              "lib": "regle-rules",
+              "retained": {
+                "median": 141156,
+                "p95": 245116,
+                "count": 12
+              },
+              "churn": {
+                "median": 432376,
+                "p95": 445572,
+                "count": 12
+              },
+              "leak": {
+                "median": 24868,
+                "p95": 148152,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  462692, 153052, 150548, 141156, 180588, 131752, 128752, 125796, 245116, 124588,
+                  142516, 119064
+                ],
+                "churn": [
+                  622120, 436372, 434168, 427864, 423616, 432336, 421388, 432376, 445572, 436308,
+                  434224, 421748
+                ],
+                "leak": [
+                  504720, 24868, 40380, 15944, 61240, 26164, 5420, 12288, 148152, 4436, 30728, 364
+                ]
+              },
+              "supported": true,
+              "ratio": 1.28,
+              "slope": 1.3
+            },
+            {
+              "lib": "formkit",
+              "retained": {
+                "median": 1189596,
+                "p95": 1262776,
+                "count": 12
+              },
+              "churn": {
+                "median": 326952,
+                "p95": 1339284,
+                "count": 12
+              },
+              "leak": {
+                "median": 48620,
+                "p95": 125700,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  2147452, 1262776, 1221688, 1189072, 1189596, 1188060, 1170328, 1169204, 1228148,
+                  1234188, 1202092, 1157296
+                ],
+                "churn": [
+                  847832, 1339284, 1383676, 548720, 539332, 326952, 372252, 314688, 223144, 317992,
+                  123164, 213516
+                ],
+                "leak": [
+                  1542124, 125700, 91888, 20616, 41304, 81164, 7536, 20968, 106800, 76132, 48620,
+                  3260
+                ]
+              },
+              "supported": true,
+              "ratio": 10.8,
+              "slope": 1.28
+            },
+            {
+              "lib": "vuelidate",
+              "retained": {
+                "median": 86344,
+                "p95": 142184,
+                "count": 12
+              },
+              "churn": {
+                "median": 125196,
+                "p95": 145520,
+                "count": 12
+              },
+              "leak": {
+                "median": 24896,
+                "p95": 83244,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  296300, 86708, 99580, 86344, 136912, 79588, 79444, 78344, 142184, 79264, 95476,
+                  85372
+                ],
+                "churn": [
+                  285616, 125196, 116832, 125628, 119880, 120380, 118100, 130084, 145520, 128820,
+                  139320, 107832
+                ],
+                "leak": [
+                  360352, 24896, 36700, 27012, 68848, 12224, 2928, 14472, 83244, 9900, 26908, 8672
+                ]
+              },
+              "supported": true,
+              "ratio": 0.78,
+              "slope": 1.25
+            }
+          ],
+          "D16": [
+            {
+              "lib": "attaform",
+              "retained": {
+                "median": 143220,
+                "p95": 341440,
+                "count": 12
+              },
+              "churn": {
+                "median": 184072,
+                "p95": 916732,
+                "count": 12
+              },
+              "leak": {
+                "median": 32532,
+                "p95": 243756,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  626800, 143820, 155856, 157572, 183504, 128948, 130812, 119952, 341440, 121504,
+                  143220, 109404
+                ],
+                "churn": [
+                  558768, 179032, 950756, 184072, 192072, 204608, 173644, 192652, 166996, 162732,
+                  916732, 172032
+                ],
+                "leak": [
+                  841260, 32532, 46520, 39964, 73292, 18236, 5204, 14392, 243756, 18820, 51688, 5380
+                ]
+              },
+              "supported": true,
+              "ratio": 1,
+              "slope": 1.47
+            },
+            {
+              "lib": "vee-validate",
+              "retained": {
+                "median": 116948,
+                "p95": 165012,
+                "count": 12
+              },
+              "churn": {
+                "median": 350536,
+                "p95": 368416,
+                "count": 12
+              },
+              "leak": {
+                "median": 19848,
+                "p95": 124228,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  351652, 110456, 155392, 144456, 142320, 116948, 117032, 75816, 165012, 84348,
+                  82820, 73688
+                ],
+                "churn": [
+                  530544, 358924, 314888, 322316, 306592, 364468, 356448, 368416, 368340, 350536,
+                  321492, 301216
+                ],
+                "leak": [
+                  449944, 44188, 66192, 44712, 73208, 16420, 11596, 1496, 124228, 8568, 19848, 2532
+                ]
+              },
+              "supported": true,
+              "ratio": 0.82,
+              "slope": 1.64
+            },
+            {
+              "lib": "tanstack",
+              "retained": {
+                "median": 66564,
+                "p95": 136800,
+                "count": 12
+              },
+              "churn": {
+                "median": 739484,
+                "p95": 790516,
+                "count": 12
+              },
+              "leak": {
+                "median": 57860,
+                "p95": 146732,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  309568, 66564, 90164, 67780, 109716, 58608, 56720, 56900, 136800, 62884, 77068,
+                  60872
+                ],
+                "churn": [
+                  1112300, 747996, 754912, 739484, 790516, 748660, 730180, 740060, 722824, 715708,
+                  733280, 700428
+                ],
+                "leak": [
+                  669536, 62504, 103748, 48968, 146732, 57860, 39952, 40876, 134504, 41200, 76260,
+                  38360
+                ]
+              },
+              "supported": true,
+              "ratio": 0.46,
+              "slope": 1.44
+            },
+            {
+              "lib": "formisch",
+              "retained": {
+                "median": 47368,
+                "p95": 89980,
+                "count": 12
+              },
+              "churn": {
+                "median": 272372,
+                "p95": 290476,
+                "count": 12
+              },
+              "leak": {
+                "median": 11516,
+                "p95": 63868,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  197328, 47368, 67436, 57108, 89980, 38332, 37104, 37228, 81064, 42860, 49696,
+                  40416
+                ],
+                "churn": [
+                  451940, 268680, 271188, 273668, 272372, 271424, 273528, 281372, 290476, 270092,
+                  273860, 260740
+                ],
+                "leak": [
+                  329548, 7116, 36924, 18916, 63868, 11516, 4848, 4456, 51012, 4596, 17056, 24
+                ]
+              },
+              "supported": true,
+              "ratio": 0.33,
+              "slope": 1.16
+            },
+            {
+              "lib": "regle-schema",
+              "retained": {
+                "median": 241212,
+                "p95": 343068,
+                "count": 12
+              },
+              "churn": {
+                "median": 867876,
+                "p95": 1678828,
+                "count": 12
+              },
+              "leak": {
+                "median": 18732,
+                "p95": 145084,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  627716, 241212, 255476, 244272, 283260, 232508, 228648, 228020, 343068, 228788,
+                  248612, 223020
+                ],
+                "churn": [
+                  802832, 1678828, 874636, 860876, 865356, 1643084, 859232, 872880, 900720, 1683448,
+                  867876, 859756
+                ],
+                "leak": [
+                  607000, 9776, 35660, 18732, 59560, 19008, 1996, 5316, 145084, 6404, 34236, 96
+                ]
+              },
+              "supported": true,
+              "ratio": 1.68,
+              "slope": 1.95
+            },
+            {
+              "lib": "regle-rules",
+              "retained": {
+                "median": 207640,
+                "p95": 316116,
+                "count": 12
+              },
+              "churn": {
+                "median": 431248,
+                "p95": 449996,
+                "count": 12
+              },
+              "leak": {
+                "median": 17016,
+                "p95": 142748,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  547040, 207640, 221956, 211948, 257096, 202044, 194584, 195404, 316116, 194188,
+                  212116, 188180
+                ],
+                "churn": [
+                  621912, 438288, 431248, 426012, 418880, 431572, 421416, 440420, 449996, 423316,
+                  434304, 421236
+                ],
+                "leak": [
+                  517120, 15660, 38624, 15860, 66732, 25992, 1652, 17016, 142748, 6388, 30728, 192
+                ]
+              },
+              "supported": true,
+              "ratio": 1.45,
+              "slope": 1.91
+            },
+            {
+              "lib": "formkit",
+              "retained": {
+                "median": 1750980,
+                "p95": 1794912,
+                "count": 12
+              },
+              "churn": {
+                "median": 1488956,
+                "p95": 1524992,
+                "count": 12
+              },
+              "leak": {
+                "median": 61936,
+                "p95": 128716,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  2760612, 1794912, 1740792, 1751680, 1744540, 1710384, 1750980, 1774320, 1771984,
+                  1784280, 1715284, 1701232
+                ],
+                "churn": [
+                  1335888, 1822912, 1524992, 1504480, 1488956, 1491964, 1492188, 1516452, 1470848,
+                  1413088, 1472732, 1466020
+                ],
+                "leak": [
+                  1824932, 128716, 76428, 44036, 61936, 48568, 59284, 113432, 77968, 65680, 19044,
+                  10536
+                ]
+              },
+              "supported": true,
+              "ratio": 12.23,
+              "slope": 1.89
+            },
+            {
+              "lib": "vuelidate",
+              "retained": {
+                "median": 131436,
+                "p95": 184808,
+                "count": 12
+              },
+              "churn": {
+                "median": 127688,
+                "p95": 147132,
+                "count": 12
+              },
+              "leak": {
+                "median": 19420,
+                "p95": 84840,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  341164, 131112, 150692, 132180, 175480, 120248, 131436, 119620, 184808, 119804,
+                  132260, 117824
+                ],
+                "churn": [
+                  286308, 127688, 119128, 121452, 121016, 123424, 128056, 132368, 147132, 130180,
+                  136628, 108668
+                ],
+                "leak": [
+                  366192, 23096, 43920, 19420, 66724, 13172, 13828, 15060, 84840, 9792, 23028, 556
+                ]
+              },
+              "supported": true,
+              "ratio": 0.92,
+              "slope": 1.91
+            }
+          ]
+        }
+      }
+    },
+    "arrays": {
+      "keystroke": {
+        "unit": "ms",
+        "byParam": {
+          "N10": [
+            {
+              "lib": "attaform",
+              "median": 0.7000000476837158,
+              "p95": 1.81000006198883,
+              "iqr": 0.7250000238418579,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 0.7999999523162842,
+              "p95": 1.100000023841858,
+              "iqr": 0.2999999523162842,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.14,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 0.7999999523162842,
+              "p95": 1.110000014305114,
+              "iqr": 0.42500007152557373,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.14,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.7000000476837158,
+              "p95": 1.1999999284744263,
+              "iqr": 0.3999999761581421,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 0.8000000715255737,
+              "p95": 1.600000023841858,
+              "iqr": 0.5250000953674316,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.14,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 0.8000000715255737,
+              "p95": 1.600000023841858,
+              "iqr": 0.6999999284744263,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.14,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 1,
+              "p95": 1.7000000476837158,
+              "iqr": 0.5250000953674316,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.43,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.7000000476837158,
+              "p95": 1.2000000476837158,
+              "iqr": 0.42499998211860657,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            }
+          ],
+          "N100": [
+            {
+              "lib": "attaform",
+              "median": 1.5,
+              "p95": 2.8000000417232513,
+              "iqr": 0.6000000536441803,
+              "count": 186,
+              "trimmed": 14,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 2.14
+            },
+            {
+              "lib": "vee-validate",
+              "median": 1.2000000476837158,
+              "p95": 2.0999999165534975,
+              "iqr": 0.8249999284744263,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.8,
+              "slope": 1.5
+            },
+            {
+              "lib": "tanstack",
+              "median": 1.5,
+              "p95": 3.2999999642372133,
+              "iqr": 0.9000000059604645,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1.88
+            },
+            {
+              "lib": "formisch",
+              "median": 1.2000000476837158,
+              "p95": 2.100000023841858,
+              "iqr": 0.9000000953674316,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.8,
+              "slope": 1.71
+            },
+            {
+              "lib": "regle-schema",
+              "median": 1.600000023841858,
+              "p95": 3.505000001192091,
+              "iqr": 1,
+              "count": 200,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.07,
+              "slope": 2
+            },
+            {
+              "lib": "regle-rules",
+              "median": 1.6999999284744263,
+              "p95": 2.2999999642372133,
+              "iqr": 1,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.13,
+              "slope": 2.12
+            },
+            {
+              "lib": "formkit",
+              "median": 1.399999976158142,
+              "p95": 3,
+              "iqr": 1.299999862909317,
+              "count": 200,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.93,
+              "slope": 1.4
+            },
+            {
+              "lib": "vuelidate",
+              "median": 1.4500000476837158,
+              "p95": 2.399999976158142,
+              "iqr": 1.2000000476837158,
+              "count": 200,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.97,
+              "slope": 2.07
+            }
+          ]
+        }
+      },
+      "mount": {
+        "unit": "ms",
+        "byParam": {
+          "N10": [
+            {
+              "lib": "attaform",
+              "median": 1.2999999523162842,
+              "p95": 1.4450000524520874,
+              "iqr": 0.15000009536743164,
+              "count": 12,
+              "trimmed": 3,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 0.8999999761581421,
+              "p95": 1.600000023841858,
+              "iqr": 0.44999998807907104,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.69,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 0.7000000476837158,
+              "p95": 0.9799999952316282,
+              "iqr": 0.19999992847442627,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.54,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.5,
+              "p95": 0.7350000143051147,
+              "iqr": 0.25,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.38,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 1.5999999046325684,
+              "p95": 1.8999999999999992,
+              "iqr": 0.34999996423721313,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.23,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 1.7999999523162842,
+              "p95": 2.060000014305114,
+              "iqr": 0.3999999761581421,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.38,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 10.399999976158142,
+              "p95": 11.240000009536743,
+              "iqr": 1.5,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 8,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.6499999761581421,
+              "p95": 1.0350000083446502,
+              "iqr": 0.34999996423721313,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.5,
+              "slope": 1
+            }
+          ],
+          "N100": [
+            {
+              "lib": "attaform",
+              "median": 11.099999964237213,
+              "p95": 14.839999991655349,
+              "iqr": 3.099999964237213,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 8.54
+            },
+            {
+              "lib": "vee-validate",
+              "median": 5.599999964237213,
+              "p95": 7.805000030994415,
+              "iqr": 1.850000023841858,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.5,
+              "slope": 6.22
+            },
+            {
+              "lib": "tanstack",
+              "median": 8.900000095367432,
+              "p95": 9.779999947547912,
+              "iqr": 0.9500001072883606,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.8,
+              "slope": 12.71
+            },
+            {
+              "lib": "formisch",
+              "median": 1.899999976158142,
+              "p95": 2.439999985694885,
+              "iqr": 0.550000011920929,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.17,
+              "slope": 3.8
+            },
+            {
+              "lib": "regle-schema",
+              "median": 6.850000023841858,
+              "p95": 9.12499994635582,
+              "iqr": 1.9000000357627869,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.62,
+              "slope": 4.28
+            },
+            {
+              "lib": "regle-rules",
+              "median": 8.100000023841858,
+              "p95": 11.199999970197677,
+              "iqr": 3.1000000834465027,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.73,
+              "slope": 4.5
+            },
+            {
+              "lib": "formkit",
+              "median": 155.19999992847443,
+              "p95": 166.33999998569487,
+              "iqr": 9.949999928474426,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 13.98,
+              "slope": 14.92
+            },
+            {
+              "lib": "vuelidate",
+              "median": 2,
+              "p95": 2.46000006198883,
+              "iqr": 0.40000003576278687,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.18,
+              "slope": 3.08
+            }
+          ]
+        }
+      },
+      "validate": {
+        "unit": "ms",
+        "byParam": {
+          "N10": [
+            {
+              "lib": "attaform",
+              "median": 0.19999992847442627,
+              "p95": 0.40000009536743164,
+              "iqr": 0.19999992847442627,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 6,
+              "p95": 6.199999940395355,
+              "iqr": 0.20000004768371582,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 30,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 0.10000002384185791,
+              "p95": 0.30000007152557373,
+              "iqr": 0.10000002384185791,
+              "count": 98,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.5,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.10000002384185791,
+              "p95": 0.29999996423721315,
+              "iqr": 0.1000000536441803,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.5,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 0.6000000238418579,
+              "p95": 1,
+              "iqr": 0.4249999523162842,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 3,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 0.6000000238418579,
+              "p95": 1.2000000476837158,
+              "iqr": 0.3999999761581421,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 3,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 1.5999999046325684,
+              "p95": 2.1249999403953552,
+              "iqr": 0.49999988079071045,
+              "count": 96,
+              "trimmed": 4,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 8,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.10000002384185791,
+              "p95": 0.10000002384185791,
+              "iqr": 0.02500009536743164,
+              "count": 81,
+              "trimmed": 19,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.5,
+              "slope": 1
+            }
+          ],
+          "N100": [
+            {
+              "lib": "attaform",
+              "median": 0.30000007152557373,
+              "p95": 0.9099999785423273,
+              "iqr": 0.30000007152557373,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1.5
+            },
+            {
+              "lib": "vee-validate",
+              "median": 6.899999976158142,
+              "p95": 7.510000002384185,
+              "iqr": 0.7000000476837158,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 23,
+              "slope": 1.15
+            },
+            {
+              "lib": "tanstack",
+              "median": 1.600000023841858,
+              "p95": 3.0999999165534975,
+              "iqr": 0.7000000476837158,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 5.33,
+              "slope": 16
+            },
+            {
+              "lib": "formisch",
+              "median": 0.10000002384185791,
+              "p95": 0.3999999761581421,
+              "iqr": 0.125,
+              "count": 98,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.33,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 1,
+              "p95": 1.5,
+              "iqr": 0.2999999523162842,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 3.33,
+              "slope": 1.67
+            },
+            {
+              "lib": "regle-rules",
+              "median": 1.5,
+              "p95": 4.204999935626983,
+              "iqr": 1.9000000059604645,
+              "count": 100,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 5,
+              "slope": 2.5
+            },
+            {
+              "lib": "formkit",
+              "median": 7.299999952316284,
+              "p95": 9.89999998807907,
+              "iqr": 1.5999999344348907,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 24.33,
+              "slope": 4.56
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.10000002384185791,
+              "p95": 0.20000004768371582,
+              "iqr": 0.19999992847442627,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.33,
+              "slope": 1
+            }
+          ]
+        }
+      },
+      "rerender": {
+        "unit": "renders",
+        "byParam": {
+          "N10": [
+            {
+              "lib": "attaform",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 1,
+              "p95": 3,
+              "iqr": 2,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "dom-mutations",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            }
+          ],
+          "N100": [
+            {
+              "lib": "attaform",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 3,
+              "p95": 3,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "dom-mutations",
+              "supported": true,
+              "ratio": 3,
+              "slope": 3
+            },
+            {
+              "lib": "vuelidate",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            }
+          ]
+        }
+      },
+      "arrayAdd": {
+        "unit": "ms",
+        "byParam": {
+          "N10": [
+            {
+              "lib": "attaform",
+              "median": 1.5,
+              "p95": 2.289999949932098,
+              "iqr": 0.5000000894069672,
+              "count": 43,
+              "trimmed": 7,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 1.100000023841858,
+              "p95": 2.460000038146972,
+              "iqr": 1.2999999523162842,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.73,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 0.6000000238418579,
+              "p95": 0.715000033378601,
+              "iqr": 0.2749999761581421,
+              "count": 38,
+              "trimmed": 12,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.4,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.8000000715255737,
+              "p95": 1.599999976158142,
+              "iqr": 0.9499999284744263,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.53,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 1.100000023841858,
+              "p95": 1.3599999666213984,
+              "iqr": 0.30000007152557373,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.73,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 1,
+              "p95": 2.2,
+              "iqr": 1.0499999523162842,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.67,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 2.399999976158142,
+              "p95": 3.0599999427795406,
+              "iqr": 0.5000000894069672,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.6,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 1.1999999284744263,
+              "p95": 2.300000023841858,
+              "iqr": 1.3000000417232513,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.8,
+              "slope": 1
+            }
+          ],
+          "N100": [
+            {
+              "lib": "attaform",
+              "median": 15.200000047683716,
+              "p95": 17.17999995946884,
+              "iqr": 1.0499999225139618,
+              "count": 47,
+              "trimmed": 3,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 10.13
+            },
+            {
+              "lib": "vee-validate",
+              "median": 4.399999976158142,
+              "p95": 5,
+              "iqr": 0.7749999463558197,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.29,
+              "slope": 4
+            },
+            {
+              "lib": "tanstack",
+              "median": 2,
+              "p95": 2.459999990463256,
+              "iqr": 0.39999985694885254,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.13,
+              "slope": 3.33
+            },
+            {
+              "lib": "formisch",
+              "median": 0.8000000715255737,
+              "p95": 1.5700000166893,
+              "iqr": 0.39999985694885254,
+              "count": 47,
+              "trimmed": 3,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.05,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 4.899999976158142,
+              "p95": 5.5,
+              "iqr": 0.3749999701976776,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.32,
+              "slope": 4.45
+            },
+            {
+              "lib": "regle-rules",
+              "median": 4.700000047683716,
+              "p95": 5.359999966621398,
+              "iqr": 0.40000006556510925,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.31,
+              "slope": 4.7
+            },
+            {
+              "lib": "formkit",
+              "median": 4.300000071525574,
+              "p95": 5.665000039339065,
+              "iqr": 1.0749999284744263,
+              "count": 48,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.28,
+              "slope": 1.79
+            },
+            {
+              "lib": "vuelidate",
+              "median": 1.7999999523162842,
+              "p95": 2.1599999666213985,
+              "iqr": 0.5,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.12,
+              "slope": 1.5
+            }
+          ]
+        }
+      },
+      "arrayReorder": {
+        "unit": "ms",
+        "byParam": {
+          "N10": [
+            {
+              "lib": "attaform",
+              "median": 1,
+              "p95": 1.600000023841858,
+              "iqr": 0.30000007152557373,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 0.8000000715255737,
+              "p95": 1.8599999666213984,
+              "iqr": 0.7000000476837158,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.8,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 0.3500000238418579,
+              "p95": 0.6850000441074373,
+              "iqr": 0.20000004768371582,
+              "count": 44,
+              "trimmed": 6,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.35,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.3999999761581421,
+              "p95": 0.8599999904632563,
+              "iqr": 0.20000004768371582,
+              "count": 45,
+              "trimmed": 5,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.4,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 0.5999999046325684,
+              "p95": 1.3599999904632563,
+              "iqr": 0.375,
+              "count": 45,
+              "trimmed": 5,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.6,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 0.5,
+              "p95": 1.599999976158142,
+              "iqr": 0.8000000417232513,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.5,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 0.7000000476837158,
+              "p95": 2.060000014305114,
+              "iqr": 0.8749999701976776,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.7,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.5,
+              "p95": 1.399999976158142,
+              "iqr": 0.8499999046325684,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.5,
+              "slope": 1
+            }
+          ],
+          "N100": [
+            {
+              "lib": "attaform",
+              "median": 7.799999952316284,
+              "p95": 9.120000028610228,
+              "iqr": 0.5750000178813934,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 7.8
+            },
+            {
+              "lib": "vee-validate",
+              "median": 2.299999952316284,
+              "p95": 2.5,
+              "iqr": 0.20000004768371582,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.29,
+              "slope": 2.87
+            },
+            {
+              "lib": "tanstack",
+              "median": 1.5,
+              "p95": 2.100000023841858,
+              "iqr": 0.5,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.19,
+              "slope": 4.29
+            },
+            {
+              "lib": "formisch",
+              "median": 0.8999999761581421,
+              "p95": 1.8599999785423273,
+              "iqr": 0.40000003576278687,
+              "count": 43,
+              "trimmed": 7,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.12,
+              "slope": 2.25
+            },
+            {
+              "lib": "regle-schema",
+              "median": 3.1999999284744263,
+              "p95": 3.5599999427795406,
+              "iqr": 0.375,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.41,
+              "slope": 5.33
+            },
+            {
+              "lib": "regle-rules",
+              "median": 2.899999976158142,
+              "p95": 3.100000023841858,
+              "iqr": 0.27500006556510925,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.37,
+              "slope": 5.8
+            },
+            {
+              "lib": "formkit",
+              "median": 2.450000047683716,
+              "p95": 3.100000023841858,
+              "iqr": 0.30000007152557373,
+              "count": 48,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.31,
+              "slope": 3.5
+            },
+            {
+              "lib": "vuelidate",
+              "median": 1,
+              "p95": 1.5300000488758085,
+              "iqr": 0.375,
+              "count": 48,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.13,
+              "slope": 2
+            }
+          ]
+        }
+      },
+      "memory": {
+        "unit": "bytes",
+        "byParam": {
+          "N10": [
+            {
+              "lib": "attaform",
+              "retained": {
+                "median": 174020,
+                "p95": 360940,
+                "count": 12
+              },
+              "churn": {
+                "median": 915960,
+                "p95": 1633096,
+                "count": 12
+              },
+              "leak": {
+                "median": 26244,
+                "p95": 211964,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  958716, 198636, 174296, 188412, 173772, 178744, 156052, 172416, 360940, 157476,
+                  174020, 154520
+                ],
+                "churn": [
+                  1982380, 915960, 1595904, 873884, 1558292, 826272, 1536192, 832096, 1633096,
+                  780632, 1532460, 829564
+                ],
+                "leak": [
+                  1146896, 66696, 36540, 70264, 28180, 18688, 10412, 25844, 211964, 5276, 26244, 0
+                ]
+              },
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "retained": {
+                "median": 173956,
+                "p95": 212084,
+                "count": 12
+              },
+              "churn": {
+                "median": 708428,
+                "p95": 759228,
+                "count": 12
+              },
+              "leak": {
+                "median": 32028,
+                "p95": 83272,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  707260, 176536, 203572, 173956, 210068, 155812, 156648, 164376, 212084, 196576,
+                  166616, 160836
+                ],
+                "churn": [
+                  816088, 712164, 723516, 759228, 704644, 707508, 697436, 708428, 741716, 714548,
+                  706172, 700260
+                ],
+                "leak": [
+                  685264, 46588, 40216, 32028, 80608, 17096, 4480, 12300, 83272, 5920, 63472, 10360
+                ]
+              },
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "retained": {
+                "median": 138536,
+                "p95": 180252,
+                "count": 12
+              },
+              "churn": {
+                "median": 426908,
+                "p95": 793156,
+                "count": 12
+              },
+              "leak": {
+                "median": 43352,
+                "p95": 77136,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  589808, 151764, 135028, 131084, 151696, 137136, 128964, 147788, 180252, 135968,
+                  138536, 142076
+                ],
+                "churn": [
+                  793156, 481820, 1270044, 478372, 450972, 464976, 410788, 413392, 422180, 413860,
+                  426908, 396488
+                ],
+                "leak": [
+                  815612, 56840, 47104, 53708, 41124, 43352, 28300, 47196, 77136, 18696, 35632,
+                  21484
+                ]
+              },
+              "supported": true,
+              "ratio": 0.8,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "retained": {
+                "median": 85584,
+                "p95": 116732,
+                "count": 12
+              },
+              "churn": {
+                "median": 328992,
+                "p95": 338144,
+                "count": 12
+              },
+              "leak": {
+                "median": 9744,
+                "p95": 44996,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  375564, 88648, 84824, 77224, 83284, 88944, 85584, 89044, 116732, 84300, 87112,
+                  81900
+                ],
+                "churn": [
+                  463732, 326136, 324756, 331352, 325596, 328992, 328640, 330216, 338144, 336868,
+                  329088, 322772
+                ],
+                "leak": [438408, 14908, 9744, 5120, 9056, 20072, 5024, 12320, 44996, 4776, 10792, 0]
+              },
+              "supported": true,
+              "ratio": 0.49,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "retained": {
+                "median": 343284,
+                "p95": 435228,
+                "count": 12
+              },
+              "churn": {
+                "median": 675960,
+                "p95": 1425648,
+                "count": 12
+              },
+              "leak": {
+                "median": 15544,
+                "p95": 123916,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  983564, 407328, 357968, 342012, 344484, 336292, 343284, 340168, 435228, 338180,
+                  351928, 332964
+                ],
+                "churn": [
+                  1815876, 727028, 700616, 675960, 635380, 1425648, 637740, 632156, 694996, 655892,
+                  1419732, 625100
+                ],
+                "leak": [
+                  810588, 66108, 18804, 14944, 10604, 17440, 5764, 15544, 123916, 1356, 24492, 3360
+                ]
+              },
+              "supported": true,
+              "ratio": 1.97,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "retained": {
+                "median": 375048,
+                "p95": 455712,
+                "count": 12
+              },
+              "churn": {
+                "median": 626828,
+                "p95": 641096,
+                "count": 12
+              },
+              "leak": {
+                "median": 16728,
+                "p95": 122892,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  1032176, 380544, 379720, 355288, 375048, 424176, 370336, 357084, 455712, 363468,
+                  376920, 350332
+                ],
+                "churn": [
+                  743560, 626828, 594076, 631388, 608224, 629832, 610656, 638520, 626836, 641096,
+                  602980, 618004
+                ],
+                "leak": [801664, 8560, 27344, 0, 35040, 75128, 16728, 60, 122892, 2396, 31080, 0]
+              },
+              "supported": true,
+              "ratio": 2.16,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "retained": {
+                "median": 3084348,
+                "p95": 3143928,
+                "count": 12
+              },
+              "churn": {
+                "median": 632836,
+                "p95": 834980,
+                "count": 12
+              },
+              "leak": {
+                "median": 64224,
+                "p95": 206336,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  4143084, 3143928, 3084348, 3091760, 3055876, 3039816, 3134568, 3025648, 3086228,
+                  3089560, 3032124, 3047664
+                ],
+                "churn": [
+                  844432, 834980, 665220, 672052, 628940, 641136, 614940, 632836, 624908, 634360,
+                  617520, 628820
+                ],
+                "leak": [
+                  1999444, 206336, 82760, 64224, 58656, 50492, 106468, 15052, 90080, 78284, 21848,
+                  49000
+                ]
+              },
+              "supported": true,
+              "ratio": 17.72,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "retained": {
+                "median": 73736,
+                "p95": 128192,
+                "count": 12
+              },
+              "churn": {
+                "median": 802532,
+                "p95": 819732,
+                "count": 12
+              },
+              "leak": {
+                "median": 17068,
+                "p95": 67944,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  393532, 79484, 80248, 64844, 100436, 68956, 72048, 67560, 128192, 73736, 75620,
+                  61448
+                ],
+                "churn": [
+                  908140, 801816, 795728, 800652, 802532, 797692, 805264, 806000, 802856, 819732,
+                  814592, 795632
+                ],
+                "leak": [
+                  433984, 17440, 17544, 6924, 39168, 16396, 17068, 13404, 67944, 10164, 20864, 6396
+                ]
+              },
+              "supported": true,
+              "ratio": 0.42,
+              "slope": 1
+            }
+          ],
+          "N100": [
+            {
+              "lib": "attaform",
+              "retained": {
+                "median": 2682120,
+                "p95": 2864372,
+                "count": 12
+              },
+              "churn": {
+                "median": 1774992,
+                "p95": 2215848,
+                "count": 12
+              },
+              "leak": {
+                "median": 26628,
+                "p95": 209744,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  3619624, 2697584, 2730984, 2705016, 2718260, 2657448, 2673552, 2635352, 2864372,
+                  2635608, 2682120, 2633632
+                ],
+                "churn": [
+                  2503848, 1774992, 1513856, 1876148, 2215848, 1696068, 1090548, 2165960, 1822680,
+                  1676000, 754708, 1799964
+                ],
+                "leak": [
+                  1237772, 64744, 80092, 100528, 44248, 23376, 15700, 17716, 209744, 0, 26628, 17328
+                ]
+              },
+              "supported": true,
+              "ratio": 1,
+              "slope": 15.41
+            },
+            {
+              "lib": "vee-validate",
+              "retained": {
+                "median": 1471588,
+                "p95": 1516624,
+                "count": 12
+              },
+              "churn": {
+                "median": 983160,
+                "p95": 1006668,
+                "count": 12
+              },
+              "leak": {
+                "median": 23028,
+                "p95": 293616,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  2082816, 1482852, 1485484, 1471588, 1507096, 1507632, 1459848, 1469180, 1516624,
+                  1468068, 1466112, 1463556
+                ],
+                "churn": [
+                  1114940, 1006668, 997504, 987672, 974420, 969464, 983160, 972344, 1003376, 970672,
+                  985220, 977772
+                ],
+                "leak": [
+                  782604, 293616, 51956, 21088, 35784, 23028, 1104, 18332, 55300, 215116, 12700,
+                  8924
+                ]
+              },
+              "supported": true,
+              "ratio": 0.55,
+              "slope": 8.46
+            },
+            {
+              "lib": "tanstack",
+              "retained": {
+                "median": 1161228,
+                "p95": 1192524,
+                "count": 12
+              },
+              "churn": {
+                "median": 767324,
+                "p95": 818560,
+                "count": 12
+              },
+              "leak": {
+                "median": 77000,
+                "p95": 141060,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  1756612, 1185940, 1169364, 1161228, 1170868, 1167856, 1155892, 1156912, 1192524,
+                  1158384, 1154724, 1160624
+                ],
+                "churn": [
+                  836544, 818560, 563032, 806372, 491052, 809100, 462264, 767324, 502020, 773728,
+                  199952, 782216
+                ],
+                "leak": [
+                  936616, 125420, 141060, 77000, 83892, 88496, 56676, 58916, 108096, 56300, 74968,
+                  64392
+                ]
+              },
+              "supported": true,
+              "ratio": 0.43,
+              "slope": 8.38
+            },
+            {
+              "lib": "formisch",
+              "retained": {
+                "median": 626964,
+                "p95": 655516,
+                "count": 12
+              },
+              "churn": {
+                "median": 301500,
+                "p95": 1004688,
+                "count": 12
+              },
+              "leak": {
+                "median": 12028,
+                "p95": 41252,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  952560, 635616, 643592, 625460, 643520, 653816, 623796, 626964, 655516, 624412,
+                  626696, 622144
+                ],
+                "churn": [
+                  301500, 1007232, 215092, 995172, 181180, 944420, 214780, 941496, 193372, 1004688,
+                  216328, 987268
+                ],
+                "leak": [459464, 24900, 36900, 12028, 20656, 34676, 0, 5048, 41252, 1588, 9472, 796]
+              },
+              "supported": true,
+              "ratio": 0.23,
+              "slope": 7.33
+            },
+            {
+              "lib": "regle-schema",
+              "retained": {
+                "median": 2752096,
+                "p95": 2830948,
+                "count": 12
+              },
+              "churn": {
+                "median": 860716,
+                "p95": 882480,
+                "count": 12
+              },
+              "leak": {
+                "median": 25160,
+                "p95": 111880,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  3597456, 2766740, 2774948, 2740744, 2769056, 2768508, 2733964, 2737540, 2830948,
+                  2733632, 2752096, 2725504
+                ],
+                "churn": [
+                  2176704, 832636, 877988, 865044, 860716, 844912, 862816, 818904, 882480, 828320,
+                  861348, 839092
+                ],
+                "leak": [990200, 37960, 41068, 25160, 47272, 32500, 0, 7264, 111880, 3672, 20340, 0]
+              },
+              "supported": true,
+              "ratio": 1.03,
+              "slope": 8.02
+            },
+            {
+              "lib": "regle-rules",
+              "retained": {
+                "median": 3176216,
+                "p95": 3255092,
+                "count": 12
+              },
+              "churn": {
+                "median": 447548,
+                "p95": 528256,
+                "count": 12
+              },
+              "leak": {
+                "median": 23504,
+                "p95": 95800,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  4007908, 3183788, 3201296, 3176216, 3189968, 3212616, 3157192, 3167560, 3255092,
+                  3164688, 3175040, 3169236
+                ],
+                "churn": [
+                  528256, 576352, 447548, 449920, 466920, 423248, 436880, 449820, 459816, 429184,
+                  442484, 429112
+                ],
+                "leak": [
+                  938584, 24188, 59980, 23504, 46408, 34380, 1264, 15468, 95800, 14704, 15060, 0
+                ]
+              },
+              "supported": true,
+              "ratio": 1.18,
+              "slope": 8.47
+            },
+            {
+              "lib": "formkit",
+              "retained": {
+                "median": 19084648,
+                "p95": 19426024,
+                "count": 12
+              },
+              "churn": {
+                "median": 884948,
+                "p95": 970400,
+                "count": 12
+              },
+              "leak": {
+                "median": 51900,
+                "p95": 414352,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  27471824, 19426024, 19269756, 19099916, 19069156, 19093016, 19061956, 19084648,
+                  18993332, 19091120, 19038724, 19065712
+                ],
+                "churn": [
+                  1154364, 970400, 910592, 906696, 878824, 894964, 880148, 883768, 894184, 884948,
+                  882628, 882748
+                ],
+                "leak": [
+                  8562580, 414352, 225408, 44092, 54668, 72416, 17188, 53616, 0, 49984, 22012, 51900
+                ]
+              },
+              "supported": true,
+              "ratio": 7.12,
+              "slope": 6.19
+            },
+            {
+              "lib": "vuelidate",
+              "retained": {
+                "median": 401752,
+                "p95": 451264,
+                "count": 12
+              },
+              "churn": {
+                "median": 1609996,
+                "p95": 1768656,
+                "count": 12
+              },
+              "leak": {
+                "median": 25876,
+                "p95": 68088,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  754860, 399792, 408696, 405464, 436008, 415612, 395476, 388440, 451264, 401752,
+                  399804, 383264
+                ],
+                "churn": [
+                  1382640, 1609996, 1778332, 1302120, 1763084, 1599500, 1282748, 1766748, 1768656,
+                  1437776, 1631188, 1763188
+                ],
+                "leak": [
+                  457472, 20044, 33208, 33340, 49296, 29248, 6052, 9392, 68088, 8768, 25876, 2688
+                ]
+              },
+              "supported": true,
+              "ratio": 0.15,
+              "slope": 5.45
+            }
+          ]
+        }
+      }
+    },
+    "grid": {
+      "keystroke": {
+        "unit": "ms",
+        "byParam": {
+          "N20M8": [
+            {
+              "lib": "attaform",
+              "median": 1.9000000953674316,
+              "p95": 4.050000011920929,
+              "iqr": 0.8250000476837158,
+              "count": 191,
+              "trimmed": 9,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 1,
+              "p95": 1.899999976158142,
+              "iqr": 0.5,
+              "count": 188,
+              "trimmed": 12,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.53,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 2.549999952316284,
+              "p95": 3.100000023841858,
+              "iqr": 1.600000023841858,
+              "count": 200,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.34,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 1.3000000715255737,
+              "p95": 2.0999999165534975,
+              "iqr": 0.8999999761581421,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.68,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 2.299999952316284,
+              "p95": 2.899999976158142,
+              "iqr": 1.399999976158142,
+              "count": 200,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.21,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 1.8000000715255737,
+              "p95": 2.7300000190734846,
+              "iqr": 0.4249999523162842,
+              "count": 195,
+              "trimmed": 5,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.95,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 2,
+              "p95": 2.700000047683716,
+              "iqr": 0.5,
+              "count": 198,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.05,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 1.7000000476837158,
+              "p95": 2.31000006198883,
+              "iqr": 0.5,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.89,
+              "slope": 1
+            }
+          ],
+          "N100M8": [
+            {
+              "lib": "attaform",
+              "median": 4,
+              "p95": 4.699999928474426,
+              "iqr": 0.40000009536743164,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 2.11
+            },
+            {
+              "lib": "vee-validate",
+              "median": 2.1999999284744263,
+              "p95": 2.5,
+              "iqr": 0.20000004768371582,
+              "count": 197,
+              "trimmed": 3,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.55,
+              "slope": 2.2
+            },
+            {
+              "lib": "tanstack",
+              "median": 4.899999976158142,
+              "p95": 5.600000023841858,
+              "iqr": 0.5999999046325684,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.22,
+              "slope": 1.92
+            },
+            {
+              "lib": "formisch",
+              "median": 2.0999999046325684,
+              "p95": 2.299999952316284,
+              "iqr": 0.2250000238418579,
+              "count": 173,
+              "trimmed": 27,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.52,
+              "slope": 1.62
+            },
+            {
+              "lib": "regle-schema",
+              "median": 3.600000023841858,
+              "p95": 4,
+              "iqr": 0.40000009536743164,
+              "count": 198,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.9,
+              "slope": 1.57
+            },
+            {
+              "lib": "regle-rules",
+              "median": 2.1999999284744263,
+              "p95": 2.5150000035762794,
+              "iqr": 0.2999999523162842,
+              "count": 178,
+              "trimmed": 22,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.55,
+              "slope": 1.22
+            },
+            {
+              "lib": "formkit",
+              "median": 1.5999999046325684,
+              "p95": 4,
+              "iqr": 2.0999999046325684,
+              "count": 200,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.4,
+              "slope": 0.8
+            },
+            {
+              "lib": "vuelidate",
+              "median": 2.700000047683716,
+              "p95": 3.100000023841858,
+              "iqr": 0.3999999761581421,
+              "count": 198,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.68,
+              "slope": 1.59
+            }
+          ]
+        }
+      },
+      "mount": {
+        "unit": "ms",
+        "byParam": {
+          "N20M8": [
+            {
+              "lib": "attaform",
+              "median": 6.600000023841858,
+              "p95": 8.859999960660934,
+              "iqr": 1.850000023841858,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 7.300000011920929,
+              "p95": 9.305000030994416,
+              "iqr": 1.850000023841858,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.11,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 22.699999928474426,
+              "p95": 23.680000042915346,
+              "iqr": 0.8500000238418579,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 3.44,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 2.5,
+              "p95": 3.2200000762939442,
+              "iqr": 0.4500000476837158,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.38,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 6.699999988079071,
+              "p95": 10.224999999999998,
+              "iqr": 2.350000023841858,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.02,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 7.400000035762787,
+              "p95": 11.795000016689299,
+              "iqr": 2.950000047683716,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.12,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 95.09999990463257,
+              "p95": 104.4000000476837,
+              "iqr": 5.050000011920929,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 14.41,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 2.550000011920929,
+              "p95": 3.380000007152557,
+              "iqr": 0.4999999403953552,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.39,
+              "slope": 1
+            }
+          ],
+          "N100M8": [
+            {
+              "lib": "attaform",
+              "median": 71.30000007152557,
+              "p95": 83.33000003099441,
+              "iqr": 5.75,
+              "count": 15,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 10.8
+            },
+            {
+              "lib": "vee-validate",
+              "median": 78.94999998807907,
+              "p95": 84.11999997496605,
+              "iqr": 4.800000011920929,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.11,
+              "slope": 10.82
+            },
+            {
+              "lib": "tanstack",
+              "median": 560.6000000238419,
+              "p95": 576.4900000095367,
+              "iqr": 14.699999928474426,
+              "count": 15,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 7.86,
+              "slope": 24.7
+            },
+            {
+              "lib": "formisch",
+              "median": 10.500000059604645,
+              "p95": 13.539999967813491,
+              "iqr": 1.8000000715255737,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.15,
+              "slope": 4.2
+            },
+            {
+              "lib": "regle-schema",
+              "median": 32.200000047683716,
+              "p95": 36.77999997138976,
+              "iqr": 3.3499999046325684,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.45,
+              "slope": 4.81
+            },
+            {
+              "lib": "regle-rules",
+              "median": 37.799999952316284,
+              "p95": 45.84000000953673,
+              "iqr": 5.649999976158142,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.53,
+              "slope": 5.11
+            },
+            {
+              "lib": "formkit",
+              "median": 641.7499999403954,
+              "p95": 793.3749999523163,
+              "iqr": 72.55000001192093,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 9,
+              "slope": 6.75
+            },
+            {
+              "lib": "vuelidate",
+              "median": 12.050000011920929,
+              "p95": 13.03500000834465,
+              "iqr": 3.199999988079071,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.17,
+              "slope": 4.73
+            }
+          ]
+        }
+      },
+      "validate": {
+        "unit": "ms",
+        "byParam": {
+          "N20M8": [
+            {
+              "lib": "attaform",
+              "median": 0.3999999761581421,
+              "p95": 0.6999999403953552,
+              "iqr": 0.2999999523162842,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 6.899999976158142,
+              "p95": 7.910000085830688,
+              "iqr": 0.8999999761581421,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 17.25,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 2.400000035762787,
+              "p95": 2.600000023841858,
+              "iqr": 0.10000002384185791,
+              "count": 96,
+              "trimmed": 4,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 6,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.20000004768371582,
+              "p95": 0.3999999761581421,
+              "iqr": 0.20000004768371582,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.5,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 1.2999999523162842,
+              "p95": 3.100000023841858,
+              "iqr": 1.725000023841858,
+              "count": 100,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 3.25,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 1.7000000476837158,
+              "p95": 2,
+              "iqr": 0.2000000774860382,
+              "count": 82,
+              "trimmed": 18,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 4.25,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 10,
+              "p95": 11.409999978542327,
+              "iqr": 1.2250000536441803,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 25,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.10000002384185791,
+              "p95": 0.20000004768371582,
+              "iqr": 0.10000002384185791,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.25,
+              "slope": 1
+            }
+          ],
+          "N100M8": [
+            {
+              "lib": "attaform",
+              "median": 0.6999999284744263,
+              "p95": 1.399999988079071,
+              "iqr": 0.7999999821186066,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1.75
+            },
+            {
+              "lib": "vee-validate",
+              "median": 9.5,
+              "p95": 10.699999940395355,
+              "iqr": 1.4999999105930328,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 13.57,
+              "slope": 1.38
+            },
+            {
+              "lib": "tanstack",
+              "median": 60.299999952316284,
+              "p95": 61.200000047683716,
+              "iqr": 0.8000000715255737,
+              "count": 94,
+              "trimmed": 6,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 86.14,
+              "slope": 25.12
+            },
+            {
+              "lib": "formisch",
+              "median": 0.5,
+              "p95": 1,
+              "iqr": 0.625,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.71,
+              "slope": 2.5
+            },
+            {
+              "lib": "regle-schema",
+              "median": 5.299999952316284,
+              "p95": 6,
+              "iqr": 0.5249999761581421,
+              "count": 96,
+              "trimmed": 4,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 7.57,
+              "slope": 4.08
+            },
+            {
+              "lib": "regle-rules",
+              "median": 8.25,
+              "p95": 10.399999976158142,
+              "iqr": 1.0250000953674316,
+              "count": 98,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 11.79,
+              "slope": 4.85
+            },
+            {
+              "lib": "formkit",
+              "median": 60.799999952316284,
+              "p95": 62.51000000238419,
+              "iqr": 1.4250000715255737,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 86.86,
+              "slope": 6.08
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.10000002384185791,
+              "p95": 0.2100000381469721,
+              "iqr": 0.19999992847442627,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.14,
+              "slope": 1
+            }
+          ]
+        }
+      },
+      "rerender": {
+        "unit": "renders",
+        "byParam": {
+          "N20M8": [
+            {
+              "lib": "attaform",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 3,
+              "p95": 3,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "dom-mutations",
+              "supported": true,
+              "ratio": 3,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            }
+          ],
+          "N100M8": [
+            {
+              "lib": "attaform",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 3,
+              "p95": 3,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "dom-mutations",
+              "supported": true,
+              "ratio": 3,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            }
+          ]
+        }
+      },
+      "arrayAdd": {
+        "unit": "ms",
+        "byParam": {
+          "N20M8": [
+            {
+              "lib": "attaform",
+              "median": 7.199999928474426,
+              "p95": 7.940000021457672,
+              "iqr": 0.44999998807907104,
+              "count": 47,
+              "trimmed": 3,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 3.200000047683716,
+              "p95": 3.600000023841858,
+              "iqr": 0.2999999523162842,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.44,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 3.1999999284744263,
+              "p95": 3.799999952316284,
+              "iqr": 0.5,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.44,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.949999988079071,
+              "p95": 1.205000042915344,
+              "iqr": 0.30000007152557373,
+              "count": 40,
+              "trimmed": 10,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.13,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 2.799999952316284,
+              "p95": 3.26000006198883,
+              "iqr": 0.4749999940395355,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.39,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 2,
+              "p95": 2.460000038146972,
+              "iqr": 0.39999985694885254,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.28,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 6.600000023841858,
+              "p95": 7.5,
+              "iqr": 0.8000000417232513,
+              "count": 47,
+              "trimmed": 3,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.92,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 1.7999999523162842,
+              "p95": 2.274999976158142,
+              "iqr": 0.30000007152557373,
+              "count": 46,
+              "trimmed": 4,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.25,
+              "slope": 1
+            }
+          ],
+          "N100M8": [
+            {
+              "lib": "attaform",
+              "median": 109.64999997615814,
+              "p95": 115.69999999403953,
+              "iqr": 5.799999892711639,
+              "count": 50,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 15.23
+            },
+            {
+              "lib": "vee-validate",
+              "median": 15.149999976158142,
+              "p95": 16.764999997615813,
+              "iqr": 1.4499999284744263,
+              "count": 50,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.14,
+              "slope": 4.73
+            },
+            {
+              "lib": "tanstack",
+              "median": 17.850000023841858,
+              "p95": 20.06500001549721,
+              "iqr": 1.4999999701976776,
+              "count": 50,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.16,
+              "slope": 5.58
+            },
+            {
+              "lib": "formisch",
+              "median": 2.5,
+              "p95": 2.899999976158142,
+              "iqr": 0.30000004172325134,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.02,
+              "slope": 2.63
+            },
+            {
+              "lib": "regle-schema",
+              "median": 12.600000023841858,
+              "p95": 14.384999960660933,
+              "iqr": 1.8499999940395355,
+              "count": 50,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.11,
+              "slope": 4.5
+            },
+            {
+              "lib": "regle-rules",
+              "median": 8.899999976158142,
+              "p95": 11.040000057220457,
+              "iqr": 1.1749999523162842,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.08,
+              "slope": 4.45
+            },
+            {
+              "lib": "formkit",
+              "median": 14,
+              "p95": 15.299999952316284,
+              "iqr": 1,
+              "count": 46,
+              "trimmed": 4,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.13,
+              "slope": 2.12
+            },
+            {
+              "lib": "vuelidate",
+              "median": 6.300000071525574,
+              "p95": 7.365000009536743,
+              "iqr": 0.5000000894069672,
+              "count": 48,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.06,
+              "slope": 3.5
+            }
+          ]
+        }
+      },
+      "arrayReorder": {
+        "unit": "ms",
+        "byParam": {
+          "N20M8": [
+            {
+              "lib": "attaform",
+              "median": 4.300000071525574,
+              "p95": 4.954999989271164,
+              "iqr": 0.5,
+              "count": 50,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 1.7999999523162842,
+              "p95": 2.0599999427795406,
+              "iqr": 0.30000004172325134,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.42,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 2,
+              "p95": 2.359999966621398,
+              "iqr": 0.20000001788139343,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.47,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 1,
+              "p95": 1.1999999463558197,
+              "iqr": 0.20000004768371582,
+              "count": 38,
+              "trimmed": 12,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.23,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 1.5,
+              "p95": 1.8000000357627868,
+              "iqr": 0.2749999463558197,
+              "count": 47,
+              "trimmed": 3,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.35,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 1.2999999523162842,
+              "p95": 1.5,
+              "iqr": 0.19999992847442627,
+              "count": 44,
+              "trimmed": 6,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.3,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 1.7999999523162842,
+              "p95": 2.0750000178813934,
+              "iqr": 0.30000007152557373,
+              "count": 46,
+              "trimmed": 4,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.42,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 1.3000000715255737,
+              "p95": 1.5,
+              "iqr": 0.20000001788139343,
+              "count": 46,
+              "trimmed": 4,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.3,
+              "slope": 1
+            }
+          ],
+          "N100M8": [
+            {
+              "lib": "attaform",
+              "median": 55,
+              "p95": 59.860000014305115,
+              "iqr": 1.8250001072883606,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 12.79
+            },
+            {
+              "lib": "vee-validate",
+              "median": 6.399999976158142,
+              "p95": 7,
+              "iqr": 0.30000007152557373,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.12,
+              "slope": 3.56
+            },
+            {
+              "lib": "tanstack",
+              "median": 8.850000023841858,
+              "p95": 10.164999973773956,
+              "iqr": 1.0750000178813934,
+              "count": 50,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.16,
+              "slope": 4.43
+            },
+            {
+              "lib": "formisch",
+              "median": 2.899999976158142,
+              "p95": 3.200000047683716,
+              "iqr": 0.20000004768371582,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.05,
+              "slope": 2.9
+            },
+            {
+              "lib": "regle-schema",
+              "median": 6.800000011920929,
+              "p95": 7.300000017881393,
+              "iqr": 0.5,
+              "count": 50,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.12,
+              "slope": 4.53
+            },
+            {
+              "lib": "regle-rules",
+              "median": 5.799999952316284,
+              "p95": 6.200000047683716,
+              "iqr": 0.3999999761581421,
+              "count": 50,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.11,
+              "slope": 4.46
+            },
+            {
+              "lib": "formkit",
+              "median": 4.399999976158142,
+              "p95": 5.100000023841858,
+              "iqr": 0.7749999761581421,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.08,
+              "slope": 2.44
+            },
+            {
+              "lib": "vuelidate",
+              "median": 4.5,
+              "p95": 5.5550000131130215,
+              "iqr": 0.6000000238418579,
+              "count": 50,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.08,
+              "slope": 3.46
+            }
+          ]
+        }
+      },
+      "memory": {
+        "unit": "bytes",
+        "byParam": {
+          "N20M8": [
+            {
+              "lib": "attaform",
+              "retained": {
+                "median": 1631048,
+                "p95": 1826792,
+                "count": 12
+              },
+              "churn": {
+                "median": 1445100,
+                "p95": 1494580,
+                "count": 12
+              },
+              "leak": {
+                "median": 35936,
+                "p95": 214304,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  2622532, 1641524, 1702428, 1631048, 1649604, 1609468, 1612076, 1604604, 1826792,
+                  1592508, 1632052, 1596104
+                ],
+                "churn": [
+                  2465432, 1494580, 1435700, 1489656, 1474660, 1416284, 1426844, 1383688, 1445260,
+                  1445100, 1492568, 1396104
+                ],
+                "leak": [
+                  1313408, 53320, 77252, 68392, 38044, 23724, 0, 372, 214304, 3716, 35936, 7492
+                ]
+              },
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "retained": {
+                "median": 1606564,
+                "p95": 1658100,
+                "count": 12
+              },
+              "churn": {
+                "median": 461832,
+                "p95": 481552,
+                "count": 12
+              },
+              "leak": {
+                "median": 23304,
+                "p95": 72288,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  2310300, 1625680, 1626140, 1658100, 1606564, 1603160, 1601192, 1599924, 1651960,
+                  1593688, 1614772, 1593704
+                ],
+                "churn": [
+                  371724, 486436, 480196, 461948, 233884, 461832, 212372, 237712, 481552, 222100,
+                  472864, 462684
+                ],
+                "leak": [852612, 72288, 65080, 40404, 6884, 26468, 0, 44, 57924, 0, 23304, 14588]
+              },
+              "supported": true,
+              "ratio": 0.98,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "retained": {
+                "median": 1815280,
+                "p95": 1884836,
+                "count": 12
+              },
+              "churn": {
+                "median": 607532,
+                "p95": 634600,
+                "count": 12
+              },
+              "leak": {
+                "median": 98396,
+                "p95": 173104,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  2453924, 1881184, 1884836, 1853056, 1815280, 1809996, 1802204, 1804300, 1847304,
+                  1799972, 1821488, 1806204
+                ],
+                "churn": [
+                  973880, 605540, 618812, 619392, 599048, 607532, 591108, 628272, 612812, 595704,
+                  634600, 599112
+                ],
+                "leak": [
+                  996140, 151816, 173104, 111356, 95348, 98396, 79720, 79200, 125964, 78216, 105860,
+                  81368
+                ]
+              },
+              "supported": true,
+              "ratio": 1.11,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "retained": {
+                "median": 904016,
+                "p95": 951552,
+                "count": 12
+              },
+              "churn": {
+                "median": 136060,
+                "p95": 148072,
+                "count": 12
+              },
+              "leak": {
+                "median": 11224,
+                "p95": 40920,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  1242336, 923740, 922528, 951552, 912936, 901808, 900896, 897952, 935304, 901208,
+                  904016, 901964
+                ],
+                "churn": [
+                  260960, 143584, 120188, 136756, 136060, 122472, 128360, 142500, 148072, 126452,
+                  144032, 121368
+                ],
+                "leak": [
+                  468936, 40920, 29672, 35640, 14388, 11224, 212, 860, 38748, 1556, 8132, 4916
+                ]
+              },
+              "supported": true,
+              "ratio": 0.55,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "retained": {
+                "median": 2783736,
+                "p95": 2855700,
+                "count": 12
+              },
+              "churn": {
+                "median": 533948,
+                "p95": 806344,
+                "count": 12
+              },
+              "leak": {
+                "median": 12780,
+                "p95": 126488,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  3555196, 2797820, 2855700, 2843468, 2783736, 2767172, 2766536, 2769400, 2854396,
+                  2770552, 2785304, 2776224
+                ],
+                "churn": [
+                  669780, 959944, 368764, 806344, 365092, 804040, 359484, 498580, 403120, 644000,
+                  533948, 620456
+                ],
+                "leak": [
+                  896400, 43932, 89836, 40148, 10864, 12780, 0, 1712, 126488, 1112, 16980, 4844
+                ]
+              },
+              "supported": true,
+              "ratio": 1.71,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "retained": {
+                "median": 3500340,
+                "p95": 3579448,
+                "count": 12
+              },
+              "churn": {
+                "median": 1644104,
+                "p95": 1685844,
+                "count": 12
+              },
+              "leak": {
+                "median": 12392,
+                "p95": 105944,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  4344252, 3516728, 3529112, 3553084, 3500340, 3479836, 3492304, 3487064, 3579448,
+                  3490200, 3508256, 3484572
+                ],
+                "churn": [
+                  478784, 1716124, 333476, 299516, 1685844, 1644104, 1653420, 1649876, 1677444,
+                  1619340, 1677524, 1619108
+                ],
+                "leak": [
+                  966500, 59144, 39204, 41236, 6476, 15044, 156, 5428, 105944, 12392, 12124, 6152
+                ]
+              },
+              "supported": true,
+              "ratio": 2.15,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "retained": {
+                "median": 24834152,
+                "p95": 25769088,
+                "count": 12
+              },
+              "churn": {
+                "median": 790048,
+                "p95": 847072,
+                "count": 12
+              },
+              "leak": {
+                "median": 49116,
+                "p95": 827464,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  33035368, 25769088, 25103244, 24834152, 24751864, 24673548, 24586664, 24991328,
+                  24935156, 24852048, 24729228, 24589292
+                ],
+                "churn": [
+                  1022572, 847072, 838472, 785496, 797012, 813592, 778864, 775932, 800656, 790048,
+                  749112, 748552
+                ],
+                "leak": [
+                  8567884, 827464, 252300, 28108, 36492, 51100, 0, 68392, 90560, 49116, 2660, 0
+                ]
+              },
+              "supported": true,
+              "ratio": 15.23,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "retained": {
+                "median": 564644,
+                "p95": 615396,
+                "count": 12
+              },
+              "churn": {
+                "median": 1276548,
+                "p95": 1762464,
+                "count": 12
+              },
+              "leak": {
+                "median": 27008,
+                "p95": 64200,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  924312, 571140, 607020, 591212, 588536, 556516, 548644, 548312, 615396, 561580,
+                  564644, 549248
+                ],
+                "churn": [
+                  1754004, 1238500, 1670796, 1253964, 1667980, 1255472, 1753644, 1276548, 1847536,
+                  1254512, 1762464, 1240992
+                ],
+                "leak": [
+                  464024, 30632, 56740, 27008, 35488, 16456, 3172, 1980, 64200, 13280, 27496, 220
+                ]
+              },
+              "supported": true,
+              "ratio": 0.35,
+              "slope": 1
+            }
+          ],
+          "N100M8": [
+            {
+              "lib": "attaform",
+              "retained": {
+                "median": 18916968,
+                "p95": 19050788,
+                "count": 12
+              },
+              "churn": {
+                "median": 7189996,
+                "p95": 10458392,
+                "count": 12
+              },
+              "leak": {
+                "median": 22824,
+                "p95": 169400,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  20335928, 18942048, 18963852, 18924600, 18916968, 18905068, 18914316, 18891220,
+                  19050788, 18914488, 18936868, 18896936
+                ],
+                "churn": [
+                  20541128, 7224524, 6299096, 9863512, 7189996, 4290864, 6123204, 4784520, 5186392,
+                  10458392, 10233672, 7674628
+                ],
+                "leak": [
+                  1645420, 42944, 30148, 42700, 17096, 31224, 17016, 0, 169400, 6020, 22824, 21820
+                ]
+              },
+              "supported": true,
+              "ratio": 1,
+              "slope": 11.6
+            },
+            {
+              "lib": "vee-validate",
+              "retained": {
+                "median": 9434816,
+                "p95": 9488156,
+                "count": 12
+              },
+              "churn": {
+                "median": 55832,
+                "p95": 1162924,
+                "count": 12
+              },
+              "leak": {
+                "median": 4104,
+                "p95": 56908,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  10442804, 9432160, 9481820, 9431440, 9445664, 9419200, 9442324, 9427760, 9488156,
+                  9414444, 9470748, 9434816
+                ],
+                "churn": [
+                  280932, 231844, 29460, 1162096, 55564, 47312, 51468, 1154332, 1163896, 39960,
+                  1162924, 55832
+                ],
+                "leak": [1079576, 24240, 32384, 10960, 0, 0, 740, 3808, 56908, 2728, 7104, 4104]
+              },
+              "supported": true,
+              "ratio": 0.5,
+              "slope": 5.87
+            },
+            {
+              "lib": "tanstack",
+              "retained": {
+                "median": 8831992,
+                "p95": 8932396,
+                "count": 12
+              },
+              "churn": {
+                "median": 1085388,
+                "p95": 2780064,
+                "count": 12
+              },
+              "leak": {
+                "median": 208756,
+                "p95": 438728,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  9855604, 8932396, 8886800, 8817004, 8831992, 8814624, 8790196, 8806948, 8863904,
+                  8808844, 8869048, 8844516
+                ],
+                "churn": [
+                  1049784, 586628, 1459764, 3401184, 1834496, 2780064, 364816, 1729420, 2737840,
+                  1085388, 296152, 494104
+                ],
+                "leak": [
+                  1591424, 438728, 358120, 0, 208756, 215904, 165980, 200196, 245916, 200872,
+                  215248, 205148
+                ]
+              },
+              "supported": true,
+              "ratio": 0.47,
+              "slope": 4.87
+            },
+            {
+              "lib": "formisch",
+              "retained": {
+                "median": 4392192,
+                "p95": 4439852,
+                "count": 12
+              },
+              "churn": {
+                "median": 914968,
+                "p95": 1070272,
+                "count": 12
+              },
+              "leak": {
+                "median": 3716,
+                "p95": 34664,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  4921308, 4369368, 4429380, 4372140, 4392192, 4349740, 4385224, 4408868, 4422024,
+                  4376120, 4439852, 4421996
+                ],
+                "churn": [
+                  972992, 693468, 45088, 914968, 650960, 707348, 983840, 1040424, 1070272, 1291864,
+                  958400, 738244
+                ],
+                "leak": [598356, 6496, 16400, 3312, 7736, 0, 0, 3300, 34664, 1836, 11992, 3716]
+              },
+              "supported": true,
+              "ratio": 0.23,
+              "slope": 4.86
+            },
+            {
+              "lib": "regle-schema",
+              "retained": {
+                "median": 13512528,
+                "p95": 13614540,
+                "count": 12
+              },
+              "churn": {
+                "median": 887372,
+                "p95": 1435684,
+                "count": 12
+              },
+              "leak": {
+                "median": 10172,
+                "p95": 112268,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  14647148, 13509880, 13586660, 13480144, 13534652, 13512528, 13535808, 13419672,
+                  13614540, 13497276, 13543768, 13413492
+                ],
+                "churn": [
+                  1225456, 1052736, 484000, 508564, 1435684, 671164, 508464, 648968, 1078668,
+                  1446432, 1064348, 887372
+                ],
+                "leak": [1228652, 9460, 43088, 10172, 10508, 16116, 0, 0, 112268, 5136, 11028, 8076]
+              },
+              "supported": true,
+              "ratio": 0.71,
+              "slope": 4.85
+            },
+            {
+              "lib": "regle-rules",
+              "retained": {
+                "median": 17097200,
+                "p95": 17196184,
+                "count": 12
+              },
+              "churn": {
+                "median": 1517980,
+                "p95": 1676288,
+                "count": 12
+              },
+              "leak": {
+                "median": 9316,
+                "p95": 101796,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  18284596, 17108944, 17169480, 17002312, 17097200, 17092784, 16996464, 17104552,
+                  17196184, 17019556, 17120620, 17084884
+                ],
+                "churn": [
+                  1517980, 1216320, 1234792, 1380316, 1524792, 1548084, 1543552, 1676288, 637828,
+                  1547748, 1712676, 1379812
+                ],
+                "leak": [1241608, 18896, 39336, 7044, 9316, 17488, 0, 0, 101796, 11256, 8852, 2608]
+              },
+              "supported": true,
+              "ratio": 0.9,
+              "slope": 4.88
+            },
+            {
+              "lib": "formkit",
+              "retained": {
+                "median": 122348216,
+                "p95": 124623924,
+                "count": 12
+              },
+              "churn": {
+                "median": 778476,
+                "p95": 822672,
+                "count": 12
+              },
+              "leak": {
+                "median": 36916,
+                "p95": 2445720,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  158069564, 124623924, 122348216, 122348876, 122167264, 122288372, 122346932,
+                  122361748, 122182656, 122304944, 122349836, 122366344
+                ],
+                "churn": [
+                  936224, 822672, 819808, 779564, 776892, 777184, 780880, 778616, 778476, 774960,
+                  772820, 769896
+                ],
+                "leak": [
+                  36126228, 2445720, 56740, 0, 71772, 70224, 0, 20892, 40684, 36916, 0, 11072
+                ]
+              },
+              "supported": true,
+              "ratio": 6.47,
+              "slope": 4.93
+            },
+            {
+              "lib": "vuelidate",
+              "retained": {
+                "median": 2622416,
+                "p95": 2695364,
+                "count": 12
+              },
+              "churn": {
+                "median": 2122212,
+                "p95": 3826932,
+                "count": 12
+              },
+              "leak": {
+                "median": 11732,
+                "p95": 64144,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  3176848, 2622416, 2691664, 2617412, 2669756, 2620912, 2594952, 2615404, 2695364,
+                  2627536, 2639312, 2617548
+                ],
+                "churn": [
+                  4204524, 3822364, 3826932, 2095844, 2103628, 2086496, 2069200, 2482804, 2082984,
+                  2122212, 2473240, 2463696
+                ],
+                "leak": [585236, 944, 28272, 5732, 39932, 15356, 0, 4804, 64144, 11732, 16140, 1772]
+              },
+              "supported": true,
+              "ratio": 0.14,
+              "slope": 4.64
+            }
+          ]
+        }
+      }
+    },
+    "discriminated-union": {
+      "keystroke": {
+        "unit": "ms",
+        "byParam": {
+          "DU": [
+            {
+              "lib": "attaform",
+              "median": 0.7000000476837158,
+              "p95": 1.2999999523162842,
+              "iqr": 0.5,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 0.3999999761581421,
+              "p95": 0.8000000715255737,
+              "iqr": 0.2999999523162842,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.57,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 0.6000000238418579,
+              "p95": 0.8999999761581421,
+              "iqr": 0.20000004768371582,
+              "count": 198,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.86,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.5,
+              "p95": 0.8000000715255737,
+              "iqr": 0.20000004768371582,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.71,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 0.8000000715255737,
+              "p95": 1.399999976158142,
+              "iqr": 0.3999999761581421,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.14,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 0.6000000238418579,
+              "p95": 0.9200000762939442,
+              "iqr": 0.20000004768371582,
+              "count": 197,
+              "trimmed": 3,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.86,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 0.7999999523162842,
+              "p95": 1.2000000476837158,
+              "iqr": 0.4000000059604645,
+              "count": 198,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.14,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.5,
+              "p95": 0.7999999523162842,
+              "iqr": 0.19999995827674866,
+              "count": 194,
+              "trimmed": 6,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.71,
+              "slope": 1
+            }
+          ]
+        }
+      },
+      "mount": {
+        "unit": "ms",
+        "byParam": {
+          "DU": [
+            {
+              "lib": "attaform",
+              "median": 0.6999999284744263,
+              "p95": 0.8799999713897703,
+              "iqr": 0.1499999761581421,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 0.5,
+              "p95": 0.8349999606609344,
+              "iqr": 0.25,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.71,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 0.3999999761581421,
+              "p95": 0.735000056028366,
+              "iqr": 0.19999992847442627,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.57,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.20000004768371582,
+              "p95": 0.5350000083446502,
+              "iqr": 0.2999999523162842,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.29,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 0.5999999642372131,
+              "p95": 1.005000078678131,
+              "iqr": 0.3999999165534973,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.86,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 0.699999988079071,
+              "p95": 1.1350000321865081,
+              "iqr": 0.3500000238418579,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 3.399999976158142,
+              "p95": 3.700000047683716,
+              "iqr": 0.6000000238418579,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 4.86,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.44999998807907104,
+              "p95": 0.9000000178813934,
+              "iqr": 0.25,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.64,
+              "slope": 1
+            }
+          ]
+        }
+      },
+      "validate": {
+        "unit": "ms",
+        "byParam": {
+          "DU": [
+            {
+              "lib": "attaform",
+              "median": 0.10000002384185791,
+              "p95": 0.3250000476837158,
+              "iqr": 0.10000002384185791,
+              "count": 96,
+              "trimmed": 4,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 5.800000071525574,
+              "p95": 6,
+              "iqr": 0.10000002384185791,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 58,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 0.10000002384185791,
+              "p95": 0.20000004768371582,
+              "iqr": 0.10000002384185791,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.10000002384185791,
+              "p95": 0.30000007152557373,
+              "iqr": 0.10000014305114746,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 0.2999999523162842,
+              "p95": 0.5,
+              "iqr": 0.12500011920928955,
+              "count": 98,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 3,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 0.30000007152557373,
+              "p95": 0.6000000238418579,
+              "iqr": 0.19999992847442627,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 3,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 1,
+              "p95": 1.899999976158142,
+              "iqr": 0.7000000476837158,
+              "count": 98,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 10,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.10000002384185791,
+              "p95": 0.20000004768371582,
+              "iqr": 0.10000002384185791,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            }
+          ]
+        }
+      },
+      "rerender": {
+        "unit": "renders",
+        "byParam": {
+          "DU": [
+            {
+              "lib": "attaform",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 28,
+              "trimmed": 2,
+              "unit": "dom-mutations",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 1,
+              "p95": 1,
+              "iqr": 0,
+              "count": 30,
+              "trimmed": 0,
+              "unit": "renders",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            }
+          ]
+        }
+      },
+      "variantFlip": {
+        "unit": "ms",
+        "byParam": {
+          "DU": [
+            {
+              "lib": "attaform",
+              "median": 0.5,
+              "p95": 1.1800000786781295,
+              "iqr": 0.30000007152557373,
+              "count": 47,
+              "trimmed": 3,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 0.6000000238418579,
+              "p95": 1.3000000238418579,
+              "iqr": 0.7000000476837158,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.2,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 0.5999999046325684,
+              "p95": 1.6200000286102283,
+              "iqr": 0.7000000178813934,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.2,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.6000000238418579,
+              "p95": 1.1999999284744263,
+              "iqr": 0.6000000238418579,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.2,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 0.9000000953674316,
+              "p95": 1.9599999904632563,
+              "iqr": 1.0749998986721039,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.8,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 0.7999999523162842,
+              "p95": 2.0599999427795406,
+              "iqr": 0.875,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.6,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 2.600000023841858,
+              "p95": 3.355000019073486,
+              "iqr": 0.700000137090683,
+              "count": 50,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 5.2,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.5,
+              "p95": 1.100000023841858,
+              "iqr": 0.5000000894069672,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            }
+          ]
+        }
+      },
+      "memory": {
+        "unit": "bytes",
+        "byParam": {
+          "DU": [
+            {
+              "lib": "attaform",
+              "retained": {
+                "median": 105896,
+                "p95": 289132,
+                "count": 12
+              },
+              "churn": {
+                "median": 603264,
+                "p95": 630004,
+                "count": 12
+              },
+              "leak": {
+                "median": 47600,
+                "p95": 215108,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  548692, 129908, 187456, 134624, 142104, 104420, 91364, 91644, 289132, 94500,
+                  105896, 93096
+                ],
+                "churn": [
+                  947192, 607420, 630004, 603264, 593428, 603256, 582444, 615196, 596220, 604824,
+                  623916, 574488
+                ],
+                "leak": [
+                  798984, 57480, 120960, 56744, 55160, 37028, 1284, 18012, 215108, 22284, 47600,
+                  16420
+                ]
+              },
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "retained": {
+                "median": 66760,
+                "p95": 150480,
+                "count": 12
+              },
+              "churn": {
+                "median": 237728,
+                "p95": 257416,
+                "count": 12
+              },
+              "leak": {
+                "median": 19276,
+                "p95": 115036,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  349448, 122688, 150480, 86480, 109980, 65076, 60108, 61236, 105412, 60320, 61712,
+                  66760
+                ],
+                "churn": [
+                  346724, 243268, 245928, 240124, 236296, 231868, 234908, 245164, 257416, 237728,
+                  229932, 218792
+                ],
+                "leak": [
+                  449308, 73996, 115036, 30024, 76496, 19276, 3092, 10448, 74048, 14564, 14244, 0
+                ]
+              },
+              "supported": true,
+              "ratio": 0.63,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "retained": {
+                "median": 58020,
+                "p95": 126684,
+                "count": 12
+              },
+              "churn": {
+                "median": 102856,
+                "p95": 871876,
+                "count": 12
+              },
+              "leak": {
+                "median": 45296,
+                "p95": 134516,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  326752, 77604, 126684, 60232, 97192, 54568, 52780, 53244, 95744, 53932, 58020,
+                  53520
+                ],
+                "churn": [
+                  455604, 89300, 101616, 102856, 124588, 89328, 88556, 91424, 871876, 859320,
+                  878336, 840612
+                ],
+                "leak": [
+                  669112, 70192, 134516, 28940, 103676, 45296, 28512, 37816, 84448, 34792, 49948,
+                  21792
+                ]
+              },
+              "supported": true,
+              "ratio": 0.55,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "retained": {
+                "median": 42532,
+                "p95": 101096,
+                "count": 12
+              },
+              "churn": {
+                "median": 213516,
+                "p95": 226276,
+                "count": 12
+              },
+              "leak": {
+                "median": 13012,
+                "p95": 73680,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  200436, 54860, 101096, 42532, 44448, 43208, 33692, 33972, 62696, 34372, 35824,
+                  31900
+                ],
+                "churn": [
+                  387504, 210432, 213516, 216108, 213348, 213104, 215208, 224628, 226276, 217312,
+                  212488, 201976
+                ],
+                "leak": [
+                  343600, 29428, 73680, 10636, 19840, 19236, 4848, 7260, 41316, 11832, 13012, 0
+                ]
+              },
+              "supported": true,
+              "ratio": 0.4,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "retained": {
+                "median": 121704,
+                "p95": 254980,
+                "count": 12
+              },
+              "churn": {
+                "median": 475952,
+                "p95": 567096,
+                "count": 12
+              },
+              "leak": {
+                "median": 24324,
+                "p95": 146692,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  424676, 149880, 254980, 133864, 146236, 114532, 109936, 110092, 173748, 121704,
+                  119960, 107700
+                ],
+                "churn": [
+                  975344, 567096, 535972, 470716, 475952, 461900, 461908, 474376, 489728, 506848,
+                  482092, 442756
+                ],
+                "leak": [
+                  541564, 49308, 146692, 24324, 46476, 15004, 156, 7736, 71344, 31212, 22752, 456
+                ]
+              },
+              "supported": true,
+              "ratio": 1.15,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "retained": {
+                "median": 151240,
+                "p95": 269180,
+                "count": 12
+              },
+              "churn": {
+                "median": 435120,
+                "p95": 466272,
+                "count": 12
+              },
+              "leak": {
+                "median": 21032,
+                "p95": 130928,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  460488, 269180, 216700, 171696, 183136, 149852, 146928, 147572, 210892, 147392,
+                  151240, 145732
+                ],
+                "churn": [
+                  626120, 438776, 435120, 431788, 434932, 435780, 426568, 437712, 442808, 466272,
+                  434024, 422944
+                ],
+                "leak": [
+                  468832, 130928, 74636, 19992, 46212, 22104, 1744, 8816, 77864, 21032, 12716, 580
+                ]
+              },
+              "supported": true,
+              "ratio": 1.43,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "retained": {
+                "median": 1103288,
+                "p95": 1260208,
+                "count": 12
+              },
+              "churn": {
+                "median": 224568,
+                "p95": 290688,
+                "count": 12
+              },
+              "leak": {
+                "median": 54708,
+                "p95": 225072,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  1910316, 1260208, 1137512, 1108120, 1103288, 1071976, 1086628, 1069016, 1138336,
+                  1145100, 1071180, 1100440
+                ],
+                "churn": [
+                  986588, 290688, 269100, 265916, 224568, 223800, 207156, 227320, 218552, 275116,
+                  192264, 187848
+                ],
+                "leak": [
+                  1243560, 225072, 117216, 62404, 54708, 29500, 3892, 27692, 86056, 101320, 17660,
+                  27868
+                ]
+              },
+              "supported": true,
+              "ratio": 10.42,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "retained": {
+                "median": 84092,
+                "p95": 143956,
+                "count": 12
+              },
+              "churn": {
+                "median": 126980,
+                "p95": 142180,
+                "count": 12
+              },
+              "leak": {
+                "median": 20188,
+                "p95": 86288,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  281400, 143956, 122920, 81232, 84092, 76788, 77676, 78320, 130104, 78744, 84852,
+                  87348
+                ],
+                "churn": [
+                  290228, 122760, 118780, 138340, 141176, 118128, 123348, 126980, 142180, 137404,
+                  130736, 112928
+                ],
+                "leak": [
+                  349884, 86288, 61016, 24168, 30404, 11420, 3384, 5856, 71376, 12112, 20188, 11688
+                ]
+              },
+              "supported": true,
+              "ratio": 0.79,
+              "slope": 1
+            }
+          ]
+        }
+      }
+    },
+    "massive": {
+      "keystroke": {
+        "unit": "ms",
+        "byParam": {
+          "L2000": [
+            {
+              "lib": "attaform",
+              "median": 6.900000095367432,
+              "p95": 8.804999953508377,
+              "iqr": 0.8999999761581421,
+              "count": 120,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 4,
+              "p95": 5.100000023841858,
+              "iqr": 0.8000000715255737,
+              "count": 120,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.58,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 11.100000023841858,
+              "p95": 13.230000019073486,
+              "iqr": 1.125,
+              "count": 115,
+              "trimmed": 5,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.61,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 4.5,
+              "p95": 5.5,
+              "iqr": 0.6999999284744263,
+              "count": 119,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.65,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 9.100000023841858,
+              "p95": 10.200000047683716,
+              "iqr": 0.7999999523162842,
+              "count": 120,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.32,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 4.5,
+              "p95": 5.299999958276748,
+              "iqr": 0.6000000238418579,
+              "count": 120,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.65,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 2.600000023841858,
+              "p95": 3.899999976158142,
+              "iqr": 0.6999999284744263,
+              "count": 119,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.38,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 4.300000071525574,
+              "p95": 5.110000026226043,
+              "iqr": 0.49999988079071045,
+              "count": 119,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.62,
+              "slope": 1
+            }
+          ],
+          "L5000": [
+            {
+              "lib": "attaform",
+              "median": 17.19999998807907,
+              "p95": 20.415000092983245,
+              "iqr": 2.450000047683716,
+              "count": 120,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 2.49
+            },
+            {
+              "lib": "vee-validate",
+              "median": 8.100000023841858,
+              "p95": 10.004999995231628,
+              "iqr": 2.6999999284744263,
+              "count": 120,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.47,
+              "slope": 2.03
+            },
+            {
+              "lib": "tanstack",
+              "median": 32.200000047683716,
+              "p95": 38.625,
+              "iqr": 2.9249999821186066,
+              "count": 116,
+              "trimmed": 4,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.87,
+              "slope": 2.9
+            },
+            {
+              "lib": "formisch",
+              "median": 8.600000023841858,
+              "p95": 9.419999980926512,
+              "iqr": 0.7000000476837158,
+              "count": 119,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.5,
+              "slope": 1.91
+            },
+            {
+              "lib": "regle-schema",
+              "median": 22,
+              "p95": 23.50499999523163,
+              "iqr": 1.2249999642372131,
+              "count": 120,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.28,
+              "slope": 2.42
+            },
+            {
+              "lib": "regle-rules",
+              "median": 7.400000035762787,
+              "p95": 9.299999958276748,
+              "iqr": 1.1250000298023224,
+              "count": 120,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.43,
+              "slope": 1.64
+            },
+            {
+              "lib": "formkit",
+              "median": 5.600000023841858,
+              "p95": 6.429999983310697,
+              "iqr": 0.7000000476837158,
+              "count": 118,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.33,
+              "slope": 2.15
+            },
+            {
+              "lib": "vuelidate",
+              "median": 8.299999952316284,
+              "p95": 10.100000023841858,
+              "iqr": 1.1249999403953552,
+              "count": 119,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.48,
+              "slope": 1.93
+            }
+          ]
+        }
+      },
+      "mount": {
+        "unit": "ms",
+        "byParam": {
+          "L2000": [
+            {
+              "lib": "attaform",
+              "median": 243,
+              "p95": 261.1299999713898,
+              "iqr": 14.900000095367432,
+              "count": 7,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 410.6999999284744,
+              "p95": 433.02999993562696,
+              "iqr": 12.749999940395355,
+              "count": 7,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.69,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 3296.25,
+              "p95": 3453.0000000298023,
+              "iqr": 134.65000009536743,
+              "count": 6,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 13.56,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 27.600000023841858,
+              "p95": 37.77000005245208,
+              "iqr": 5.75,
+              "count": 7,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.11,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 92.10000002384186,
+              "p95": 115.63000004291533,
+              "iqr": 16.449999928474426,
+              "count": 7,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.38,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 106.39999997615814,
+              "p95": 145.83000000715256,
+              "iqr": 22.750000059604645,
+              "count": 7,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.44,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 5229,
+              "p95": 5608.280000007152,
+              "iqr": 265.60000002384186,
+              "count": 7,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 21.52,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 45.89999997615814,
+              "p95": 57.14999995231628,
+              "iqr": 6.799999952316284,
+              "count": 7,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.19,
+              "slope": 1
+            }
+          ]
+        }
+      },
+      "validate": {
+        "unit": "ms",
+        "byParam": {
+          "L2000": [
+            {
+              "lib": "attaform",
+              "median": 1.2999999523162842,
+              "p95": 1.754999959468841,
+              "iqr": 0.3999999761581421,
+              "count": 24,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 12.25,
+              "p95": 12.854999983310698,
+              "iqr": 0.3999999761581421,
+              "count": 24,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 9.42,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 382.6999999284744,
+              "p95": 388.66000003814696,
+              "iqr": 3.4999998807907104,
+              "count": 25,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 294.38,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.8999999761581421,
+              "p95": 1.3849999725818631,
+              "iqr": 0.2999999523162842,
+              "count": 24,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.69,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 16.399999976158142,
+              "p95": 19.520000052452083,
+              "iqr": 2,
+              "count": 25,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 12.62,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 39.60000002384186,
+              "p95": 41.290000069141385,
+              "iqr": 1,
+              "count": 22,
+              "trimmed": 3,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 30.46,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 175.09999990463257,
+              "p95": 179.70000005960463,
+              "iqr": 4.799999952316284,
+              "count": 23,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 134.69,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.20000004768371582,
+              "p95": 0.30000007152557373,
+              "iqr": 0.10000002384185791,
+              "count": 24,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.15,
+              "slope": 1
+            }
+          ],
+          "L5000": [
+            {
+              "lib": "attaform",
+              "median": 1.6999999284744263,
+              "p95": 1.9000000774860382,
+              "iqr": 0.3999999761581421,
+              "count": 24,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1.31
+            },
+            {
+              "lib": "vee-validate",
+              "median": 20.399999976158142,
+              "p95": 24.479999923706053,
+              "iqr": 1.9000000953674316,
+              "count": 25,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 12,
+              "slope": 1.67
+            },
+            {
+              "lib": "tanstack",
+              "median": 2773.5,
+              "p95": 2821.2599999904633,
+              "iqr": 28.200000047683716,
+              "count": 25,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1631.47,
+              "slope": 7.25
+            },
+            {
+              "lib": "formisch",
+              "median": 1.2999999523162842,
+              "p95": 1.585000020265579,
+              "iqr": 0.30000007152557373,
+              "count": 24,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.76,
+              "slope": 1.44
+            },
+            {
+              "lib": "regle-schema",
+              "median": 42,
+              "p95": 46.21999998092651,
+              "iqr": 2.200000047683716,
+              "count": 25,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 24.71,
+              "slope": 2.56
+            },
+            {
+              "lib": "regle-rules",
+              "median": 104.1499999165535,
+              "p95": 108.40999999642372,
+              "iqr": 4,
+              "count": 24,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 61.26,
+              "slope": 2.63
+            },
+            {
+              "lib": "formkit",
+              "median": 520.8999999761581,
+              "p95": 532.3000000238419,
+              "iqr": 18.199999928474426,
+              "count": 25,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 306.41,
+              "slope": 2.97
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.3999999761581421,
+              "p95": 0.6000000238418579,
+              "iqr": 0.19999992847442627,
+              "count": 22,
+              "trimmed": 3,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.24,
+              "slope": 2
+            }
+          ]
+        }
+      },
+      "memory": {
+        "unit": "bytes",
+        "byParam": {
+          "L2000": [
+            {
+              "lib": "attaform",
+              "retained": {
+                "median": 67216356,
+                "p95": 67323384,
+                "count": 5
+              },
+              "churn": {
+                "median": 17005244,
+                "p95": 19917628,
+                "count": 5
+              },
+              "leak": {
+                "median": 39824,
+                "p95": 92416,
+                "count": 5
+              },
+              "series": {
+                "retained": [69073408, 67323384, 67216356, 67171244, 67156156],
+                "churn": [19917628, 16984000, 16907952, 26044656, 17005244],
+                "leak": [2036972, 92416, 39464, 39824, 932]
+              },
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "retained": {
+                "median": 23177628,
+                "p95": 23210348,
+                "count": 5
+              },
+              "churn": {
+                "median": 1516832,
+                "p95": 1789484,
+                "count": 5
+              },
+              "leak": {
+                "median": 1546772,
+                "p95": 1559552,
+                "count": 5
+              },
+              "series": {
+                "retained": [22400996, 23211104, 23177628, 23164644, 23210348],
+                "churn": [1789484, 851428, 1516832, 1004280, 1932840],
+                "leak": [1206332, 1561896, 1546772, 1559552, 1538792]
+              },
+              "supported": true,
+              "ratio": 0.34,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "retained": {
+                "median": 23106236,
+                "p95": 23201240,
+                "count": 5
+              },
+              "churn": {
+                "median": 7402324,
+                "p95": 7418324,
+                "count": 5
+              },
+              "leak": {
+                "median": 1685744,
+                "p95": 1695056,
+                "count": 5
+              },
+              "series": {
+                "retained": [24319208, 23201240, 23060060, 23072264, 23106236],
+                "churn": [2898340, 7402324, 5542784, 7577920, 7418324],
+                "leak": [4432448, 524876, 1665348, 1685744, 1695056]
+              },
+              "supported": true,
+              "ratio": 0.34,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "retained": {
+                "median": 11800624,
+                "p95": 11802992,
+                "count": 5
+              },
+              "churn": {
+                "median": 298516,
+                "p95": 1132960,
+                "count": 5
+              },
+              "leak": {
+                "median": 6116,
+                "p95": 12456,
+                "count": 5
+              },
+              "series": {
+                "retained": [12346960, 11800624, 11762732, 11763764, 11802992],
+                "churn": [1132960, 1135044, 184996, 298516, 153820],
+                "leak": [674900, 6116, 2896, 2716, 12456]
+              },
+              "supported": true,
+              "ratio": 0.18,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "retained": {
+                "median": 34331760,
+                "p95": 34398156,
+                "count": 5
+              },
+              "churn": {
+                "median": 2457224,
+                "p95": 7131440,
+                "count": 5
+              },
+              "leak": {
+                "median": 26212,
+                "p95": 28116,
+                "count": 5
+              },
+              "series": {
+                "retained": [35604004, 34398156, 34170884, 34331760, 34170544],
+                "churn": [1410896, 7131440, 2457224, 7221784, 1243716],
+                "leak": [1474400, 28116, 26212, 9088, 6972]
+              },
+              "supported": true,
+              "ratio": 0.51,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "retained": {
+                "median": 42661708,
+                "p95": 42673716,
+                "count": 5
+              },
+              "churn": {
+                "median": 1022788,
+                "p95": 1866612,
+                "count": 5
+              },
+              "leak": {
+                "median": 33112,
+                "p95": 36532,
+                "count": 5
+              },
+              "series": {
+                "retained": [43958232, 42661708, 42673716, 42376016, 42654744],
+                "churn": [868180, 1894344, 486552, 1866612, 1022788],
+                "leak": [1548576, 36532, 33112, 10072, 0]
+              },
+              "supported": true,
+              "ratio": 0.63,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "retained": {
+                "median": 386180468,
+                "p95": 386383152,
+                "count": 5
+              },
+              "churn": {
+                "median": 1075104,
+                "p95": 1117440,
+                "count": 5
+              },
+              "leak": {
+                "median": 10784,
+                "p95": 75916,
+                "count": 5
+              },
+              "series": {
+                "retained": [398013852, 386180468, 386000732, 386175916, 386383152],
+                "churn": [1136584, 1048788, 1117440, 1075104, 1046620],
+                "leak": [12182184, 75916, 4456, 10784, 6940]
+              },
+              "supported": true,
+              "ratio": 5.75,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "retained": {
+                "median": 15177156,
+                "p95": 15221312,
+                "count": 5
+              },
+              "churn": {
+                "median": 4170380,
+                "p95": 4305280,
+                "count": 5
+              },
+              "leak": {
+                "median": 9720,
+                "p95": 17892,
+                "count": 5
+              },
+              "series": {
+                "retained": [16018352, 15221312, 15166576, 15177156, 15174272],
+                "churn": [4170380, 2611168, 5112836, 4305280, 3723404],
+                "leak": [902156, 9720, 8356, 17892, 3884]
+              },
+              "supported": true,
+              "ratio": 0.23,
+              "slope": 1
+            }
+          ]
+        }
+      }
+    },
+    "wizard": {
+      "validate": {
+        "unit": "ms",
+        "byParam": {
+          "S4": [
+            {
+              "lib": "attaform",
+              "median": 0.20000004768371582,
+              "p95": 0.5,
+              "iqr": 0.20000004768371582,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 6,
+              "p95": 6.299999952316284,
+              "iqr": 0.2999999523162842,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 30,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 0.19999992847442627,
+              "p95": 0.30000007152557373,
+              "iqr": 0.19999992847442627,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.19999992847442627,
+              "p95": 0.30000007152557373,
+              "iqr": 0.10000002384185791,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 0.5,
+              "p95": 0.8999999761581421,
+              "iqr": 0.3999999761581421,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 2.5,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 0.30000007152557373,
+              "p95": 0.8000000715255737,
+              "iqr": 0.2999999523162842,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.5,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 1.5,
+              "p95": 2.100000023841858,
+              "iqr": 0.5000000298023224,
+              "count": 92,
+              "trimmed": 8,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 7.5,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.10000002384185791,
+              "p95": 0.20000004768371582,
+              "iqr": 0.10000002384185791,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.5,
+              "slope": 1
+            }
+          ]
+        }
+      },
+      "stepTransition": {
+        "unit": "ms",
+        "byParam": {
+          "S4": [
+            {
+              "lib": "attaform",
+              "median": 0.2999999523162842,
+              "p95": 0.8000000715255737,
+              "iqr": 0.27500009536743164,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 6,
+              "p95": 6.200000047683716,
+              "iqr": 0.2999999523162842,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 20,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 0.20000004768371582,
+              "p95": 0.8000000715255737,
+              "iqr": 0.30000007152557373,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.67,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.09999990463256836,
+              "p95": 0.20000004768371582,
+              "iqr": 0.10000002384185791,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.33,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 0.3999999761581421,
+              "p95": 0.5749999284744263,
+              "iqr": 0.10000002384185791,
+              "count": 46,
+              "trimmed": 4,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.33,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 0.10000002384185791,
+              "p95": 0.2999999523162842,
+              "iqr": 0.10000002384185791,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.33,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 1.1999999284744263,
+              "p95": 1.600000023841858,
+              "iqr": 0.30000004172325134,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 4,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.10000002384185791,
+              "p95": 0.20000004768371582,
+              "iqr": 0.10000002384185791,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.33,
+              "slope": 1
+            }
+          ]
+        }
+      },
+      "memory": {
+        "unit": "bytes",
+        "byParam": {
+          "S4": [
+            {
+              "lib": "attaform",
+              "retained": {
+                "median": 223216,
+                "p95": 373308,
+                "count": 12
+              },
+              "churn": {
+                "median": 457360,
+                "p95": 488316,
+                "count": 12
+              },
+              "leak": {
+                "median": 30308,
+                "p95": 199104,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  920428, 284732, 373308, 211256, 259136, 218560, 205588, 212240, 256520, 220244,
+                  223652, 223216
+                ],
+                "churn": [
+                  708616, 452616, 455844, 462360, 462124, 469120, 462736, 451864, 457360, 435320,
+                  488316, 433648
+                ],
+                "leak": [
+                  966780, 79000, 199104, 30308, 67068, 26296, 26512, 18016, 48860, 15240, 45060,
+                  10008
+                ]
+              },
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "retained": {
+                "median": 163984,
+                "p95": 212408,
+                "count": 12
+              },
+              "churn": {
+                "median": 246596,
+                "p95": 268852,
+                "count": 12
+              },
+              "leak": {
+                "median": 15380,
+                "p95": 61644,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  648676, 163508, 171556, 155764, 163984, 154492, 182564, 154940, 212408, 177736,
+                  155916, 174784
+                ],
+                "churn": [
+                  340184, 215476, 255492, 222816, 211628, 254268, 257664, 245660, 268852, 246596,
+                  248156, 238216
+                ],
+                "leak": [
+                  633516, 44472, 59496, 20352, 11736, 15380, 20520, 2824, 61644, 1040, 14968, 13932
+                ]
+              },
+              "supported": true,
+              "ratio": 0.73,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "retained": {
+                "median": 173132,
+                "p95": 230900,
+                "count": 12
+              },
+              "churn": {
+                "median": 514208,
+                "p95": 1288100,
+                "count": 12
+              },
+              "leak": {
+                "median": 58680,
+                "p95": 86876,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  659116, 181472, 167592, 171212, 184216, 169260, 178612, 171268, 230900, 170912,
+                  173508, 173132
+                ],
+                "churn": [
+                  839724, 551572, 1308892, 528212, 514208, 512696, 513780, 491956, 1288100, 496956,
+                  520320, 504248
+                ],
+                "leak": [
+                  826804, 70272, 58680, 68492, 58204, 60576, 61792, 33496, 86876, 38928, 53860,
+                  34404
+                ]
+              },
+              "supported": true,
+              "ratio": 0.78,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "retained": {
+                "median": 94012,
+                "p95": 133408,
+                "count": 12
+              },
+              "churn": {
+                "median": 277768,
+                "p95": 293492,
+                "count": 12
+              },
+              "leak": {
+                "median": 10064,
+                "p95": 42756,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  387356, 103352, 91092, 94012, 103672, 96584, 96748, 93204, 133408, 92092, 93764,
+                  90776
+                ],
+                "churn": [
+                  402932, 276328, 279184, 277768, 280664, 278668, 289060, 269196, 293492, 269972,
+                  272936, 265860
+                ],
+                "leak": [
+                  432968, 17576, 6476, 10064, 15004, 14840, 15748, 2408, 42756, 3488, 8544, 0
+                ]
+              },
+              "supported": true,
+              "ratio": 0.42,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "retained": {
+                "median": 280300,
+                "p95": 351488,
+                "count": 12
+              },
+              "churn": {
+                "median": 813396,
+                "p95": 824600,
+                "count": 12
+              },
+              "leak": {
+                "median": 13056,
+                "p95": 86848,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  842120, 327904, 292992, 280300, 282276, 275204, 274240, 274464, 351488, 275252,
+                  286092, 271528
+                ],
+                "churn": [
+                  516712, 818244, 821204, 824600, 806808, 816568, 814968, 783708, 846240, 768404,
+                  813396, 761476
+                ],
+                "leak": [
+                  720236, 47792, 20124, 13056, 8432, 10116, 14864, 9060, 86848, 1824, 16828, 36
+                ]
+              },
+              "supported": true,
+              "ratio": 1.26,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "retained": {
+                "median": 309272,
+                "p95": 378712,
+                "count": 12
+              },
+              "churn": {
+                "median": 471348,
+                "p95": 518712,
+                "count": 12
+              },
+              "leak": {
+                "median": 14552,
+                "p95": 86024,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  865492, 362936, 315412, 307828, 310956, 309272, 305404, 308900, 378712, 304860,
+                  321268, 301864
+                ],
+                "churn": [
+                  594460, 485568, 471348, 467388, 476552, 465512, 478848, 479276, 518712, 456716,
+                  466792, 454704
+                ],
+                "leak": [
+                  666828, 55892, 12936, 7696, 17996, 14552, 18980, 4976, 86024, 1696, 25096, 0
+                ]
+              },
+              "supported": true,
+              "ratio": 1.39,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "retained": {
+                "median": 3001856,
+                "p95": 3048360,
+                "count": 12
+              },
+              "churn": {
+                "median": 281840,
+                "p95": 386068,
+                "count": 12
+              },
+              "leak": {
+                "median": 62032,
+                "p95": 183568,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  4083036, 3048360, 2994296, 3022808, 3001856, 2967400, 2996292, 3022108, 3015732,
+                  3022652, 2948128, 2954112
+                ],
+                "churn": [
+                  438564, 386068, 341820, 293876, 296500, 281840, 298424, 259556, 256756, 259688,
+                  256548, 245148
+                ],
+                "leak": [
+                  1895944, 183568, 93324, 52440, 64192, 42724, 51384, 77620, 87628, 62032, 29440,
+                  16544
+                ]
+              },
+              "supported": true,
+              "ratio": 13.45,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "retained": {
+                "median": 179468,
+                "p95": 234348,
+                "count": 12
+              },
+              "churn": {
+                "median": 247944,
+                "p95": 277388,
+                "count": 12
+              },
+              "leak": {
+                "median": 21412,
+                "p95": 78676,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  546488, 186848, 182404, 182836, 187420, 179468, 170068, 169880, 234348, 170276,
+                  175292, 168552
+                ],
+                "churn": [
+                  369708, 259272, 249228, 251604, 240472, 238000, 277388, 237368, 255216, 247944,
+                  246280, 229340
+                ],
+                "leak": [
+                  499916, 38388, 22948, 22072, 22812, 21412, 7608, 1528, 78676, 1292, 14576, 0
+                ]
+              },
+              "supported": true,
+              "ratio": 0.8,
+              "slope": 1
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/apps/bench-arena/results.json
+++ b/apps/bench-arena/results.json
@@ -12,7 +12,7 @@
       "cpuCount": 14
     },
     "node": "v25.6.1",
-    "timestamp": "2026-06-10T19:56:16.031Z",
+    "timestamp": "2026-06-10T20:37:04.692Z",
     "libVersions": {
       "attaform": "0.21.2",
       "vee-validate": "4.15.1",
@@ -39,7 +39,14 @@
       "grid": "native",
       "discriminated-union": "native",
       "massive": "native",
-      "wizard": "native"
+      "wizard": "native",
+      "repo": "github.com/attaform/Attaform",
+      "repoUrl": "https://github.com/attaform/Attaform",
+      "scorecardUrl": "https://scorecard.dev/viewer/?uri=github.com/attaform/Attaform",
+      "scorecard": {
+        "score": 7.9,
+        "date": "2026-06-10T05:33:32Z"
+      }
     },
     {
       "lib": "vee-validate",
@@ -53,7 +60,14 @@
       "grid": "native",
       "discriminated-union": "hand-rolled",
       "massive": "native",
-      "wizard": "hand-rolled"
+      "wizard": "hand-rolled",
+      "repo": "github.com/logaretm/vee-validate",
+      "repoUrl": "https://github.com/logaretm/vee-validate",
+      "scorecardUrl": "https://scorecard.dev/viewer/?uri=github.com/logaretm/vee-validate",
+      "scorecard": {
+        "score": 3.6,
+        "date": "2026-06-08"
+      }
     },
     {
       "lib": "tanstack",
@@ -67,7 +81,11 @@
       "grid": "native",
       "discriminated-union": "hand-rolled",
       "massive": "native",
-      "wizard": "hand-rolled"
+      "wizard": "hand-rolled",
+      "repo": "github.com/TanStack/form",
+      "repoUrl": "https://github.com/TanStack/form",
+      "scorecardUrl": "https://scorecard.dev/viewer/?uri=github.com/TanStack/form",
+      "scorecard": null
     },
     {
       "lib": "formisch",
@@ -81,7 +99,11 @@
       "grid": "native",
       "discriminated-union": "hand-rolled",
       "massive": "native",
-      "wizard": "hand-rolled"
+      "wizard": "hand-rolled",
+      "repo": "github.com/open-circle/formisch",
+      "repoUrl": "https://github.com/open-circle/formisch",
+      "scorecardUrl": "https://scorecard.dev/viewer/?uri=github.com/open-circle/formisch",
+      "scorecard": null
     },
     {
       "lib": "regle-schema",
@@ -95,7 +117,11 @@
       "grid": "native",
       "discriminated-union": "native",
       "massive": "native",
-      "wizard": "hand-rolled"
+      "wizard": "hand-rolled",
+      "repo": "github.com/victorgarciaesgi/regle",
+      "repoUrl": "https://github.com/victorgarciaesgi/regle",
+      "scorecardUrl": "https://scorecard.dev/viewer/?uri=github.com/victorgarciaesgi/regle",
+      "scorecard": null
     },
     {
       "lib": "regle-rules",
@@ -109,7 +135,11 @@
       "grid": "native",
       "discriminated-union": "hand-rolled",
       "massive": "native",
-      "wizard": "hand-rolled"
+      "wizard": "hand-rolled",
+      "repo": "github.com/victorgarciaesgi/regle",
+      "repoUrl": "https://github.com/victorgarciaesgi/regle",
+      "scorecardUrl": "https://scorecard.dev/viewer/?uri=github.com/victorgarciaesgi/regle",
+      "scorecard": null
     },
     {
       "lib": "formkit",
@@ -123,7 +153,11 @@
       "grid": "native",
       "discriminated-union": "hand-rolled",
       "massive": "native",
-      "wizard": "hand-rolled"
+      "wizard": "hand-rolled",
+      "repo": "github.com/formkit/formkit",
+      "repoUrl": "https://github.com/formkit/formkit",
+      "scorecardUrl": "https://scorecard.dev/viewer/?uri=github.com/formkit/formkit",
+      "scorecard": null
     },
     {
       "lib": "vuelidate",
@@ -137,7 +171,14 @@
       "grid": "hand-rolled",
       "discriminated-union": "hand-rolled",
       "massive": "native",
-      "wizard": "hand-rolled"
+      "wizard": "hand-rolled",
+      "repo": "github.com/vuelidate/vuelidate",
+      "repoUrl": "https://github.com/vuelidate/vuelidate",
+      "scorecardUrl": "https://scorecard.dev/viewer/?uri=github.com/vuelidate/vuelidate",
+      "scorecard": {
+        "score": 4.4,
+        "date": "2026-06-01"
+      }
     }
   ],
   "bundle": [
@@ -206,9 +247,9 @@
           "F10": [
             {
               "lib": "attaform",
-              "median": 0.6000000238418579,
-              "p95": 1.2999999523162842,
-              "iqr": 0.42500007152557373,
+              "median": 0.8000000715255737,
+              "p95": 1.5,
+              "iqr": 0.5,
               "count": 199,
               "trimmed": 1,
               "unit": "ms",
@@ -218,9 +259,9 @@
             },
             {
               "lib": "vee-validate",
-              "median": 0.2999999523162842,
-              "p95": 1,
-              "iqr": 0.39999985694885254,
+              "median": 0.3999999761581421,
+              "p95": 1.0999999046325684,
+              "iqr": 0.4000000059604645,
               "count": 199,
               "trimmed": 1,
               "unit": "ms",
@@ -232,117 +273,129 @@
               "lib": "tanstack",
               "median": 0.8000000715255737,
               "p95": 1.399999976158142,
-              "iqr": 0.39999985694885254,
-              "count": 199,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1.33,
-              "slope": 1
-            },
-            {
-              "lib": "formisch",
-              "median": 0.8000000715255737,
-              "p95": 1.1999999284744263,
-              "iqr": 0.29999998211860657,
-              "count": 199,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1.33,
-              "slope": 1
-            },
-            {
-              "lib": "regle-schema",
-              "median": 0.8000000715255737,
-              "p95": 1.3000000715255737,
-              "iqr": 0.4500000476837158,
-              "count": 199,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1.33,
-              "slope": 1
-            },
-            {
-              "lib": "regle-rules",
-              "median": 0.7999999523162842,
-              "p95": 1.299999964237213,
-              "iqr": 0.5,
-              "count": 199,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1.33,
-              "slope": 1
-            },
-            {
-              "lib": "formkit",
-              "median": 0.9000000953674316,
-              "p95": 1.399999976158142,
-              "iqr": 0.5,
-              "count": 199,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1.5,
-              "slope": 1
-            },
-            {
-              "lib": "vuelidate",
-              "median": 0.6000000238418579,
-              "p95": 1,
-              "iqr": 0.39999985694885254,
+              "iqr": 0.6000000238418579,
               "count": 199,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
               "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.5999999046325684,
+              "p95": 1.0099999904632562,
+              "iqr": 0.49999988079071045,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.75,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 1,
+              "p95": 1.4100000858306878,
+              "iqr": 0.5,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.25,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 0.7999999523162842,
+              "p95": 1.2000000476837158,
+              "iqr": 0.5,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 0.8000000715255737,
+              "p95": 1.5,
+              "iqr": 0.6999999284744263,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.7000000476837158,
+              "p95": 1.2000000476837158,
+              "iqr": 0.5249999761581421,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.87,
               "slope": 1
             }
           ],
           "F50": [
             {
               "lib": "attaform",
-              "median": 0.7999999523162842,
-              "p95": 1.710000038146972,
-              "iqr": 0.7999999523162842,
+              "median": 1,
+              "p95": 1.899999976158142,
+              "iqr": 0.8999999761581421,
               "count": 199,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
               "ratio": 1,
-              "slope": 1.33
+              "slope": 1.25
             },
             {
               "lib": "vee-validate",
               "median": 0.7999999523162842,
-              "p95": 1.399999976158142,
-              "iqr": 0.5999999344348907,
+              "p95": 1.600000023841858,
+              "iqr": 0.7000000476837158,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.8,
+              "slope": 2
+            },
+            {
+              "lib": "tanstack",
+              "median": 1.399999976158142,
+              "p95": 2.3000000715255737,
+              "iqr": 0.8999999761581421,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.4,
+              "slope": 1.75
+            },
+            {
+              "lib": "formisch",
+              "median": 1,
+              "p95": 1.5,
+              "iqr": 0.6000000238418579,
               "count": 199,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
               "ratio": 1,
-              "slope": 2.67
+              "slope": 1.67
             },
             {
-              "lib": "tanstack",
+              "lib": "regle-schema",
               "median": 1.5,
-              "p95": 2.1999999403953554,
-              "iqr": 0.5999999046325684,
-              "count": 199,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1.88,
-              "slope": 1.87
-            },
-            {
-              "lib": "formisch",
-              "median": 1.1999999284744263,
-              "p95": 1.600000023841858,
-              "iqr": 0.3999999761581421,
+              "p95": 2.399999976158142,
+              "iqr": 0.8999999761581421,
               "count": 199,
               "trimmed": 1,
               "unit": "ms",
@@ -351,52 +404,40 @@
               "slope": 1.5
             },
             {
-              "lib": "regle-schema",
-              "median": 1.5,
-              "p95": 2.200000047683716,
-              "iqr": 0.5999999344348907,
-              "count": 199,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1.88,
-              "slope": 1.87
-            },
-            {
               "lib": "regle-rules",
               "median": 1.100000023841858,
-              "p95": 1.5,
-              "iqr": 0.5000001192092896,
+              "p95": 1.7999999523162842,
+              "iqr": 0.5999999046325684,
               "count": 199,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.38,
+              "ratio": 1.1,
               "slope": 1.38
             },
             {
               "lib": "formkit",
-              "median": 1.399999976158142,
-              "p95": 2.0999999046325684,
-              "iqr": 0.5999999046325684,
+              "median": 1.4000000357627869,
+              "p95": 2.3000000715255737,
+              "iqr": 1,
               "count": 198,
               "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.75,
-              "slope": 1.56
+              "ratio": 1.4,
+              "slope": 1.75
             },
             {
               "lib": "vuelidate",
-              "median": 0.7999999523162842,
-              "p95": 1.4099999785423274,
-              "iqr": 0.5,
+              "median": 1,
+              "p95": 1.5100000023841853,
+              "iqr": 0.3999999761581421,
               "count": 199,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
               "ratio": 1,
-              "slope": 1.33
+              "slope": 1.43
             }
           ]
         }
@@ -407,9 +448,9 @@
           "F10": [
             {
               "lib": "attaform",
-              "median": 0.8999999761581421,
-              "p95": 1.0350000083446502,
-              "iqr": 0.15000009536743164,
+              "median": 0.8499999642372131,
+              "p95": 1.4400000631809233,
+              "iqr": 0.3500000238418579,
               "count": 14,
               "trimmed": 1,
               "unit": "ms",
@@ -419,185 +460,185 @@
             },
             {
               "lib": "vee-validate",
-              "median": 0.6499999761581421,
-              "p95": 1.0050000011920928,
-              "iqr": 0.2000001072883606,
-              "count": 14,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.72,
-              "slope": 1
-            },
-            {
-              "lib": "tanstack",
-              "median": 0.7999999523162842,
-              "p95": 0.9699999928474425,
-              "iqr": 0.10000002384185791,
-              "count": 14,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.89,
-              "slope": 1
-            },
-            {
-              "lib": "formisch",
-              "median": 0.6000000238418579,
-              "p95": 0.8000000715255737,
+              "median": 0.7000000476837158,
+              "p95": 1,
               "iqr": 0.20000004768371582,
               "count": 14,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.67,
+              "ratio": 0.82,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 0.800000011920929,
+              "p95": 1.1349999904632568,
+              "iqr": 0.3500000238418579,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.94,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.5,
+              "p95": 0.6000000238418579,
+              "iqr": 0.10000002384185791,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.59,
               "slope": 1
             },
             {
               "lib": "regle-schema",
-              "median": 0.7999999523162842,
-              "p95": 1.1799999952316282,
-              "iqr": 0.34999996423721313,
-              "count": 13,
-              "trimmed": 2,
+              "median": 0.949999988079071,
+              "p95": 1.2700000643730163,
+              "iqr": 0.19999992847442627,
+              "count": 14,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.89,
+              "ratio": 1.12,
               "slope": 1
             },
             {
               "lib": "regle-rules",
-              "median": 0.7999999523162842,
-              "p95": 1.0799999713897703,
-              "iqr": 0.2999999523162842,
+              "median": 0.9000000953674316,
+              "p95": 1.1800000429153439,
+              "iqr": 0.20000004768371582,
               "count": 13,
               "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.89,
+              "ratio": 1.06,
               "slope": 1
             },
             {
               "lib": "formkit",
-              "median": 5.650000035762787,
-              "p95": 8.235000008344649,
-              "iqr": 1.7499999403953552,
+              "median": 5.75,
+              "p95": 8.085000014305114,
+              "iqr": 1.800000011920929,
               "count": 14,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 6.28,
+              "ratio": 6.76,
               "slope": 1
             },
             {
               "lib": "vuelidate",
-              "median": 0.7500000596046448,
-              "p95": 1.0050000011920928,
-              "iqr": 0.19999998807907104,
-              "count": 14,
-              "trimmed": 1,
+              "median": 0.6999999284744263,
+              "p95": 0.8399999618530272,
+              "iqr": 0.1499999761581421,
+              "count": 13,
+              "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.83,
+              "ratio": 0.82,
               "slope": 1
             }
           ],
           "F50": [
             {
               "lib": "attaform",
-              "median": 1.899999976158142,
-              "p95": 2.380000042915344,
+              "median": 1.7000000476837158,
+              "p95": 2.280000019073486,
               "iqr": 0.6500000953674316,
               "count": 13,
               "trimmed": 2,
               "unit": "ms",
               "supported": true,
               "ratio": 1,
-              "slope": 2.11
-            },
-            {
-              "lib": "vee-validate",
-              "median": 1.9000000357627869,
-              "p95": 2.7349999368190767,
-              "iqr": 0.6500000357627869,
-              "count": 14,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1,
-              "slope": 2.92
-            },
-            {
-              "lib": "tanstack",
-              "median": 2.8000000715255737,
-              "p95": 3.7200000286102277,
-              "iqr": 0.5500000715255737,
-              "count": 13,
-              "trimmed": 2,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1.47,
-              "slope": 3.5
-            },
-            {
-              "lib": "formisch",
-              "median": 1.1999999284744263,
-              "p95": 1.520000028610229,
-              "iqr": 0.4500000476837158,
-              "count": 13,
-              "trimmed": 2,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.63,
               "slope": 2
             },
             {
-              "lib": "regle-schema",
-              "median": 2.350000023841858,
-              "p95": 3.2350000143051147,
-              "iqr": 0.9500000476837158,
+              "lib": "vee-validate",
+              "median": 1.899999976158142,
+              "p95": 2.7350000143051147,
+              "iqr": 0.7499999403953552,
               "count": 14,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.24,
-              "slope": 2.94
+              "ratio": 1.12,
+              "slope": 2.71
             },
             {
-              "lib": "regle-rules",
-              "median": 2.5,
-              "p95": 2.740000009536743,
+              "lib": "tanstack",
+              "median": 3.100000023841858,
+              "p95": 3.439999985694885,
               "iqr": 0.3999999761581421,
               "count": 13,
               "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.32,
-              "slope": 3.13
+              "ratio": 1.82,
+              "slope": 3.87
             },
             {
-              "lib": "formkit",
-              "median": 24.80000001192093,
-              "p95": 31.065000039339065,
-              "iqr": 3.549999952316284,
-              "count": 14,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 13.05,
-              "slope": 4.39
-            },
-            {
-              "lib": "vuelidate",
-              "median": 1.8000000715255737,
-              "p95": 2.6599999904632563,
-              "iqr": 0.5500000715255737,
+              "lib": "formisch",
+              "median": 1.0999999046325684,
+              "p95": 1.5000000238418572,
+              "iqr": 0.2500000596046448,
               "count": 13,
               "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.95,
-              "slope": 2.4
+              "ratio": 0.65,
+              "slope": 2.2
+            },
+            {
+              "lib": "regle-schema",
+              "median": 2.300000011920929,
+              "p95": 3.2349999368190767,
+              "iqr": 0.5999999642372131,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.35,
+              "slope": 2.42
+            },
+            {
+              "lib": "regle-rules",
+              "median": 2.650000035762787,
+              "p95": 3.5449999690055845,
+              "iqr": 0.8999999761581421,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.56,
+              "slope": 2.94
+            },
+            {
+              "lib": "formkit",
+              "median": 25,
+              "p95": 30.050000047683717,
+              "iqr": 5.199999988079071,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 14.71,
+              "slope": 4.35
+            },
+            {
+              "lib": "vuelidate",
+              "median": 1.9000000953674316,
+              "p95": 2.459999990463256,
+              "iqr": 0.3500000238418579,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.12,
+              "slope": 2.71
             }
           ]
         }
@@ -609,10 +650,10 @@
             {
               "lib": "attaform",
               "median": 0.19999992847442627,
-              "p95": 0.40000009536743164,
+              "p95": 0.5,
               "iqr": 0.19999992847442627,
-              "count": 99,
-              "trimmed": 1,
+              "count": 98,
+              "trimmed": 2,
               "unit": "ms",
               "supported": true,
               "ratio": 1,
@@ -621,8 +662,8 @@
             {
               "lib": "vee-validate",
               "median": 6,
-              "p95": 6.299999964237213,
-              "iqr": 0.20000004768371582,
+              "p95": 6.200000047683716,
+              "iqr": 0.2999999523162842,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
@@ -633,7 +674,7 @@
             {
               "lib": "tanstack",
               "median": 0.19999992847442627,
-              "p95": 0.30000007152557373,
+              "p95": 0.2999999523162842,
               "iqr": 0.10000002384185791,
               "count": 99,
               "trimmed": 1,
@@ -644,33 +685,33 @@
             },
             {
               "lib": "formisch",
-              "median": 0.19999992847442627,
-              "p95": 0.30000007152557373,
+              "median": 0.10000002384185791,
+              "p95": 0.20000004768371582,
               "iqr": 0.10000002384185791,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1,
+              "ratio": 0.5,
               "slope": 1
             },
             {
               "lib": "regle-schema",
-              "median": 0.3999999761581421,
-              "p95": 0.7999999523162842,
-              "iqr": 0.3999999761581421,
+              "median": 0.5,
+              "p95": 0.8999999761581421,
+              "iqr": 0.49999991059303284,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 2,
+              "ratio": 2.5,
               "slope": 1
             },
             {
               "lib": "regle-rules",
-              "median": 0.2999999523162842,
-              "p95": 0.5,
-              "iqr": 0.20000004768371582,
+              "median": 0.30000007152557373,
+              "p95": 0.5999999165534973,
+              "iqr": 0.30000007152557373,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
@@ -680,14 +721,14 @@
             },
             {
               "lib": "formkit",
-              "median": 1.3000000715255737,
-              "p95": 2.799999952316284,
-              "iqr": 0.9000000953674316,
+              "median": 1.2000000476837158,
+              "p95": 3.0999999165534975,
+              "iqr": 0.8999999761581421,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 6.5,
+              "ratio": 6,
               "slope": 1
             },
             {
@@ -706,98 +747,98 @@
           "F50": [
             {
               "lib": "attaform",
-              "median": 0.20000004768371582,
-              "p95": 0.41500008106231606,
-              "iqr": 0.19999992847442627,
-              "count": 98,
-              "trimmed": 2,
+              "median": 0.2999999523162842,
+              "p95": 0.5,
+              "iqr": 0.20000004768371582,
+              "count": 99,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
               "ratio": 1,
-              "slope": 1
+              "slope": 1.5
             },
             {
               "lib": "vee-validate",
-              "median": 6.299999952316284,
-              "p95": 6.799999964237213,
-              "iqr": 0.5,
+              "median": 6.200000047683716,
+              "p95": 6.699999928474426,
+              "iqr": 0.3000001013278961,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 31.5,
-              "slope": 1.05
+              "ratio": 20.67,
+              "slope": 1.03
             },
             {
               "lib": "tanstack",
-              "median": 0.3999999761581421,
+              "median": 0.30000007152557373,
               "p95": 0.6000000238418579,
-              "iqr": 0.2999999523162842,
+              "iqr": 0.19999998807907104,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 2,
-              "slope": 2
+              "ratio": 1,
+              "slope": 1.5
             },
             {
               "lib": "formisch",
-              "median": 0.10000002384185791,
-              "p95": 0.2100000381469721,
+              "median": 0.19999992847442627,
+              "p95": 0.30000007152557373,
               "iqr": 0.10000002384185791,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.5,
-              "slope": 0.5
+              "ratio": 0.67,
+              "slope": 2
             },
             {
               "lib": "regle-schema",
               "median": 1,
-              "p95": 1.8000000715255737,
-              "iqr": 0.8999999761581421,
+              "p95": 1.9099999785423274,
+              "iqr": 0.925000011920929,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 5,
-              "slope": 2.5
+              "ratio": 3.33,
+              "slope": 2
             },
             {
               "lib": "regle-rules",
-              "median": 0.3999999761581421,
-              "p95": 1,
-              "iqr": 0.3250000476837158,
-              "count": 97,
-              "trimmed": 3,
+              "median": 0.7000000476837158,
+              "p95": 1.3000000715255737,
+              "iqr": 0.5250000953674316,
+              "count": 99,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 2,
-              "slope": 1.33
+              "ratio": 2.33,
+              "slope": 2.33
             },
             {
               "lib": "formkit",
-              "median": 2.8000000715255737,
-              "p95": 3.2500000298023224,
-              "iqr": 0.2999999523162842,
-              "count": 96,
-              "trimmed": 4,
+              "median": 2.700000047683716,
+              "p95": 3.409999978542327,
+              "iqr": 0.5999999046325684,
+              "count": 99,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 14,
-              "slope": 2.15
+              "ratio": 9,
+              "slope": 2.25
             },
             {
               "lib": "vuelidate",
               "median": 0.10000002384185791,
               "p95": 0.20000004768371582,
-              "iqr": 0.10000002384185791,
+              "iqr": 0.09999990463256836,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.5,
+              "ratio": 0.33,
               "slope": 1
             }
           ]
@@ -1011,13 +1052,13 @@
             {
               "lib": "attaform",
               "retained": {
-                "median": 128372,
-                "p95": 311988,
+                "median": 128332,
+                "p95": 311588,
                 "count": 12
               },
               "churn": {
-                "median": 457660,
-                "p95": 485236,
+                "median": 457628,
+                "p95": 485296,
                 "count": 12
               },
               "leak": {
@@ -1027,15 +1068,15 @@
               },
               "series": {
                 "retained": [
-                  732276, 144032, 125128, 129740, 128372, 115500, 129244, 115976, 311988, 109972,
-                  131880, 98668
+                  732404, 144000, 125088, 129700, 128332, 115460, 129204, 115936, 311588, 118008,
+                  131868, 98628
                 ],
                 "churn": [
-                  708476, 451940, 466876, 457660, 457664, 462060, 455172, 452540, 464916, 447192,
-                  485236, 433312
+                  708636, 451896, 466852, 457640, 457628, 462036, 455152, 452508, 464840, 447128,
+                  485296, 433272
                 ],
                 "leak": [
-                  891596, 42296, 40980, 32180, 28324, 26748, 18948, 19912, 226216, 2576, 52348, 3540
+                  891884, 42280, 40980, 32180, 28324, 26748, 18948, 19912, 226216, 2824, 52400, 3540
                 ]
               },
               "supported": true,
@@ -1045,66 +1086,31 @@
             {
               "lib": "vee-validate",
               "retained": {
-                "median": 131844,
-                "p95": 172892,
+                "median": 141944,
+                "p95": 187748,
                 "count": 12
               },
               "churn": {
-                "median": 234232,
-                "p95": 244596,
+                "median": 232704,
+                "p95": 244316,
                 "count": 12
               },
               "leak": {
-                "median": 17040,
-                "p95": 129588,
+                "median": 17060,
+                "p95": 59788,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  594188, 131844, 156036, 145372, 135672, 140808, 125076, 130988, 172892, 126404,
-                  127272, 120948
+                  594188, 150636, 156036, 128536, 150228, 140808, 125076, 145128, 187748, 126672,
+                  141944, 120948
                 ],
                 "churn": [
-                  726896, 243548, 211036, 244596, 238988, 239476, 232704, 234232, 222572, 241372,
-                  230948, 221956
+                  331776, 238936, 232672, 222296, 238164, 217272, 232704, 233408, 244316, 241372,
+                  229548, 221956
                 ],
                 "leak": [
-                  639772, 34212, 36268, 25512, 19488, 17040, 2896, 13188, 129588, 3740, 13452, 1112
-                ]
-              },
-              "supported": true,
-              "ratio": 1.03,
-              "slope": 1
-            },
-            {
-              "lib": "tanstack",
-              "retained": {
-                "median": 142156,
-                "p95": 187104,
-                "count": 12
-              },
-              "churn": {
-                "median": 770308,
-                "p95": 829812,
-                "count": 12
-              },
-              "leak": {
-                "median": 47780,
-                "p95": 79224,
-                "count": 12
-              },
-              "series": {
-                "retained": [
-                  601800, 149320, 139152, 136940, 155448, 142156, 134012, 152728, 187104, 140828,
-                  143384, 141048
-                ],
-                "churn": [
-                  1076456, 829812, 793584, 789340, 773608, 764788, 749784, 757804, 770308, 766012,
-                  771616, 749100
-                ],
-                "leak": [
-                  810752, 52780, 51280, 59384, 45528, 47780, 29084, 49052, 79224, 30840, 39072,
-                  20568
+                  639772, 34896, 35584, 25492, 19488, 17060, 2896, 13008, 59788, 3848, 13452, 1112
                 ]
               },
               "supported": true,
@@ -1112,15 +1118,50 @@
               "slope": 1
             },
             {
+              "lib": "tanstack",
+              "retained": {
+                "median": 141716,
+                "p95": 187104,
+                "count": 12
+              },
+              "churn": {
+                "median": 767492,
+                "p95": 829148,
+                "count": 12
+              },
+              "leak": {
+                "median": 47396,
+                "p95": 79264,
+                "count": 12
+              },
+              "series": {
+                "retained": [
+                  601864, 149352, 137124, 136940, 149276, 141716, 133840, 152728, 187104, 140828,
+                  143384, 139444
+                ],
+                "churn": [
+                  1075544, 829148, 795796, 785808, 780140, 763088, 750748, 756964, 767492, 765220,
+                  771092, 748352
+                ],
+                "leak": [
+                  811040, 52812, 49324, 59324, 43316, 47396, 31152, 49000, 79264, 30840, 36860,
+                  20700
+                ]
+              },
+              "supported": true,
+              "ratio": 1.1,
+              "slope": 1
+            },
+            {
               "lib": "formisch",
               "retained": {
-                "median": 81132,
+                "median": 79168,
                 "p95": 108348,
                 "count": 12
               },
               "churn": {
-                "median": 244944,
-                "p95": 254832,
+                "median": 242368,
+                "p95": 253996,
                 "count": 12
               },
               "leak": {
@@ -1130,47 +1171,47 @@
               },
               "series": {
                 "retained": [
-                  368608, 86544, 73240, 74732, 79168, 91860, 81132, 84944, 108348, 79636, 82232,
-                  74680
+                  368480, 86512, 73240, 74732, 79168, 91860, 81132, 84860, 108348, 76808, 78676,
+                  74872
                 ],
                 "churn": [
-                  365656, 241668, 245364, 247420, 241820, 245148, 244944, 241844, 254832, 253124,
-                  238976, 235784
+                  365560, 241668, 242368, 247420, 241820, 244312, 244944, 242096, 253996, 253124,
+                  238976, 231972
                 ],
-                "leak": [429016, 16296, 2940, 6760, 9120, 25868, 4768, 12976, 40828, 4252, 9336, 0]
+                "leak": [428792, 16264, 2940, 6760, 9120, 25868, 4768, 12976, 40828, 4980, 9336, 0]
               },
               "supported": true,
-              "ratio": 0.63,
+              "ratio": 0.62,
               "slope": 1
             },
             {
               "lib": "regle-schema",
               "retained": {
                 "median": 208768,
-                "p95": 302440,
+                "p95": 302132,
                 "count": 12
               },
               "churn": {
-                "median": 622428,
-                "p95": 647544,
+                "median": 625860,
+                "p95": 669124,
                 "count": 12
               },
               "leak": {
                 "median": 15552,
-                "p95": 121872,
+                "p95": 121812,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  749872, 226800, 217036, 204964, 209840, 206376, 204520, 208768, 302440, 206488,
+                  749776, 226800, 217004, 204964, 209840, 206376, 204520, 208768, 302132, 206488,
                   215184, 200752
                 ],
                 "churn": [
-                  306560, 721440, 634608, 603296, 628024, 608420, 622748, 623912, 647544, 622428,
-                  602648, 604196
+                  309080, 699216, 658724, 617384, 625944, 615268, 625860, 621524, 669124, 641144,
+                  628336, 623644
                 ],
                 "leak": [
-                  700804, 18572, 21004, 17284, 6508, 15552, 2592, 11488, 121872, 960, 19404, 0
+                  700676, 18572, 20972, 17284, 4204, 15552, 2544, 11488, 121812, 3372, 19440, 0
                 ]
               },
               "supported": true,
@@ -1181,41 +1222,41 @@
               "lib": "regle-rules",
               "retained": {
                 "median": 238060,
-                "p95": 333048,
+                "p95": 328616,
                 "count": 12
               },
               "churn": {
-                "median": 466384,
-                "p95": 507232,
+                "median": 466312,
+                "p95": 512260,
                 "count": 12
               },
               "leak": {
-                "median": 13804,
-                "p95": 119620,
+                "median": 13808,
+                "p95": 122084,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  774660, 250416, 259256, 234048, 241912, 234712, 232952, 238060, 333048, 234532,
+                  774564, 250416, 256736, 234048, 241912, 234712, 232952, 238060, 328616, 234532,
                   238288, 229880
                 ],
                 "churn": [
-                  595604, 466656, 467588, 463612, 464824, 466512, 460044, 466384, 507232, 477448,
+                  595572, 466656, 467588, 463612, 465076, 466584, 460044, 466312, 512260, 472604,
                   463908, 449328
                 ],
                 "leak": [
-                  649232, 13184, 30468, 4524, 16208, 16708, 5468, 14248, 119620, 3092, 13804, 0
+                  649104, 13184, 27948, 4524, 16292, 16732, 5468, 14224, 122084, 3068, 13808, 0
                 ]
               },
               "supported": true,
-              "ratio": 1.85,
+              "ratio": 1.86,
               "slope": 1
             },
             {
               "lib": "formkit",
               "retained": {
-                "median": 2315688,
-                "p95": 2375788,
+                "median": 2317148,
+                "p95": 2374324,
                 "count": 12
               },
               "churn": {
@@ -1224,26 +1265,26 @@
                 "count": 12
               },
               "leak": {
-                "median": 52512,
-                "p95": 139788,
+                "median": 52428,
+                "p95": 139752,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  3384884, 2371752, 2315688, 2340828, 2349292, 2299772, 2312364, 2304692, 2375788,
-                  2372388, 2282900, 2296488
+                  3403680, 2352272, 2317148, 2339656, 2348848, 2301224, 2310900, 2305732, 2374324,
+                  2370888, 2284780, 2289464
                 ],
                 "churn": [
-                  426084, 833584, 767152, 755344, 755988, 741936, 736856, 764564, 755120, 743064,
-                  736128, 737360
+                  426676, 833852, 767152, 755344, 755988, 741936, 736840, 764564, 755104, 743064,
+                  736128, 737448
                 ],
                 "leak": [
-                  1682108, 139788, 61020, 52512, 84744, 34532, 21908, 47400, 116140, 76676, 4364,
-                  19592
+                  1681820, 139752, 60996, 52428, 84744, 34532, 21908, 47400, 116140, 75596, 4372,
+                  13616
                 ]
               },
               "supported": true,
-              "ratio": 18.04,
+              "ratio": 18.06,
               "slope": 1
             },
             {
@@ -1265,15 +1306,15 @@
               },
               "series": {
                 "retained": [
-                  501556, 137140, 149844, 130704, 142176, 133320, 129040, 138752, 182392, 130744,
+                  501620, 137140, 149876, 130704, 142176, 133320, 129040, 138752, 182392, 130744,
                   132076, 138560
                 ],
                 "churn": [
-                  347056, 223328, 224556, 229784, 234924, 216364, 237884, 229256, 237532, 211376,
+                  347120, 223328, 224556, 229784, 234924, 216364, 237884, 229256, 237532, 211376,
                   232744, 208224
                 ],
                 "leak": [
-                  492916, 25148, 31648, 12472, 31676, 17152, 9128, 11428, 66784, 1808, 13032, 10036
+                  493044, 25148, 31680, 12472, 31676, 17152, 9128, 11428, 66784, 1808, 13032, 10036
                 ]
               },
               "supported": true,
@@ -1285,70 +1326,70 @@
             {
               "lib": "attaform",
               "retained": {
-                "median": 376796,
-                "p95": 559144,
+                "median": 375852,
+                "p95": 558608,
                 "count": 12
               },
               "churn": {
-                "median": 473720,
-                "p95": 525092,
+                "median": 473864,
+                "p95": 525496,
                 "count": 12
               },
               "leak": {
-                "median": 34088,
+                "median": 33320,
                 "p95": 227936,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  1042196, 353056, 393876, 376796, 396452, 382116, 344376, 350444, 559144, 367496,
-                  387020, 339372
+                  1042196, 353056, 393828, 375852, 400052, 385820, 348272, 354268, 558608, 367304,
+                  389524, 343408
                 ],
                 "churn": [
-                  704764, 477500, 483000, 475684, 473720, 466760, 458980, 463612, 474388, 454748,
-                  525092, 455600
+                  704764, 477500, 483000, 475684, 473864, 466760, 458980, 463612, 474388, 456064,
+                  525496, 455600
                 ],
                 "leak": [
-                  946100, 27748, 51144, 34088, 57224, 41164, 13092, 11376, 227936, 3116, 72728, 2788
+                  946100, 27748, 51096, 33320, 57148, 41152, 13272, 11484, 227936, 3116, 72776, 3268
                 ]
               },
               "supported": true,
               "ratio": 1,
-              "slope": 2.94
+              "slope": 2.93
             },
             {
               "lib": "vee-validate",
               "retained": {
-                "median": 517472,
-                "p95": 554096,
+                "median": 515148,
+                "p95": 558144,
                 "count": 12
               },
               "churn": {
-                "median": 307260,
-                "p95": 329964,
+                "median": 299064,
+                "p95": 319972,
                 "count": 12
               },
               "leak": {
-                "median": 22520,
-                "p95": 324352,
+                "median": 22356,
+                "p95": 65652,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  1044356, 499292, 504992, 517472, 525304, 536100, 512504, 517504, 554096, 508832,
-                  537260, 504676
+                  1044188, 499324, 512804, 513092, 524904, 536124, 515148, 524236, 558144, 513472,
+                  541372, 505104
                 ],
                 "churn": [
-                  389096, 307260, 325404, 308120, 329964, 300404, 305352, 295100, 319972, 293492,
-                  309284, 296656
+                  274196, 307260, 226868, 308120, 327144, 300404, 299064, 295152, 319972, 296004,
+                  309284, 294456
                 ],
                 "leak": [
-                  704664, 16124, 37888, 22520, 36892, 34812, 8736, 18012, 66092, 0, 324352, 0
+                  704476, 16544, 40576, 22356, 30108, 34796, 3520, 20812, 65652, 2164, 38268, 0
                 ]
               },
               "supported": true,
               "ratio": 1.37,
-              "slope": 3.92
+              "slope": 3.63
             },
             {
               "lib": "tanstack",
@@ -1358,43 +1399,43 @@
                 "count": 12
               },
               "churn": {
-                "median": 118828,
-                "p95": 163012,
+                "median": 121080,
+                "p95": 163208,
                 "count": 12
               },
               "leak": {
-                "median": 107340,
+                "median": 108924,
                 "p95": 136500,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  1179140, 644712, 632148, 621876, 649420, 686328, 626012, 628176, 673100, 631760,
+                  1178980, 644712, 632148, 621876, 649420, 686328, 626012, 628204, 673100, 623920,
                   654764, 624492
                 ],
                 "churn": [
-                  463860, 153792, 142912, 115948, 104508, 123768, 109284, 117244, 122620, 115792,
-                  163012, 118828
+                  466592, 155956, 139720, 114724, 104368, 123268, 110068, 120004, 121080, 127952,
+                  163208, 118968
                 ],
                 "leak": [
-                  910048, 134048, 136500, 98300, 107340, 133348, 85652, 82412, 122212, 79764,
-                  117404, 75308
+                  909728, 134048, 136500, 99356, 108924, 134496, 76316, 82324, 124980, 83736,
+                  119692, 77244
                 ]
               },
               "supported": true,
               "ratio": 1.68,
-              "slope": 4.45
+              "slope": 4.46
             },
             {
               "lib": "formisch",
               "retained": {
-                "median": 328432,
-                "p95": 350532,
+                "median": 330872,
+                "p95": 354028,
                 "count": 12
               },
               "churn": {
-                "median": 734752,
-                "p95": 740952,
+                "median": 734776,
+                "p95": 741048,
                 "count": 12
               },
               "leak": {
@@ -1404,31 +1445,31 @@
               },
               "series": {
                 "retained": [
-                  630272, 336912, 326620, 328432, 345360, 341064, 322424, 327316, 349116, 324152,
-                  350532, 321780
+                  630272, 336744, 326620, 328432, 345360, 344204, 325980, 330872, 352672, 327708,
+                  354028, 325420
                 ],
                 "churn": [
-                  847264, 729988, 737672, 734776, 727852, 740952, 734752, 717556, 738616, 726168,
+                  847264, 729988, 737672, 734776, 727852, 741048, 734856, 717556, 738616, 726336,
                   736112, 722476
                 ],
                 "leak": [
-                  447704, 16912, 15912, 12980, 25928, 17620, 6752, 13724, 40476, 3304, 31132, 1636
+                  447704, 16744, 15912, 12980, 25928, 17204, 6752, 13724, 40476, 3364, 31072, 1720
                 ]
               },
               "supported": true,
-              "ratio": 0.87,
-              "slope": 4.05
+              "ratio": 0.88,
+              "slope": 4.18
             },
             {
               "lib": "regle-schema",
               "retained": {
                 "median": 873608,
-                "p95": 962972,
+                "p95": 962664,
                 "count": 12
               },
               "churn": {
-                "median": 443340,
-                "p95": 463132,
+                "median": 446516,
+                "p95": 461956,
                 "count": 12
               },
               "leak": {
@@ -1438,15 +1479,15 @@
               },
               "series": {
                 "retained": [
-                  1473812, 882608, 863088, 873608, 869348, 907132, 864864, 874196, 962972, 863660,
+                  1473788, 882608, 863088, 873608, 869348, 907132, 864864, 874196, 962664, 863660,
                   906336, 857800
                 ],
                 "churn": [
-                  1861296, 443340, 415260, 451868, 423908, 448732, 463132, 432080, 445892, 439572,
-                  460084, 438780
+                  1862332, 446516, 422732, 444512, 437668, 457772, 450056, 429396, 461956, 438600,
+                  456028, 448800
                 ],
                 "leak": [
-                  737008, 20308, 13736, 25668, 7560, 44060, 10700, 13148, 114472, 5196, 31144, 2216
+                  736984, 20308, 13736, 25668, 7560, 44060, 10700, 13148, 114472, 5196, 31168, 2216
                 ]
               },
               "supported": true,
@@ -1457,30 +1498,30 @@
               "lib": "regle-rules",
               "retained": {
                 "median": 1061368,
-                "p95": 1167944,
+                "p95": 1167896,
                 "count": 12
               },
               "churn": {
                 "median": 623800,
-                "p95": 640404,
+                "p95": 641156,
                 "count": 12
               },
               "leak": {
-                "median": 18312,
-                "p95": 110820,
+                "median": 18300,
+                "p95": 110856,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  1666920, 1064096, 1058036, 1059568, 1073880, 1097632, 1056172, 1061368, 1167944,
-                  1055436, 1103152, 1050612
+                  1663444, 1063880, 1058228, 1059280, 1074368, 1096640, 1056172, 1061368, 1167896,
+                  1055436, 1103152, 1050576
                 ],
                 "churn": [
-                  728812, 623888, 617952, 640404, 617912, 630384, 613396, 623800, 629860, 609900,
-                  630040, 608652
+                  729248, 623888, 617908, 641156, 617912, 630216, 613396, 623800, 630112, 609900,
+                  629832, 608652
                 ],
                 "leak": [
-                  696284, 16112, 9588, 21560, 19836, 48288, 8244, 18312, 110820, 5900, 36148, 4880
+                  692960, 15896, 9768, 21572, 20396, 47728, 8244, 18300, 110856, 5900, 36088, 4844
                 ]
               },
               "supported": true,
@@ -1490,69 +1531,69 @@
             {
               "lib": "formkit",
               "retained": {
-                "median": 9845720,
-                "p95": 9999892,
+                "median": 9843768,
+                "p95": 10005220,
                 "count": 12
               },
               "churn": {
-                "median": 372548,
-                "p95": 464040,
+                "median": 372536,
+                "p95": 466540,
                 "count": 12
               },
               "leak": {
-                "median": 80484,
-                "p95": 313960,
+                "median": 80916,
+                "p95": 313696,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  11040304, 9999892, 9902416, 9851776, 9826104, 9846560, 9795060, 9796908, 9768660,
-                  9845720, 9966384, 9683416
+                  11034140, 10005220, 9902388, 9853140, 9826044, 9846460, 9795156, 9796476, 9769172,
+                  9843768, 9966396, 9683664
                 ],
                 "churn": [
-                  517644, 464040, 415088, 427064, 372548, 372044, 348840, 354356, 390276, 392820,
-                  355132, 352592
+                  519960, 466540, 420768, 420356, 372536, 371164, 345584, 351336, 384708, 391092,
+                  351584, 349224
                 ],
                 "leak": [
-                  3418580, 313960, 171252, 90460, 50664, 129344, 15496, 24656, 80484, 78608, 180192,
+                  3418588, 313696, 171276, 90460, 50592, 129348, 15496, 24224, 80916, 78608, 180192,
                   4912
                 ]
               },
               "supported": true,
-              "ratio": 26.13,
+              "ratio": 26.19,
               "slope": 4.25
             },
             {
               "lib": "vuelidate",
               "retained": {
-                "median": 563584,
-                "p95": 608516,
+                "median": 555424,
+                "p95": 600328,
                 "count": 12
               },
               "churn": {
-                "median": 289448,
-                "p95": 448916,
+                "median": 285120,
+                "p95": 441960,
                 "count": 12
               },
               "leak": {
-                "median": 22404,
+                "median": 21972,
                 "p95": 76516,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  968072, 570440, 563584, 546056, 571872, 576512, 559784, 547704, 608516, 544788,
-                  587432, 548820
+                  964928, 563008, 555424, 537896, 563684, 568764, 551620, 540140, 600328, 536628,
+                  578656, 540660
                 ],
                 "churn": [
-                  1336444, 438144, 441996, 448916, 432336, 318808, 236500, 289448, 270228, 266640,
-                  271988, 258808
+                  1333032, 438072, 435456, 441960, 426696, 317744, 243580, 285120, 270932, 261764,
+                  271720, 251668
                 ],
-                "leak": [569256, 31376, 26032, 1296, 22404, 26856, 8860, 1544, 76516, 0, 41124, 0]
+                "leak": [570428, 32140, 26032, 1296, 21972, 27288, 8212, 2788, 76516, 0, 39556, 0]
               },
               "supported": true,
-              "ratio": 1.5,
-              "slope": 4.11
+              "ratio": 1.48,
+              "slope": 4.05
             }
           ]
         }
@@ -1565,9 +1606,9 @@
           "D4": [
             {
               "lib": "attaform",
-              "median": 0.3999999761581421,
-              "p95": 1.0999999165534973,
-              "iqr": 0.30000007152557373,
+              "median": 0.7999999523162842,
+              "p95": 1.2000000476837158,
+              "iqr": 0.3250000774860382,
               "count": 199,
               "trimmed": 1,
               "unit": "ms",
@@ -1577,32 +1618,8 @@
             },
             {
               "lib": "vee-validate",
-              "median": 0.3999999761581421,
-              "p95": 0.899999988079071,
-              "iqr": 0.30000007152557373,
-              "count": 199,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1,
-              "slope": 1
-            },
-            {
-              "lib": "tanstack",
-              "median": 0.3999999761581421,
+              "median": 0.6000000238418579,
               "p95": 1,
-              "iqr": 0.40000009536743164,
-              "count": 199,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1,
-              "slope": 1
-            },
-            {
-              "lib": "formisch",
-              "median": 0.2999999523162842,
-              "p95": 0.81000006198883,
               "iqr": 0.30000007152557373,
               "count": 199,
               "trimmed": 1,
@@ -1612,248 +1629,272 @@
               "slope": 1
             },
             {
-              "lib": "regle-schema",
-              "median": 0.5,
-              "p95": 1.2000000476837158,
-              "iqr": 0.40000009536743164,
-              "count": 199,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1.25,
-              "slope": 1
-            },
-            {
-              "lib": "regle-rules",
-              "median": 0.5,
-              "p95": 1.2000000476837158,
-              "iqr": 0.42500007152557373,
-              "count": 199,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1.25,
-              "slope": 1
-            },
-            {
-              "lib": "formkit",
-              "median": 0.7000000476837158,
-              "p95": 1.5999999046325684,
-              "iqr": 0.7000000476837158,
-              "count": 199,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1.75,
-              "slope": 1
-            },
-            {
-              "lib": "vuelidate",
-              "median": 0.3999999761581421,
-              "p95": 0.8999999761581421,
-              "iqr": 0.2999999523162842,
-              "count": 199,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1,
-              "slope": 1
-            }
-          ],
-          "D8": [
-            {
-              "lib": "attaform",
-              "median": 0.30000007152557373,
-              "p95": 0.7150000333786016,
-              "iqr": 0.20000004768371582,
-              "count": 178,
-              "trimmed": 22,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1,
-              "slope": 0.75
-            },
-            {
-              "lib": "vee-validate",
-              "median": 0.30000001192092896,
-              "p95": 0.8999999761581421,
-              "iqr": 0.2999999523162842,
-              "count": 198,
-              "trimmed": 2,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1,
-              "slope": 0.75
-            },
-            {
               "lib": "tanstack",
-              "median": 0.2999999523162842,
-              "p95": 1,
-              "iqr": 0.2999999523162842,
-              "count": 195,
-              "trimmed": 5,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1,
-              "slope": 0.75
-            },
-            {
-              "lib": "formisch",
-              "median": 0.2999999523162842,
-              "p95": 0.7999999642372131,
-              "iqr": 0.30000007152557373,
-              "count": 199,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1,
-              "slope": 1
-            },
-            {
-              "lib": "regle-schema",
-              "median": 0.5,
-              "p95": 1.2000000476837158,
+              "median": 0.7000000476837158,
+              "p95": 1.100000023841858,
               "iqr": 0.3999999761581421,
               "count": 199,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.67,
+              "ratio": 0.88,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.5,
+              "p95": 1,
+              "iqr": 0.49999988079071045,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.63,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 0.8999999761581421,
+              "p95": 1.399999976158142,
+              "iqr": 0.6000000238418579,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.13,
               "slope": 1
             },
             {
               "lib": "regle-rules",
               "median": 0.6999999284744263,
               "p95": 1.100000023841858,
-              "iqr": 0.4249999523162842,
-              "count": 199,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 2.33,
-              "slope": 1.4
-            },
-            {
-              "lib": "formkit",
-              "median": 1,
-              "p95": 1.7000000476837158,
-              "iqr": 0.5,
-              "count": 198,
-              "trimmed": 2,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 3.33,
-              "slope": 1.43
-            },
-            {
-              "lib": "vuelidate",
-              "median": 0.5,
-              "p95": 1,
               "iqr": 0.3999999761581421,
               "count": 199,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.67,
-              "slope": 1.25
-            }
-          ],
-          "D16": [
-            {
-              "lib": "attaform",
-              "median": 0.40000009536743164,
-              "p95": 1.210000038146972,
-              "iqr": 0.42500007152557373,
-              "count": 199,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1,
+              "ratio": 0.87,
               "slope": 1
             },
             {
-              "lib": "vee-validate",
-              "median": 0.30000007152557373,
-              "p95": 0.9100000858306879,
-              "iqr": 0.2999999523162842,
+              "lib": "formkit",
+              "median": 0.8999999761581421,
+              "p95": 1.7999999523162842,
+              "iqr": 0.6999999582767487,
               "count": 199,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.75,
-              "slope": 0.75
-            },
-            {
-              "lib": "tanstack",
-              "median": 0.30000007152557373,
-              "p95": 0.7999999523162842,
-              "iqr": 0.20000004768371582,
-              "count": 190,
-              "trimmed": 10,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.75,
-              "slope": 0.75
-            },
-            {
-              "lib": "formisch",
-              "median": 0.2999999523162842,
-              "p95": 0.8999999761581421,
-              "iqr": 0.29999998211860657,
-              "count": 199,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.75,
+              "ratio": 1.13,
               "slope": 1
             },
             {
-              "lib": "regle-schema",
-              "median": 0.3999999761581421,
-              "p95": 1,
-              "iqr": 0.2999998927116394,
-              "count": 191,
-              "trimmed": 9,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1,
-              "slope": 0.8
-            },
-            {
-              "lib": "regle-rules",
-              "median": 0.3999999761581421,
+              "lib": "vuelidate",
+              "median": 0.5,
               "p95": 1,
               "iqr": 0.40000009536743164,
               "count": 199,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1,
-              "slope": 0.8
-            },
+              "ratio": 0.63,
+              "slope": 1
+            }
+          ],
+          "D8": [
             {
-              "lib": "formkit",
-              "median": 1.3000000715255737,
-              "p95": 2.399999976158142,
-              "iqr": 0.9000000059604645,
+              "lib": "attaform",
+              "median": 0.7000000476837158,
+              "p95": 1.2000000476837158,
+              "iqr": 0.40000009536743164,
               "count": 199,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 3.25,
-              "slope": 1.86
+              "ratio": 1,
+              "slope": 0.88
             },
             {
-              "lib": "vuelidate",
-              "median": 0.5,
-              "p95": 1,
+              "lib": "vee-validate",
+              "median": 0.6000000238418579,
+              "p95": 0.899999988079071,
+              "iqr": 0.2999999523162842,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.86,
+              "slope": 1
+            },
+            {
+              "lib": "tanstack",
+              "median": 0.7000000476837158,
+              "p95": 1.2000000476837158,
+              "iqr": 0.5,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.6000000238418579,
+              "p95": 0.9000000953674316,
               "iqr": 0.3999999761581421,
               "count": 199,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.25,
-              "slope": 1.25
+              "ratio": 0.86,
+              "slope": 1.2
+            },
+            {
+              "lib": "regle-schema",
+              "median": 0.8000000715255737,
+              "p95": 1.399999976158142,
+              "iqr": 0.6000000238418579,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.14,
+              "slope": 0.89
+            },
+            {
+              "lib": "regle-rules",
+              "median": 0.5,
+              "p95": 1.0999999165534973,
+              "iqr": 0.3999999761581421,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.71,
+              "slope": 0.71
+            },
+            {
+              "lib": "formkit",
+              "median": 1,
+              "p95": 1.8000000715255737,
+              "iqr": 0.7999999523162842,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.43,
+              "slope": 1.11
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.5,
+              "p95": 0.899999988079071,
+              "iqr": 0.40000009536743164,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.71,
+              "slope": 1
+            }
+          ],
+          "D16": [
+            {
+              "lib": "attaform",
+              "median": 0.7000000476837158,
+              "p95": 1.399999988079071,
+              "iqr": 0.5,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 0.88
+            },
+            {
+              "lib": "vee-validate",
+              "median": 0.30000007152557373,
+              "p95": 1,
+              "iqr": 0.5,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.43,
+              "slope": 0.5
+            },
+            {
+              "lib": "tanstack",
+              "median": 0.5,
+              "p95": 1.110000014305114,
+              "iqr": 0.5000001192092896,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.71,
+              "slope": 0.71
+            },
+            {
+              "lib": "formisch",
+              "median": 0.40000009536743164,
+              "p95": 0.9000000953674316,
+              "iqr": 0.3999999761581421,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.57,
+              "slope": 0.8
+            },
+            {
+              "lib": "regle-schema",
+              "median": 0.7999999523162842,
+              "p95": 1.5,
+              "iqr": 0.6999999284744263,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.14,
+              "slope": 0.89
+            },
+            {
+              "lib": "regle-rules",
+              "median": 0.7000000476837158,
+              "p95": 1.2000000476837158,
+              "iqr": 0.3999999761581421,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 1.2000000476837158,
+              "p95": 2.5,
+              "iqr": 1,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.71,
+              "slope": 1.33
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.3999999761581421,
+              "p95": 1,
+              "iqr": 0.5,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.57,
+              "slope": 0.8
             }
           ]
         }
@@ -1864,9 +1905,9 @@
           "D4": [
             {
               "lib": "attaform",
-              "median": 0.699999988079071,
-              "p95": 0.9349999845027923,
-              "iqr": 0.20000004768371582,
+              "median": 0.5,
+              "p95": 1,
+              "iqr": 0.4500000476837158,
               "count": 14,
               "trimmed": 1,
               "unit": "ms",
@@ -1876,283 +1917,283 @@
             },
             {
               "lib": "vee-validate",
-              "median": 0.3999999761581421,
-              "p95": 0.6349999904632568,
-              "iqr": 0.10000002384185791,
+              "median": 0.3500000238418579,
+              "p95": 0.6350000321865081,
+              "iqr": 0.2500000596046448,
               "count": 14,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.57,
+              "ratio": 0.7,
               "slope": 1
             },
             {
               "lib": "tanstack",
-              "median": 0.3999999761581421,
-              "p95": 0.6349999904632568,
-              "iqr": 0.25,
-              "count": 14,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.57,
-              "slope": 1
-            },
-            {
-              "lib": "formisch",
-              "median": 0.3500000238418579,
-              "p95": 0.6000000238418579,
+              "median": 0.40000003576278687,
+              "p95": 0.5350000083446502,
               "iqr": 0.20000004768371582,
               "count": 14,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.5,
+              "ratio": 0.8,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.20000004768371582,
+              "p95": 0.5350000083446502,
+              "iqr": 0.2500000596046448,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.4,
               "slope": 1
             },
             {
               "lib": "regle-schema",
-              "median": 0.7999999523162842,
-              "p95": 1.0700000166893004,
-              "iqr": 0.25,
-              "count": 14,
-              "trimmed": 1,
+              "median": 0.6000000238418579,
+              "p95": 0.8400000810623167,
+              "iqr": 0.30000001192092896,
+              "count": 13,
+              "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.14,
+              "ratio": 1.2,
               "slope": 1
             },
             {
               "lib": "regle-rules",
-              "median": 0.5,
-              "p95": 0.8350000023841857,
-              "iqr": 0.2999999523162842,
-              "count": 14,
-              "trimmed": 1,
+              "median": 0.6000000238418579,
+              "p95": 0.740000009536743,
+              "iqr": 0.25,
+              "count": 13,
+              "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.71,
+              "ratio": 1.2,
               "slope": 1
             },
             {
               "lib": "formkit",
-              "median": 3.699999988079071,
-              "p95": 5.06000000834465,
-              "iqr": 1.25,
-              "count": 14,
-              "trimmed": 1,
+              "median": 3.100000023841858,
+              "p95": 3.899999976158142,
+              "iqr": 0.699999988079071,
+              "count": 13,
+              "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 5.29,
+              "ratio": 6.2,
               "slope": 1
             },
             {
               "lib": "vuelidate",
-              "median": 0.5499999523162842,
-              "p95": 0.770000022649765,
-              "iqr": 0.30000007152557373,
+              "median": 0.40000003576278687,
+              "p95": 0.735000056028366,
+              "iqr": 0.15000003576278687,
               "count": 14,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.79,
+              "ratio": 0.8,
               "slope": 1
             }
           ],
           "D8": [
             {
               "lib": "attaform",
-              "median": 0.6999999284744263,
-              "p95": 0.9349999845027923,
-              "iqr": 0.2999999523162842,
+              "median": 0.5499999523162842,
+              "p95": 0.9699999928474425,
+              "iqr": 0.19999992847442627,
               "count": 14,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
               "ratio": 1,
-              "slope": 1
+              "slope": 1.1
             },
             {
               "lib": "vee-validate",
               "median": 0.40000009536743164,
-              "p95": 0.7000000476837158,
-              "iqr": 0.2500000596046448,
-              "count": 13,
-              "trimmed": 2,
+              "p95": 0.6000000238418579,
+              "iqr": 0.15000003576278687,
+              "count": 14,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.57,
-              "slope": 1
+              "ratio": 0.73,
+              "slope": 1.14
             },
             {
               "lib": "tanstack",
-              "median": 0.3999999761581421,
-              "p95": 0.6999999701976776,
+              "median": 0.25,
+              "p95": 0.5350000083446502,
+              "iqr": 0.19999998807907104,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.45,
+              "slope": 0.62
+            },
+            {
+              "lib": "formisch",
+              "median": 0.3500000238418579,
+              "p95": 0.5350000083446502,
+              "iqr": 0.25,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.64,
+              "slope": 1.75
+            },
+            {
+              "lib": "regle-schema",
+              "median": 0.7000000476837158,
+              "p95": 1.0700000166893004,
+              "iqr": 0.25,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.27,
+              "slope": 1.17
+            },
+            {
+              "lib": "regle-rules",
+              "median": 0.6999999284744263,
+              "p95": 1.0050000011920928,
               "iqr": 0.20000004768371582,
               "count": 14,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.57,
-              "slope": 1
+              "ratio": 1.27,
+              "slope": 1.17
             },
             {
-              "lib": "formisch",
-              "median": 0.30000007152557373,
-              "p95": 0.5,
-              "iqr": 0.15000009536743164,
-              "count": 14,
-              "trimmed": 1,
+              "lib": "formkit",
+              "median": 4.600000023841858,
+              "p95": 5.3,
+              "iqr": 0.8499999642372131,
+              "count": 13,
+              "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.43,
-              "slope": 0.86
+              "ratio": 8.36,
+              "slope": 1.48
             },
             {
-              "lib": "regle-schema",
-              "median": 0.7999999523162842,
-              "p95": 0.9699999511241912,
-              "iqr": 0.1499999761581421,
-              "count": 14,
-              "trimmed": 1,
+              "lib": "vuelidate",
+              "median": 0.3999999761581421,
+              "p95": 0.7200000047683711,
+              "iqr": 0.19999998807907104,
+              "count": 13,
+              "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.14,
+              "ratio": 0.73,
               "slope": 1
-            },
+            }
+          ],
+          "D16": [
             {
-              "lib": "regle-rules",
-              "median": 0.699999988079071,
-              "p95": 1.3000000715255737,
-              "iqr": 0.2999999523162842,
-              "count": 14,
-              "trimmed": 1,
+              "lib": "attaform",
+              "median": 0.7000000476837158,
+              "p95": 1.0199999570846554,
+              "iqr": 0.20000004768371582,
+              "count": 13,
+              "trimmed": 2,
               "unit": "ms",
               "supported": true,
               "ratio": 1,
               "slope": 1.4
             },
             {
-              "lib": "formkit",
-              "median": 4.900000035762787,
-              "p95": 6.63000002503395,
-              "iqr": 1.25,
-              "count": 14,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 7,
-              "slope": 1.32
-            },
-            {
-              "lib": "vuelidate",
-              "median": 0.40000009536743164,
-              "p95": 0.6399999618530272,
-              "iqr": 0.1499999761581421,
-              "count": 13,
-              "trimmed": 2,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.57,
-              "slope": 0.73
-            }
-          ],
-          "D16": [
-            {
-              "lib": "attaform",
-              "median": 0.75,
-              "p95": 1.3450000405311582,
-              "iqr": 0.3500000834465027,
-              "count": 14,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1,
-              "slope": 1.07
-            },
-            {
               "lib": "vee-validate",
-              "median": 0.5,
-              "p95": 0.780000019073486,
-              "iqr": 0.25,
-              "count": 13,
-              "trimmed": 2,
+              "median": 0.5499999523162842,
+              "p95": 0.770000022649765,
+              "iqr": 0.2500000596046448,
+              "count": 14,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.67,
-              "slope": 1.25
+              "ratio": 0.79,
+              "slope": 1.57
             },
             {
               "lib": "tanstack",
-              "median": 0.40000003576278687,
-              "p95": 0.770000022649765,
-              "iqr": 0.20000004768371582,
+              "median": 0.3500000834465027,
+              "p95": 0.6349999904632568,
+              "iqr": 0.25,
               "count": 14,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.53,
-              "slope": 1
+              "ratio": 0.5,
+              "slope": 0.88
             },
             {
               "lib": "formisch",
-              "median": 0.30000001192092896,
-              "p95": 0.7000000476837158,
-              "iqr": 0.3999999761581421,
+              "median": 0.34999996423721313,
+              "p95": 0.5,
+              "iqr": 0.15000009536743164,
               "count": 14,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.4,
-              "slope": 0.86
+              "ratio": 0.5,
+              "slope": 1.75
             },
             {
               "lib": "regle-schema",
-              "median": 0.8999999761581421,
-              "p95": 1.1999999761581421,
-              "iqr": 0.25,
+              "median": 0.9000000953674316,
+              "p95": 1.3399999141693106,
+              "iqr": 0.24999988079071045,
               "count": 13,
               "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.2,
-              "slope": 1.13
+              "ratio": 1.29,
+              "slope": 1.5
             },
             {
               "lib": "regle-rules",
               "median": 0.8999999761581421,
-              "p95": 1.3699999690055846,
-              "iqr": 0.30000007152557373,
+              "p95": 1.120000028610229,
+              "iqr": 0.19999998807907104,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.29,
+              "slope": 1.5
+            },
+            {
+              "lib": "formkit",
+              "median": 7.600000023841858,
+              "p95": 9.23999993801117,
+              "iqr": 1.5499999523162842,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 10.86,
+              "slope": 2.45
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.550000011920929,
+              "p95": 1.0700000166893004,
+              "iqr": 0.2500000596046448,
               "count": 14,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.2,
-              "slope": 1.8
-            },
-            {
-              "lib": "formkit",
-              "median": 8,
-              "p95": 8.7,
-              "iqr": 0.75,
-              "count": 13,
-              "trimmed": 2,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 10.67,
-              "slope": 2.16
-            },
-            {
-              "lib": "vuelidate",
-              "median": 0.6000000238418579,
-              "p95": 0.7400000572204588,
-              "iqr": 0.10000002384185791,
-              "count": 13,
-              "trimmed": 2,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.8,
-              "slope": 1.09
+              "ratio": 0.79,
+              "slope": 1.37
             }
           ]
         }
@@ -2163,9 +2204,9 @@
           "D4": [
             {
               "lib": "attaform",
-              "median": 0.19999992847442627,
-              "p95": 0.3999999761581421,
-              "iqr": 0.19999992847442627,
+              "median": 0.20000004768371582,
+              "p95": 0.39999998807907106,
+              "iqr": 0.20000004768371582,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
@@ -2175,20 +2216,20 @@
             },
             {
               "lib": "vee-validate",
-              "median": 5.800000071525574,
-              "p95": 6.110000026226043,
-              "iqr": 0.2999999523162842,
+              "median": 5.899999976158142,
+              "p95": 6.100000023841858,
+              "iqr": 0.20000004768371582,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 29,
+              "ratio": 29.5,
               "slope": 1
             },
             {
               "lib": "tanstack",
               "median": 0.10000002384185791,
-              "p95": 0.30000007152557373,
+              "p95": 0.29999996423721315,
               "iqr": 0.1000000536441803,
               "count": 99,
               "trimmed": 1,
@@ -2200,8 +2241,8 @@
             {
               "lib": "formisch",
               "median": 0.10000002384185791,
-              "p95": 0.20000004768371582,
-              "iqr": 0.10000002384185791,
+              "p95": 0.30000007152557373,
+              "iqr": 0.10000014305114746,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
@@ -2211,21 +2252,21 @@
             },
             {
               "lib": "regle-schema",
-              "median": 0.10000002384185791,
-              "p95": 0.40000001788139344,
-              "iqr": 0.125,
-              "count": 94,
-              "trimmed": 6,
+              "median": 0.20000004768371582,
+              "p95": 0.6000000238418579,
+              "iqr": 0.30000007152557373,
+              "count": 99,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.5,
+              "ratio": 1,
               "slope": 1
             },
             {
               "lib": "regle-rules",
               "median": 0.20000004768371582,
-              "p95": 0.3999999761581421,
-              "iqr": 0.19999992847442627,
+              "p95": 0.5,
+              "iqr": 0.2250000238418579,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
@@ -2235,23 +2276,23 @@
             },
             {
               "lib": "formkit",
-              "median": 0.6000000238418579,
-              "p95": 1.399999976158142,
-              "iqr": 0.30000007152557373,
-              "count": 91,
-              "trimmed": 9,
+              "median": 0.7999999523162842,
+              "p95": 1.8999999940395356,
+              "iqr": 0.625,
+              "count": 98,
+              "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 3,
+              "ratio": 4,
               "slope": 1
             },
             {
               "lib": "vuelidate",
               "median": 0.10000002384185791,
-              "p95": 0.10000002384185791,
-              "iqr": 1.1920928955078125e-7,
-              "count": 76,
-              "trimmed": 24,
+              "p95": 0.29999996423721315,
+              "iqr": 0.125,
+              "count": 99,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
               "ratio": 0.5,
@@ -2261,109 +2302,109 @@
           "D8": [
             {
               "lib": "attaform",
-              "median": 0.10000002384185791,
-              "p95": 0.2999999523162842,
-              "iqr": 0.10000014305114746,
-              "count": 97,
-              "trimmed": 3,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1,
-              "slope": 0.5
-            },
-            {
-              "lib": "vee-validate",
-              "median": 5.800000071525574,
-              "p95": 6.100000023841858,
+              "median": 0.20000004768371582,
+              "p95": 0.40000009536743164,
               "iqr": 0.20000004768371582,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 58,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "vee-validate",
+              "median": 5.900000095367432,
+              "p95": 6.199999928474426,
+              "iqr": 0.20000004768371582,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 29.5,
               "slope": 1
             },
             {
               "lib": "tanstack",
               "median": 0.10000002384185791,
-              "p95": 0.2100000381469721,
-              "iqr": 0.10000002384185791,
+              "p95": 0.30000007152557373,
+              "iqr": 0.10000014305114746,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1,
+              "ratio": 0.5,
               "slope": 1
             },
             {
               "lib": "formisch",
               "median": 0.10000002384185791,
-              "p95": 0.30000007152557373,
-              "iqr": 0.10000002384185791,
+              "p95": 0.2999999523162842,
+              "iqr": 0.10000014305114746,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1,
+              "ratio": 0.5,
               "slope": 1
             },
             {
               "lib": "regle-schema",
-              "median": 0.20000004768371582,
-              "p95": 0.5,
-              "iqr": 0.15000009536743164,
-              "count": 97,
-              "trimmed": 3,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 2,
-              "slope": 2
-            },
-            {
-              "lib": "regle-rules",
-              "median": 0.3999999761581421,
-              "p95": 0.7000000476837158,
+              "median": 0.2999999523162842,
+              "p95": 0.6000000238418579,
               "iqr": 0.3999999761581421,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 4,
-              "slope": 2
+              "ratio": 1.5,
+              "slope": 1.5
             },
             {
-              "lib": "formkit",
-              "median": 1.2000000476837158,
-              "p95": 2.399999976158142,
-              "iqr": 0.8999998867511749,
+              "lib": "regle-rules",
+              "median": 0.2999999523162842,
+              "p95": 0.7000000476837158,
+              "iqr": 0.29999998211860657,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 12,
-              "slope": 2
+              "ratio": 1.5,
+              "slope": 1.5
+            },
+            {
+              "lib": "formkit",
+              "median": 1.2000000476837158,
+              "p95": 2.3999999880790712,
+              "iqr": 0.7250000238418579,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 6,
+              "slope": 1.5
             },
             {
               "lib": "vuelidate",
               "median": 0.10000002384185791,
-              "p95": 0.20000004768371582,
+              "p95": 0.2999999523162842,
               "iqr": 0.10000002384185791,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1,
+              "ratio": 0.5,
               "slope": 1
             }
           ],
           "D16": [
             {
               "lib": "attaform",
-              "median": 0.19999992847442627,
-              "p95": 0.3999999761581421,
-              "iqr": 0.125,
-              "count": 98,
-              "trimmed": 2,
+              "median": 0.20000004768371582,
+              "p95": 0.5,
+              "iqr": 0.2999999523162842,
+              "count": 99,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
               "ratio": 1,
@@ -2371,21 +2412,21 @@
             },
             {
               "lib": "vee-validate",
-              "median": 5.800000071525574,
-              "p95": 6,
-              "iqr": 0.10000002384185791,
-              "count": 91,
-              "trimmed": 9,
+              "median": 5.899999976158142,
+              "p95": 6.199999940395355,
+              "iqr": 0.19999995827674866,
+              "count": 99,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 29,
+              "ratio": 29.5,
               "slope": 1
             },
             {
               "lib": "tanstack",
               "median": 0.10000002384185791,
               "p95": 0.2999999523162842,
-              "iqr": 0.10000002384185791,
+              "iqr": 0.10000014305114746,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
@@ -2396,10 +2437,10 @@
             {
               "lib": "formisch",
               "median": 0.10000002384185791,
-              "p95": 0.10000002384185791,
-              "iqr": 0.02500009536743164,
-              "count": 80,
-              "trimmed": 20,
+              "p95": 0.30000007152557373,
+              "iqr": 0.10000014305114746,
+              "count": 99,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
               "ratio": 0.5,
@@ -2407,21 +2448,21 @@
             },
             {
               "lib": "regle-schema",
-              "median": 0.20000004768371582,
-              "p95": 0.5,
-              "iqr": 0.19999992847442627,
-              "count": 97,
-              "trimmed": 3,
+              "median": 0.2999999523162842,
+              "p95": 0.7000000476837158,
+              "iqr": 0.30000007152557373,
+              "count": 99,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1,
-              "slope": 2
+              "ratio": 1.5,
+              "slope": 1.5
             },
             {
               "lib": "regle-rules",
               "median": 0.6000000238418579,
-              "p95": 1.5099999904632562,
-              "iqr": 0.5,
+              "p95": 1.3200000643730152,
+              "iqr": 0.3999999761581421,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
@@ -2431,21 +2472,21 @@
             },
             {
               "lib": "formkit",
-              "median": 1.4000000953674316,
-              "p95": 2.060000014305114,
-              "iqr": 0.5,
-              "count": 89,
-              "trimmed": 11,
+              "median": 1.399999976158142,
+              "p95": 2,
+              "iqr": 0.6000000238418579,
+              "count": 94,
+              "trimmed": 6,
               "unit": "ms",
               "supported": true,
               "ratio": 7,
-              "slope": 2.33
+              "slope": 1.75
             },
             {
               "lib": "vuelidate",
               "median": 0.10000002384185791,
-              "p95": 0.2100000381469721,
-              "iqr": 0.10000002384185791,
+              "p95": 0.20000004768371582,
+              "iqr": 0.09999990463256836,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
@@ -2763,7 +2804,7 @@
               "lib": "attaform",
               "retained": {
                 "median": 97520,
-                "p95": 293312,
+                "p95": 293296,
                 "count": 12
               },
               "churn": {
@@ -2778,11 +2819,11 @@
               },
               "series": {
                 "retained": [
-                  479284, 140516, 122364, 109516, 142432, 82248, 74076, 75796, 293312, 75712, 97520,
+                  479284, 140516, 122364, 109516, 142432, 82248, 74076, 75796, 293296, 75712, 97520,
                   62100
                 ],
                 "churn": [
-                  1021984, 688892, 683692, 669876, 665664, 670188, 656868, 677060, 684188, 662120,
+                  1021984, 688892, 683692, 669876, 665664, 670188, 656868, 677060, 684136, 662120,
                   706848, 664944
                 ],
                 "leak": [
@@ -2801,26 +2842,26 @@
                 "count": 12
               },
               "churn": {
-                "median": 250136,
-                "p95": 384004,
+                "median": 258068,
+                "p95": 274180,
                 "count": 12
               },
               "leak": {
-                "median": 16588,
-                "p95": 132520,
+                "median": 18856,
+                "p95": 132488,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  308892, 84372, 105220, 78228, 127044, 48824, 47372, 63336, 136680, 71132, 70764,
-                  51708
+                  308860, 84372, 105220, 78164, 127044, 48824, 47372, 63336, 136680, 71132, 70764,
+                  70196
                 ],
                 "churn": [
-                  384004, 260264, 419360, 261404, 234860, 250136, 251368, 241460, 265436, 249856,
-                  234024, 242552
+                  415948, 260264, 274180, 261404, 258068, 250788, 251368, 262404, 265436, 249856,
+                  254360, 219320
                 ],
                 "leak": [
-                  425028, 49172, 70188, 48220, 73112, 14828, 2676, 4228, 132520, 7856, 16588, 8848
+                  424868, 49172, 70188, 48156, 73112, 14828, 2676, 4228, 132488, 7856, 18856, 9496
                 ]
               },
               "supported": true,
@@ -2835,27 +2876,27 @@
                 "count": 12
               },
               "churn": {
-                "median": 118984,
-                "p95": 172212,
+                "median": 120252,
+                "p95": 174324,
                 "count": 12
               },
               "leak": {
-                "median": 36364,
+                "median": 36192,
                 "p95": 124940,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  283264, 46140, 69688, 52876, 90228, 38516, 36368, 36548, 116448, 42532, 56608,
-                  40520
+                  283264, 46140, 69688, 52876, 90228, 38344, 36368, 36548, 116448, 42532, 50204,
+                  40596
                 ],
                 "churn": [
-                  497716, 136476, 131740, 120352, 172212, 112896, 94740, 103368, 118984, 107896,
-                  131540, 97296
+                  493500, 136464, 131904, 120252, 174324, 112308, 94180, 103040, 121772, 114720,
+                  130240, 95276
                 ],
                 "leak": [
-                  642200, 42212, 82024, 29496, 124940, 36364, 18640, 19620, 113192, 20076, 55068,
-                  17028
+                  642200, 42212, 82024, 29496, 124940, 36192, 18640, 19620, 113192, 26988, 48608,
+                  14992
                 ]
               },
               "supported": true,
@@ -2904,8 +2945,8 @@
                 "count": 12
               },
               "churn": {
-                "median": 681704,
-                "p95": 740784,
+                "median": 682780,
+                "p95": 740976,
                 "count": 12
               },
               "leak": {
@@ -2919,8 +2960,8 @@
                   123956, 97168
                 ],
                 "churn": [
-                  446752, 813808, 740784, 705448, 700108, 670572, 681704, 675112, 702960, 691740,
-                  663376, 644376
+                  441072, 813988, 740976, 705448, 697076, 667252, 681688, 672764, 699532, 691548,
+                  682780, 667052
                 ],
                 "leak": [
                   535980, 59188, 43236, 28976, 59312, 13028, 0, 5000, 142916, 10968, 33576, 544
@@ -2953,7 +2994,7 @@
                   108668, 84680
                 ],
                 "churn": [
-                  640888, 438420, 429112, 430892, 424588, 427512, 427356, 432208, 437736, 431056,
+                  640888, 438420, 429112, 430892, 424588, 427512, 427356, 432208, 436448, 431024,
                   447940, 415700
                 ],
                 "leak": [
@@ -2968,30 +3009,30 @@
               "lib": "formkit",
               "retained": {
                 "median": 926480,
-                "p95": 1058760,
+                "p95": 1058468,
                 "count": 12
               },
               "churn": {
-                "median": 589668,
-                "p95": 762064,
+                "median": 589916,
+                "p95": 763876,
                 "count": 12
               },
               "leak": {
                 "median": 49920,
-                "p95": 230892,
+                "p95": 230940,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  1720272, 1058760, 927572, 955652, 926480, 907036, 918644, 898652, 970764, 981720,
-                  902928, 906384
+                  1720272, 1058468, 927332, 955892, 926480, 908540, 918640, 898644, 970772, 983064,
+                  902924, 906624
                 ],
                 "churn": [
-                  1548536, 762064, 703952, 659452, 589668, 627724, 595668, 556820, 557612, 551348,
-                  544048, 543932
+                  1547924, 763876, 703632, 659760, 589916, 630100, 595668, 556372, 557528, 552136,
+                  542624, 544716
                 ],
                 "leak": [
-                  1266032, 230892, 74952, 49920, 35716, 57988, 15084, 9456, 106056, 81180, 21128,
+                  1266032, 230940, 74952, 49920, 35716, 57988, 15084, 9456, 106056, 81180, 21128,
                   21416
                 ]
               },
@@ -3043,26 +3084,26 @@
                 "count": 12
               },
               "churn": {
-                "median": 180424,
-                "p95": 214100,
+                "median": 183040,
+                "p95": 215720,
                 "count": 12
               },
               "leak": {
                 "median": 34724,
-                "p95": 239840,
+                "p95": 239864,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  560188, 131040, 124752, 110156, 155220, 97308, 103232, 89424, 308576, 92348,
+                  560092, 131008, 124688, 110156, 155220, 97308, 103232, 89424, 308576, 92348,
                   120828, 78296
                 ],
                 "churn": [
-                  541008, 191752, 171560, 188204, 160988, 180424, 153180, 192380, 191316, 167400,
-                  214100, 164340
+                  536700, 201020, 171560, 188148, 161260, 183040, 152972, 197204, 191468, 168280,
+                  215720, 162360
                 ],
                 "leak": [
-                  798484, 67908, 50468, 34724, 74736, 23804, 1596, 10472, 239840, 7912, 67948, 7072
+                  798228, 67876, 50404, 34724, 74736, 23804, 1596, 10472, 239864, 7912, 67948, 7072
                 ]
               },
               "supported": true,
@@ -3072,31 +3113,31 @@
             {
               "lib": "vee-validate",
               "retained": {
-                "median": 83008,
-                "p95": 172844,
+                "median": 83060,
+                "p95": 148940,
                 "count": 12
               },
               "churn": {
-                "median": 294660,
-                "p95": 426576,
+                "median": 301520,
+                "p95": 757148,
                 "count": 12
               },
               "leak": {
-                "median": 17432,
-                "p95": 130500,
+                "median": 17468,
+                "p95": 130476,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  328456, 91508, 96736, 83008, 118496, 58060, 56812, 83976, 172844, 64756, 63064,
-                  54808
+                  328456, 118256, 96624, 83060, 118420, 81940, 56812, 60096, 148940, 88636, 63064,
+                  54768
                 ],
                 "churn": [
-                  426576, 264596, 491920, 302308, 266920, 297012, 274200, 314028, 276260, 302584,
-                  270716, 294660
+                  814932, 298580, 757148, 307652, 299232, 295908, 305492, 312712, 308696, 301520,
+                  300396, 294752
                 ],
                 "leak": [
-                  500184, 95596, 78548, 40508, 66092, 15552, 0, 15600, 130500, 8052, 17432, 7732
+                  438876, 43040, 78604, 40592, 65932, 15552, 0, 13096, 130476, 8040, 17468, 7728
                 ]
               },
               "supported": true,
@@ -3111,27 +3152,27 @@
                 "count": 12
               },
               "churn": {
-                "median": 312120,
-                "p95": 368680,
+                "median": 312400,
+                "p95": 368336,
                 "count": 12
               },
               "leak": {
-                "median": 43316,
-                "p95": 131100,
+                "median": 43144,
+                "p95": 131272,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  292604, 53144, 79552, 54276, 96192, 45212, 43152, 43332, 123232, 49316, 56952,
-                  47304
+                  292604, 53144, 79552, 54276, 96192, 45040, 43152, 43332, 123232, 49316, 56952,
+                  48488
                 ],
                 "churn": [
-                  681236, 317348, 333692, 315844, 368680, 306148, 288220, 296904, 312120, 308032,
-                  322412, 289200
+                  681800, 320412, 333740, 315428, 368336, 306104, 288128, 297796, 312400, 308116,
+                  322932, 286712
                 ],
                 "leak": [
-                  653412, 45832, 92468, 34776, 131100, 43316, 25744, 26688, 121888, 33964, 55612,
-                  24152
+                  653408, 45832, 92468, 34776, 131272, 43144, 25744, 26688, 121888, 34132, 55612,
+                  23140
                 ]
               },
               "supported": true,
@@ -3157,15 +3198,15 @@
               },
               "series": {
                 "retained": [
-                  184532, 40136, 59948, 41356, 79428, 29068, 35784, 27964, 71800, 33596, 40432,
+                  184468, 40136, 59916, 41356, 79428, 29068, 35784, 27964, 71800, 33596, 40432,
                   31152
                 ],
                 "churn": [
-                  399332, 220752, 219800, 225808, 224328, 219376, 225528, 233336, 230972, 222092,
+                  399204, 220752, 219800, 225808, 224328, 219376, 225528, 233336, 230972, 222092,
                   225860, 208752
                 ],
                 "leak": [
-                  325736, 9004, 39272, 12516, 62584, 11540, 12792, 4444, 52492, 4596, 17056, 24
+                  325544, 9004, 39240, 12516, 62584, 11540, 12792, 4444, 52492, 4596, 17056, 24
                 ]
               },
               "supported": true,
@@ -3176,30 +3217,30 @@
               "lib": "regle-schema",
               "retained": {
                 "median": 162492,
-                "p95": 261216,
+                "p95": 261184,
                 "count": 12
               },
               "churn": {
-                "median": 756728,
-                "p95": 882280,
+                "median": 750196,
+                "p95": 868808,
                 "count": 12
               },
               "leak": {
-                "median": 21248,
-                "p95": 151972,
+                "median": 21000,
+                "p95": 151940,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  520320, 166880, 170972, 169088, 197120, 144268, 142992, 143772, 261216, 145060,
+                  520256, 166880, 175472, 164488, 197120, 144268, 142992, 143772, 261184, 145060,
                   162492, 138600
                 ],
                 "churn": [
-                  516832, 882280, 751128, 754760, 753100, 758984, 756728, 1510632, 799636, 764820,
-                  757224, 744068
+                  563448, 868808, 749608, 766712, 751784, 746016, 745392, 1523968, 798444, 750196,
+                  756508, 743700
                 ],
                 "leak": [
-                  588936, 22256, 36236, 21248, 57784, 14224, 56, 5812, 151972, 7132, 30040, 0
+                  588840, 22256, 36360, 21000, 57784, 14224, 32, 5812, 151940, 7152, 30040, 0
                 ]
               },
               "supported": true,
@@ -3243,31 +3284,31 @@
             {
               "lib": "formkit",
               "retained": {
-                "median": 1189596,
-                "p95": 1262776,
+                "median": 1189592,
+                "p95": 1262824,
                 "count": 12
               },
               "churn": {
-                "median": 326952,
-                "p95": 1339284,
+                "median": 332432,
+                "p95": 1340500,
                 "count": 12
               },
               "leak": {
                 "median": 48620,
-                "p95": 125700,
+                "p95": 125748,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  2147452, 1262776, 1221688, 1189072, 1189596, 1188060, 1170328, 1169204, 1228148,
-                  1234188, 1202092, 1157296
+                  2147176, 1262824, 1221692, 1189072, 1189592, 1188056, 1170340, 1169200, 1228148,
+                  1234180, 1202096, 1157292
                 ],
                 "churn": [
-                  847832, 1339284, 1383676, 548720, 539332, 326952, 372252, 314688, 223144, 317992,
-                  123164, 213516
+                  851668, 1340500, 1384096, 1324048, 539404, 332432, 375360, 308816, 310468, 316992,
+                  120608, 213532
                 ],
                 "leak": [
-                  1542124, 125700, 91888, 20616, 41304, 81164, 7536, 20968, 106800, 76132, 48620,
+                  1542076, 125748, 91888, 20616, 41304, 81164, 7536, 20968, 106800, 76132, 48620,
                   3260
                 ]
               },
@@ -3314,31 +3355,31 @@
             {
               "lib": "attaform",
               "retained": {
-                "median": 143220,
-                "p95": 341440,
+                "median": 143756,
+                "p95": 341096,
                 "count": 12
               },
               "churn": {
-                "median": 184072,
-                "p95": 916732,
+                "median": 179032,
+                "p95": 555452,
                 "count": 12
               },
               "leak": {
-                "median": 32532,
+                "median": 32468,
                 "p95": 243756,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  626800, 143820, 155856, 157572, 183504, 128948, 130812, 119952, 341440, 121504,
-                  143220, 109404
+                  626672, 143756, 155824, 157572, 183504, 128948, 130812, 119952, 341096, 121504,
+                  146300, 109404
                 ],
                 "churn": [
-                  558768, 179032, 950756, 184072, 192072, 204608, 173644, 192652, 166996, 162732,
-                  916732, 172032
+                  555452, 179032, 178384, 184836, 190032, 205724, 173644, 190908, 166996, 165396,
+                  915176, 175352
                 ],
                 "leak": [
-                  841260, 32532, 46520, 39964, 73292, 18236, 5204, 14392, 243756, 18820, 51688, 5380
+                  841004, 32468, 46488, 39964, 73292, 18236, 5204, 14392, 243756, 18820, 51740, 5380
                 ]
               },
               "supported": true,
@@ -3348,65 +3389,65 @@
             {
               "lib": "vee-validate",
               "retained": {
-                "median": 116948,
-                "p95": 165012,
+                "median": 111704,
+                "p95": 206448,
                 "count": 12
               },
               "churn": {
-                "median": 350536,
-                "p95": 368416,
+                "median": 361712,
+                "p95": 375464,
                 "count": 12
               },
               "leak": {
-                "median": 19848,
-                "p95": 124228,
+                "median": 17440,
+                "p95": 125968,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  351652, 110456, 155392, 144456, 142320, 116948, 117032, 75816, 165012, 84348,
-                  82820, 73688
+                  351652, 154160, 111704, 101760, 137256, 116948, 77000, 78276, 206448, 84348,
+                  82784, 113656
                 ],
                 "churn": [
-                  530544, 358924, 314888, 322316, 306592, 364468, 356448, 368416, 368340, 350536,
-                  321492, 301216
+                  873320, 354472, 375464, 370344, 353428, 364420, 357772, 361712, 367704, 350536,
+                  373788, 338560
                 ],
                 "leak": [
-                  449944, 44188, 66192, 44712, 73208, 16420, 11596, 1496, 124228, 8568, 19848, 2532
+                  449944, 44188, 66280, 45072, 65684, 16388, 11588, 6144, 125968, 8568, 17440, 0
                 ]
               },
               "supported": true,
-              "ratio": 0.82,
-              "slope": 1.64
+              "ratio": 0.78,
+              "slope": 1.57
             },
             {
               "lib": "tanstack",
               "retained": {
-                "median": 66564,
+                "median": 66596,
                 "p95": 136800,
                 "count": 12
               },
               "churn": {
-                "median": 739484,
-                "p95": 790516,
+                "median": 739120,
+                "p95": 791096,
                 "count": 12
               },
               "leak": {
-                "median": 57860,
-                "p95": 146732,
+                "median": 57360,
+                "p95": 146764,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  309568, 66564, 90164, 67780, 109716, 58608, 56720, 56900, 136800, 62884, 77068,
+                  309600, 66596, 90196, 67780, 109716, 58780, 56720, 56900, 136800, 62884, 70520,
                   60872
                 ],
                 "churn": [
-                  1112300, 747996, 754912, 739484, 790516, 748660, 730180, 740060, 722824, 715708,
-                  733280, 700428
+                  1112672, 747996, 755340, 739120, 791096, 749404, 731140, 740456, 723544, 722772,
+                  733956, 700676
                 ],
                 "leak": [
-                  669536, 62504, 103748, 48968, 146732, 57860, 39952, 40876, 134504, 41200, 76260,
+                  669792, 62536, 103780, 48968, 146764, 57360, 39952, 40896, 134504, 48012, 69652,
                   38360
                 ]
               },
@@ -3451,31 +3492,31 @@
             {
               "lib": "regle-schema",
               "retained": {
-                "median": 241212,
-                "p95": 343068,
+                "median": 241252,
+                "p95": 342832,
                 "count": 12
               },
               "churn": {
-                "median": 867876,
+                "median": 873012,
                 "p95": 1678828,
                 "count": 12
               },
               "leak": {
-                "median": 18732,
-                "p95": 145084,
+                "median": 18932,
+                "p95": 145116,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  627716, 241212, 255476, 244272, 283260, 232508, 228648, 228020, 343068, 228788,
-                  248612, 223020
+                  627780, 241252, 255548, 244512, 283300, 232548, 228688, 228060, 342832, 228828,
+                  248652, 223060
                 ],
                 "churn": [
-                  802832, 1678828, 874636, 860876, 865356, 1643084, 859232, 872880, 900720, 1683448,
+                  875052, 1678828, 875040, 860928, 865216, 1678788, 853440, 873012, 900636, 1684640,
                   867876, 859756
                 ],
                 "leak": [
-                  607000, 9776, 35660, 18732, 59560, 19008, 1996, 5316, 145084, 6404, 34236, 96
+                  607096, 9776, 35524, 18932, 59560, 19008, 1996, 5316, 145116, 6404, 34236, 96
                 ]
               },
               "supported": true,
@@ -3513,48 +3554,48 @@
                 ]
               },
               "supported": true,
-              "ratio": 1.45,
+              "ratio": 1.44,
               "slope": 1.91
             },
             {
               "lib": "formkit",
               "retained": {
-                "median": 1750980,
-                "p95": 1794912,
+                "median": 1749592,
+                "p95": 1784472,
                 "count": 12
               },
               "churn": {
-                "median": 1488956,
-                "p95": 1524992,
+                "median": 1472804,
+                "p95": 1524848,
                 "count": 12
               },
               "leak": {
-                "median": 61936,
-                "p95": 128716,
+                "median": 62652,
+                "p95": 128696,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  2760612, 1794912, 1740792, 1751680, 1744540, 1710384, 1750980, 1774320, 1771984,
-                  1784280, 1715284, 1701232
+                  2778372, 1776020, 1742176, 1750264, 1745260, 1711760, 1749592, 1775780, 1770524,
+                  1784472, 1715280, 1701224
                 ],
                 "churn": [
-                  1335888, 1822912, 1524992, 1504480, 1488956, 1491964, 1492188, 1516452, 1470848,
-                  1413088, 1472732, 1466020
+                  1338384, 1816564, 1524848, 1471812, 1492912, 1492424, 1495296, 1516432, 1470724,
+                  1469912, 1472804, 1468976
                 ],
                 "leak": [
-                  1824932, 128716, 76428, 44036, 61936, 48568, 59284, 113432, 77968, 65680, 19044,
+                  1825000, 128696, 76360, 43388, 62652, 50140, 57712, 113432, 77968, 65680, 19044,
                   10536
                 ]
               },
               "supported": true,
-              "ratio": 12.23,
+              "ratio": 12.17,
               "slope": 1.89
             },
             {
               "lib": "vuelidate",
               "retained": {
-                "median": 131436,
+                "median": 131364,
                 "p95": 184808,
                 "count": 12
               },
@@ -3564,25 +3605,25 @@
                 "count": 12
               },
               "leak": {
-                "median": 19420,
+                "median": 19148,
                 "p95": 84840,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  341164, 131112, 150692, 132180, 175480, 120248, 131436, 119620, 184808, 119804,
-                  132260, 117824
+                  341196, 131112, 155236, 131908, 175420, 120248, 131364, 119620, 184808, 119804,
+                  135352, 117824
                 ],
                 "churn": [
-                  286308, 127688, 119128, 121452, 121016, 123424, 128056, 132368, 147132, 130180,
-                  136628, 108668
+                  286372, 127688, 118984, 121452, 121124, 123424, 128056, 132400, 147132, 130172,
+                  136752, 108668
                 ],
                 "leak": [
-                  366192, 23096, 43920, 19420, 66724, 13172, 13828, 15060, 84840, 9792, 23028, 556
+                  366288, 23096, 44260, 19148, 66700, 13172, 13756, 15092, 84840, 9792, 23028, 556
                 ]
               },
               "supported": true,
-              "ratio": 0.92,
+              "ratio": 0.91,
               "slope": 1.91
             }
           ]
@@ -3596,9 +3637,9 @@
           "N10": [
             {
               "lib": "attaform",
-              "median": 0.7000000476837158,
+              "median": 0.6000000238418579,
               "p95": 1.81000006198883,
-              "iqr": 0.7250000238418579,
+              "iqr": 0.7999999523162842,
               "count": 199,
               "trimmed": 1,
               "unit": "ms",
@@ -3608,32 +3649,8 @@
             },
             {
               "lib": "vee-validate",
-              "median": 0.7999999523162842,
-              "p95": 1.100000023841858,
-              "iqr": 0.2999999523162842,
-              "count": 199,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1.14,
-              "slope": 1
-            },
-            {
-              "lib": "tanstack",
-              "median": 0.7999999523162842,
-              "p95": 1.110000014305114,
-              "iqr": 0.42500007152557373,
-              "count": 199,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1.14,
-              "slope": 1
-            },
-            {
-              "lib": "formisch",
-              "median": 0.7000000476837158,
-              "p95": 1.1999999284744263,
+              "median": 0.6000000238418579,
+              "p95": 1.2999999523162842,
               "iqr": 0.3999999761581421,
               "count": 199,
               "trimmed": 1,
@@ -3643,46 +3660,70 @@
               "slope": 1
             },
             {
-              "lib": "regle-schema",
-              "median": 0.8000000715255737,
-              "p95": 1.600000023841858,
-              "iqr": 0.5250000953674316,
+              "lib": "tanstack",
+              "median": 0.9000000953674316,
+              "p95": 1.399999976158142,
+              "iqr": 0.5,
               "count": 199,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.14,
+              "ratio": 1.5,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.6999999284744263,
+              "p95": 1,
+              "iqr": 0.40000009536743164,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.17,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 0.8999999761581421,
+              "p95": 1.600000023841858,
+              "iqr": 0.6000000238418579,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.5,
               "slope": 1
             },
             {
               "lib": "regle-rules",
-              "median": 0.8000000715255737,
-              "p95": 1.600000023841858,
-              "iqr": 0.6999999284744263,
+              "median": 0.7999999523162842,
+              "p95": 1.399999976158142,
+              "iqr": 0.6999999582767487,
               "count": 199,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.14,
+              "ratio": 1.33,
               "slope": 1
             },
             {
               "lib": "formkit",
-              "median": 1,
+              "median": 0.8999999761581421,
               "p95": 1.7000000476837158,
-              "iqr": 0.5250000953674316,
+              "iqr": 0.8000000715255737,
               "count": 199,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.43,
+              "ratio": 1.5,
               "slope": 1
             },
             {
               "lib": "vuelidate",
-              "median": 0.7000000476837158,
-              "p95": 1.2000000476837158,
-              "iqr": 0.42499998211860657,
+              "median": 0.6000000238418579,
+              "p95": 1.1999999403953552,
+              "iqr": 0.5,
               "count": 199,
               "trimmed": 1,
               "unit": "ms",
@@ -3694,99 +3735,99 @@
           "N100": [
             {
               "lib": "attaform",
-              "median": 1.5,
-              "p95": 2.8000000417232513,
-              "iqr": 0.6000000536441803,
-              "count": 186,
-              "trimmed": 14,
+              "median": 1.600000023841858,
+              "p95": 3.715000033378599,
+              "iqr": 0.9000000059604645,
+              "count": 198,
+              "trimmed": 2,
               "unit": "ms",
               "supported": true,
               "ratio": 1,
-              "slope": 2.14
+              "slope": 2.67
             },
             {
               "lib": "vee-validate",
-              "median": 1.2000000476837158,
-              "p95": 2.0999999165534975,
-              "iqr": 0.8249999284744263,
+              "median": 0.8999999761581421,
+              "p95": 2.100000023841858,
+              "iqr": 0.7999999523162842,
               "count": 199,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.8,
+              "ratio": 0.56,
               "slope": 1.5
             },
             {
               "lib": "tanstack",
-              "median": 1.5,
-              "p95": 3.2999999642372133,
-              "iqr": 0.9000000059604645,
-              "count": 199,
-              "trimmed": 1,
+              "median": 1.600000023841858,
+              "p95": 3.200000047683716,
+              "iqr": 1.3000000715255737,
+              "count": 200,
+              "trimmed": 0,
               "unit": "ms",
               "supported": true,
               "ratio": 1,
-              "slope": 1.88
+              "slope": 1.78
             },
             {
               "lib": "formisch",
               "median": 1.2000000476837158,
               "p95": 2.100000023841858,
-              "iqr": 0.9000000953674316,
+              "iqr": 1,
               "count": 199,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.8,
+              "ratio": 0.75,
               "slope": 1.71
             },
             {
               "lib": "regle-schema",
-              "median": 1.600000023841858,
-              "p95": 3.505000001192091,
-              "iqr": 1,
+              "median": 1.4500000476837158,
+              "p95": 3.105000025033949,
+              "iqr": 1.3000001907348633,
               "count": 200,
               "trimmed": 0,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.07,
-              "slope": 2
+              "ratio": 0.91,
+              "slope": 1.61
             },
             {
               "lib": "regle-rules",
-              "median": 1.6999999284744263,
-              "p95": 2.2999999642372133,
+              "median": 1.399999976158142,
+              "p95": 2.8000000715255737,
               "iqr": 1,
               "count": 199,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.13,
-              "slope": 2.12
+              "ratio": 0.87,
+              "slope": 1.75
             },
             {
               "lib": "formkit",
-              "median": 1.399999976158142,
+              "median": 1.3000000715255737,
               "p95": 3,
-              "iqr": 1.299999862909317,
+              "iqr": 1.4000000953674316,
               "count": 200,
               "trimmed": 0,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.93,
-              "slope": 1.4
+              "ratio": 0.81,
+              "slope": 1.44
             },
             {
               "lib": "vuelidate",
-              "median": 1.4500000476837158,
+              "median": 1.2999999523162842,
               "p95": 2.399999976158142,
-              "iqr": 1.2000000476837158,
-              "count": 200,
-              "trimmed": 0,
+              "iqr": 0.7999999523162842,
+              "count": 199,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.97,
-              "slope": 2.07
+              "ratio": 0.81,
+              "slope": 2.17
             }
           ]
         }
@@ -3797,9 +3838,9 @@
           "N10": [
             {
               "lib": "attaform",
-              "median": 1.2999999523162842,
-              "p95": 1.4450000524520874,
-              "iqr": 0.15000009536743164,
+              "median": 1.2000000476837158,
+              "p95": 1.399999976158142,
+              "iqr": 0.20000004768371582,
               "count": 12,
               "trimmed": 3,
               "unit": "ms",
@@ -3809,83 +3850,83 @@
             },
             {
               "lib": "vee-validate",
-              "median": 0.8999999761581421,
-              "p95": 1.600000023841858,
-              "iqr": 0.44999998807907104,
+              "median": 0.949999988079071,
+              "p95": 1.5350000083446502,
+              "iqr": 0.24999994039535522,
               "count": 14,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.69,
+              "ratio": 0.79,
               "slope": 1
             },
             {
               "lib": "tanstack",
               "median": 0.7000000476837158,
-              "p95": 0.9799999952316282,
-              "iqr": 0.19999992847442627,
-              "count": 13,
-              "trimmed": 2,
+              "p95": 1.1700000405311584,
+              "iqr": 0.30000007152557373,
+              "count": 14,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.54,
+              "ratio": 0.58,
               "slope": 1
             },
             {
               "lib": "formisch",
               "median": 0.5,
-              "p95": 0.7350000143051147,
-              "iqr": 0.25,
+              "p95": 0.6999999284744263,
+              "iqr": 0.14999991655349731,
               "count": 14,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.38,
+              "ratio": 0.42,
               "slope": 1
             },
             {
               "lib": "regle-schema",
-              "median": 1.5999999046325684,
-              "p95": 1.8999999999999992,
-              "iqr": 0.34999996423721313,
+              "median": 1.600000023841858,
+              "p95": 1.7000000476837158,
+              "iqr": 0.15000003576278687,
               "count": 13,
               "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.23,
+              "ratio": 1.33,
               "slope": 1
             },
             {
               "lib": "regle-rules",
-              "median": 1.7999999523162842,
-              "p95": 2.060000014305114,
-              "iqr": 0.3999999761581421,
+              "median": 1.4000000953674316,
+              "p95": 1.8399999618530272,
+              "iqr": 0.4999999403953552,
               "count": 13,
               "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.38,
+              "ratio": 1.17,
               "slope": 1
             },
             {
               "lib": "formkit",
-              "median": 10.399999976158142,
-              "p95": 11.240000009536743,
-              "iqr": 1.5,
-              "count": 13,
-              "trimmed": 2,
+              "median": 10.299999952316284,
+              "p95": 12.42500005364418,
+              "iqr": 1.649999976158142,
+              "count": 14,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 8,
+              "ratio": 8.58,
               "slope": 1
             },
             {
               "lib": "vuelidate",
-              "median": 0.6499999761581421,
-              "p95": 1.0350000083446502,
-              "iqr": 0.34999996423721313,
-              "count": 14,
-              "trimmed": 1,
+              "median": 0.6000000238418579,
+              "p95": 0.840000033378601,
+              "iqr": 0.30000001192092896,
+              "count": 13,
+              "trimmed": 2,
               "unit": "ms",
               "supported": true,
               "ratio": 0.5,
@@ -3895,99 +3936,99 @@
           "N100": [
             {
               "lib": "attaform",
-              "median": 11.099999964237213,
-              "p95": 14.839999991655349,
-              "iqr": 3.099999964237213,
+              "median": 10.75,
+              "p95": 14.465000015497207,
+              "iqr": 2.149999976158142,
               "count": 14,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
               "ratio": 1,
-              "slope": 8.54
+              "slope": 8.96
             },
             {
               "lib": "vee-validate",
-              "median": 5.599999964237213,
-              "p95": 7.805000030994415,
-              "iqr": 1.850000023841858,
+              "median": 5.349999964237213,
+              "p95": 6.880000048875808,
+              "iqr": 1.449999988079071,
               "count": 14,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
               "ratio": 0.5,
-              "slope": 6.22
+              "slope": 5.63
             },
             {
               "lib": "tanstack",
-              "median": 8.900000095367432,
-              "p95": 9.779999947547912,
-              "iqr": 0.9500001072883606,
+              "median": 9.5,
+              "p95": 10.619999980926513,
+              "iqr": 1.1500000357627869,
               "count": 13,
               "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.8,
-              "slope": 12.71
+              "ratio": 0.88,
+              "slope": 13.57
             },
             {
               "lib": "formisch",
-              "median": 1.899999976158142,
-              "p95": 2.439999985694885,
+              "median": 1.6999999284744263,
+              "p95": 2.4600000143051144,
               "iqr": 0.550000011920929,
               "count": 13,
               "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.17,
-              "slope": 3.8
+              "ratio": 0.16,
+              "slope": 3.4
             },
             {
               "lib": "regle-schema",
-              "median": 6.850000023841858,
-              "p95": 9.12499994635582,
-              "iqr": 1.9000000357627869,
+              "median": 7.050000011920929,
+              "p95": 8.9200000166893,
+              "iqr": 1.7499999403953552,
               "count": 14,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.62,
-              "slope": 4.28
+              "ratio": 0.66,
+              "slope": 4.41
             },
             {
               "lib": "regle-rules",
-              "median": 8.100000023841858,
-              "p95": 11.199999970197677,
-              "iqr": 3.1000000834465027,
+              "median": 8.449999988079071,
+              "p95": 12.244999969005583,
+              "iqr": 4,
               "count": 14,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.73,
-              "slope": 4.5
+              "ratio": 0.79,
+              "slope": 6.04
             },
             {
               "lib": "formkit",
-              "median": 155.19999992847443,
-              "p95": 166.33999998569487,
-              "iqr": 9.949999928474426,
+              "median": 152.90000009536743,
+              "p95": 163.339999961853,
+              "iqr": 9.349999964237213,
               "count": 13,
               "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 13.98,
-              "slope": 14.92
+              "ratio": 14.22,
+              "slope": 14.84
             },
             {
               "lib": "vuelidate",
-              "median": 2,
-              "p95": 2.46000006198883,
-              "iqr": 0.40000003576278687,
+              "median": 2.100000023841858,
+              "p95": 2.339999961853027,
+              "iqr": 0.25,
               "count": 13,
               "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.18,
-              "slope": 3.08
+              "ratio": 0.2,
+              "slope": 3.5
             }
           ]
         }
@@ -3998,9 +4039,9 @@
           "N10": [
             {
               "lib": "attaform",
-              "median": 0.19999992847442627,
-              "p95": 0.40000009536743164,
-              "iqr": 0.19999992847442627,
+              "median": 0.20000004768371582,
+              "p95": 0.5,
+              "iqr": 0.2999999523162842,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
@@ -4011,8 +4052,8 @@
             {
               "lib": "vee-validate",
               "median": 6,
-              "p95": 6.199999940395355,
-              "iqr": 0.20000004768371582,
+              "p95": 6.399999976158142,
+              "iqr": 0.3999999761581421,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
@@ -4025,8 +4066,8 @@
               "median": 0.10000002384185791,
               "p95": 0.30000007152557373,
               "iqr": 0.10000002384185791,
-              "count": 98,
-              "trimmed": 2,
+              "count": 99,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
               "ratio": 0.5,
@@ -4035,8 +4076,8 @@
             {
               "lib": "formisch",
               "median": 0.10000002384185791,
-              "p95": 0.29999996423721315,
-              "iqr": 0.1000000536441803,
+              "p95": 0.2999999523162842,
+              "iqr": 0.10000002384185791,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
@@ -4046,47 +4087,47 @@
             },
             {
               "lib": "regle-schema",
-              "median": 0.6000000238418579,
-              "p95": 1,
-              "iqr": 0.4249999523162842,
+              "median": 0.3999999761581421,
+              "p95": 0.8999999761581421,
+              "iqr": 0.3250000476837158,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 3,
+              "ratio": 2,
               "slope": 1
             },
             {
               "lib": "regle-rules",
-              "median": 0.6000000238418579,
+              "median": 0.7999999523162842,
               "p95": 1.2000000476837158,
-              "iqr": 0.3999999761581421,
+              "iqr": 0.6000000238418579,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 3,
+              "ratio": 4,
               "slope": 1
             },
             {
               "lib": "formkit",
-              "median": 1.5999999046325684,
-              "p95": 2.1249999403953552,
-              "iqr": 0.49999988079071045,
+              "median": 1.399999976158142,
+              "p95": 2,
+              "iqr": 0.4500000476837158,
               "count": 96,
               "trimmed": 4,
               "unit": "ms",
               "supported": true,
-              "ratio": 8,
+              "ratio": 7,
               "slope": 1
             },
             {
               "lib": "vuelidate",
               "median": 0.10000002384185791,
-              "p95": 0.10000002384185791,
-              "iqr": 0.02500009536743164,
-              "count": 81,
-              "trimmed": 19,
+              "p95": 0.2999999523162842,
+              "iqr": 0.1000000536441803,
+              "count": 99,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
               "ratio": 0.5,
@@ -4096,87 +4137,87 @@
           "N100": [
             {
               "lib": "attaform",
-              "median": 0.30000007152557373,
-              "p95": 0.9099999785423273,
-              "iqr": 0.30000007152557373,
+              "median": 0.40000009536743164,
+              "p95": 0.8999999761581421,
+              "iqr": 0.3999999761581421,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
               "ratio": 1,
-              "slope": 1.5
+              "slope": 2
             },
             {
               "lib": "vee-validate",
-              "median": 6.899999976158142,
+              "median": 6.600000023841858,
               "p95": 7.510000002384185,
-              "iqr": 0.7000000476837158,
+              "iqr": 0.6999999284744263,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 23,
-              "slope": 1.15
+              "ratio": 16.5,
+              "slope": 1.1
             },
             {
               "lib": "tanstack",
-              "median": 1.600000023841858,
-              "p95": 3.0999999165534975,
-              "iqr": 0.7000000476837158,
-              "count": 99,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 5.33,
-              "slope": 16
-            },
-            {
-              "lib": "formisch",
-              "median": 0.10000002384185791,
-              "p95": 0.3999999761581421,
-              "iqr": 0.125,
-              "count": 98,
-              "trimmed": 2,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.33,
-              "slope": 1
-            },
-            {
-              "lib": "regle-schema",
-              "median": 1,
-              "p95": 1.5,
-              "iqr": 0.2999999523162842,
-              "count": 99,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 3.33,
-              "slope": 1.67
-            },
-            {
-              "lib": "regle-rules",
-              "median": 1.5,
-              "p95": 4.204999935626983,
-              "iqr": 1.9000000059604645,
+              "median": 1.899999976158142,
+              "p95": 3.399999976158142,
+              "iqr": 1.5999999046325684,
               "count": 100,
               "trimmed": 0,
               "unit": "ms",
               "supported": true,
-              "ratio": 5,
-              "slope": 2.5
+              "ratio": 4.75,
+              "slope": 19
             },
             {
-              "lib": "formkit",
-              "median": 7.299999952316284,
-              "p95": 9.89999998807907,
-              "iqr": 1.5999999344348907,
+              "lib": "formisch",
+              "median": 0.19999992847442627,
+              "p95": 0.40000009536743164,
+              "iqr": 0.19999992847442627,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 24.33,
-              "slope": 4.56
+              "ratio": 0.5,
+              "slope": 2
+            },
+            {
+              "lib": "regle-schema",
+              "median": 1.399999976158142,
+              "p95": 3,
+              "iqr": 0.6999999582767487,
+              "count": 93,
+              "trimmed": 7,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 3.5,
+              "slope": 3.5
+            },
+            {
+              "lib": "regle-rules",
+              "median": 2.100000023841858,
+              "p95": 2.7999999642372133,
+              "iqr": 0.7000000476837158,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 5.25,
+              "slope": 2.63
+            },
+            {
+              "lib": "formkit",
+              "median": 6.700000047683716,
+              "p95": 9.12000000476837,
+              "iqr": 1.4249999821186066,
+              "count": 97,
+              "trimmed": 3,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 16.75,
+              "slope": 4.79
             },
             {
               "lib": "vuelidate",
@@ -4187,7 +4228,7 @@
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.33,
+              "ratio": 0.25,
               "slope": 1
             }
           ]
@@ -4401,10 +4442,10 @@
             {
               "lib": "attaform",
               "median": 1.5,
-              "p95": 2.289999949932098,
-              "iqr": 0.5000000894069672,
-              "count": 43,
-              "trimmed": 7,
+              "p95": 2.200000011920929,
+              "iqr": 0.5750000178813934,
+              "count": 47,
+              "trimmed": 3,
               "unit": "ms",
               "supported": true,
               "ratio": 1,
@@ -4412,185 +4453,185 @@
             },
             {
               "lib": "vee-validate",
-              "median": 1.100000023841858,
-              "p95": 2.460000038146972,
-              "iqr": 1.2999999523162842,
-              "count": 49,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.73,
-              "slope": 1
-            },
-            {
-              "lib": "tanstack",
-              "median": 0.6000000238418579,
-              "p95": 0.715000033378601,
-              "iqr": 0.2749999761581421,
-              "count": 38,
-              "trimmed": 12,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.4,
-              "slope": 1
-            },
-            {
-              "lib": "formisch",
-              "median": 0.8000000715255737,
-              "p95": 1.599999976158142,
-              "iqr": 0.9499999284744263,
-              "count": 49,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.53,
-              "slope": 1
-            },
-            {
-              "lib": "regle-schema",
-              "median": 1.100000023841858,
-              "p95": 1.3599999666213984,
-              "iqr": 0.30000007152557373,
-              "count": 49,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.73,
-              "slope": 1
-            },
-            {
-              "lib": "regle-rules",
-              "median": 1,
-              "p95": 2.2,
-              "iqr": 1.0499999523162842,
-              "count": 49,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.67,
-              "slope": 1
-            },
-            {
-              "lib": "formkit",
-              "median": 2.399999976158142,
-              "p95": 3.0599999427795406,
-              "iqr": 0.5000000894069672,
-              "count": 49,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1.6,
-              "slope": 1
-            },
-            {
-              "lib": "vuelidate",
-              "median": 1.1999999284744263,
-              "p95": 2.300000023841858,
-              "iqr": 1.3000000417232513,
+              "median": 1.2000000476837158,
+              "p95": 3.360000038146972,
+              "iqr": 0.9750000238418579,
               "count": 49,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
               "ratio": 0.8,
               "slope": 1
-            }
-          ],
-          "N100": [
-            {
-              "lib": "attaform",
-              "median": 15.200000047683716,
-              "p95": 17.17999995946884,
-              "iqr": 1.0499999225139618,
-              "count": 47,
-              "trimmed": 3,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1,
-              "slope": 10.13
-            },
-            {
-              "lib": "vee-validate",
-              "median": 4.399999976158142,
-              "p95": 5,
-              "iqr": 0.7749999463558197,
-              "count": 49,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.29,
-              "slope": 4
             },
             {
               "lib": "tanstack",
-              "median": 2,
-              "p95": 2.459999990463256,
-              "iqr": 0.39999985694885254,
+              "median": 0.6999999284744263,
+              "p95": 1.2999999523162842,
+              "iqr": 0.5,
+              "count": 46,
+              "trimmed": 4,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.47,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.5,
+              "p95": 1.5,
+              "iqr": 0.7749999761581421,
               "count": 49,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.13,
-              "slope": 3.33
-            },
-            {
-              "lib": "formisch",
-              "median": 0.8000000715255737,
-              "p95": 1.5700000166893,
-              "iqr": 0.39999985694885254,
-              "count": 47,
-              "trimmed": 3,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.05,
+              "ratio": 0.33,
               "slope": 1
             },
             {
               "lib": "regle-schema",
-              "median": 4.899999976158142,
-              "p95": 5.5,
-              "iqr": 0.3749999701976776,
+              "median": 1.100000023841858,
+              "p95": 2.8600000143051143,
+              "iqr": 0.974999874830246,
               "count": 49,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.32,
-              "slope": 4.45
+              "ratio": 0.73,
+              "slope": 1
             },
             {
               "lib": "regle-rules",
-              "median": 4.700000047683716,
-              "p95": 5.359999966621398,
+              "median": 0.8999999761581421,
+              "p95": 2.300000023841858,
+              "iqr": 0.6000000238418579,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.6,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 2.100000023841858,
+              "p95": 2.800000023841858,
               "iqr": 0.40000006556510925,
               "count": 49,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.31,
-              "slope": 4.7
-            },
-            {
-              "lib": "formkit",
-              "median": 4.300000071525574,
-              "p95": 5.665000039339065,
-              "iqr": 1.0749999284744263,
-              "count": 48,
-              "trimmed": 2,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.28,
-              "slope": 1.79
+              "ratio": 1.4,
+              "slope": 1
             },
             {
               "lib": "vuelidate",
-              "median": 1.7999999523162842,
-              "p95": 2.1599999666213985,
-              "iqr": 0.5,
+              "median": 0.7000000476837158,
+              "p95": 1.8200000047683704,
+              "iqr": 0.8749999701976776,
               "count": 49,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.12,
-              "slope": 1.5
+              "ratio": 0.47,
+              "slope": 1
+            }
+          ],
+          "N100": [
+            {
+              "lib": "attaform",
+              "median": 15.100000023841858,
+              "p95": 18.25499999523163,
+              "iqr": 1.3000000715255737,
+              "count": 50,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1,
+              "slope": 10.07
+            },
+            {
+              "lib": "vee-validate",
+              "median": 4.200000047683716,
+              "p95": 5.320000004768371,
+              "iqr": 0.4750000238418579,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.28,
+              "slope": 3.5
+            },
+            {
+              "lib": "tanstack",
+              "median": 2,
+              "p95": 2.2599999904632564,
+              "iqr": 0.29999983310699463,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.13,
+              "slope": 2.86
+            },
+            {
+              "lib": "formisch",
+              "median": 0.6999999284744263,
+              "p95": 0.9000000596046448,
+              "iqr": 0.19999992847442627,
+              "count": 47,
+              "trimmed": 3,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.05,
+              "slope": 1.4
+            },
+            {
+              "lib": "regle-schema",
+              "median": 4.799999952316284,
+              "p95": 5.700000005960464,
+              "iqr": 0.30000007152557373,
+              "count": 48,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.32,
+              "slope": 4.36
+            },
+            {
+              "lib": "regle-rules",
+              "median": 4.5,
+              "p95": 5.064999938011169,
+              "iqr": 0.30000007152557373,
+              "count": 48,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.3,
+              "slope": 5
+            },
+            {
+              "lib": "formkit",
+              "median": 4.200000047683716,
+              "p95": 5.819999957084654,
+              "iqr": 0.8999999761581421,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.28,
+              "slope": 2
+            },
+            {
+              "lib": "vuelidate",
+              "median": 1.7000000476837158,
+              "p95": 2.100000023841858,
+              "iqr": 0.3999999761581421,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.11,
+              "slope": 2.43
             }
           ]
         }
@@ -4601,11 +4642,11 @@
           "N10": [
             {
               "lib": "attaform",
-              "median": 1,
-              "p95": 1.600000023841858,
-              "iqr": 0.30000007152557373,
-              "count": 49,
-              "trimmed": 1,
+              "median": 1.100000023841858,
+              "p95": 1.8749999701976776,
+              "iqr": 0.5,
+              "count": 46,
+              "trimmed": 4,
               "unit": "ms",
               "supported": true,
               "ratio": 1,
@@ -4613,185 +4654,185 @@
             },
             {
               "lib": "vee-validate",
-              "median": 0.8000000715255737,
-              "p95": 1.8599999666213984,
-              "iqr": 0.7000000476837158,
-              "count": 49,
-              "trimmed": 1,
+              "median": 0.6000000238418579,
+              "p95": 1.080000019073486,
+              "iqr": 0.30000007152557373,
+              "count": 43,
+              "trimmed": 7,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.8,
+              "ratio": 0.55,
               "slope": 1
             },
             {
               "lib": "tanstack",
-              "median": 0.3500000238418579,
-              "p95": 0.6850000441074373,
-              "iqr": 0.20000004768371582,
-              "count": 44,
-              "trimmed": 6,
+              "median": 0.3999999761581421,
+              "p95": 1.3800000190734847,
+              "iqr": 0.6000000238418579,
+              "count": 49,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.35,
+              "ratio": 0.36,
               "slope": 1
             },
             {
               "lib": "formisch",
-              "median": 0.3999999761581421,
-              "p95": 0.8599999904632563,
-              "iqr": 0.20000004768371582,
-              "count": 45,
-              "trimmed": 5,
+              "median": 0.7000000476837158,
+              "p95": 1.5599999427795403,
+              "iqr": 0.9000000953674316,
+              "count": 49,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.4,
+              "ratio": 0.64,
               "slope": 1
             },
             {
               "lib": "regle-schema",
-              "median": 0.5999999046325684,
-              "p95": 1.3599999904632563,
-              "iqr": 0.375,
-              "count": 45,
-              "trimmed": 5,
+              "median": 0.6000000238418579,
+              "p95": 2,
+              "iqr": 1.0249999463558197,
+              "count": 49,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.6,
+              "ratio": 0.55,
               "slope": 1
             },
             {
               "lib": "regle-rules",
               "median": 0.5,
-              "p95": 1.599999976158142,
-              "iqr": 0.8000000417232513,
+              "p95": 1.899999976158142,
+              "iqr": 0.7499999403953552,
               "count": 49,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.5,
+              "ratio": 0.45,
               "slope": 1
             },
             {
               "lib": "formkit",
-              "median": 0.7000000476837158,
-              "p95": 2.060000014305114,
-              "iqr": 0.8749999701976776,
-              "count": 49,
-              "trimmed": 1,
+              "median": 0.6999999284744263,
+              "p95": 1.080000019073486,
+              "iqr": 0.375,
+              "count": 45,
+              "trimmed": 5,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.7,
+              "ratio": 0.64,
               "slope": 1
             },
             {
               "lib": "vuelidate",
               "median": 0.5,
-              "p95": 1.399999976158142,
-              "iqr": 0.8499999046325684,
+              "p95": 1.360000014305114,
+              "iqr": 0.4999999701976776,
               "count": 49,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.5,
+              "ratio": 0.45,
               "slope": 1
             }
           ],
           "N100": [
             {
               "lib": "attaform",
-              "median": 7.799999952316284,
-              "p95": 9.120000028610228,
-              "iqr": 0.5750000178813934,
-              "count": 49,
-              "trimmed": 1,
+              "median": 7.649999976158142,
+              "p95": 9.010000056028366,
+              "iqr": 0.7000000178813934,
+              "count": 50,
+              "trimmed": 0,
               "unit": "ms",
               "supported": true,
               "ratio": 1,
-              "slope": 7.8
+              "slope": 6.95
             },
             {
               "lib": "vee-validate",
-              "median": 2.299999952316284,
-              "p95": 2.5,
-              "iqr": 0.20000004768371582,
+              "median": 2.5,
+              "p95": 2.7599999904632564,
+              "iqr": 0.375,
               "count": 49,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.29,
-              "slope": 2.87
+              "ratio": 0.33,
+              "slope": 4.17
             },
             {
               "lib": "tanstack",
-              "median": 1.5,
-              "p95": 2.100000023841858,
-              "iqr": 0.5,
+              "median": 1.600000023841858,
+              "p95": 1.9599999904632563,
+              "iqr": 0.30000007152557373,
               "count": 49,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.19,
-              "slope": 4.29
+              "ratio": 0.21,
+              "slope": 4
             },
             {
               "lib": "formisch",
-              "median": 0.8999999761581421,
-              "p95": 1.8599999785423273,
-              "iqr": 0.40000003576278687,
-              "count": 43,
-              "trimmed": 7,
+              "median": 0.7000000476837158,
+              "p95": 1.5749999284744263,
+              "iqr": 0.5,
+              "count": 46,
+              "trimmed": 4,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.12,
-              "slope": 2.25
+              "ratio": 0.09,
+              "slope": 1
             },
             {
               "lib": "regle-schema",
-              "median": 3.1999999284744263,
-              "p95": 3.5599999427795406,
-              "iqr": 0.375,
+              "median": 3.0999999046325684,
+              "p95": 3.460000038146972,
+              "iqr": 0.5750000476837158,
               "count": 49,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
               "ratio": 0.41,
-              "slope": 5.33
+              "slope": 5.17
             },
             {
               "lib": "regle-rules",
-              "median": 2.899999976158142,
-              "p95": 3.100000023841858,
-              "iqr": 0.27500006556510925,
+              "median": 3,
+              "p95": 3.399999976158142,
+              "iqr": 0.3999999761581421,
+              "count": 50,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.39,
+              "slope": 6
+            },
+            {
+              "lib": "formkit",
+              "median": 2.1999999284744263,
+              "p95": 2.6599999666213985,
+              "iqr": 0.5,
               "count": 49,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.37,
-              "slope": 5.8
-            },
-            {
-              "lib": "formkit",
-              "median": 2.450000047683716,
-              "p95": 3.100000023841858,
-              "iqr": 0.30000007152557373,
-              "count": 48,
-              "trimmed": 2,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.31,
-              "slope": 3.5
+              "ratio": 0.29,
+              "slope": 3.14
             },
             {
               "lib": "vuelidate",
-              "median": 1,
-              "p95": 1.5300000488758085,
-              "iqr": 0.375,
+              "median": 1.2000000476837158,
+              "p95": 1.764999985694885,
+              "iqr": 0.5,
               "count": 48,
               "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.13,
-              "slope": 2
+              "ratio": 0.16,
+              "slope": 2.4
             }
           ]
         }
@@ -4804,30 +4845,30 @@
               "lib": "attaform",
               "retained": {
                 "median": 174020,
-                "p95": 360940,
+                "p95": 361124,
                 "count": 12
               },
               "churn": {
-                "median": 915960,
-                "p95": 1633096,
+                "median": 849824,
+                "p95": 1619592,
                 "count": 12
               },
               "leak": {
-                "median": 26244,
+                "median": 26196,
                 "p95": 211964,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  958716, 198636, 174296, 188412, 173772, 178744, 156052, 172416, 360940, 157476,
+                  958588, 198540, 174296, 188412, 173772, 178744, 156052, 172416, 361124, 157476,
                   174020, 154520
                 ],
                 "churn": [
-                  1982380, 915960, 1595904, 873884, 1558292, 826272, 1536192, 832096, 1633096,
-                  780632, 1532460, 829564
+                  2060136, 823760, 1534348, 849824, 1619592, 799124, 1580428, 814972, 1559344,
+                  801360, 1541844, 803176
                 ],
                 "leak": [
-                  1146896, 66696, 36540, 70264, 28180, 18688, 10412, 25844, 211964, 5276, 26244, 0
+                  1146576, 66600, 36540, 70264, 28180, 18688, 10412, 25844, 211964, 5276, 26196, 0
                 ]
               },
               "supported": true,
@@ -4837,35 +4878,35 @@
             {
               "lib": "vee-validate",
               "retained": {
-                "median": 173956,
-                "p95": 212084,
+                "median": 196756,
+                "p95": 348424,
                 "count": 12
               },
               "churn": {
-                "median": 708428,
-                "p95": 759228,
+                "median": 706112,
+                "p95": 741136,
                 "count": 12
               },
               "leak": {
-                "median": 32028,
-                "p95": 83272,
+                "median": 29692,
+                "p95": 83012,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  707260, 176536, 203572, 173956, 210068, 155812, 156648, 164376, 212084, 196576,
-                  166616, 160836
+                  707100, 176488, 166032, 211148, 210068, 190460, 161276, 348424, 212036, 196756,
+                  201264, 195484
                 ],
                 "churn": [
-                  816088, 712164, 723516, 759228, 704644, 707508, 697436, 708428, 741716, 714548,
-                  706172, 700260
+                  816056, 712164, 728188, 722036, 704748, 706112, 697436, 517232, 741136, 713824,
+                  704716, 694608
                 ],
                 "leak": [
-                  685264, 46588, 40216, 32028, 80608, 17096, 4480, 12300, 83272, 5920, 63472, 10360
+                  685096, 46564, 40184, 32028, 22504, 17096, 4852, 67388, 83012, 5812, 29692, 6188
                 ]
               },
               "supported": true,
-              "ratio": 1,
+              "ratio": 1.13,
               "slope": 1
             },
             {
@@ -4876,27 +4917,27 @@
                 "count": 12
               },
               "churn": {
-                "median": 426908,
-                "p95": 793156,
+                "median": 431024,
+                "p95": 787272,
                 "count": 12
               },
               "leak": {
-                "median": 43352,
-                "p95": 77136,
+                "median": 42492,
+                "p95": 79232,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  589808, 151764, 135028, 131084, 151696, 137136, 128964, 147788, 180252, 135968,
-                  138536, 142076
+                  589808, 151764, 133000, 131084, 145524, 136696, 128964, 147788, 180252, 135968,
+                  138536, 140548
                 ],
                 "churn": [
-                  793156, 481820, 1270044, 478372, 450972, 464976, 410788, 413392, 422180, 413860,
-                  426908, 396488
+                  787272, 483212, 1271080, 474152, 457336, 465044, 406464, 410260, 423608, 411416,
+                  431024, 398496
                 ],
                 "leak": [
-                  815612, 56840, 47104, 53708, 41124, 43352, 28300, 47196, 77136, 18696, 35632,
-                  21484
+                  815612, 56832, 45120, 53620, 39324, 42492, 28240, 44480, 79232, 18544, 33316,
+                  20068
                 ]
               },
               "supported": true,
@@ -4906,7 +4947,7 @@
             {
               "lib": "formisch",
               "retained": {
-                "median": 85584,
+                "median": 85344,
                 "p95": 116732,
                 "count": 12
               },
@@ -4916,20 +4957,20 @@
                 "count": 12
               },
               "leak": {
-                "median": 9744,
+                "median": 9684,
                 "p95": 44996,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  375564, 88648, 84824, 77224, 83284, 88944, 85584, 89044, 116732, 84300, 87112,
-                  81900
+                  375648, 88668, 84728, 77244, 83204, 89208, 85344, 88988, 116732, 84360, 87108,
+                  81944
                 ],
                 "churn": [
                   463732, 326136, 324756, 331352, 325596, 328992, 328640, 330216, 338144, 336868,
                   329088, 322772
                 ],
-                "leak": [438408, 14908, 9744, 5120, 9056, 20072, 5024, 12320, 44996, 4776, 10792, 0]
+                "leak": [438408, 14908, 9684, 5120, 9056, 20336, 4796, 12320, 44996, 4776, 10792, 0]
               },
               "supported": true,
               "ratio": 0.49,
@@ -4938,13 +4979,13 @@
             {
               "lib": "regle-schema",
               "retained": {
-                "median": 343284,
-                "p95": 435228,
+                "median": 343276,
+                "p95": 435236,
                 "count": 12
               },
               "churn": {
-                "median": 675960,
-                "p95": 1425648,
+                "median": 675828,
+                "p95": 1461100,
                 "count": 12
               },
               "leak": {
@@ -4954,15 +4995,15 @@
               },
               "series": {
                 "retained": [
-                  983564, 407328, 357968, 342012, 344484, 336292, 343284, 340168, 435228, 338180,
-                  351928, 332964
+                  983392, 359760, 405584, 341988, 344488, 336288, 343276, 340176, 435236, 338176,
+                  351956, 332940
                 ],
                 "churn": [
-                  1815876, 727028, 700616, 675960, 635380, 1425648, 637740, 632156, 694996, 655892,
-                  1419732, 625100
+                  1839836, 785288, 700616, 675828, 633096, 1461100, 655604, 652104, 694996, 674292,
+                  1396956, 646004
                 ],
                 "leak": [
-                  810588, 66108, 18804, 14944, 10604, 17440, 5764, 15544, 123916, 1356, 24492, 3360
+                  810588, 18492, 66420, 14944, 10604, 17440, 5764, 15544, 123916, 1356, 24492, 3360
                 ]
               },
               "supported": true,
@@ -4972,68 +5013,68 @@
             {
               "lib": "regle-rules",
               "retained": {
-                "median": 375048,
-                "p95": 455712,
+                "median": 370300,
+                "p95": 520216,
                 "count": 12
               },
               "churn": {
-                "median": 626828,
-                "p95": 641096,
+                "median": 624148,
+                "p95": 647256,
                 "count": 12
               },
               "leak": {
-                "median": 16728,
-                "p95": 122892,
+                "median": 16668,
+                "p95": 187488,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  1032176, 380544, 379720, 355288, 375048, 424176, 370336, 357084, 455712, 363468,
-                  376920, 350332
+                  984576, 431620, 379736, 355384, 374992, 359680, 370300, 357068, 520216, 363468,
+                  376924, 350340
                 ],
                 "churn": [
-                  743560, 626828, 594076, 631388, 608224, 629832, 610656, 638520, 626836, 641096,
-                  602980, 618004
+                  742736, 626128, 595308, 634324, 615832, 624148, 591456, 633212, 626084, 647256,
+                  601064, 611044
                 ],
-                "leak": [801664, 8560, 27344, 0, 35040, 75128, 16728, 60, 122892, 2396, 31080, 0]
+                "leak": [754048, 59568, 27320, 0, 34980, 10688, 16668, 60, 187488, 2396, 31116, 0]
               },
               "supported": true,
-              "ratio": 2.16,
+              "ratio": 2.13,
               "slope": 1
             },
             {
               "lib": "formkit",
               "retained": {
-                "median": 3084348,
-                "p95": 3143928,
+                "median": 3082200,
+                "p95": 3144196,
                 "count": 12
               },
               "churn": {
-                "median": 632836,
-                "p95": 834980,
+                "median": 633088,
+                "p95": 839104,
                 "count": 12
               },
               "leak": {
-                "median": 64224,
-                "p95": 206336,
+                "median": 59388,
+                "p95": 206396,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  4143084, 3143928, 3084348, 3091760, 3055876, 3039816, 3134568, 3025648, 3086228,
-                  3089560, 3032124, 3047664
+                  4142996, 3144196, 3084360, 3087804, 3055876, 3042956, 3138376, 3025692, 3082200,
+                  3102316, 3032188, 3054100
                 ],
                 "churn": [
-                  844432, 834980, 665220, 672052, 628940, 641136, 614940, 632836, 624908, 634360,
-                  617520, 628820
+                  844872, 839104, 667748, 674748, 635112, 641868, 613444, 633088, 625392, 616916,
+                  616308, 616036
                 ],
                 "leak": [
-                  1999444, 206336, 82760, 64224, 58656, 50492, 106468, 15052, 90080, 78284, 21848,
+                  1999384, 206396, 82308, 59388, 58368, 51160, 111376, 15052, 89996, 78368, 21848,
                   49000
                 ]
               },
               "supported": true,
-              "ratio": 17.72,
+              "ratio": 17.71,
               "slope": 1
             },
             {
@@ -5075,13 +5116,13 @@
             {
               "lib": "attaform",
               "retained": {
-                "median": 2682120,
-                "p95": 2864372,
+                "median": 2681360,
+                "p95": 2859392,
                 "count": 12
               },
               "churn": {
-                "median": 1774992,
-                "p95": 2215848,
+                "median": 1772620,
+                "p95": 2184840,
                 "count": 12
               },
               "leak": {
@@ -5091,15 +5132,15 @@
               },
               "series": {
                 "retained": [
-                  3619624, 2697584, 2730984, 2705016, 2718260, 2657448, 2673552, 2635352, 2864372,
-                  2635608, 2682120, 2633632
+                  3621856, 2697696, 2731800, 2704064, 2719100, 2657680, 2673592, 2635600, 2859392,
+                  2635684, 2681360, 2634664
                 ],
                 "churn": [
-                  2503848, 1774992, 1513856, 1876148, 2215848, 1696068, 1090548, 2165960, 1822680,
-                  1676000, 754708, 1799964
+                  1005008, 1772620, 741836, 1479484, 1823884, 1690496, 1840144, 2186640, 1832792,
+                  1679984, 1872720, 2184840
                 ],
                 "leak": [
-                  1237772, 64744, 80092, 100528, 44248, 23376, 15700, 17716, 209744, 0, 26628, 17328
+                  1237708, 64864, 80068, 100528, 44248, 23376, 15700, 17716, 209744, 0, 26628, 17328
                 ]
               },
               "supported": true,
@@ -5109,132 +5150,131 @@
             {
               "lib": "vee-validate",
               "retained": {
-                "median": 1471588,
-                "p95": 1516624,
+                "median": 1470832,
+                "p95": 1516684,
                 "count": 12
               },
               "churn": {
-                "median": 983160,
-                "p95": 1006668,
+                "median": 973412,
+                "p95": 999796,
                 "count": 12
               },
               "leak": {
-                "median": 23028,
-                "p95": 293616,
+                "median": 19896,
+                "p95": 61788,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  2082816, 1482852, 1485484, 1471588, 1507096, 1507632, 1459848, 1469180, 1516624,
-                  1468068, 1466112, 1463556
+                  2090420, 1482896, 1485244, 1470832, 1511476, 1507280, 1462520, 1469160, 1516684,
+                  1468000, 1466008, 1470608
                 ],
                 "churn": [
-                  1114940, 1006668, 997504, 987672, 974420, 969464, 983160, 972344, 1003376, 970672,
-                  985220, 977772
+                  1114748, 999796, 991200, 982976, 967832, 963384, 973412, 966644, 997260, 964576,
+                  980152, 964788
                 ],
                 "leak": [
-                  782604, 293616, 51956, 21088, 35784, 23028, 1104, 18332, 55300, 215116, 12700,
-                  8924
+                  782568, 61788, 51836, 19896, 36112, 42344, 2504, 0, 56156, 10128, 11628, 6008
                 ]
               },
               "supported": true,
               "ratio": 0.55,
-              "slope": 8.46
+              "slope": 7.48
             },
             {
               "lib": "tanstack",
               "retained": {
-                "median": 1161228,
-                "p95": 1192524,
+                "median": 1167892,
+                "p95": 1192492,
                 "count": 12
               },
               "churn": {
-                "median": 767324,
-                "p95": 818560,
+                "median": 779740,
+                "p95": 1748128,
                 "count": 12
               },
               "leak": {
-                "median": 77000,
-                "p95": 141060,
+                "median": 84056,
+                "p95": 133496,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  1756612, 1185940, 1169364, 1161228, 1170868, 1167856, 1155892, 1156912, 1192524,
-                  1158384, 1154724, 1160624
+                  1756580, 1187708, 1169284, 1168676, 1170844, 1167892, 1156640, 1157464, 1192492,
+                  1158080, 1154692, 1161072
                 ],
                 "churn": [
-                  836544, 818560, 563032, 806372, 491052, 809100, 462264, 767324, 502020, 773728,
-                  199952, 782216
+                  837616, 799440, 1792980, 806676, 491048, 810232, 495884, 768096, 1748128, 774236,
+                  199960, 779740
                 ],
                 "leak": [
-                  936616, 125420, 141060, 77000, 83892, 88496, 56676, 58916, 108096, 56300, 74968,
-                  64392
+                  936616, 127440, 133496, 84088, 84056, 88532, 56672, 58304, 108092, 55272, 74044,
+                  63284
                 ]
               },
               "supported": true,
-              "ratio": 0.43,
-              "slope": 8.38
+              "ratio": 0.44,
+              "slope": 8.43
             },
             {
               "lib": "formisch",
               "retained": {
-                "median": 626964,
-                "p95": 655516,
+                "median": 626332,
+                "p95": 652328,
                 "count": 12
               },
               "churn": {
-                "median": 301500,
-                "p95": 1004688,
+                "median": 303668,
+                "p95": 1003928,
                 "count": 12
               },
               "leak": {
-                "median": 12028,
-                "p95": 41252,
+                "median": 12864,
+                "p95": 41848,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  952560, 635616, 643592, 625460, 643520, 653816, 623796, 626964, 655516, 624412,
-                  626696, 622144
+                  952612, 639524, 647336, 626332, 640120, 650120, 619984, 623552, 652328, 620992,
+                  622380, 618608
                 ],
                 "churn": [
-                  301500, 1007232, 215092, 995172, 181180, 944420, 214780, 941496, 193372, 1004688,
-                  216328, 987268
+                  303668, 1008692, 217764, 993588, 180940, 942400, 212348, 940504, 195988, 1003928,
+                  217780, 988132
                 ],
-                "leak": [459464, 24900, 36900, 12028, 20656, 34676, 0, 5048, 41252, 1588, 9472, 796]
+                "leak": [459280, 24924, 37024, 12864, 20644, 34520, 0, 5048, 41848, 1588, 8876, 796]
               },
               "supported": true,
               "ratio": 0.23,
-              "slope": 7.33
+              "slope": 7.34
             },
             {
               "lib": "regle-schema",
               "retained": {
-                "median": 2752096,
-                "p95": 2830948,
+                "median": 2751992,
+                "p95": 2830980,
                 "count": 12
               },
               "churn": {
-                "median": 860716,
-                "p95": 882480,
+                "median": 858796,
+                "p95": 879116,
                 "count": 12
               },
               "leak": {
                 "median": 25160,
-                "p95": 111880,
+                "p95": 111860,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  3597456, 2766740, 2774948, 2740744, 2769056, 2768508, 2733964, 2737540, 2830948,
-                  2733632, 2752096, 2725504
+                  3597672, 2766876, 2774628, 2740768, 2768716, 2768428, 2733736, 2737556, 2830980,
+                  2733580, 2751992, 2725548
                 ],
                 "churn": [
-                  2176704, 832636, 877988, 865044, 860716, 844912, 862816, 818904, 882480, 828320,
-                  861348, 839092
+                  2181876, 826200, 879116, 858796, 861988, 844828, 866452, 817516, 874484, 835292,
+                  859640, 841060
                 ],
-                "leak": [990200, 37960, 41068, 25160, 47272, 32500, 0, 7264, 111880, 3672, 20340, 0]
+                "leak": [990032, 37984, 41068, 25160, 47272, 32520, 0, 7300, 111860, 3648, 20340, 0]
               },
               "supported": true,
               "ratio": 1.03,
@@ -5243,65 +5283,65 @@
             {
               "lib": "regle-rules",
               "retained": {
-                "median": 3176216,
-                "p95": 3255092,
+                "median": 3180776,
+                "p95": 3253984,
                 "count": 12
               },
               "churn": {
-                "median": 447548,
-                "p95": 528256,
+                "median": 444356,
+                "p95": 521660,
                 "count": 12
               },
               "leak": {
                 "median": 23504,
-                "p95": 95800,
+                "p95": 94432,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  4007908, 3183788, 3201296, 3176216, 3189968, 3212616, 3157192, 3167560, 3255092,
-                  3164688, 3175040, 3169236
+                  4008124, 3186624, 3200184, 3180776, 3191864, 3212012, 3152868, 3167288, 3253984,
+                  3162152, 3177336, 3172884
                 ],
                 "churn": [
-                  528256, 576352, 447548, 449920, 466920, 423248, 436880, 449820, 459816, 429184,
-                  442484, 429112
+                  521660, 589040, 433484, 451860, 453444, 424912, 452996, 433272, 444356, 428976,
+                  446424, 433072
                 ],
                 "leak": [
-                  938584, 24188, 59980, 23504, 46408, 34380, 1264, 15468, 95800, 14704, 15060, 0
+                  938744, 24188, 58564, 23504, 47780, 35616, 1284, 15276, 94432, 14344, 15048, 0
                 ]
               },
               "supported": true,
-              "ratio": 1.18,
-              "slope": 8.47
+              "ratio": 1.19,
+              "slope": 8.59
             },
             {
               "lib": "formkit",
               "retained": {
-                "median": 19084648,
-                "p95": 19426024,
+                "median": 19084512,
+                "p95": 19426312,
                 "count": 12
               },
               "churn": {
-                "median": 884948,
-                "p95": 970400,
+                "median": 890628,
+                "p95": 969364,
                 "count": 12
               },
               "leak": {
-                "median": 51900,
-                "p95": 414352,
+                "median": 52216,
+                "p95": 414612,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  27471824, 19426024, 19269756, 19099916, 19069156, 19093016, 19061956, 19084648,
-                  18993332, 19091120, 19038724, 19065712
+                  27475352, 19426312, 19262116, 19106128, 19075940, 19086952, 19063356, 19084512,
+                  18995056, 19095968, 19042276, 19067876
                 ],
                 "churn": [
-                  1154364, 970400, 910592, 906696, 878824, 894964, 880148, 883768, 894184, 884948,
-                  882628, 882748
+                  1153572, 969364, 909328, 898212, 883016, 892784, 883340, 885524, 891380, 886280,
+                  879524, 890628
                 ],
                 "leak": [
-                  8562580, 414352, 225408, 44092, 54668, 72416, 17188, 53616, 0, 49984, 22012, 51900
+                  8562344, 414612, 225312, 44180, 54580, 72440, 17484, 53240, 0, 50284, 21712, 52216
                 ]
               },
               "supported": true,
@@ -5311,31 +5351,31 @@
             {
               "lib": "vuelidate",
               "retained": {
-                "median": 401752,
+                "median": 402184,
                 "p95": 451264,
                 "count": 12
               },
               "churn": {
-                "median": 1609996,
-                "p95": 1768656,
+                "median": 1763284,
+                "p95": 1784972,
                 "count": 12
               },
               "leak": {
-                "median": 25876,
-                "p95": 68088,
+                "median": 25912,
+                "p95": 67764,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  754860, 399792, 408696, 405464, 436008, 415612, 395476, 388440, 451264, 401752,
+                  754860, 399792, 408696, 405464, 436008, 411492, 395476, 392120, 451264, 402184,
                   399804, 383264
                 ],
                 "churn": [
-                  1382640, 1609996, 1778332, 1302120, 1763084, 1599500, 1282748, 1766748, 1768656,
-                  1437776, 1631188, 1763188
+                  1352112, 1776564, 1784972, 1302192, 1763832, 1758068, 1279244, 1770664, 1776536,
+                  1426756, 1795428, 1763284
                 ],
                 "leak": [
-                  457472, 20044, 33208, 33340, 49296, 29248, 6052, 9392, 68088, 8768, 25876, 2688
+                  457484, 20044, 33208, 33340, 49296, 29104, 6088, 9392, 67764, 9164, 25912, 2688
                 ]
               },
               "supported": true,
@@ -5353,11 +5393,11 @@
           "N20M8": [
             {
               "lib": "attaform",
-              "median": 1.9000000953674316,
-              "p95": 4.050000011920929,
-              "iqr": 0.8250000476837158,
-              "count": 191,
-              "trimmed": 9,
+              "median": 1.7000000476837158,
+              "p95": 3,
+              "iqr": 0.7999998331069946,
+              "count": 195,
+              "trimmed": 5,
               "unit": "ms",
               "supported": true,
               "ratio": 1,
@@ -5365,11 +5405,11 @@
             },
             {
               "lib": "vee-validate",
-              "median": 1,
-              "p95": 1.899999976158142,
-              "iqr": 0.5,
-              "count": 188,
-              "trimmed": 12,
+              "median": 0.9000000953674316,
+              "p95": 1.5999999046325684,
+              "iqr": 0.40000009536743164,
+              "count": 192,
+              "trimmed": 8,
               "unit": "ms",
               "supported": true,
               "ratio": 0.53,
@@ -5377,74 +5417,74 @@
             },
             {
               "lib": "tanstack",
-              "median": 2.549999952316284,
-              "p95": 3.100000023841858,
-              "iqr": 1.600000023841858,
-              "count": 200,
-              "trimmed": 0,
+              "median": 1.7000000476837158,
+              "p95": 3,
+              "iqr": 0.7000000476837158,
+              "count": 196,
+              "trimmed": 4,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.34,
+              "ratio": 1,
               "slope": 1
             },
             {
               "lib": "formisch",
-              "median": 1.3000000715255737,
-              "p95": 2.0999999165534975,
-              "iqr": 0.8999999761581421,
+              "median": 1.2999999523162842,
+              "p95": 2.5,
+              "iqr": 1,
               "count": 199,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.68,
+              "ratio": 0.76,
               "slope": 1
             },
             {
               "lib": "regle-schema",
-              "median": 2.299999952316284,
-              "p95": 2.899999976158142,
-              "iqr": 1.399999976158142,
-              "count": 200,
-              "trimmed": 0,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1.21,
-              "slope": 1
-            },
-            {
-              "lib": "regle-rules",
-              "median": 1.8000000715255737,
-              "p95": 2.7300000190734846,
-              "iqr": 0.4249999523162842,
-              "count": 195,
-              "trimmed": 5,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.95,
-              "slope": 1
-            },
-            {
-              "lib": "formkit",
-              "median": 2,
-              "p95": 2.700000047683716,
-              "iqr": 0.5,
-              "count": 198,
-              "trimmed": 2,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1.05,
-              "slope": 1
-            },
-            {
-              "lib": "vuelidate",
-              "median": 1.7000000476837158,
-              "p95": 2.31000006198883,
-              "iqr": 0.5,
+              "median": 1.5,
+              "p95": 3.6100000143051143,
+              "iqr": 1.1999999284744263,
               "count": 199,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.89,
+              "ratio": 0.88,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 1.399999976158142,
+              "p95": 2.710000038146972,
+              "iqr": 0.8000000715255737,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.82,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 1.2999999523162842,
+              "p95": 3.100000023841858,
+              "iqr": 1.100000023841858,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.76,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.8999999761581421,
+              "p95": 1.4000000178813934,
+              "iqr": 0.30000007152557373,
+              "count": 174,
+              "trimmed": 26,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.53,
               "slope": 1
             }
           ],
@@ -5452,98 +5492,98 @@
             {
               "lib": "attaform",
               "median": 4,
-              "p95": 4.699999928474426,
-              "iqr": 0.40000009536743164,
-              "count": 199,
-              "trimmed": 1,
+              "p95": 4.505000001192091,
+              "iqr": 0.3999999761581421,
+              "count": 200,
+              "trimmed": 0,
               "unit": "ms",
               "supported": true,
               "ratio": 1,
-              "slope": 2.11
+              "slope": 2.35
             },
             {
               "lib": "vee-validate",
               "median": 2.1999999284744263,
               "p95": 2.5,
-              "iqr": 0.20000004768371582,
-              "count": 197,
-              "trimmed": 3,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.55,
-              "slope": 2.2
-            },
-            {
-              "lib": "tanstack",
-              "median": 4.899999976158142,
-              "p95": 5.600000023841858,
-              "iqr": 0.5999999046325684,
+              "iqr": 0.30000007152557373,
               "count": 199,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.22,
-              "slope": 1.92
+              "ratio": 0.55,
+              "slope": 2.44
+            },
+            {
+              "lib": "tanstack",
+              "median": 4.700000047683716,
+              "p95": 5.699999928474426,
+              "iqr": 0.7000000476837158,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.18,
+              "slope": 2.76
             },
             {
               "lib": "formisch",
-              "median": 2.0999999046325684,
-              "p95": 2.299999952316284,
-              "iqr": 0.2250000238418579,
-              "count": 173,
-              "trimmed": 27,
+              "median": 2.399999976158142,
+              "p95": 3.100000023841858,
+              "iqr": 0.6000000238418579,
+              "count": 199,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.52,
-              "slope": 1.62
+              "ratio": 0.6,
+              "slope": 1.85
             },
             {
               "lib": "regle-schema",
-              "median": 3.600000023841858,
+              "median": 3.299999952316284,
               "p95": 4,
-              "iqr": 0.40000009536743164,
-              "count": 198,
-              "trimmed": 2,
+              "iqr": 0.3999999761581421,
+              "count": 197,
+              "trimmed": 3,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.9,
-              "slope": 1.57
+              "ratio": 0.82,
+              "slope": 2.2
             },
             {
               "lib": "regle-rules",
-              "median": 2.1999999284744263,
-              "p95": 2.5150000035762794,
-              "iqr": 0.2999999523162842,
-              "count": 178,
-              "trimmed": 22,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.55,
-              "slope": 1.22
-            },
-            {
-              "lib": "formkit",
-              "median": 1.5999999046325684,
-              "p95": 4,
-              "iqr": 2.0999999046325684,
-              "count": 200,
-              "trimmed": 0,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.4,
-              "slope": 0.8
-            },
-            {
-              "lib": "vuelidate",
               "median": 2.700000047683716,
-              "p95": 3.100000023841858,
-              "iqr": 0.3999999761581421,
-              "count": 198,
-              "trimmed": 2,
+              "p95": 3.200000047683716,
+              "iqr": 0.2999999523162842,
+              "count": 196,
+              "trimmed": 4,
               "unit": "ms",
               "supported": true,
               "ratio": 0.68,
-              "slope": 1.59
+              "slope": 1.93
+            },
+            {
+              "lib": "formkit",
+              "median": 1.899999976158142,
+              "p95": 2.5,
+              "iqr": 0.5,
+              "count": 192,
+              "trimmed": 8,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.47,
+              "slope": 1.46
+            },
+            {
+              "lib": "vuelidate",
+              "median": 2.699999988079071,
+              "p95": 3.100000023841858,
+              "iqr": 0.22500014305114746,
+              "count": 194,
+              "trimmed": 6,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.67,
+              "slope": 3
             }
           ]
         }
@@ -5554,9 +5594,9 @@
           "N20M8": [
             {
               "lib": "attaform",
-              "median": 6.600000023841858,
-              "p95": 8.859999960660934,
-              "iqr": 1.850000023841858,
+              "median": 6.699999988079071,
+              "p95": 9.019999921321869,
+              "iqr": 2.1000000834465027,
               "count": 14,
               "trimmed": 1,
               "unit": "ms",
@@ -5566,83 +5606,83 @@
             },
             {
               "lib": "vee-validate",
-              "median": 7.300000011920929,
-              "p95": 9.305000030994416,
-              "iqr": 1.850000023841858,
+              "median": 7.25,
+              "p95": 8.310000032186508,
+              "iqr": 1.4499999284744263,
               "count": 14,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.11,
+              "ratio": 1.08,
               "slope": 1
             },
             {
               "lib": "tanstack",
-              "median": 22.699999928474426,
-              "p95": 23.680000042915346,
-              "iqr": 0.8500000238418579,
+              "median": 22,
+              "p95": 25.5400000333786,
+              "iqr": 2.400000035762787,
               "count": 13,
               "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 3.44,
+              "ratio": 3.28,
               "slope": 1
             },
             {
               "lib": "formisch",
               "median": 2.5,
-              "p95": 3.2200000762939442,
-              "iqr": 0.4500000476837158,
+              "p95": 3.2800000190734853,
+              "iqr": 0.6499999761581421,
               "count": 13,
               "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.38,
+              "ratio": 0.37,
               "slope": 1
             },
             {
               "lib": "regle-schema",
-              "median": 6.699999988079071,
-              "p95": 10.224999999999998,
-              "iqr": 2.350000023841858,
+              "median": 7.699999988079071,
+              "p95": 10.459999936819075,
+              "iqr": 2.050000011920929,
               "count": 14,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.02,
+              "ratio": 1.15,
               "slope": 1
             },
             {
               "lib": "regle-rules",
-              "median": 7.400000035762787,
-              "p95": 11.795000016689299,
-              "iqr": 2.950000047683716,
+              "median": 8.649999976158142,
+              "p95": 14.534999936819073,
+              "iqr": 3.75,
               "count": 14,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.12,
+              "ratio": 1.29,
               "slope": 1
             },
             {
               "lib": "formkit",
-              "median": 95.09999990463257,
-              "p95": 104.4000000476837,
-              "iqr": 5.050000011920929,
-              "count": 13,
-              "trimmed": 2,
+              "median": 92.75,
+              "p95": 95.06500003933907,
+              "iqr": 5.550000071525574,
+              "count": 12,
+              "trimmed": 3,
               "unit": "ms",
               "supported": true,
-              "ratio": 14.41,
+              "ratio": 13.84,
               "slope": 1
             },
             {
               "lib": "vuelidate",
-              "median": 2.550000011920929,
-              "p95": 3.380000007152557,
-              "iqr": 0.4999999403953552,
-              "count": 14,
-              "trimmed": 1,
+              "median": 2.5999999046325684,
+              "p95": 2.939999985694885,
+              "iqr": 0.5499999523162842,
+              "count": 13,
+              "trimmed": 2,
               "unit": "ms",
               "supported": true,
               "ratio": 0.39,
@@ -5652,99 +5692,99 @@
           "N100M8": [
             {
               "lib": "attaform",
-              "median": 71.30000007152557,
-              "p95": 83.33000003099441,
-              "iqr": 5.75,
+              "median": 70.79999995231628,
+              "p95": 83.98999996185303,
+              "iqr": 8.850000023841858,
               "count": 15,
               "trimmed": 0,
               "unit": "ms",
               "supported": true,
               "ratio": 1,
-              "slope": 10.8
+              "slope": 10.57
             },
             {
               "lib": "vee-validate",
-              "median": 78.94999998807907,
-              "p95": 84.11999997496605,
+              "median": 79.19999992847443,
+              "p95": 92.90999999046325,
+              "iqr": 6.199999988079071,
+              "count": 15,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.12,
+              "slope": 10.92
+            },
+            {
+              "lib": "tanstack",
+              "median": 522.1999999284744,
+              "p95": 551.3599999785423,
+              "iqr": 12.149999976158142,
+              "count": 15,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 7.38,
+              "slope": 23.74
+            },
+            {
+              "lib": "formisch",
+              "median": 10.250000059604645,
+              "p95": 13.374999970197678,
+              "iqr": 2.200000047683716,
+              "count": 14,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.14,
+              "slope": 4.1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 30.55000001192093,
+              "p95": 39.4200000166893,
               "iqr": 4.800000011920929,
               "count": 14,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.11,
-              "slope": 10.82
+              "ratio": 0.43,
+              "slope": 3.97
             },
             {
-              "lib": "tanstack",
-              "median": 560.6000000238419,
-              "p95": 576.4900000095367,
-              "iqr": 14.699999928474426,
-              "count": 15,
-              "trimmed": 0,
+              "lib": "regle-rules",
+              "median": 36.10000002384186,
+              "p95": 43.72000002861022,
+              "iqr": 5.599999964237213,
+              "count": 13,
+              "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 7.86,
-              "slope": 24.7
+              "ratio": 0.51,
+              "slope": 4.17
             },
             {
-              "lib": "formisch",
-              "median": 10.500000059604645,
-              "p95": 13.539999967813491,
-              "iqr": 1.8000000715255737,
+              "lib": "formkit",
+              "median": 611.6000000238419,
+              "p95": 644.3700000584125,
+              "iqr": 39.3500000834465,
+              "count": 12,
+              "trimmed": 3,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 8.64,
+              "slope": 6.59
+            },
+            {
+              "lib": "vuelidate",
+              "median": 10.949999988079071,
+              "p95": 12.609999984502792,
+              "iqr": 1.449999988079071,
               "count": 14,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
               "ratio": 0.15,
-              "slope": 4.2
-            },
-            {
-              "lib": "regle-schema",
-              "median": 32.200000047683716,
-              "p95": 36.77999997138976,
-              "iqr": 3.3499999046325684,
-              "count": 13,
-              "trimmed": 2,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.45,
-              "slope": 4.81
-            },
-            {
-              "lib": "regle-rules",
-              "median": 37.799999952316284,
-              "p95": 45.84000000953673,
-              "iqr": 5.649999976158142,
-              "count": 13,
-              "trimmed": 2,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.53,
-              "slope": 5.11
-            },
-            {
-              "lib": "formkit",
-              "median": 641.7499999403954,
-              "p95": 793.3749999523163,
-              "iqr": 72.55000001192093,
-              "count": 14,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 9,
-              "slope": 6.75
-            },
-            {
-              "lib": "vuelidate",
-              "median": 12.050000011920929,
-              "p95": 13.03500000834465,
-              "iqr": 3.199999988079071,
-              "count": 14,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.17,
-              "slope": 4.73
+              "slope": 4.21
             }
           ]
         }
@@ -5755,9 +5795,9 @@
           "N20M8": [
             {
               "lib": "attaform",
-              "median": 0.3999999761581421,
-              "p95": 0.6999999403953552,
-              "iqr": 0.2999999523162842,
+              "median": 0.2999999523162842,
+              "p95": 0.5999999046325684,
+              "iqr": 0.20000004768371582,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
@@ -5767,184 +5807,184 @@
             },
             {
               "lib": "vee-validate",
-              "median": 6.899999976158142,
-              "p95": 7.910000085830688,
-              "iqr": 0.8999999761581421,
+              "median": 6.600000023841858,
+              "p95": 7.399999976158142,
+              "iqr": 0.40000009536743164,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 17.25,
+              "ratio": 22,
               "slope": 1
             },
             {
               "lib": "tanstack",
-              "median": 2.400000035762787,
-              "p95": 2.600000023841858,
-              "iqr": 0.10000002384185791,
-              "count": 96,
-              "trimmed": 4,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 6,
-              "slope": 1
-            },
-            {
-              "lib": "formisch",
-              "median": 0.20000004768371582,
-              "p95": 0.3999999761581421,
+              "median": 3,
+              "p95": 3.3000000715255737,
               "iqr": 0.20000004768371582,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.5,
+              "ratio": 10,
               "slope": 1
             },
             {
-              "lib": "regle-schema",
-              "median": 1.2999999523162842,
-              "p95": 3.100000023841858,
-              "iqr": 1.725000023841858,
-              "count": 100,
-              "trimmed": 0,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 3.25,
-              "slope": 1
-            },
-            {
-              "lib": "regle-rules",
-              "median": 1.7000000476837158,
-              "p95": 2,
-              "iqr": 0.2000000774860382,
-              "count": 82,
-              "trimmed": 18,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 4.25,
-              "slope": 1
-            },
-            {
-              "lib": "formkit",
-              "median": 10,
-              "p95": 11.409999978542327,
-              "iqr": 1.2250000536441803,
+              "lib": "formisch",
+              "median": 0.19999992847442627,
+              "p95": 0.3999999761581421,
+              "iqr": 0.19999992847442627,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 25,
+              "ratio": 0.67,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 1.399999976158142,
+              "p95": 2.799999952316284,
+              "iqr": 0.625,
+              "count": 95,
+              "trimmed": 5,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 4.67,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 2.399999976158142,
+              "p95": 2.899999976158142,
+              "iqr": 0.30000007152557373,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 8,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 8.399999976158142,
+              "p95": 10.700000047683716,
+              "iqr": 1.5999999046325684,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 28,
               "slope": 1
             },
             {
               "lib": "vuelidate",
               "median": 0.10000002384185791,
               "p95": 0.20000004768371582,
-              "iqr": 0.10000002384185791,
+              "iqr": 0.19999992847442627,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.25,
+              "ratio": 0.33,
               "slope": 1
             }
           ],
           "N100M8": [
             {
               "lib": "attaform",
-              "median": 0.6999999284744263,
-              "p95": 1.399999988079071,
-              "iqr": 0.7999999821186066,
+              "median": 0.5,
+              "p95": 1.5100000023841853,
+              "iqr": 0.6000000238418579,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
               "ratio": 1,
-              "slope": 1.75
+              "slope": 1.67
             },
             {
               "lib": "vee-validate",
-              "median": 9.5,
-              "p95": 10.699999940395355,
-              "iqr": 1.4999999105930328,
+              "median": 9.399999976158142,
+              "p95": 10.5,
+              "iqr": 0.8250000476837158,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 13.57,
-              "slope": 1.38
+              "ratio": 18.8,
+              "slope": 1.42
             },
             {
               "lib": "tanstack",
-              "median": 60.299999952316284,
-              "p95": 61.200000047683716,
-              "iqr": 0.8000000715255737,
-              "count": 94,
-              "trimmed": 6,
+              "median": 58.800000071525574,
+              "p95": 63.904999977350236,
+              "iqr": 2.5,
+              "count": 100,
+              "trimmed": 0,
               "unit": "ms",
               "supported": true,
-              "ratio": 86.14,
-              "slope": 25.12
+              "ratio": 117.6,
+              "slope": 19.6
             },
             {
               "lib": "formisch",
-              "median": 0.5,
-              "p95": 1,
-              "iqr": 0.625,
-              "count": 99,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.71,
-              "slope": 2.5
-            },
-            {
-              "lib": "regle-schema",
-              "median": 5.299999952316284,
-              "p95": 6,
-              "iqr": 0.5249999761581421,
-              "count": 96,
-              "trimmed": 4,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 7.57,
-              "slope": 4.08
-            },
-            {
-              "lib": "regle-rules",
-              "median": 8.25,
-              "p95": 10.399999976158142,
-              "iqr": 1.0250000953674316,
+              "median": 0.2999999523162842,
+              "p95": 0.8999999761581421,
+              "iqr": 0.2999999523162842,
               "count": 98,
               "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 11.79,
-              "slope": 4.85
+              "ratio": 0.6,
+              "slope": 1.5
             },
             {
-              "lib": "formkit",
-              "median": 60.799999952316284,
-              "p95": 62.51000000238419,
-              "iqr": 1.4250000715255737,
+              "lib": "regle-schema",
+              "median": 4.399999976158142,
+              "p95": 5.800000071525574,
+              "iqr": 0.8250000476837158,
+              "count": 98,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 8.8,
+              "slope": 3.14
+            },
+            {
+              "lib": "regle-rules",
+              "median": 8.100000023841858,
+              "p95": 10.510000002384185,
+              "iqr": 1.3000000715255737,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 86.86,
-              "slope": 6.08
+              "ratio": 16.2,
+              "slope": 3.38
+            },
+            {
+              "lib": "formkit",
+              "median": 57.44999998807907,
+              "p95": 63.29999995827675,
+              "iqr": 4.350000083446503,
+              "count": 100,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 114.9,
+              "slope": 6.84
             },
             {
               "lib": "vuelidate",
               "median": 0.10000002384185791,
-              "p95": 0.2100000381469721,
+              "p95": 0.2150000333786002,
               "iqr": 0.19999992847442627,
-              "count": 99,
-              "trimmed": 1,
+              "count": 98,
+              "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.14,
+              "ratio": 0.2,
               "slope": 1
             }
           ]
@@ -6157,11 +6197,11 @@
           "N20M8": [
             {
               "lib": "attaform",
-              "median": 7.199999928474426,
-              "p95": 7.940000021457672,
-              "iqr": 0.44999998807907104,
-              "count": 47,
-              "trimmed": 3,
+              "median": 7.25,
+              "p95": 8.96499999165535,
+              "iqr": 0.7000000476837158,
+              "count": 48,
+              "trimmed": 2,
               "unit": "ms",
               "supported": true,
               "ratio": 1,
@@ -6169,9 +6209,9 @@
             },
             {
               "lib": "vee-validate",
-              "median": 3.200000047683716,
-              "p95": 3.600000023841858,
-              "iqr": 0.2999999523162842,
+              "median": 3.1999999284744263,
+              "p95": 3.800000023841858,
+              "iqr": 0.4750000238418579,
               "count": 49,
               "trimmed": 1,
               "unit": "ms",
@@ -6181,33 +6221,33 @@
             },
             {
               "lib": "tanstack",
-              "median": 3.1999999284744263,
-              "p95": 3.799999952316284,
-              "iqr": 0.5,
+              "median": 3.399999976158142,
+              "p95": 3.8000000715255737,
+              "iqr": 0.37500008940696716,
               "count": 49,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.44,
+              "ratio": 0.47,
               "slope": 1
             },
             {
               "lib": "formisch",
-              "median": 0.949999988079071,
-              "p95": 1.205000042915344,
-              "iqr": 0.30000007152557373,
-              "count": 40,
-              "trimmed": 10,
+              "median": 1.2999999523162842,
+              "p95": 2.5599999427795406,
+              "iqr": 0.5749999284744263,
+              "count": 49,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.13,
+              "ratio": 0.18,
               "slope": 1
             },
             {
               "lib": "regle-schema",
               "median": 2.799999952316284,
-              "p95": 3.26000006198883,
-              "iqr": 0.4749999940395355,
+              "p95": 3.2599999904632564,
+              "iqr": 0.3999999761581421,
               "count": 49,
               "trimmed": 1,
               "unit": "ms",
@@ -6217,137 +6257,137 @@
             },
             {
               "lib": "regle-rules",
+              "median": 2.399999976158142,
+              "p95": 2.7599999904632564,
+              "iqr": 0.2999999523162842,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.33,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 6.25,
+              "p95": 7.5300000488758085,
+              "iqr": 0.8750000894069672,
+              "count": 48,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.86,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
               "median": 2,
-              "p95": 2.460000038146972,
-              "iqr": 0.39999985694885254,
+              "p95": 2.5,
+              "iqr": 0.30000004172325134,
               "count": 49,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
               "ratio": 0.28,
               "slope": 1
-            },
-            {
-              "lib": "formkit",
-              "median": 6.600000023841858,
-              "p95": 7.5,
-              "iqr": 0.8000000417232513,
-              "count": 47,
-              "trimmed": 3,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.92,
-              "slope": 1
-            },
-            {
-              "lib": "vuelidate",
-              "median": 1.7999999523162842,
-              "p95": 2.274999976158142,
-              "iqr": 0.30000007152557373,
-              "count": 46,
-              "trimmed": 4,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.25,
-              "slope": 1
             }
           ],
           "N100M8": [
             {
               "lib": "attaform",
-              "median": 109.64999997615814,
-              "p95": 115.69999999403953,
-              "iqr": 5.799999892711639,
+              "median": 112.75,
+              "p95": 116.95499998927116,
+              "iqr": 5.900000095367432,
               "count": 50,
               "trimmed": 0,
               "unit": "ms",
               "supported": true,
               "ratio": 1,
-              "slope": 15.23
+              "slope": 15.55
             },
             {
               "lib": "vee-validate",
-              "median": 15.149999976158142,
-              "p95": 16.764999997615813,
-              "iqr": 1.4499999284744263,
+              "median": 13.950000047683716,
+              "p95": 16.46500004529953,
+              "iqr": 1.7749999463558197,
               "count": 50,
               "trimmed": 0,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.14,
-              "slope": 4.73
+              "ratio": 0.12,
+              "slope": 4.36
             },
             {
               "lib": "tanstack",
-              "median": 17.850000023841858,
-              "p95": 20.06500001549721,
-              "iqr": 1.4999999701976776,
+              "median": 16.700000047683716,
+              "p95": 20.330000013113022,
+              "iqr": 1.7999998927116394,
               "count": 50,
               "trimmed": 0,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.16,
-              "slope": 5.58
+              "ratio": 0.15,
+              "slope": 4.91
             },
             {
               "lib": "formisch",
-              "median": 2.5,
-              "p95": 2.899999976158142,
-              "iqr": 0.30000004172325134,
+              "median": 2.8000000715255737,
+              "p95": 3.2599999904632564,
+              "iqr": 0.2999999523162842,
               "count": 49,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
               "ratio": 0.02,
-              "slope": 2.63
+              "slope": 2.15
             },
             {
               "lib": "regle-schema",
-              "median": 12.600000023841858,
-              "p95": 14.384999960660933,
-              "iqr": 1.8499999940395355,
+              "median": 10.800000071525574,
+              "p95": 13.600000023841858,
+              "iqr": 1.8750000894069672,
               "count": 50,
               "trimmed": 0,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.11,
-              "slope": 4.5
+              "ratio": 0.1,
+              "slope": 3.86
             },
             {
               "lib": "regle-rules",
-              "median": 8.899999976158142,
-              "p95": 11.040000057220457,
+              "median": 8,
+              "p95": 9.269999980926514,
+              "iqr": 0.8749999701976776,
+              "count": 47,
+              "trimmed": 3,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.07,
+              "slope": 3.33
+            },
+            {
+              "lib": "formkit",
+              "median": 13.399999976158142,
+              "p95": 15.680000042915342,
+              "iqr": 1.3249999582767487,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.12,
+              "slope": 2.14
+            },
+            {
+              "lib": "vuelidate",
+              "median": 6.200000047683716,
+              "p95": 7.899999976158142,
               "iqr": 1.1749999523162842,
               "count": 49,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.08,
-              "slope": 4.45
-            },
-            {
-              "lib": "formkit",
-              "median": 14,
-              "p95": 15.299999952316284,
-              "iqr": 1,
-              "count": 46,
-              "trimmed": 4,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.13,
-              "slope": 2.12
-            },
-            {
-              "lib": "vuelidate",
-              "median": 6.300000071525574,
-              "p95": 7.365000009536743,
-              "iqr": 0.5000000894069672,
-              "count": 48,
-              "trimmed": 2,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.06,
-              "slope": 3.5
+              "ratio": 0.05,
+              "slope": 3.1
             }
           ]
         }
@@ -6358,9 +6398,9 @@
           "N20M8": [
             {
               "lib": "attaform",
-              "median": 4.300000071525574,
-              "p95": 4.954999989271164,
-              "iqr": 0.5,
+              "median": 4.299999952316284,
+              "p95": 5.1549999713897705,
+              "iqr": 0.4999999701976776,
               "count": 50,
               "trimmed": 0,
               "unit": "ms",
@@ -6371,8 +6411,8 @@
             {
               "lib": "vee-validate",
               "median": 1.7999999523162842,
-              "p95": 2.0599999427795406,
-              "iqr": 0.30000004172325134,
+              "p95": 2.160000038146972,
+              "iqr": 0.20000013709068298,
               "count": 49,
               "trimmed": 1,
               "unit": "ms",
@@ -6382,74 +6422,74 @@
             },
             {
               "lib": "tanstack",
-              "median": 2,
-              "p95": 2.359999966621398,
-              "iqr": 0.20000001788139343,
+              "median": 2.200000047683716,
+              "p95": 2.5,
+              "iqr": 0.27500006556510925,
               "count": 49,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.47,
+              "ratio": 0.51,
               "slope": 1
             },
             {
               "lib": "formisch",
-              "median": 1,
-              "p95": 1.1999999463558197,
-              "iqr": 0.20000004768371582,
-              "count": 38,
-              "trimmed": 12,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.23,
-              "slope": 1
-            },
-            {
-              "lib": "regle-schema",
-              "median": 1.5,
-              "p95": 1.8000000357627868,
-              "iqr": 0.2749999463558197,
-              "count": 47,
-              "trimmed": 3,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.35,
-              "slope": 1
-            },
-            {
-              "lib": "regle-rules",
               "median": 1.2999999523162842,
-              "p95": 1.5,
-              "iqr": 0.19999992847442627,
-              "count": 44,
-              "trimmed": 6,
+              "p95": 3.1800000429153426,
+              "iqr": 1.1750000417232513,
+              "count": 49,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
               "ratio": 0.3,
               "slope": 1
             },
             {
-              "lib": "formkit",
+              "lib": "regle-schema",
               "median": 1.7999999523162842,
-              "p95": 2.0750000178813934,
+              "p95": 2.1999999284744263,
               "iqr": 0.30000007152557373,
-              "count": 46,
-              "trimmed": 4,
+              "count": 49,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
               "ratio": 0.42,
               "slope": 1
             },
             {
-              "lib": "vuelidate",
-              "median": 1.3000000715255737,
-              "p95": 1.5,
-              "iqr": 0.20000001788139343,
-              "count": 46,
-              "trimmed": 4,
+              "lib": "regle-rules",
+              "median": 1.5999999046325684,
+              "p95": 1.9599999904632563,
+              "iqr": 0.2749999463558197,
+              "count": 49,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.3,
+              "ratio": 0.37,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 2.0999999046325684,
+              "p95": 2.660000038146972,
+              "iqr": 0.30000007152557373,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.49,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 1.600000023841858,
+              "p95": 2.100000023841858,
+              "iqr": 0.5749999284744263,
+              "count": 49,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.37,
               "slope": 1
             }
           ],
@@ -6457,8 +6497,8 @@
             {
               "lib": "attaform",
               "median": 55,
-              "p95": 59.860000014305115,
-              "iqr": 1.8250001072883606,
+              "p95": 61.25999999046326,
+              "iqr": 2.349999964237213,
               "count": 49,
               "trimmed": 1,
               "unit": "ms",
@@ -6468,87 +6508,87 @@
             },
             {
               "lib": "vee-validate",
-              "median": 6.399999976158142,
-              "p95": 7,
-              "iqr": 0.30000007152557373,
-              "count": 49,
-              "trimmed": 1,
+              "median": 5.600000023841858,
+              "p95": 6.674999976158141,
+              "iqr": 0.6749999225139618,
+              "count": 50,
+              "trimmed": 0,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.12,
-              "slope": 3.56
+              "ratio": 0.1,
+              "slope": 3.11
             },
             {
               "lib": "tanstack",
-              "median": 8.850000023841858,
-              "p95": 10.164999973773956,
+              "median": 9,
+              "p95": 10.354999965429306,
               "iqr": 1.0750000178813934,
               "count": 50,
               "trimmed": 0,
               "unit": "ms",
               "supported": true,
               "ratio": 0.16,
-              "slope": 4.43
+              "slope": 4.09
             },
             {
               "lib": "formisch",
-              "median": 2.899999976158142,
-              "p95": 3.200000047683716,
-              "iqr": 0.20000004768371582,
+              "median": 2.799999952316284,
+              "p95": 3.399999976158142,
+              "iqr": 0.3500000238418579,
               "count": 49,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
               "ratio": 0.05,
-              "slope": 2.9
+              "slope": 2.15
             },
             {
               "lib": "regle-schema",
-              "median": 6.800000011920929,
-              "p95": 7.300000017881393,
-              "iqr": 0.5,
+              "median": 6.600000023841858,
+              "p95": 7.855000019073486,
+              "iqr": 1.050000011920929,
               "count": 50,
               "trimmed": 0,
               "unit": "ms",
               "supported": true,
               "ratio": 0.12,
-              "slope": 4.53
+              "slope": 3.67
             },
             {
               "lib": "regle-rules",
-              "median": 5.799999952316284,
-              "p95": 6.200000047683716,
-              "iqr": 0.3999999761581421,
-              "count": 50,
-              "trimmed": 0,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.11,
-              "slope": 4.46
-            },
-            {
-              "lib": "formkit",
-              "median": 4.399999976158142,
-              "p95": 5.100000023841858,
-              "iqr": 0.7749999761581421,
+              "median": 5.299999952316284,
+              "p95": 6.060000014305114,
+              "iqr": 0.6000000238418579,
               "count": 49,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.08,
-              "slope": 2.44
+              "ratio": 0.1,
+              "slope": 3.31
+            },
+            {
+              "lib": "formkit",
+              "median": 3.850000023841858,
+              "p95": 5.030000007152557,
+              "iqr": 0.875,
+              "count": 48,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.07,
+              "slope": 1.83
             },
             {
               "lib": "vuelidate",
-              "median": 4.5,
-              "p95": 5.5550000131130215,
-              "iqr": 0.6000000238418579,
+              "median": 4.599999904632568,
+              "p95": 5.1549999713897705,
+              "iqr": 0.5,
               "count": 50,
               "trimmed": 0,
               "unit": "ms",
               "supported": true,
               "ratio": 0.08,
-              "slope": 3.46
+              "slope": 2.87
             }
           ]
         }
@@ -6560,31 +6600,31 @@
             {
               "lib": "attaform",
               "retained": {
-                "median": 1631048,
-                "p95": 1826792,
+                "median": 1632040,
+                "p95": 1828040,
                 "count": 12
               },
               "churn": {
-                "median": 1445100,
-                "p95": 1494580,
+                "median": 1437172,
+                "p95": 1486552,
                 "count": 12
               },
               "leak": {
-                "median": 35936,
-                "p95": 214304,
+                "median": 35912,
+                "p95": 215520,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  2622532, 1641524, 1702428, 1631048, 1649604, 1609468, 1612076, 1604604, 1826792,
-                  1592508, 1632052, 1596104
+                  2622532, 1641524, 1705820, 1632288, 1649588, 1608172, 1612124, 1603320, 1828040,
+                  1592540, 1632040, 1596104
                 ],
                 "churn": [
-                  2465432, 1494580, 1435700, 1489656, 1474660, 1416284, 1426844, 1383688, 1445260,
-                  1445100, 1492568, 1396104
+                  2453752, 1480984, 1424864, 1486552, 1437172, 1401580, 1425968, 1391744, 1444204,
+                  1417816, 1476716, 1437640
                 ],
                 "leak": [
-                  1313408, 53320, 77252, 68392, 38044, 23724, 0, 372, 214304, 3716, 35936, 7492
+                  1313408, 53320, 80576, 68392, 38044, 23748, 0, 0, 215520, 3716, 35912, 7492
                 ]
               },
               "supported": true,
@@ -6594,30 +6634,32 @@
             {
               "lib": "vee-validate",
               "retained": {
-                "median": 1606564,
-                "p95": 1658100,
+                "median": 1606512,
+                "p95": 1658076,
                 "count": 12
               },
               "churn": {
-                "median": 461832,
-                "p95": 481552,
+                "median": 229888,
+                "p95": 459048,
                 "count": 12
               },
               "leak": {
-                "median": 23304,
-                "p95": 72288,
+                "median": 24168,
+                "p95": 325716,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  2310300, 1625680, 1626140, 1658100, 1606564, 1603160, 1601192, 1599924, 1651960,
-                  1593688, 1614772, 1593704
+                  2310316, 1625572, 1625316, 1658076, 1606512, 1603208, 1600540, 1600000, 1651756,
+                  1599160, 1609068, 1593536
                 ],
                 "churn": [
-                  371724, 486436, 480196, 461948, 233884, 461832, 212372, 237712, 481552, 222100,
-                  472864, 462684
+                  350396, 230184, 236852, 459048, 217912, 466372, 206224, 227424, 256000, 209272,
+                  229888, 227016
                 ],
-                "leak": [852612, 72288, 65080, 40404, 6884, 26468, 0, 44, 57924, 0, 23304, 14588]
+                "leak": [
+                  852728, 133076, 66212, 38212, 9076, 24168, 112, 0, 60140, 325716, 17152, 8520
+                ]
               },
               "supported": true,
               "ratio": 0.98,
@@ -6626,32 +6668,32 @@
             {
               "lib": "tanstack",
               "retained": {
-                "median": 1815280,
-                "p95": 1884836,
+                "median": 1815336,
+                "p95": 1891668,
                 "count": 12
               },
               "churn": {
-                "median": 607532,
-                "p95": 634600,
+                "median": 605100,
+                "p95": 634976,
                 "count": 12
               },
               "leak": {
-                "median": 98396,
-                "p95": 173104,
+                "median": 94912,
+                "p95": 169000,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  2453924, 1881184, 1884836, 1853056, 1815280, 1809996, 1802204, 1804300, 1847304,
-                  1799972, 1821488, 1806204
+                  2453852, 1880068, 1891668, 1853084, 1816272, 1810128, 1802232, 1804328, 1847656,
+                  1800108, 1815336, 1806232
                 ],
                 "churn": [
-                  973880, 605540, 618812, 619392, 599048, 607532, 591108, 628272, 612812, 595704,
-                  634600, 599112
+                  976276, 603792, 609040, 618464, 597148, 605100, 589632, 627692, 611904, 601392,
+                  634976, 598392
                 ],
                 "leak": [
-                  996140, 151816, 173104, 111356, 95348, 98396, 79720, 79200, 125964, 78216, 105860,
-                  81368
+                  995860, 149192, 169000, 108048, 92828, 94912, 76236, 75892, 122656, 81440, 96148,
+                  77884
                 ]
               },
               "supported": true,
@@ -6661,31 +6703,31 @@
             {
               "lib": "formisch",
               "retained": {
-                "median": 904016,
+                "median": 903420,
                 "p95": 951552,
                 "count": 12
               },
               "churn": {
-                "median": 136060,
-                "p95": 148072,
+                "median": 135528,
+                "p95": 145248,
                 "count": 12
               },
               "leak": {
                 "median": 11224,
-                "p95": 40920,
+                "p95": 39984,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  1242336, 923740, 922528, 951552, 912936, 901808, 900896, 897952, 935304, 901208,
-                  904016, 901964
+                  1242460, 926492, 926444, 951552, 909120, 897900, 901492, 897920, 935304, 900888,
+                  903420, 901964
                 ],
                 "churn": [
-                  260960, 143584, 120188, 136756, 136060, 122472, 128360, 142500, 148072, 126452,
-                  144032, 121368
+                  258480, 145248, 122836, 135528, 137408, 117152, 130576, 140328, 139260, 132852,
+                  144912, 118972
                 ],
                 "leak": [
-                  468936, 40920, 29672, 35640, 14388, 11224, 212, 860, 38748, 1556, 8132, 4916
+                  468772, 39984, 29736, 35640, 14244, 11224, 808, 860, 38748, 1556, 7536, 4916
                 ]
               },
               "supported": true,
@@ -6695,31 +6737,31 @@
             {
               "lib": "regle-schema",
               "retained": {
-                "median": 2783736,
-                "p95": 2855700,
+                "median": 2786596,
+                "p95": 2910520,
                 "count": 12
               },
               "churn": {
-                "median": 533948,
-                "p95": 806344,
+                "median": 684068,
+                "p95": 836288,
                 "count": 12
               },
               "leak": {
                 "median": 12780,
-                "p95": 126488,
+                "p95": 125416,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  3555196, 2797820, 2855700, 2843468, 2783736, 2767172, 2766536, 2769400, 2854396,
-                  2770552, 2785304, 2776224
+                  3595592, 2803224, 2807356, 2910520, 2789152, 2765816, 2774628, 2764680, 2861888,
+                  2768292, 2786596, 2773616
                 ],
                 "churn": [
-                  669780, 959944, 368764, 806344, 365092, 804040, 359484, 498580, 403120, 644000,
-                  533948, 620456
+                  684068, 962940, 369380, 797296, 368572, 803532, 382172, 646172, 392088, 790572,
+                  836288, 783056
                 ],
                 "leak": [
-                  896400, 43932, 89836, 40148, 10864, 12780, 0, 1712, 126488, 1112, 16980, 4844
+                  940428, 44720, 41624, 104740, 9612, 12780, 0, 2920, 125416, 1840, 19124, 4844
                 ]
               },
               "supported": true,
@@ -6729,31 +6771,31 @@
             {
               "lib": "regle-rules",
               "retained": {
-                "median": 3500340,
-                "p95": 3579448,
+                "median": 3516488,
+                "p95": 3579460,
                 "count": 12
               },
               "churn": {
-                "median": 1644104,
-                "p95": 1685844,
+                "median": 1645704,
+                "p95": 1704472,
                 "count": 12
               },
               "leak": {
-                "median": 12392,
+                "median": 39204,
                 "p95": 105944,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  4344252, 3516728, 3529112, 3553084, 3500340, 3479836, 3492304, 3487064, 3579448,
-                  3490200, 3508256, 3484572
+                  4232396, 3516488, 3529128, 3553020, 3500416, 3527252, 3556752, 3487024, 3579460,
+                  3490188, 3507968, 3484692
                 ],
                 "churn": [
-                  478784, 1716124, 333476, 299516, 1685844, 1644104, 1653420, 1649876, 1677444,
-                  1619340, 1677524, 1619108
+                  500160, 350008, 309068, 1698332, 1716404, 1652320, 1624044, 1647472, 1704472,
+                  1645704, 1676012, 1616168
                 ],
                 "leak": [
-                  966500, 59144, 39204, 41236, 6476, 15044, 156, 5428, 105944, 12392, 12124, 6152
+                  854372, 59144, 39204, 41236, 6476, 62660, 64668, 5428, 105944, 12392, 12124, 6152
                 ]
               },
               "supported": true,
@@ -6763,47 +6805,47 @@
             {
               "lib": "formkit",
               "retained": {
-                "median": 24834152,
-                "p95": 25769088,
+                "median": 24830416,
+                "p95": 25771580,
                 "count": 12
               },
               "churn": {
-                "median": 790048,
-                "p95": 847072,
+                "median": 786228,
+                "p95": 847068,
                 "count": 12
               },
               "leak": {
-                "median": 49116,
-                "p95": 827464,
+                "median": 49216,
+                "p95": 827440,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  33035368, 25769088, 25103244, 24834152, 24751864, 24673548, 24586664, 24991328,
-                  24935156, 24852048, 24729228, 24589292
+                  33035676, 25771580, 25098452, 24830416, 24748588, 24670024, 24596212, 24991168,
+                  24940404, 24852176, 24731440, 24586872
                 ],
                 "churn": [
-                  1022572, 847072, 838472, 785496, 797012, 813592, 778864, 775932, 800656, 790048,
-                  749112, 748552
+                  1023304, 847068, 829284, 784580, 786228, 804908, 781576, 783908, 794672, 792512,
+                  747388, 742184
                 ],
                 "leak": [
-                  8567884, 827464, 252300, 28108, 36492, 51100, 0, 68392, 90560, 49116, 2660, 0
+                  8567908, 827440, 252300, 28108, 36552, 50944, 0, 68292, 90600, 49216, 2612, 0
                 ]
               },
               "supported": true,
-              "ratio": 15.23,
+              "ratio": 15.21,
               "slope": 1
             },
             {
               "lib": "vuelidate",
               "retained": {
-                "median": 564644,
+                "median": 561960,
                 "p95": 615396,
                 "count": 12
               },
               "churn": {
-                "median": 1276548,
-                "p95": 1762464,
+                "median": 1251556,
+                "p95": 1760868,
                 "count": 12
               },
               "leak": {
@@ -6813,19 +6855,19 @@
               },
               "series": {
                 "retained": [
-                  924312, 571140, 607020, 591212, 588536, 556516, 548644, 548312, 615396, 561580,
-                  564644, 549248
+                  924312, 569260, 607020, 591212, 588536, 556516, 548452, 548312, 615396, 561664,
+                  561960, 549248
                 ],
                 "churn": [
-                  1754004, 1238500, 1670796, 1253964, 1667980, 1255472, 1753644, 1276548, 1847536,
-                  1254512, 1762464, 1240992
+                  1737184, 1239540, 1572480, 1251556, 1665504, 1228752, 1760868, 1248888, 1894760,
+                  1284936, 624044, 1245908
                 ],
                 "leak": [
-                  464024, 30632, 56740, 27008, 35488, 16456, 3172, 1980, 64200, 13280, 27496, 220
+                  464024, 30632, 56740, 27008, 35488, 16456, 3232, 1900, 64200, 13388, 27388, 196
                 ]
               },
               "supported": true,
-              "ratio": 0.35,
+              "ratio": 0.34,
               "slope": 1
             }
           ],
@@ -6833,64 +6875,66 @@
             {
               "lib": "attaform",
               "retained": {
-                "median": 18916968,
-                "p95": 19050788,
+                "median": 18921132,
+                "p95": 19048500,
                 "count": 12
               },
               "churn": {
-                "median": 7189996,
-                "p95": 10458392,
+                "median": 8469076,
+                "p95": 10258636,
                 "count": 12
               },
               "leak": {
-                "median": 22824,
-                "p95": 169400,
+                "median": 24228,
+                "p95": 170480,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  20335928, 18942048, 18963852, 18924600, 18916968, 18905068, 18914316, 18891220,
-                  19050788, 18914488, 18936868, 18896936
+                  20340220, 18958144, 18962524, 18924540, 18921132, 18904024, 18913260, 18892668,
+                  19048500, 18913460, 18937940, 18898436
                 ],
                 "churn": [
-                  20541128, 7224524, 6299096, 9863512, 7189996, 4290864, 6123204, 4784520, 5186392,
-                  10458392, 10233672, 7674628
+                  20514884, 7224672, 8469076, 9782588, 5994184, 10009744, 5200592, 5646468, 9935556,
+                  4717828, 10258636, 8728776
                 ],
                 "leak": [
-                  1645420, 42944, 30148, 42700, 17096, 31224, 17016, 0, 169400, 6020, 22824, 21820
+                  1636756, 49680, 32280, 42252, 18016, 30096, 16752, 0, 170480, 4976, 24228, 19264
                 ]
               },
               "supported": true,
               "ratio": 1,
-              "slope": 11.6
+              "slope": 11.59
             },
             {
               "lib": "vee-validate",
               "retained": {
-                "median": 9434816,
-                "p95": 9488156,
+                "median": 9432080,
+                "p95": 9498184,
                 "count": 12
               },
               "churn": {
-                "median": 55832,
-                "p95": 1162924,
+                "median": 74832,
+                "p95": 1165488,
                 "count": 12
               },
               "leak": {
-                "median": 4104,
-                "p95": 56908,
+                "median": 11688,
+                "p95": 152936,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  10442804, 9432160, 9481820, 9431440, 9445664, 9419200, 9442324, 9427760, 9488156,
-                  9414444, 9470748, 9434816
+                  10442592, 9440084, 9498184, 9430444, 9447540, 9432080, 9411824, 9429532, 9483756,
+                  9404628, 9474272, 9428248
                 ],
                 "churn": [
-                  280932, 231844, 29460, 1162096, 55564, 47312, 51468, 1154332, 1163896, 39960,
-                  1162924, 55832
+                  290408, 218960, 1314156, 1157184, 36972, 1165488, 55996, 43832, 1158076, 44488,
+                  74832, 60328
                 ],
-                "leak": [1079576, 24240, 32384, 10960, 0, 0, 740, 3808, 56908, 2728, 7104, 4104]
+                "leak": [
+                  1073416, 27044, 152936, 11688, 121208, 19188, 0, 2856, 58188, 3908, 6060, 2980
+                ]
               },
               "supported": true,
               "ratio": 0.5,
@@ -6899,80 +6943,80 @@
             {
               "lib": "tanstack",
               "retained": {
-                "median": 8831992,
-                "p95": 8932396,
+                "median": 8818612,
+                "p95": 8931356,
                 "count": 12
               },
               "churn": {
-                "median": 1085388,
-                "p95": 2780064,
+                "median": 1155336,
+                "p95": 1947096,
                 "count": 12
               },
               "leak": {
-                "median": 208756,
-                "p95": 438728,
+                "median": 215652,
+                "p95": 437860,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  9855604, 8932396, 8886800, 8817004, 8831992, 8814624, 8790196, 8806948, 8863904,
-                  8808844, 8869048, 8844516
+                  9854024, 8931356, 8886152, 8818612, 8345476, 8814656, 8784536, 8807932, 8864536,
+                  8809820, 8869252, 8844240
                 ],
                 "churn": [
-                  1049784, 586628, 1459764, 3401184, 1834496, 2780064, 364816, 1729420, 2737840,
-                  1085388, 296152, 494104
+                  1067932, 1947096, 1532460, 1004972, 1155336, 1251260, 300236, 325968, 1071228,
+                  1817132, 1667916, 2796804
                 ],
                 "leak": [
-                  1591424, 438728, 358120, 0, 208756, 215904, 165980, 200196, 245916, 200872,
-                  215248, 205148
+                  1590584, 437860, 353780, 332536, 0, 215652, 167572, 202084, 246136, 198464,
+                  216412, 204856
                 ]
               },
               "supported": true,
               "ratio": 0.47,
-              "slope": 4.87
+              "slope": 4.86
             },
             {
               "lib": "formisch",
               "retained": {
-                "median": 4392192,
-                "p95": 4439852,
+                "median": 4380148,
+                "p95": 4431936,
                 "count": 12
               },
               "churn": {
-                "median": 914968,
-                "p95": 1070272,
+                "median": 749412,
+                "p95": 972384,
                 "count": 12
               },
               "leak": {
-                "median": 3716,
+                "median": 7480,
                 "p95": 34664,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  4921308, 4369368, 4429380, 4372140, 4392192, 4349740, 4385224, 4408868, 4422024,
-                  4376120, 4439852, 4421996
+                  4926380, 4362936, 4431936, 4370712, 4390496, 4380148, 4354484, 4373620, 4422008,
+                  4376584, 4405196, 4383216
                 ],
                 "churn": [
-                  972992, 693468, 45088, 914968, 650960, 707348, 983840, 1040424, 1070272, 1291864,
-                  958400, 738244
+                  972384, 698064, 289308, 704812, 1067940, 749412, 692116, 750636, 781808, 746508,
+                  962484, 871220
                 ],
-                "leak": [598356, 6496, 16400, 3312, 7736, 0, 0, 3300, 34664, 1836, 11992, 3716]
+                "leak": [603504, 740, 15792, 4044, 8752, 9964, 0, 3300, 34664, 1836, 8248, 7480]
               },
               "supported": true,
               "ratio": 0.23,
-              "slope": 4.86
+              "slope": 4.85
             },
             {
               "lib": "regle-schema",
               "retained": {
-                "median": 13512528,
-                "p95": 13614540,
+                "median": 13513036,
+                "p95": 13611780,
                 "count": 12
               },
               "churn": {
-                "median": 887372,
-                "p95": 1435684,
+                "median": 1046228,
+                "p95": 1584240,
                 "count": 12
               },
               "leak": {
@@ -6982,14 +7026,14 @@
               },
               "series": {
                 "retained": [
-                  14647148, 13509880, 13586660, 13480144, 13534652, 13512528, 13535808, 13419672,
-                  13614540, 13497276, 13543768, 13413492
+                  14647420, 13509812, 13583260, 13479376, 13535456, 13513036, 13533620, 13424424,
+                  13611780, 13498004, 13543392, 13418620
                 ],
                 "churn": [
-                  1225456, 1052736, 484000, 508564, 1435684, 671164, 508464, 648968, 1078668,
-                  1446432, 1064348, 887372
+                  1227412, 1056320, 1606916, 1584240, 1038064, 1046228, 1161172, 1129404, 339808,
+                  513120, 453136, 1033784
                 ],
-                "leak": [1228652, 9460, 43088, 10172, 10508, 16116, 0, 0, 112268, 5136, 11028, 8076]
+                "leak": [1228652, 9460, 43088, 10172, 10508, 16100, 0, 0, 112268, 5288, 13776, 5308]
               },
               "supported": true,
               "ratio": 0.71,
@@ -6998,63 +7042,63 @@
             {
               "lib": "regle-rules",
               "retained": {
-                "median": 17097200,
-                "p95": 17196184,
+                "median": 17097196,
+                "p95": 17192752,
                 "count": 12
               },
               "churn": {
-                "median": 1517980,
-                "p95": 1676288,
+                "median": 1251948,
+                "p95": 1711280,
                 "count": 12
               },
               "leak": {
-                "median": 9316,
+                "median": 11256,
                 "p95": 101796,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  18284596, 17108944, 17169480, 17002312, 17097200, 17092784, 16996464, 17104552,
-                  17196184, 17019556, 17120620, 17084884
+                  18281412, 17108904, 17170248, 17001860, 17097196, 17092920, 16995928, 17104380,
+                  17192752, 17019296, 17120656, 17089856
                 ],
                 "churn": [
-                  1517980, 1216320, 1234792, 1380316, 1524792, 1548084, 1543552, 1676288, 637828,
-                  1547748, 1712676, 1379812
+                  1504988, 1224556, 1251948, 1047432, 1711280, 1547984, 634908, 1538496, 1558172,
+                  304672, 1725200, 472284
                 ],
-                "leak": [1241608, 18896, 39336, 7044, 9316, 17488, 0, 0, 101796, 11256, 8852, 2608]
+                "leak": [1242628, 17748, 39380, 7000, 9316, 17488, 0, 0, 101796, 11256, 11600, 0]
               },
               "supported": true,
               "ratio": 0.9,
-              "slope": 4.88
+              "slope": 4.86
             },
             {
               "lib": "formkit",
               "retained": {
-                "median": 122348216,
-                "p95": 124623924,
+                "median": 122327688,
+                "p95": 124634820,
                 "count": 12
               },
               "churn": {
-                "median": 778476,
-                "p95": 822672,
+                "median": 777540,
+                "p95": 820824,
                 "count": 12
               },
               "leak": {
-                "median": 36916,
-                "p95": 2445720,
+                "median": 35804,
+                "p95": 2459720,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  158069564, 124623924, 122348216, 122348876, 122167264, 122288372, 122346932,
-                  122361748, 122182656, 122304944, 122349836, 122366344
+                  157874544, 124634820, 122366920, 122315172, 122191008, 122273816, 122327688,
+                  122385564, 122184152, 122282440, 122370132, 122368460
                 ],
                 "churn": [
-                  936224, 822672, 819808, 779564, 776892, 777184, 780880, 778616, 778476, 774960,
-                  772820, 769896
+                  1003964, 820824, 807140, 792852, 777144, 777540, 779908, 771652, 783728, 773772,
+                  767220, 769592
                 ],
                 "leak": [
-                  36126228, 2445720, 56740, 0, 71772, 70224, 0, 20892, 40684, 36916, 0, 11072
+                  36123188, 2459720, 65152, 0, 69944, 52216, 0, 21260, 42052, 35804, 0, 10612
                 ]
               },
               "supported": true,
@@ -7064,13 +7108,13 @@
             {
               "lib": "vuelidate",
               "retained": {
-                "median": 2622416,
+                "median": 2621608,
                 "p95": 2695364,
                 "count": 12
               },
               "churn": {
-                "median": 2122212,
-                "p95": 3826932,
+                "median": 2460100,
+                "p95": 4136940,
                 "count": 12
               },
               "leak": {
@@ -7080,18 +7124,18 @@
               },
               "series": {
                 "retained": [
-                  3176848, 2622416, 2691664, 2617412, 2669756, 2620912, 2594952, 2615404, 2695364,
-                  2627536, 2639312, 2617548
+                  3176816, 2621608, 2691664, 2617472, 2669672, 2620912, 2594952, 2615404, 2695364,
+                  2627536, 2639372, 2617300
                 ],
                 "churn": [
-                  4204524, 3822364, 3826932, 2095844, 2103628, 2086496, 2069200, 2482804, 2082984,
-                  2122212, 2473240, 2463696
+                  4170992, 3812988, 4136940, 2120572, 2460100, 2073136, 2088664, 2447460, 3497176,
+                  2468976, 2479156, 2105220
                 ],
-                "leak": [585236, 944, 28272, 5732, 39932, 15356, 0, 4804, 64144, 11732, 16140, 1772]
+                "leak": [585144, 944, 29284, 5732, 38836, 15356, 0, 4804, 64144, 11732, 16448, 1524]
               },
               "supported": true,
               "ratio": 0.14,
-              "slope": 4.64
+              "slope": 4.67
             }
           ]
         }
@@ -7104,9 +7148,9 @@
           "DU": [
             {
               "lib": "attaform",
-              "median": 0.7000000476837158,
-              "p95": 1.2999999523162842,
-              "iqr": 0.5,
+              "median": 0.5999999046325684,
+              "p95": 1.100000023841858,
+              "iqr": 0.3999999761581421,
               "count": 199,
               "trimmed": 1,
               "unit": "ms",
@@ -7116,86 +7160,86 @@
             },
             {
               "lib": "vee-validate",
-              "median": 0.3999999761581421,
-              "p95": 0.8000000715255737,
-              "iqr": 0.2999999523162842,
+              "median": 0.5,
+              "p95": 1,
+              "iqr": 0.49999988079071045,
               "count": 199,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.57,
+              "ratio": 0.83,
               "slope": 1
             },
             {
               "lib": "tanstack",
-              "median": 0.6000000238418579,
-              "p95": 0.8999999761581421,
-              "iqr": 0.20000004768371582,
-              "count": 198,
-              "trimmed": 2,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.86,
-              "slope": 1
-            },
-            {
-              "lib": "formisch",
-              "median": 0.5,
-              "p95": 0.8000000715255737,
-              "iqr": 0.20000004768371582,
-              "count": 199,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.71,
-              "slope": 1
-            },
-            {
-              "lib": "regle-schema",
-              "median": 0.8000000715255737,
-              "p95": 1.399999976158142,
+              "median": 0.6999999284744263,
+              "p95": 1.2000000476837158,
               "iqr": 0.3999999761581421,
               "count": 199,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.14,
+              "ratio": 1.17,
+              "slope": 1
+            },
+            {
+              "lib": "formisch",
+              "median": 0.3999999761581421,
+              "p95": 0.9100000858306879,
+              "iqr": 0.30000007152557373,
+              "count": 199,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.67,
+              "slope": 1
+            },
+            {
+              "lib": "regle-schema",
+              "median": 0.40000009536743164,
+              "p95": 1,
+              "iqr": 0.2999999523162842,
+              "count": 196,
+              "trimmed": 4,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.67,
               "slope": 1
             },
             {
               "lib": "regle-rules",
-              "median": 0.6000000238418579,
-              "p95": 0.9200000762939442,
-              "iqr": 0.20000004768371582,
-              "count": 197,
-              "trimmed": 3,
+              "median": 0.5,
+              "p95": 1.1999999284744263,
+              "iqr": 0.40000009536743164,
+              "count": 199,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.86,
+              "ratio": 0.83,
               "slope": 1
             },
             {
               "lib": "formkit",
-              "median": 0.7999999523162842,
-              "p95": 1.2000000476837158,
-              "iqr": 0.4000000059604645,
-              "count": 198,
-              "trimmed": 2,
+              "median": 0.6000000238418579,
+              "p95": 1.5,
+              "iqr": 0.6000000238418579,
+              "count": 199,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.14,
+              "ratio": 1,
               "slope": 1
             },
             {
               "lib": "vuelidate",
               "median": 0.5,
-              "p95": 0.7999999523162842,
-              "iqr": 0.19999995827674866,
-              "count": 194,
-              "trimmed": 6,
+              "p95": 0.899999988079071,
+              "iqr": 0.3999999761581421,
+              "count": 199,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.71,
+              "ratio": 0.83,
               "slope": 1
             }
           ]
@@ -7207,9 +7251,9 @@
           "DU": [
             {
               "lib": "attaform",
-              "median": 0.6999999284744263,
-              "p95": 0.8799999713897703,
-              "iqr": 0.1499999761581421,
+              "median": 0.7000000476837158,
+              "p95": 1.040000009536743,
+              "iqr": 0.2999999523162842,
               "count": 13,
               "trimmed": 2,
               "unit": "ms",
@@ -7219,21 +7263,21 @@
             },
             {
               "lib": "vee-validate",
-              "median": 0.5,
-              "p95": 0.8349999606609344,
-              "iqr": 0.25,
-              "count": 14,
-              "trimmed": 1,
+              "median": 0.6000000238418579,
+              "p95": 0.8000000715255737,
+              "iqr": 0.20000004768371582,
+              "count": 13,
+              "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.71,
+              "ratio": 0.86,
               "slope": 1
             },
             {
               "lib": "tanstack",
-              "median": 0.3999999761581421,
-              "p95": 0.735000056028366,
-              "iqr": 0.19999992847442627,
+              "median": 0.40000003576278687,
+              "p95": 0.9349999845027923,
+              "iqr": 0.20000004768371582,
               "count": 14,
               "trimmed": 1,
               "unit": "ms",
@@ -7243,21 +7287,9 @@
             },
             {
               "lib": "formisch",
-              "median": 0.20000004768371582,
-              "p95": 0.5350000083446502,
-              "iqr": 0.2999999523162842,
-              "count": 14,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.29,
-              "slope": 1
-            },
-            {
-              "lib": "regle-schema",
               "median": 0.5999999642372131,
-              "p95": 1.005000078678131,
-              "iqr": 0.3999999165534973,
+              "p95": 0.835000079870224,
+              "iqr": 0.2500000596046448,
               "count": 14,
               "trimmed": 1,
               "unit": "ms",
@@ -7266,39 +7298,51 @@
               "slope": 1
             },
             {
-              "lib": "regle-rules",
-              "median": 0.699999988079071,
-              "p95": 1.1350000321865081,
-              "iqr": 0.3500000238418579,
+              "lib": "regle-schema",
+              "median": 0.8999999761581421,
+              "p95": 1.2700000643730163,
+              "iqr": 0.20000004768371582,
               "count": 14,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1,
+              "ratio": 1.29,
               "slope": 1
             },
             {
-              "lib": "formkit",
-              "median": 3.399999976158142,
-              "p95": 3.700000047683716,
-              "iqr": 0.6000000238418579,
+              "lib": "regle-rules",
+              "median": 0.8000000715255737,
+              "p95": 1.1800000429153439,
+              "iqr": 0.2500000596046448,
               "count": 13,
               "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 4.86,
+              "ratio": 1.14,
               "slope": 1
             },
             {
-              "lib": "vuelidate",
-              "median": 0.44999998807907104,
-              "p95": 0.9000000178813934,
-              "iqr": 0.25,
+              "lib": "formkit",
+              "median": 3.2499999403953552,
+              "p95": 5.125000023841857,
+              "iqr": 1.7000000476837158,
               "count": 14,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.64,
+              "ratio": 4.64,
+              "slope": 1
+            },
+            {
+              "lib": "vuelidate",
+              "median": 0.5,
+              "p95": 0.6799999237060544,
+              "iqr": 0.14999991655349731,
+              "count": 13,
+              "trimmed": 2,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.71,
               "slope": 1
             }
           ]
@@ -7310,11 +7354,11 @@
           "DU": [
             {
               "lib": "attaform",
-              "median": 0.10000002384185791,
-              "p95": 0.3250000476837158,
-              "iqr": 0.10000002384185791,
-              "count": 96,
-              "trimmed": 4,
+              "median": 0.20000004768371582,
+              "p95": 0.30000007152557373,
+              "iqr": 0.19999992847442627,
+              "count": 99,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
               "ratio": 1,
@@ -7322,86 +7366,86 @@
             },
             {
               "lib": "vee-validate",
-              "median": 5.800000071525574,
-              "p95": 6,
-              "iqr": 0.10000002384185791,
+              "median": 5.900000095367432,
+              "p95": 6.100000023841858,
+              "iqr": 0.19999992847442627,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 58,
+              "ratio": 29.5,
               "slope": 1
             },
             {
               "lib": "tanstack",
               "median": 0.10000002384185791,
-              "p95": 0.20000004768371582,
+              "p95": 0.30000007152557373,
               "iqr": 0.10000002384185791,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1,
+              "ratio": 0.5,
               "slope": 1
             },
             {
               "lib": "formisch",
               "median": 0.10000002384185791,
-              "p95": 0.30000007152557373,
-              "iqr": 0.10000014305114746,
+              "p95": 0.29999996423721315,
+              "iqr": 0.19999992847442627,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1,
+              "ratio": 0.5,
               "slope": 1
             },
             {
               "lib": "regle-schema",
-              "median": 0.2999999523162842,
-              "p95": 0.5,
-              "iqr": 0.12500011920928955,
-              "count": 98,
-              "trimmed": 2,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 3,
-              "slope": 1
-            },
-            {
-              "lib": "regle-rules",
-              "median": 0.30000007152557373,
+              "median": 0.20000004768371582,
               "p95": 0.6000000238418579,
               "iqr": 0.19999992847442627,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 3,
+              "ratio": 1,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 0.2999999523162842,
+              "p95": 0.6000000238418579,
+              "iqr": 0.19999995827674866,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.5,
               "slope": 1
             },
             {
               "lib": "formkit",
-              "median": 1,
-              "p95": 1.899999976158142,
-              "iqr": 0.7000000476837158,
-              "count": 98,
-              "trimmed": 2,
+              "median": 0.7000000476837158,
+              "p95": 1.6999999284744263,
+              "iqr": 0.3999999761581421,
+              "count": 92,
+              "trimmed": 8,
               "unit": "ms",
               "supported": true,
-              "ratio": 10,
+              "ratio": 3.5,
               "slope": 1
             },
             {
               "lib": "vuelidate",
               "median": 0.10000002384185791,
-              "p95": 0.20000004768371582,
-              "iqr": 0.10000002384185791,
+              "p95": 0.2999999523162842,
+              "iqr": 0.19999992847442627,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1,
+              "ratio": 0.5,
               "slope": 1
             }
           ]
@@ -7516,11 +7560,11 @@
           "DU": [
             {
               "lib": "attaform",
-              "median": 0.5,
-              "p95": 1.1800000786781295,
-              "iqr": 0.30000007152557373,
-              "count": 47,
-              "trimmed": 3,
+              "median": 0.6000000238418579,
+              "p95": 1.6600000381469722,
+              "iqr": 0.875,
+              "count": 49,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
               "ratio": 1,
@@ -7529,85 +7573,85 @@
             {
               "lib": "vee-validate",
               "median": 0.6000000238418579,
-              "p95": 1.3000000238418579,
-              "iqr": 0.7000000476837158,
-              "count": 49,
-              "trimmed": 1,
+              "p95": 0.970000028610229,
+              "iqr": 0.20000004768371582,
+              "count": 47,
+              "trimmed": 3,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.2,
+              "ratio": 1,
               "slope": 1
             },
             {
               "lib": "tanstack",
-              "median": 0.5999999046325684,
+              "median": 0.7999999523162842,
               "p95": 1.6200000286102283,
-              "iqr": 0.7000000178813934,
+              "iqr": 0.4999999701976776,
               "count": 49,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.2,
+              "ratio": 1.33,
               "slope": 1
             },
             {
               "lib": "formisch",
-              "median": 0.6000000238418579,
-              "p95": 1.1999999284744263,
-              "iqr": 0.6000000238418579,
+              "median": 0.5,
+              "p95": 1.399999976158142,
+              "iqr": 0.574999988079071,
               "count": 49,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.2,
+              "ratio": 0.83,
               "slope": 1
             },
             {
               "lib": "regle-schema",
-              "median": 0.9000000953674316,
-              "p95": 1.9599999904632563,
-              "iqr": 1.0749998986721039,
-              "count": 49,
-              "trimmed": 1,
+              "median": 0.6000000238418579,
+              "p95": 1.1749999523162842,
+              "iqr": 0.2749999761581421,
+              "count": 46,
+              "trimmed": 4,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.8,
+              "ratio": 1,
               "slope": 1
             },
             {
               "lib": "regle-rules",
-              "median": 0.7999999523162842,
-              "p95": 2.0599999427795406,
-              "iqr": 0.875,
-              "count": 49,
-              "trimmed": 1,
+              "median": 0.7000000476837158,
+              "p95": 1.100000023841858,
+              "iqr": 0.2999999523162842,
+              "count": 48,
+              "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.6,
+              "ratio": 1.17,
               "slope": 1
             },
             {
               "lib": "formkit",
               "median": 2.600000023841858,
               "p95": 3.355000019073486,
-              "iqr": 0.700000137090683,
+              "iqr": 0.7000000178813934,
               "count": 50,
               "trimmed": 0,
               "unit": "ms",
               "supported": true,
-              "ratio": 5.2,
+              "ratio": 4.33,
               "slope": 1
             },
             {
               "lib": "vuelidate",
               "median": 0.5,
-              "p95": 1.100000023841858,
-              "iqr": 0.5000000894069672,
+              "p95": 1.2199999809265125,
+              "iqr": 0.6000000238418579,
               "count": 49,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1,
+              "ratio": 0.83,
               "slope": 1
             }
           ]
@@ -7621,7 +7665,7 @@
               "lib": "attaform",
               "retained": {
                 "median": 105896,
-                "p95": 289132,
+                "p95": 288788,
                 "count": 12
               },
               "churn": {
@@ -7636,15 +7680,15 @@
               },
               "series": {
                 "retained": [
-                  548692, 129908, 187456, 134624, 142104, 104420, 91364, 91644, 289132, 94500,
+                  539876, 129908, 187456, 133852, 142876, 104420, 91364, 91644, 288788, 94500,
                   105896, 93096
                 ],
                 "churn": [
-                  947192, 607420, 630004, 603264, 593428, 603256, 582444, 615196, 596220, 604824,
+                  970392, 607420, 630004, 603264, 593428, 603256, 582444, 615196, 596220, 604808,
                   623916, 574488
                 ],
                 "leak": [
-                  798984, 57480, 120960, 56744, 55160, 37028, 1284, 18012, 215108, 22284, 47600,
+                  798984, 57480, 120960, 55972, 55932, 37028, 1284, 18012, 215108, 22284, 47600,
                   16420
                 ]
               },
@@ -7655,66 +7699,66 @@
             {
               "lib": "vee-validate",
               "retained": {
-                "median": 66760,
-                "p95": 150480,
+                "median": 65076,
+                "p95": 150512,
                 "count": 12
               },
               "churn": {
-                "median": 237728,
-                "p95": 257416,
+                "median": 231868,
+                "p95": 253972,
                 "count": 12
               },
               "leak": {
-                "median": 19276,
-                "p95": 115036,
+                "median": 19256,
+                "p95": 136220,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  349448, 122688, 150480, 86480, 109980, 65076, 60108, 61236, 105412, 60320, 61712,
-                  66760
+                  349480, 122688, 150512, 73844, 109592, 65076, 60108, 61936, 117032, 60320, 61712,
+                  55140
                 ],
                 "churn": [
-                  346724, 243268, 245928, 240124, 236296, 231868, 234908, 245164, 257416, 237728,
-                  229932, 218792
+                  387588, 214324, 219748, 241228, 236296, 231868, 234908, 245164, 253972, 220688,
+                  229932, 219776
                 ],
                 "leak": [
-                  449308, 73996, 115036, 30024, 76496, 19276, 3092, 10448, 74048, 14564, 14244, 0
+                  449468, 73964, 115052, 29760, 136220, 19256, 3092, 11148, 73232, 14564, 14244, 0
                 ]
               },
               "supported": true,
-              "ratio": 0.63,
+              "ratio": 0.61,
               "slope": 1
             },
             {
               "lib": "tanstack",
               "retained": {
                 "median": 58020,
-                "p95": 126684,
+                "p95": 126716,
                 "count": 12
               },
               "churn": {
-                "median": 102856,
-                "p95": 871876,
+                "median": 105352,
+                "p95": 872252,
                 "count": 12
               },
               "leak": {
-                "median": 45296,
-                "p95": 134516,
+                "median": 45524,
+                "p95": 134580,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  326752, 77604, 126684, 60232, 97192, 54568, 52780, 53244, 95744, 53932, 58020,
-                  53520
+                  326816, 77604, 126716, 60232, 96992, 54740, 52608, 53244, 95744, 53932, 58020,
+                  51916
                 ],
                 "churn": [
-                  455604, 89300, 101616, 102856, 124588, 89328, 88556, 91424, 871876, 859320,
-                  878336, 840612
+                  454248, 88400, 105352, 102228, 125848, 89856, 61348, 99872, 872252, 858564,
+                  877964, 842904
                 ],
                 "leak": [
-                  669112, 70192, 134516, 28940, 103676, 45296, 28512, 37816, 84448, 34792, 49948,
-                  21792
+                  669372, 70192, 134580, 28312, 102968, 45524, 28988, 37796, 84420, 34112, 49344,
+                  22548
                 ]
               },
               "supported": true,
@@ -7759,30 +7803,30 @@
               "lib": "regle-schema",
               "retained": {
                 "median": 121704,
-                "p95": 254980,
+                "p95": 255044,
                 "count": 12
               },
               "churn": {
-                "median": 475952,
-                "p95": 567096,
+                "median": 475456,
+                "p95": 582508,
                 "count": 12
               },
               "leak": {
                 "median": 24324,
-                "p95": 146692,
+                "p95": 146756,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  424676, 149880, 254980, 133864, 146236, 114532, 109936, 110092, 173748, 121704,
+                  424740, 149880, 255044, 133864, 146236, 114532, 109936, 110092, 173748, 121704,
                   119960, 107700
                 ],
                 "churn": [
-                  975344, 567096, 535972, 470716, 475952, 461900, 461908, 474376, 489728, 506848,
-                  482092, 442756
+                  962548, 582508, 535988, 452808, 475456, 461900, 461936, 474376, 489456, 488628,
+                  481608, 460872
                 ],
                 "leak": [
-                  541564, 49308, 146692, 24324, 46476, 15004, 156, 7736, 71344, 31212, 22752, 456
+                  541660, 49308, 146756, 24324, 46476, 15004, 156, 7736, 71344, 31212, 22752, 456
                 ]
               },
               "supported": true,
@@ -7798,7 +7842,7 @@
               },
               "churn": {
                 "median": 435120,
-                "p95": 466272,
+                "p95": 466288,
                 "count": 12
               },
               "leak": {
@@ -7812,7 +7856,7 @@
                   151240, 145732
                 ],
                 "churn": [
-                  626120, 438776, 435120, 431788, 434932, 435780, 426568, 437712, 442808, 466272,
+                  626120, 438776, 435120, 431788, 434932, 435780, 426568, 437712, 442808, 466288,
                   434024, 422944
                 ],
                 "leak": [
@@ -7826,36 +7870,36 @@
             {
               "lib": "formkit",
               "retained": {
-                "median": 1103288,
-                "p95": 1260208,
+                "median": 1100340,
+                "p95": 1260260,
                 "count": 12
               },
               "churn": {
-                "median": 224568,
-                "p95": 290688,
+                "median": 226668,
+                "p95": 291128,
                 "count": 12
               },
               "leak": {
-                "median": 54708,
-                "p95": 225072,
+                "median": 62172,
+                "p95": 225132,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  1910316, 1260208, 1137512, 1108120, 1103288, 1071976, 1086628, 1069016, 1138336,
-                  1145100, 1071180, 1100440
+                  1910348, 1260260, 1131040, 1087588, 1122344, 1071872, 1067800, 1089408, 1136900,
+                  1126104, 1090368, 1100340
                 ],
                 "churn": [
-                  986588, 290688, 269100, 265916, 224568, 223800, 207156, 227320, 218552, 275116,
-                  192264, 187848
+                  982356, 291128, 270048, 268832, 246420, 220572, 204472, 226668, 218692, 275320,
+                  191388, 188716
                 ],
                 "leak": [
-                  1243560, 225072, 117216, 62404, 54708, 29500, 3892, 27692, 86056, 101320, 17660,
-                  27868
+                  1243560, 225132, 109164, 62172, 67972, 29472, 4016, 28036, 86000, 101320, 17856,
+                  27792
                 ]
               },
               "supported": true,
-              "ratio": 10.42,
+              "ratio": 10.39,
               "slope": 1
             },
             {
@@ -7903,7 +7947,7 @@
           "L2000": [
             {
               "lib": "attaform",
-              "median": 6.900000095367432,
+              "median": 7.100000023841858,
               "p95": 8.804999953508377,
               "iqr": 0.8999999761581421,
               "count": 120,
@@ -7916,22 +7960,22 @@
             {
               "lib": "vee-validate",
               "median": 4,
-              "p95": 5.100000023841858,
-              "iqr": 0.8000000715255737,
+              "p95": 5,
+              "iqr": 0.8999999761581421,
               "count": 120,
               "trimmed": 0,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.58,
+              "ratio": 0.56,
               "slope": 1
             },
             {
               "lib": "tanstack",
-              "median": 11.100000023841858,
-              "p95": 13.230000019073486,
-              "iqr": 1.125,
-              "count": 115,
-              "trimmed": 5,
+              "median": 11.399999976158142,
+              "p95": 13.720000040531158,
+              "iqr": 1.2999999821186066,
+              "count": 119,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
               "ratio": 1.61,
@@ -7939,59 +7983,59 @@
             },
             {
               "lib": "formisch",
-              "median": 4.5,
-              "p95": 5.5,
-              "iqr": 0.6999999284744263,
+              "median": 5.199999928474426,
+              "p95": 5.81000006198883,
+              "iqr": 0.7000000476837158,
               "count": 119,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.65,
+              "ratio": 0.73,
               "slope": 1
             },
             {
               "lib": "regle-schema",
-              "median": 9.100000023841858,
-              "p95": 10.200000047683716,
-              "iqr": 0.7999999523162842,
+              "median": 7.899999976158142,
+              "p95": 9.69999993443489,
+              "iqr": 0.9250000715255737,
               "count": 120,
               "trimmed": 0,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.32,
+              "ratio": 1.11,
               "slope": 1
             },
             {
               "lib": "regle-rules",
-              "median": 4.5,
-              "p95": 5.299999958276748,
-              "iqr": 0.6000000238418579,
-              "count": 120,
-              "trimmed": 0,
+              "median": 4.399999976158142,
+              "p95": 5.200000047683716,
+              "iqr": 0.4000000059604645,
+              "count": 119,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.65,
+              "ratio": 0.62,
               "slope": 1
             },
             {
               "lib": "formkit",
-              "median": 2.600000023841858,
-              "p95": 3.899999976158142,
-              "iqr": 0.6999999284744263,
-              "count": 119,
-              "trimmed": 1,
+              "median": 2.899999976158142,
+              "p95": 3.720000028610228,
+              "iqr": 0.42500007152557373,
+              "count": 117,
+              "trimmed": 3,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.38,
+              "ratio": 0.41,
               "slope": 1
             },
             {
               "lib": "vuelidate",
-              "median": 4.300000071525574,
-              "p95": 5.110000026226043,
-              "iqr": 0.49999988079071045,
-              "count": 119,
-              "trimmed": 1,
+              "median": 4.400000095367432,
+              "p95": 4.900000095367432,
+              "iqr": 0.29999998211860657,
+              "count": 117,
+              "trimmed": 3,
               "unit": "ms",
               "supported": true,
               "ratio": 0.62,
@@ -8001,99 +8045,99 @@
           "L5000": [
             {
               "lib": "attaform",
-              "median": 17.19999998807907,
-              "p95": 20.415000092983245,
-              "iqr": 2.450000047683716,
+              "median": 16.899999976158142,
+              "p95": 19.80999995470047,
+              "iqr": 1.9249999523162842,
               "count": 120,
               "trimmed": 0,
               "unit": "ms",
               "supported": true,
               "ratio": 1,
-              "slope": 2.49
+              "slope": 2.38
             },
             {
               "lib": "vee-validate",
-              "median": 8.100000023841858,
-              "p95": 10.004999995231628,
-              "iqr": 2.6999999284744263,
+              "median": 7.700000047683716,
+              "p95": 9.705000042915344,
+              "iqr": 2.599999964237213,
+              "count": 120,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.46,
+              "slope": 1.93
+            },
+            {
+              "lib": "tanstack",
+              "median": 37.799999952316284,
+              "p95": 46.75000004768371,
+              "iqr": 8.299999952316284,
+              "count": 120,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 2.24,
+              "slope": 3.32
+            },
+            {
+              "lib": "formisch",
+              "median": 7.799999952316284,
+              "p95": 9.5,
+              "iqr": 1.5500000715255737,
+              "count": 120,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.46,
+              "slope": 1.5
+            },
+            {
+              "lib": "regle-schema",
+              "median": 20.200000047683716,
+              "p95": 23.30999995470047,
+              "iqr": 1.4249999821186066,
+              "count": 119,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 1.2,
+              "slope": 2.56
+            },
+            {
+              "lib": "regle-rules",
+              "median": 7,
+              "p95": 9.600000023841858,
+              "iqr": 1.2999999523162842,
+              "count": 120,
+              "trimmed": 0,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.41,
+              "slope": 1.59
+            },
+            {
+              "lib": "formkit",
+              "median": 4.099999904632568,
+              "p95": 6,
+              "iqr": 1.0250000953674316,
+              "count": 119,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 0.24,
+              "slope": 1.41
+            },
+            {
+              "lib": "vuelidate",
+              "median": 8,
+              "p95": 9.605000019073486,
+              "iqr": 1.100000023841858,
               "count": 120,
               "trimmed": 0,
               "unit": "ms",
               "supported": true,
               "ratio": 0.47,
-              "slope": 2.03
-            },
-            {
-              "lib": "tanstack",
-              "median": 32.200000047683716,
-              "p95": 38.625,
-              "iqr": 2.9249999821186066,
-              "count": 116,
-              "trimmed": 4,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1.87,
-              "slope": 2.9
-            },
-            {
-              "lib": "formisch",
-              "median": 8.600000023841858,
-              "p95": 9.419999980926512,
-              "iqr": 0.7000000476837158,
-              "count": 119,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.5,
-              "slope": 1.91
-            },
-            {
-              "lib": "regle-schema",
-              "median": 22,
-              "p95": 23.50499999523163,
-              "iqr": 1.2249999642372131,
-              "count": 120,
-              "trimmed": 0,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1.28,
-              "slope": 2.42
-            },
-            {
-              "lib": "regle-rules",
-              "median": 7.400000035762787,
-              "p95": 9.299999958276748,
-              "iqr": 1.1250000298023224,
-              "count": 120,
-              "trimmed": 0,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.43,
-              "slope": 1.64
-            },
-            {
-              "lib": "formkit",
-              "median": 5.600000023841858,
-              "p95": 6.429999983310697,
-              "iqr": 0.7000000476837158,
-              "count": 118,
-              "trimmed": 2,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.33,
-              "slope": 2.15
-            },
-            {
-              "lib": "vuelidate",
-              "median": 8.299999952316284,
-              "p95": 10.100000023841858,
-              "iqr": 1.1249999403953552,
-              "count": 119,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 0.48,
-              "slope": 1.93
+              "slope": 1.82
             }
           ]
         }
@@ -8104,9 +8148,9 @@
           "L2000": [
             {
               "lib": "attaform",
-              "median": 243,
-              "p95": 261.1299999713898,
-              "iqr": 14.900000095367432,
+              "median": 241.79999995231628,
+              "p95": 259.3700000286102,
+              "iqr": 17.899999976158142,
               "count": 7,
               "trimmed": 0,
               "unit": "ms",
@@ -8116,86 +8160,86 @@
             },
             {
               "lib": "vee-validate",
-              "median": 410.6999999284744,
-              "p95": 433.02999993562696,
-              "iqr": 12.749999940395355,
+              "median": 411.5,
+              "p95": 430.9900000333786,
+              "iqr": 11.149999976158142,
               "count": 7,
               "trimmed": 0,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.69,
+              "ratio": 1.7,
               "slope": 1
             },
             {
               "lib": "tanstack",
-              "median": 3296.25,
-              "p95": 3453.0000000298023,
-              "iqr": 134.65000009536743,
-              "count": 6,
-              "trimmed": 1,
+              "median": 3305.100000023842,
+              "p95": 3683.570000004768,
+              "iqr": 199.0999999642372,
+              "count": 7,
+              "trimmed": 0,
               "unit": "ms",
               "supported": true,
-              "ratio": 13.56,
+              "ratio": 13.67,
               "slope": 1
             },
             {
               "lib": "formisch",
-              "median": 27.600000023841858,
-              "p95": 37.77000005245208,
-              "iqr": 5.75,
-              "count": 7,
-              "trimmed": 0,
+              "median": 29.44999998807907,
+              "p95": 30.999999970197678,
+              "iqr": 1.75,
+              "count": 6,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.11,
+              "ratio": 0.12,
               "slope": 1
             },
             {
               "lib": "regle-schema",
-              "median": 92.10000002384186,
-              "p95": 115.63000004291533,
-              "iqr": 16.449999928474426,
+              "median": 88,
+              "p95": 118.920000064373,
+              "iqr": 20.15000009536743,
               "count": 7,
               "trimmed": 0,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.38,
+              "ratio": 0.36,
               "slope": 1
             },
             {
               "lib": "regle-rules",
-              "median": 106.39999997615814,
-              "p95": 145.83000000715256,
+              "median": 105,
+              "p95": 146.10999999046325,
               "iqr": 22.750000059604645,
               "count": 7,
               "trimmed": 0,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.44,
+              "ratio": 0.43,
               "slope": 1
             },
             {
               "lib": "formkit",
-              "median": 5229,
-              "p95": 5608.280000007152,
-              "iqr": 265.60000002384186,
+              "median": 4623.899999976158,
+              "p95": 5497.4,
+              "iqr": 724.9499999284744,
               "count": 7,
               "trimmed": 0,
               "unit": "ms",
               "supported": true,
-              "ratio": 21.52,
+              "ratio": 19.12,
               "slope": 1
             },
             {
               "lib": "vuelidate",
-              "median": 45.89999997615814,
-              "p95": 57.14999995231628,
-              "iqr": 6.799999952316284,
+              "median": 42.89999997615814,
+              "p95": 56.609999966621395,
+              "iqr": 9.800000071525574,
               "count": 7,
               "trimmed": 0,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.19,
+              "ratio": 0.18,
               "slope": 1
             }
           ]
@@ -8207,9 +8251,9 @@
           "L2000": [
             {
               "lib": "attaform",
-              "median": 1.2999999523162842,
-              "p95": 1.754999959468841,
-              "iqr": 0.3999999761581421,
+              "median": 1.2000000476837158,
+              "p95": 1.5,
+              "iqr": 0.5,
               "count": 24,
               "trimmed": 1,
               "unit": "ms",
@@ -8219,86 +8263,86 @@
             },
             {
               "lib": "vee-validate",
-              "median": 12.25,
-              "p95": 12.854999983310698,
-              "iqr": 0.3999999761581421,
+              "median": 12.349999964237213,
+              "p95": 13.324999994039535,
+              "iqr": 0.6999999284744263,
               "count": 24,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 9.42,
+              "ratio": 10.29,
               "slope": 1
             },
             {
               "lib": "tanstack",
-              "median": 382.6999999284744,
-              "p95": 388.66000003814696,
-              "iqr": 3.4999998807907104,
+              "median": 386.2999999523163,
+              "p95": 391.16000003814696,
+              "iqr": 5,
               "count": 25,
               "trimmed": 0,
               "unit": "ms",
               "supported": true,
-              "ratio": 294.38,
+              "ratio": 321.92,
               "slope": 1
             },
             {
               "lib": "formisch",
-              "median": 0.8999999761581421,
-              "p95": 1.3849999725818631,
+              "median": 1,
+              "p95": 1.6399999320507042,
               "iqr": 0.2999999523162842,
               "count": 24,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.69,
+              "ratio": 0.83,
               "slope": 1
             },
             {
               "lib": "regle-schema",
-              "median": 16.399999976158142,
-              "p95": 19.520000052452083,
-              "iqr": 2,
+              "median": 14.199999928474426,
+              "p95": 17.59999995231628,
+              "iqr": 3.100000023841858,
               "count": 25,
               "trimmed": 0,
               "unit": "ms",
               "supported": true,
-              "ratio": 12.62,
+              "ratio": 11.83,
               "slope": 1
             },
             {
               "lib": "regle-rules",
-              "median": 39.60000002384186,
-              "p95": 41.290000069141385,
-              "iqr": 1,
-              "count": 22,
-              "trimmed": 3,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 30.46,
-              "slope": 1
-            },
-            {
-              "lib": "formkit",
-              "median": 175.09999990463257,
-              "p95": 179.70000005960463,
-              "iqr": 4.799999952316284,
+              "median": 38.5,
+              "p95": 40.369999980926515,
+              "iqr": 1.2000000476837158,
               "count": 23,
               "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 134.69,
+              "ratio": 32.08,
+              "slope": 1
+            },
+            {
+              "lib": "formkit",
+              "median": 163.89999997615814,
+              "p95": 177.8650000810623,
+              "iqr": 8.899999976158142,
+              "count": 24,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 136.58,
               "slope": 1
             },
             {
               "lib": "vuelidate",
               "median": 0.20000004768371582,
-              "p95": 0.30000007152557373,
-              "iqr": 0.10000002384185791,
-              "count": 24,
-              "trimmed": 1,
+              "p95": 0.20000004768371582,
+              "iqr": 0,
+              "count": 19,
+              "trimmed": 6,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.15,
+              "ratio": 0.17,
               "slope": 1
             }
           ],
@@ -8307,93 +8351,93 @@
               "lib": "attaform",
               "median": 1.6999999284744263,
               "p95": 1.9000000774860382,
-              "iqr": 0.3999999761581421,
+              "iqr": 0.5999999046325684,
               "count": 24,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
               "ratio": 1,
-              "slope": 1.31
+              "slope": 1.42
             },
             {
               "lib": "vee-validate",
-              "median": 20.399999976158142,
-              "p95": 24.479999923706053,
-              "iqr": 1.9000000953674316,
-              "count": 25,
-              "trimmed": 0,
+              "median": 20.350000023841858,
+              "p95": 23.854999983310698,
+              "iqr": 2,
+              "count": 24,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 12,
-              "slope": 1.67
+              "ratio": 11.97,
+              "slope": 1.65
             },
             {
               "lib": "tanstack",
-              "median": 2773.5,
-              "p95": 2821.2599999904633,
-              "iqr": 28.200000047683716,
-              "count": 25,
-              "trimmed": 0,
+              "median": 2740.149999976158,
+              "p95": 2782.4050000071525,
+              "iqr": 31.299999952316284,
+              "count": 24,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1631.47,
-              "slope": 7.25
+              "ratio": 1611.85,
+              "slope": 7.09
             },
             {
               "lib": "formisch",
-              "median": 1.2999999523162842,
-              "p95": 1.585000020265579,
-              "iqr": 0.30000007152557373,
+              "median": 1.3499999642372131,
+              "p95": 1.9700000107288356,
+              "iqr": 0.5999999046325684,
               "count": 24,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 0.76,
-              "slope": 1.44
+              "ratio": 0.79,
+              "slope": 1.35
             },
             {
               "lib": "regle-schema",
-              "median": 42,
-              "p95": 46.21999998092651,
-              "iqr": 2.200000047683716,
+              "median": 41,
+              "p95": 45.839999961853025,
+              "iqr": 3.4000000953674316,
               "count": 25,
               "trimmed": 0,
               "unit": "ms",
               "supported": true,
-              "ratio": 24.71,
-              "slope": 2.56
+              "ratio": 24.12,
+              "slope": 2.89
             },
             {
               "lib": "regle-rules",
-              "median": 104.1499999165535,
-              "p95": 108.40999999642372,
-              "iqr": 4,
+              "median": 99.05000001192093,
+              "p95": 103.18000006079673,
+              "iqr": 3.5,
               "count": 24,
               "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 61.26,
-              "slope": 2.63
+              "ratio": 58.26,
+              "slope": 2.57
             },
             {
               "lib": "formkit",
-              "median": 520.8999999761581,
-              "p95": 532.3000000238419,
-              "iqr": 18.199999928474426,
+              "median": 493.7999999523163,
+              "p95": 507.02000002861024,
+              "iqr": 9.800000071525574,
               "count": 25,
               "trimmed": 0,
               "unit": "ms",
               "supported": true,
-              "ratio": 306.41,
-              "slope": 2.97
+              "ratio": 290.47,
+              "slope": 3.01
             },
             {
               "lib": "vuelidate",
               "median": 0.3999999761581421,
-              "p95": 0.6000000238418579,
-              "iqr": 0.19999992847442627,
-              "count": 22,
-              "trimmed": 3,
+              "p95": 0.6999999284744263,
+              "iqr": 0.2999999523162842,
+              "count": 23,
+              "trimmed": 2,
               "unit": "ms",
               "supported": true,
               "ratio": 0.24,
@@ -8409,24 +8453,24 @@
             {
               "lib": "attaform",
               "retained": {
-                "median": 67216356,
-                "p95": 67323384,
+                "median": 67215112,
+                "p95": 67325568,
                 "count": 5
               },
               "churn": {
-                "median": 17005244,
-                "p95": 19917628,
+                "median": 19251768,
+                "p95": 22102916,
                 "count": 5
               },
               "leak": {
                 "median": 39824,
-                "p95": 92416,
+                "p95": 92320,
                 "count": 5
               },
               "series": {
-                "retained": [69073408, 67323384, 67216356, 67171244, 67156156],
-                "churn": [19917628, 16984000, 16907952, 26044656, 17005244],
-                "leak": [2036972, 92416, 39464, 39824, 932]
+                "retained": [69073484, 67325568, 67215112, 67168496, 67158672],
+                "churn": [22102916, 19251768, 16934220, 16965576, 24348360],
+                "leak": [2036924, 92320, 39272, 39824, 644]
               },
               "supported": true,
               "ratio": 1,
@@ -8435,24 +8479,24 @@
             {
               "lib": "vee-validate",
               "retained": {
-                "median": 23177628,
-                "p95": 23210348,
+                "median": 23177652,
+                "p95": 23210376,
                 "count": 5
               },
               "churn": {
-                "median": 1516832,
-                "p95": 1789484,
+                "median": 1068464,
+                "p95": 1512172,
                 "count": 5
               },
               "leak": {
-                "median": 1546772,
-                "p95": 1559552,
+                "median": 1547692,
+                "p95": 1558608,
                 "count": 5
               },
               "series": {
-                "retained": [22400996, 23211104, 23177628, 23164644, 23210348],
-                "churn": [1789484, 851428, 1516832, 1004280, 1932840],
-                "leak": [1206332, 1561896, 1546772, 1559552, 1538792]
+                "retained": [22401480, 23211108, 23177652, 23164664, 23210376],
+                "churn": [1068464, 851020, 1512172, 998340, 1942444],
+                "leak": [1206332, 1561928, 1547692, 1558608, 1538784]
               },
               "supported": true,
               "ratio": 0.34,
@@ -8461,24 +8505,24 @@
             {
               "lib": "tanstack",
               "retained": {
-                "median": 23106236,
-                "p95": 23201240,
+                "median": 23132104,
+                "p95": 23204772,
                 "count": 5
               },
               "churn": {
-                "median": 7402324,
-                "p95": 7418324,
+                "median": 4966044,
+                "p95": 4978444,
                 "count": 5
               },
               "leak": {
-                "median": 1685744,
-                "p95": 1695056,
+                "median": 1677544,
+                "p95": 1714744,
                 "count": 5
               },
               "series": {
-                "retained": [24319208, 23201240, 23060060, 23072264, 23106236],
-                "churn": [2898340, 7402324, 5542784, 7577920, 7418324],
-                "leak": [4432448, 524876, 1665348, 1685744, 1695056]
+                "retained": [24316108, 23204772, 23067768, 23087896, 23132104],
+                "churn": [3077572, 5025852, 4978444, 2459216, 4966044],
+                "leak": [4429748, 514412, 1668060, 1677544, 1714744]
               },
               "supported": true,
               "ratio": 0.34,
@@ -8487,24 +8531,24 @@
             {
               "lib": "formisch",
               "retained": {
-                "median": 11800624,
-                "p95": 11802992,
+                "median": 11801512,
+                "p95": 11804568,
                 "count": 5
               },
               "churn": {
-                "median": 298516,
-                "p95": 1132960,
+                "median": 995268,
+                "p95": 1233860,
                 "count": 5
               },
               "leak": {
-                "median": 6116,
+                "median": 4424,
                 "p95": 12456,
                 "count": 5
               },
               "series": {
-                "retained": [12346960, 11800624, 11762732, 11763764, 11802992],
-                "churn": [1132960, 1135044, 184996, 298516, 153820],
-                "leak": [674900, 6116, 2896, 2716, 12456]
+                "retained": [12348240, 11801512, 11766176, 11765700, 11804568],
+                "churn": [1233860, 995268, 434540, 935848, 1678196],
+                "leak": [676132, 4424, 3548, 2564, 12456]
               },
               "supported": true,
               "ratio": 0.18,
@@ -8513,24 +8557,24 @@
             {
               "lib": "regle-schema",
               "retained": {
-                "median": 34331760,
-                "p95": 34398156,
+                "median": 34331196,
+                "p95": 34398132,
                 "count": 5
               },
               "churn": {
-                "median": 2457224,
-                "p95": 7131440,
+                "median": 4389700,
+                "p95": 4880396,
                 "count": 5
               },
               "leak": {
-                "median": 26212,
-                "p95": 28116,
+                "median": 26048,
+                "p95": 26912,
                 "count": 5
               },
               "series": {
-                "retained": [35604004, 34398156, 34170884, 34331760, 34170544],
-                "churn": [1410896, 7131440, 2457224, 7221784, 1243716],
-                "leak": [1474400, 28116, 26212, 9088, 6972]
+                "retained": [35617208, 34398132, 34169160, 34331196, 34168604],
+                "churn": [4389700, 4880396, 5911200, 1210260, 1155072],
+                "leak": [1475648, 26912, 26048, 9016, 6576]
               },
               "supported": true,
               "ratio": 0.51,
@@ -8539,24 +8583,24 @@
             {
               "lib": "regle-rules",
               "retained": {
-                "median": 42661708,
-                "p95": 42673716,
+                "median": 42675656,
+                "p95": 42695704,
                 "count": 5
               },
               "churn": {
-                "median": 1022788,
-                "p95": 1866612,
+                "median": 1014252,
+                "p95": 1353352,
                 "count": 5
               },
               "leak": {
-                "median": 33112,
-                "p95": 36532,
+                "median": 35204,
+                "p95": 36428,
                 "count": 5
               },
               "series": {
-                "retained": [43958232, 42661708, 42673716, 42376016, 42654744],
-                "churn": [868180, 1894344, 486552, 1866612, 1022788],
-                "leak": [1548576, 36532, 33112, 10072, 0]
+                "retained": [43958064, 42660748, 42675656, 42388364, 42695704],
+                "churn": [580704, 1894776, 320976, 1014252, 1353352],
+                "leak": [1548456, 36428, 33648, 0, 35204]
               },
               "supported": true,
               "ratio": 0.63,
@@ -8565,24 +8609,24 @@
             {
               "lib": "formkit",
               "retained": {
-                "median": 386180468,
-                "p95": 386383152,
+                "median": 386199804,
+                "p95": 386366480,
                 "count": 5
               },
               "churn": {
-                "median": 1075104,
-                "p95": 1117440,
+                "median": 1103312,
+                "p95": 1129952,
                 "count": 5
               },
               "leak": {
-                "median": 10784,
-                "p95": 75916,
+                "median": 71588,
+                "p95": 12178964,
                 "count": 5
               },
               "series": {
-                "retained": [398013852, 386180468, 386000732, 386175916, 386383152],
-                "churn": [1136584, 1048788, 1117440, 1075104, 1046620],
-                "leak": [12182184, 75916, 4456, 10784, 6940]
+                "retained": [397733712, 386111520, 386009988, 386199804, 386366480],
+                "churn": [1137488, 1056068, 1129952, 1103312, 1046056],
+                "leak": [12178964, 71588, 85673676, 15572, 5328]
               },
               "supported": true,
               "ratio": 5.75,
@@ -8591,24 +8635,24 @@
             {
               "lib": "vuelidate",
               "retained": {
-                "median": 15177156,
-                "p95": 15221312,
+                "median": 15184248,
+                "p95": 15226544,
                 "count": 5
               },
               "churn": {
-                "median": 4170380,
-                "p95": 4305280,
+                "median": 3609900,
+                "p95": 4264456,
                 "count": 5
               },
               "leak": {
-                "median": 9720,
-                "p95": 17892,
+                "median": 9780,
+                "p95": 17916,
                 "count": 5
               },
               "series": {
-                "retained": [16018352, 15221312, 15166576, 15177156, 15174272],
-                "churn": [4170380, 2611168, 5112836, 4305280, 3723404],
-                "leak": [902156, 9720, 8356, 17892, 3884]
+                "retained": [16016780, 15226544, 15169408, 15184248, 15171748],
+                "churn": [5144792, 3609900, 2622040, 3246868, 4264456],
+                "leak": [902156, 9780, 7232, 17916, 1132]
               },
               "supported": true,
               "ratio": 0.23,
@@ -8626,8 +8670,8 @@
             {
               "lib": "attaform",
               "median": 0.20000004768371582,
-              "p95": 0.5,
-              "iqr": 0.20000004768371582,
+              "p95": 0.40000009536743164,
+              "iqr": 0.19999995827674866,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
@@ -8637,45 +8681,57 @@
             },
             {
               "lib": "vee-validate",
-              "median": 6,
-              "p95": 6.299999952316284,
-              "iqr": 0.2999999523162842,
-              "count": 99,
-              "trimmed": 1,
+              "median": 5.950000047683716,
+              "p95": 6.1999999463558195,
+              "iqr": 0.19999992847442627,
+              "count": 98,
+              "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 30,
+              "ratio": 29.75,
               "slope": 1
             },
             {
               "lib": "tanstack",
-              "median": 0.19999992847442627,
-              "p95": 0.30000007152557373,
-              "iqr": 0.19999992847442627,
-              "count": 99,
-              "trimmed": 1,
+              "median": 0.10000002384185791,
+              "p95": 0.2999999701976776,
+              "iqr": 0.10000002384185791,
+              "count": 98,
+              "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 1,
+              "ratio": 0.5,
               "slope": 1
             },
             {
               "lib": "formisch",
-              "median": 0.19999992847442627,
-              "p95": 0.30000007152557373,
-              "iqr": 0.10000002384185791,
-              "count": 99,
-              "trimmed": 1,
+              "median": 0.10000002384185791,
+              "p95": 0.10000002384185791,
+              "iqr": 1.1920928955078125e-7,
+              "count": 78,
+              "trimmed": 22,
               "unit": "ms",
               "supported": true,
-              "ratio": 1,
+              "ratio": 0.5,
               "slope": 1
             },
             {
               "lib": "regle-schema",
-              "median": 0.5,
-              "p95": 0.8999999761581421,
+              "median": 0.5999999046325684,
+              "p95": 1.0099999904632562,
               "iqr": 0.3999999761581421,
+              "count": 99,
+              "trimmed": 1,
+              "unit": "ms",
+              "supported": true,
+              "ratio": 3,
+              "slope": 1
+            },
+            {
+              "lib": "regle-rules",
+              "median": 0.5,
+              "p95": 0.7999999642372131,
+              "iqr": 0.2999999523162842,
               "count": 99,
               "trimmed": 1,
               "unit": "ms",
@@ -8684,36 +8740,24 @@
               "slope": 1
             },
             {
-              "lib": "regle-rules",
-              "median": 0.30000007152557373,
-              "p95": 0.8000000715255737,
-              "iqr": 0.2999999523162842,
-              "count": 99,
-              "trimmed": 1,
-              "unit": "ms",
-              "supported": true,
-              "ratio": 1.5,
-              "slope": 1
-            },
-            {
               "lib": "formkit",
-              "median": 1.5,
+              "median": 1.3000000715255737,
               "p95": 2.100000023841858,
-              "iqr": 0.5000000298023224,
-              "count": 92,
-              "trimmed": 8,
+              "iqr": 0.5999999046325684,
+              "count": 95,
+              "trimmed": 5,
               "unit": "ms",
               "supported": true,
-              "ratio": 7.5,
+              "ratio": 6.5,
               "slope": 1
             },
             {
               "lib": "vuelidate",
               "median": 0.10000002384185791,
-              "p95": 0.20000004768371582,
-              "iqr": 0.10000002384185791,
-              "count": 99,
-              "trimmed": 1,
+              "p95": 0.10000002384185791,
+              "iqr": 1.1920928955078125e-7,
+              "count": 77,
+              "trimmed": 23,
               "unit": "ms",
               "supported": true,
               "ratio": 0.5,
@@ -8729,10 +8773,10 @@
             {
               "lib": "attaform",
               "median": 0.2999999523162842,
-              "p95": 0.8000000715255737,
-              "iqr": 0.27500009536743164,
-              "count": 49,
-              "trimmed": 1,
+              "p95": 0.5,
+              "iqr": 0.19999992847442627,
+              "count": 48,
+              "trimmed": 2,
               "unit": "ms",
               "supported": true,
               "ratio": 1,
@@ -8742,7 +8786,7 @@
               "lib": "vee-validate",
               "median": 6,
               "p95": 6.200000047683716,
-              "iqr": 0.2999999523162842,
+              "iqr": 0.10000002384185791,
               "count": 49,
               "trimmed": 1,
               "unit": "ms",
@@ -8753,10 +8797,10 @@
             {
               "lib": "tanstack",
               "median": 0.20000004768371582,
-              "p95": 0.8000000715255737,
-              "iqr": 0.30000007152557373,
-              "count": 49,
-              "trimmed": 1,
+              "p95": 0.3999999761581421,
+              "iqr": 0.10000014305114746,
+              "count": 47,
+              "trimmed": 3,
               "unit": "ms",
               "supported": true,
               "ratio": 0.67,
@@ -8765,7 +8809,7 @@
             {
               "lib": "formisch",
               "median": 0.09999990463256836,
-              "p95": 0.20000004768371582,
+              "p95": 0.19999992847442627,
               "iqr": 0.10000002384185791,
               "count": 49,
               "trimmed": 1,
@@ -8776,21 +8820,21 @@
             },
             {
               "lib": "regle-schema",
-              "median": 0.3999999761581421,
-              "p95": 0.5749999284744263,
-              "iqr": 0.10000002384185791,
-              "count": 46,
-              "trimmed": 4,
+              "median": 0.7000000476837158,
+              "p95": 1.7,
+              "iqr": 0.6999999284744263,
+              "count": 49,
+              "trimmed": 1,
               "unit": "ms",
               "supported": true,
-              "ratio": 1.33,
+              "ratio": 2.33,
               "slope": 1
             },
             {
               "lib": "regle-rules",
               "median": 0.10000002384185791,
-              "p95": 0.2999999523162842,
-              "iqr": 0.10000002384185791,
+              "p95": 0.3000000238418579,
+              "iqr": 0.10000014305114746,
               "count": 49,
               "trimmed": 1,
               "unit": "ms",
@@ -8800,14 +8844,14 @@
             },
             {
               "lib": "formkit",
-              "median": 1.1999999284744263,
-              "p95": 1.600000023841858,
-              "iqr": 0.30000004172325134,
-              "count": 49,
-              "trimmed": 1,
+              "median": 1.3000000715255737,
+              "p95": 1.7999999523162842,
+              "iqr": 0.40000009536743164,
+              "count": 48,
+              "trimmed": 2,
               "unit": "ms",
               "supported": true,
-              "ratio": 4,
+              "ratio": 4.33,
               "slope": 1
             },
             {
@@ -8852,7 +8896,7 @@
                   223652, 223216
                 ],
                 "churn": [
-                  708616, 452616, 455844, 462360, 462124, 469120, 462736, 451864, 457360, 435320,
+                  708616, 452616, 455844, 462360, 462116, 469120, 462736, 451864, 457360, 435320,
                   488316, 433648
                 ],
                 "leak": [
@@ -8867,31 +8911,31 @@
             {
               "lib": "vee-validate",
               "retained": {
-                "median": 163984,
-                "p95": 212408,
+                "median": 162524,
+                "p95": 210520,
                 "count": 12
               },
               "churn": {
-                "median": 246596,
-                "p95": 268852,
+                "median": 254160,
+                "p95": 268828,
                 "count": 12
               },
               "leak": {
-                "median": 15380,
-                "p95": 61644,
+                "median": 19568,
+                "p95": 77396,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  648676, 163508, 171556, 155764, 163984, 154492, 182564, 154940, 212408, 177736,
-                  155916, 174784
+                  648860, 162524, 198364, 180972, 189144, 154516, 182684, 155920, 210520, 159084,
+                  156076, 150780
                 ],
                 "churn": [
-                  340184, 215476, 255492, 222816, 211628, 254268, 257664, 245660, 268852, 246596,
-                  248156, 238216
+                  340184, 262564, 254744, 259964, 243980, 254160, 257664, 209144, 268828, 250544,
+                  248180, 241972
                 ],
                 "leak": [
-                  633516, 44472, 59496, 20352, 11736, 15380, 20520, 2824, 61644, 1040, 14968, 13932
+                  633724, 39140, 59600, 23012, 12584, 17200, 19568, 3588, 59724, 1128, 14972, 77396
                 ]
               },
               "supported": true,
@@ -8901,13 +8945,13 @@
             {
               "lib": "tanstack",
               "retained": {
-                "median": 173132,
+                "median": 173508,
                 "p95": 230900,
                 "count": 12
               },
               "churn": {
-                "median": 514208,
-                "p95": 1288100,
+                "median": 513976,
+                "p95": 1288048,
                 "count": 12
               },
               "leak": {
@@ -8917,16 +8961,16 @@
               },
               "series": {
                 "retained": [
-                  659116, 181472, 167592, 171212, 184216, 169260, 178612, 171268, 230900, 170912,
-                  173508, 173132
+                  659212, 181504, 167592, 171212, 184216, 169260, 178612, 171268, 230900, 170912,
+                  173508, 177516
                 ],
                 "churn": [
-                  839724, 551572, 1308892, 528212, 514208, 512696, 513780, 491956, 1288100, 496956,
-                  520320, 504248
+                  837468, 551572, 1309568, 528212, 511328, 512736, 513976, 496548, 1288048, 496956,
+                  525468, 505160
                 ],
                 "leak": [
-                  826804, 70272, 58680, 68492, 58204, 60576, 61792, 33496, 86876, 38928, 53860,
-                  34404
+                  827124, 70304, 58680, 68452, 58204, 60576, 62016, 32872, 86876, 38928, 53748,
+                  38712
                 ]
               },
               "supported": true,
@@ -8936,8 +8980,8 @@
             {
               "lib": "formisch",
               "retained": {
-                "median": 94012,
-                "p95": 133408,
+                "median": 96032,
+                "p95": 134136,
                 "count": 12
               },
               "churn": {
@@ -8947,12 +8991,12 @@
               },
               "leak": {
                 "median": 10064,
-                "p95": 42756,
+                "p95": 43484,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  387356, 103352, 91092, 94012, 103672, 96584, 96748, 93204, 133408, 92092, 93764,
+                  387356, 103352, 91092, 94012, 103936, 96584, 96448, 96032, 134136, 92092, 93764,
                   90776
                 ],
                 "churn": [
@@ -8960,23 +9004,23 @@
                   272936, 265860
                 ],
                 "leak": [
-                  432968, 17576, 6476, 10064, 15004, 14840, 15748, 2408, 42756, 3488, 8544, 0
+                  432968, 17576, 6476, 10064, 15268, 14840, 15448, 1680, 43484, 3488, 8544, 0
                 ]
               },
               "supported": true,
-              "ratio": 0.42,
+              "ratio": 0.43,
               "slope": 1
             },
             {
               "lib": "regle-schema",
               "retained": {
                 "median": 280300,
-                "p95": 351488,
+                "p95": 351180,
                 "count": 12
               },
               "churn": {
-                "median": 813396,
-                "p95": 824600,
+                "median": 804876,
+                "p95": 845160,
                 "count": 12
               },
               "leak": {
@@ -8986,12 +9030,12 @@
               },
               "series": {
                 "retained": [
-                  842120, 327904, 292992, 280300, 282276, 275204, 274240, 274464, 351488, 275252,
+                  842120, 327904, 292992, 280300, 282276, 275204, 274240, 274464, 351180, 275252,
                   286092, 271528
                 ],
                 "churn": [
-                  516712, 818244, 821204, 824600, 806808, 816568, 814968, 783708, 846240, 768404,
-                  813396, 761476
+                  516712, 1552820, 804876, 809160, 804808, 814700, 814460, 768132, 845160, 766416,
+                  824228, 772196
                 ],
                 "leak": [
                   720236, 47792, 20124, 13056, 8432, 10116, 14864, 9060, 86848, 1824, 16828, 36
@@ -9020,7 +9064,7 @@
               },
               "series": {
                 "retained": [
-                  865492, 362936, 315412, 307828, 310956, 309272, 305404, 308900, 378712, 304860,
+                  865492, 363920, 315412, 307828, 310956, 309272, 305404, 308900, 378712, 304860,
                   321268, 301864
                 ],
                 "churn": [
@@ -9028,7 +9072,7 @@
                   466792, 454704
                 ],
                 "leak": [
-                  666828, 55892, 12936, 7696, 17996, 14552, 18980, 4976, 86024, 1696, 25096, 0
+                  666828, 56876, 12936, 7696, 17996, 14552, 18980, 4976, 86024, 1696, 25096, 0
                 ]
               },
               "supported": true,
@@ -9038,36 +9082,36 @@
             {
               "lib": "formkit",
               "retained": {
-                "median": 3001856,
-                "p95": 3048360,
+                "median": 3001096,
+                "p95": 3067280,
                 "count": 12
               },
               "churn": {
-                "median": 281840,
-                "p95": 386068,
+                "median": 286920,
+                "p95": 395940,
                 "count": 12
               },
               "leak": {
                 "median": 62032,
-                "p95": 183568,
+                "p95": 183604,
                 "count": 12
               },
               "series": {
                 "retained": [
-                  4083036, 3048360, 2994296, 3022808, 3001856, 2967400, 2996292, 3022108, 3015732,
-                  3022652, 2948128, 2954112
+                  4063444, 3067280, 2995272, 3022648, 3001096, 2968904, 2989996, 3019116, 3016764,
+                  3024164, 2946464, 2955260
                 ],
                 "churn": [
-                  438564, 386068, 341820, 293876, 296500, 281840, 298424, 259556, 256756, 259688,
-                  256548, 245148
+                  439768, 395940, 345400, 289544, 301124, 286920, 299380, 255428, 253448, 261676,
+                  257844, 247312
                 ],
                 "leak": [
-                  1895944, 183568, 93324, 52440, 64192, 42724, 51384, 77620, 87628, 62032, 29440,
-                  16544
+                  1895420, 183604, 93408, 52360, 64296, 42724, 48548, 77620, 87568, 62032, 28732,
+                  17372
                 ]
               },
               "supported": true,
-              "ratio": 13.45,
+              "ratio": 13.44,
               "slope": 1
             },
             {
@@ -9089,15 +9133,15 @@
               },
               "series": {
                 "retained": [
-                  546488, 186848, 182404, 182836, 187420, 179468, 170068, 169880, 234348, 170276,
+                  546424, 186848, 182372, 182836, 187420, 179468, 170068, 169880, 234348, 170276,
                   175292, 168552
                 ],
                 "churn": [
-                  369708, 259272, 249228, 251604, 240472, 238000, 277388, 237368, 255216, 247944,
+                  369644, 259272, 249116, 251604, 240472, 238000, 277388, 237368, 255224, 247944,
                   246280, 229340
                 ],
                 "leak": [
-                  499916, 38388, 22948, 22072, 22812, 21412, 7608, 1528, 78676, 1292, 14576, 0
+                  499788, 38388, 22916, 22072, 22812, 21412, 7608, 1528, 78676, 1292, 14576, 0
                 ]
               },
               "supported": true,

--- a/apps/bench-arena/scripts/installed-version.mjs
+++ b/apps/bench-arena/scripts/installed-version.mjs
@@ -31,3 +31,29 @@ export function readInstalledVersions(names) {
   for (const name of names) out[name] = readInstalledVersion(name)
   return out
 }
+
+/**
+ * The GitHub repository for an installed package, as a "github.com/owner/repo"
+ * slug (null if absent or non-GitHub). Read straight off the package's own
+ * `repository` field so the slug always tracks the version the lockfile pinned,
+ * which is what keeps the Scorecard lookup reproducible and self-correcting when
+ * a project moves orgs. Handles the common npm forms: a bare "owner/repo" or
+ * "github:owner/repo" shorthand, and `git+https`, `https`, `git://`, or `git@`
+ * URLs, with or without a `.git` suffix or a monorepo `#`/path tail.
+ */
+export function readInstalledRepoSlug(name) {
+  const pkgPath = join(PACKAGE_ROOT, 'node_modules', name, 'package.json')
+  let repository
+  try {
+    repository = JSON.parse(readFileSync(pkgPath, 'utf8')).repository
+  } catch {
+    return null
+  }
+  const raw = typeof repository === 'string' ? repository : repository?.url
+  if (!raw) return null
+  const fromUrl = raw.match(/github\.com[:/]+([^/]+)\/([^/]+?)(?:\.git)?(?:[/#].*)?$/i)
+  if (fromUrl) return `github.com/${fromUrl[1]}/${fromUrl[2]}`
+  const shorthand = raw.match(/^(?:github:)?([\w.-]+)\/([\w.-]+?)(?:\.git)?$/i)
+  if (shorthand) return `github.com/${shorthand[1]}/${shorthand[2]}`
+  return null
+}

--- a/apps/bench-arena/scripts/installed-version.mjs
+++ b/apps/bench-arena/scripts/installed-version.mjs
@@ -1,0 +1,33 @@
+/**
+ * Read an installed package's version WITHOUT going through its `exports` map.
+ *
+ * Several cohort packages deliberately omit `./package.json` from `exports`
+ * (so `require('<pkg>/package.json')` throws ERR_PACKAGE_PATH_NOT_EXPORTED),
+ * and ESM-only packages such as @formisch/vue cannot be `require.resolve`d
+ * from a CJS context at all. Reading the package's own package.json straight
+ * off disk, following pnpm's node_modules symlink, sidesteps both: it works
+ * uniformly across the entire cohort.
+ *
+ * Used by run-arena.mjs (the provenance block's resolved `libVersions`) and
+ * measure-bundles.mjs (the per-entry version label), so every reported number
+ * carries the exact version the lockfile pinned and the harness measured.
+ */
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// scripts/installed-version.mjs -> scripts/ -> package root.
+const PACKAGE_ROOT = dirname(dirname(fileURLToPath(import.meta.url)))
+
+/** Resolved version string for one installed package (throws if absent). */
+export function readInstalledVersion(name) {
+  const pkgPath = join(PACKAGE_ROOT, 'node_modules', name, 'package.json')
+  return JSON.parse(readFileSync(pkgPath, 'utf8')).version
+}
+
+/** Map of name -> resolved version for a list of packages. */
+export function readInstalledVersions(names) {
+  const out = {}
+  for (const name of names) out[name] = readInstalledVersion(name)
+  return out
+}

--- a/apps/bench-arena/scripts/measure-bundles.mjs
+++ b/apps/bench-arena/scripts/measure-bundles.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+/**
+ * Per-library gzipped bundle measurement for the benchmark arena.
+ *
+ * A structural sibling of the repo-root scripts/check-eager-size.mjs (same
+ * pnpm-store esbuild resolver, same gzip level, same production define), but it
+ * weighs a different thing: the cost a CONSUMER pays to ship a minimal real
+ * form in each library. Every entry under entries/ is the SAME minimal form
+ * (one text field, one email field, schema-validated, a submit handler) written
+ * in that library's idiomatic API, so the comparison is like against like.
+ *
+ * Fairness:
+ *  - The library AND its validator are bundled and weighed together (vee +
+ *    zod, formisch + valibot, FormKit + its zod plugin, Vuelidate + its native
+ *    validators). That is the honest "for better or worse" figure, including
+ *    where Attaform is heavier.
+ *  - `vue` is external: every Vue app ships Vue exactly once, so counting it in
+ *    every row would mislead. (Stated as a footnote on the docs page.)
+ *  - `zod` and `valibot` resolve to the arena's single installed copy via an
+ *    alias, so a symlinked workspace package's own `import 'zod'` cannot pull a
+ *    second copy into one row. That is the single-validator install a real
+ *    consumer has, and it mirrors the vite config's dedupe.
+ *
+ * Run `pnpm prepack` at the repo root first so the Attaform row weighs the real
+ * published dist, not a stale or stubbed build.
+ *
+ * CLI: `node scripts/measure-bundles.mjs` prints the table.
+ * Library: `import { measureBundles }` powers the orchestrator (run-arena.mjs).
+ */
+import { readdirSync, realpathSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { argv } from 'node:process'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { gzipSync } from 'node:zlib'
+import { readInstalledVersion } from './installed-version.mjs'
+
+// scripts/measure-bundles.mjs -> scripts/ -> package root -> apps/ -> repo root.
+const PKG_ROOT = dirname(dirname(fileURLToPath(import.meta.url)))
+const REPO_ROOT = join(PKG_ROOT, '..', '..')
+const NODE_MODULES = join(PKG_ROOT, 'node_modules')
+
+// Resolve esbuild from the workspace pnpm store (a transitive dep of vite, not
+// in any top-level node_modules); pick the newest by numeric semver so a
+// version bump needs no edit here. Same walker as scripts/check-eager-size.mjs.
+function resolveEsbuild() {
+  const store = join(REPO_ROOT, 'node_modules', '.pnpm')
+  const dirs = readdirSync(store).filter((d) => /^esbuild@\d+\.\d+\.\d+/.test(d))
+  if (!dirs.length) throw new Error('esbuild not found under node_modules/.pnpm')
+  const parts = (d) =>
+    d
+      .slice('esbuild@'.length)
+      .split('.')
+      .map((n) => parseInt(n, 10))
+  dirs.sort((a, b) => {
+    const [A0, A1, A2] = parts(a)
+    const [B0, B1, B2] = parts(b)
+    return A0 - B0 || A1 - B1 || A2 - B2
+  })
+  return join(store, dirs[dirs.length - 1], 'node_modules', 'esbuild', 'lib', 'main.js')
+}
+const esbuild = (await import(resolveEsbuild())).default
+
+/**
+ * The cohort entries, in display order. `pkg` is the package whose resolved
+ * version labels the row; `validatorPkg` names the validator package weighed
+ * alongside it (null for the native-validator libraries, which ship no separate
+ * schema package). Regle is measured once, in schema mode, for the Zod row.
+ */
+const ENTRIES = [
+  {
+    id: 'attaform',
+    lib: 'Attaform',
+    file: 'attaform.form.ts',
+    pkg: 'attaform',
+    validatorPkg: 'zod',
+  },
+  {
+    id: 'vee-validate',
+    lib: 'vee-validate',
+    file: 'vee-validate.form.ts',
+    pkg: 'vee-validate',
+    validatorPkg: 'zod',
+  },
+  {
+    id: 'tanstack',
+    lib: '@tanstack/vue-form',
+    file: 'tanstack.form.ts',
+    pkg: '@tanstack/vue-form',
+    validatorPkg: 'zod',
+  },
+  {
+    id: 'formisch',
+    lib: '@formisch/vue',
+    file: 'formisch.form.ts',
+    pkg: '@formisch/vue',
+    validatorPkg: 'valibot',
+  },
+  { id: 'regle', lib: 'Regle', file: 'regle.form.ts', pkg: '@regle/core', validatorPkg: 'zod' },
+  {
+    id: 'formkit',
+    lib: 'FormKit',
+    file: 'formkit.form.ts',
+    pkg: '@formkit/vue',
+    validatorPkg: 'zod',
+  },
+  {
+    id: 'vuelidate',
+    lib: 'Vuelidate',
+    file: 'vuelidate.form.ts',
+    pkg: '@vuelidate/core',
+    validatorPkg: null,
+  },
+]
+
+const PROD_DEFINE = { 'process.env.NODE_ENV': '"production"' }
+
+function validatorLabel(validatorPkg) {
+  if (validatorPkg === null) return 'native validators'
+  return `${validatorPkg} ${readInstalledVersion(validatorPkg)}`
+}
+
+/** Bundle one entry (lib + validator, Vue external) and return its gzipped size. */
+async function gzippedSize(file) {
+  const result = await esbuild.build({
+    entryPoints: [join(PKG_ROOT, 'entries', file)],
+    bundle: true,
+    minify: true,
+    format: 'esm',
+    target: 'es2020',
+    platform: 'browser',
+    // Vue is shipped once by every app, so it is never counted in a row.
+    external: ['vue', '@vue/*'],
+    // Pin the single installed validator copy (mirrors the vite dedupe), so a
+    // symlinked workspace package's own `import 'zod'` cannot bundle a 2nd copy.
+    alias: {
+      zod: join(NODE_MODULES, 'zod'),
+      valibot: join(NODE_MODULES, 'valibot'),
+    },
+    define: PROD_DEFINE,
+    write: false,
+    legalComments: 'none',
+    logLevel: 'silent',
+  })
+  const js = result.outputFiles.map((f) => f.text).join('')
+  return gzipSync(Buffer.from(js), { level: 9 }).length
+}
+
+/**
+ * Measure every entry and return one row per library: resolved version, the
+ * validator weighed with it, gzipped bytes, and the ratio to Attaform's row
+ * (the baseline). The orchestrator embeds these rows verbatim in results.json.
+ */
+export async function measureBundles() {
+  const rows = []
+  for (const entry of ENTRIES) {
+    const gzBytes = await gzippedSize(entry.file)
+    rows.push({
+      id: entry.id,
+      lib: entry.lib,
+      version: readInstalledVersion(entry.pkg),
+      validator: validatorLabel(entry.validatorPkg),
+      gzBytes,
+    })
+  }
+  const baseline = rows.find((r) => r.id === 'attaform')?.gzBytes ?? 0
+  for (const row of rows) {
+    row.ratio = baseline > 0 ? Number((row.gzBytes / baseline).toFixed(2)) : 1
+  }
+  return rows
+}
+
+const isMain = import.meta.url === pathToFileURL(realpathSync(argv[1])).href
+if (isMain) {
+  const rows = await measureBundles()
+  const kb = (b) => (b / 1024).toFixed(2)
+  for (const row of [...rows].sort((a, b) => a.gzBytes - b.gzBytes)) {
+    const size = `${kb(row.gzBytes)} kB gz`.padStart(13)
+    const ratio = `x${row.ratio.toFixed(2)}`.padStart(7)
+    console.log(`${row.lib.padEnd(20)} ${size} ${ratio}  (${row.validator})`)
+  }
+}

--- a/apps/bench-arena/scripts/run-arena.mjs
+++ b/apps/bench-arena/scripts/run-arena.mjs
@@ -1,0 +1,318 @@
+#!/usr/bin/env node
+/**
+ * The benchmark orchestrator: it produces the provenance-stamped results.json
+ * the documentation renders.
+ *
+ * Rather than re-drive the cohort (which would duplicate the spec's cell matrix
+ * and its CDP memory loop, two copies that could silently drift), it RUNS the
+ * Playwright spec and harvests each cell's measurement from a per-test
+ * attachment. So the published numbers and the gate that asserts they are
+ * well-formed come from the exact same green run: they cannot diverge. The spec
+ * config already builds the production preview and exposes gc, so this script
+ * only orchestrates, aggregates, and writes.
+ *
+ * Steps: run the spec (abort if it is red) -> harvest the cell + meta
+ * attachments -> measure bundles -> compute ratios and slopes -> stamp
+ * provenance -> write results.json.
+ *
+ * Run `pnpm prepack` at the repo root first so the Attaform rows measure the
+ * real published dist. The committed results.json must always come from CI; a
+ * local run (or a --grep smoke run, which writes results.smoke.json) is for
+ * development only and stamps its provenance source as "local".
+ *
+ * CLI:
+ *   node scripts/run-arena.mjs                 full run -> results.json
+ *   node scripts/run-arena.mjs --grep <pat>    partial smoke run -> results.smoke.json
+ */
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import { dirname, join } from 'node:path'
+import { argv, env, exit, version as nodeVersion } from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { readInstalledVersions } from './installed-version.mjs'
+import { measureBundles } from './measure-bundles.mjs'
+
+const PKG_ROOT = dirname(dirname(fileURLToPath(import.meta.url)))
+const SCHEMA_VERSION = 1
+const BASELINE = 'attaform'
+
+// Stable output ordering, so the committed results.json diffs minimally run to
+// run. Scenarios and dimensions emit in these orders; params sort by size and
+// rows by the cohort order the registry defines (read from the meta payload).
+const SCENARIO_ORDER = [
+  'flat',
+  'nested',
+  'arrays',
+  'grid',
+  'discriminated-union',
+  'massive',
+  'wizard',
+]
+const DIM_ORDER = [
+  'keystroke',
+  'mount',
+  'validate',
+  'rerender',
+  'arrayAdd',
+  'arrayReorder',
+  'variantFlip',
+  'stepTransition',
+  'memory',
+]
+
+// Packages whose resolved (lockfile-pinned) versions stamp the provenance block.
+const LIB_VERSION_PKGS = [
+  'attaform',
+  'vee-validate',
+  '@tanstack/vue-form',
+  '@formisch/vue',
+  '@regle/core',
+  '@formkit/vue',
+  '@vuelidate/core',
+  'zod',
+  'valibot',
+]
+
+/** Round a ratio/slope to two decimals; medians keep their measured precision. */
+function round2(value) {
+  return Number(value.toFixed(2))
+}
+
+/** A param label's relative size: the product of its numeric codes (F50 -> 50,
+ *  N100M8 -> 800), so the smallest param (the slope baseline) sorts first. */
+function paramSize(label) {
+  const nums = label.match(/\d+/g)
+  if (!nums) return 0
+  return nums.reduce((acc, n) => acc * Number(n), 1)
+}
+
+/** 95th percentile of a small sample (the memory cycles); coarse but adequate. */
+function p95(samples) {
+  if (samples.length === 0) return 0
+  const sorted = [...samples].sort((a, b) => a - b)
+  const index = Math.min(sorted.length - 1, Math.floor(0.95 * (sorted.length - 1)))
+  return sorted[index] ?? 0
+}
+
+/** The value a cell's ratio and slope are computed on: keystroke/mount/etc. use
+ *  the timed median; memory uses retained heap (its headline, churn is noisier). */
+function cellValue(cell) {
+  return cell.kind === 'memory' ? cell.retained : cell.summary.median
+}
+
+function parseArgs() {
+  const grepIndex = argv.indexOf('--grep')
+  const grep = grepIndex >= 0 ? (argv[grepIndex + 1] ?? null) : null
+  return { grep }
+}
+
+/** Run the Playwright spec (live `list` output) and tee a JSON report to disk. */
+function runSpec(grep) {
+  const reportPath = join(PKG_ROOT, 'test-results', 'arena-report.json')
+  mkdirSync(dirname(reportPath), { recursive: true })
+  const args = ['exec', 'playwright', 'test', '--reporter=list,json']
+  if (grep) args.push('--grep', grep)
+  const result = spawnSync('pnpm', args, {
+    cwd: PKG_ROOT,
+    stdio: 'inherit',
+    env: { ...env, PLAYWRIGHT_JSON_OUTPUT_NAME: reportPath },
+  })
+  return { status: result.status ?? 1, reportPath }
+}
+
+/** Depth-first walk of the report's nested suites, yielding every spec. */
+function* walkSpecs(suite) {
+  for (const child of suite.suites ?? []) yield* walkSpecs(child)
+  for (const spec of suite.specs ?? []) yield spec
+}
+
+/** Decode the cell + meta attachments the spec emitted (inline base64 JSON). */
+function harvest(reportPath) {
+  const report = JSON.parse(readFileSync(reportPath, 'utf8'))
+  const cells = []
+  let meta = null
+  for (const top of report.suites ?? []) {
+    for (const spec of walkSpecs(top)) {
+      for (const test of spec.tests ?? []) {
+        for (const result of test.results ?? []) {
+          for (const att of result.attachments ?? []) {
+            if (typeof att.body !== 'string') continue
+            const payload = JSON.parse(Buffer.from(att.body, 'base64').toString('utf8'))
+            if (att.name === 'cell') cells.push(payload)
+            else if (att.name === 'meta') meta = payload
+          }
+        }
+      }
+    }
+  }
+  return { cells, meta }
+}
+
+/** Capability matrix + display metadata, straight from the built adapters' meta. */
+function capabilitiesOf(meta) {
+  return (meta ?? []).map((m) => {
+    const row = {
+      lib: m.id,
+      displayName: m.displayName,
+      layer: m.layer,
+      schemaLib: m.schemaLib,
+      ownsInputs: m.ownsInputs,
+    }
+    for (const scenario of SCENARIO_ORDER)
+      row[scenario] = m.capabilities?.[scenario] ?? 'unsupported'
+    return row
+  })
+}
+
+/**
+ * The cohort display order for stable row sorting: the registry order from meta
+ * first, then any adapter seen only in the cells (so a --grep smoke run with no
+ * meta attachment still orders its rows).
+ */
+function libOrderOf(meta, cells) {
+  const order = new Map()
+  ;(meta ?? []).forEach((m) => order.set(m.id, order.size))
+  for (const cell of cells) if (!order.has(cell.adapter)) order.set(cell.adapter, order.size)
+  return order
+}
+
+/** Build one results-row from a harvested cell (timed dims and memory differ). */
+function rowOf(cell) {
+  if (cell.kind === 'memory') {
+    return {
+      lib: cell.adapter,
+      retained: { median: cell.retained, p95: p95(cell.series.retained), count: cell.cycles },
+      churn: { median: cell.churn, p95: p95(cell.series.churn), count: cell.cycles },
+      leak: { median: cell.leak, p95: p95(cell.series.leak), count: cell.cycles },
+      series: cell.series,
+      supported: true,
+    }
+  }
+  return {
+    lib: cell.adapter,
+    median: cell.summary.median,
+    p95: cell.summary.p95,
+    iqr: cell.summary.iqr,
+    count: cell.summary.count,
+    trimmed: cell.summary.trimmed,
+    unit: cell.unit,
+    supported: cell.supported,
+  }
+}
+
+/**
+ * Assemble the runtime block: scenario -> dim -> { unit, byParam }, with ratio
+ * (versus the baseline at the same param) and slope (versus the same library at
+ * the scenario's smallest param) computed per row. Emitted in stable order.
+ */
+function buildRuntime(cells, libOrder) {
+  // Index cells by scenario|dim|param|lib for the ratio/slope lookups.
+  const index = new Map()
+  const key = (s, d, p, lib) => `${s}|${d}|${p}|${lib}`
+  const grouped = {}
+  for (const cell of cells) {
+    const dim = cell.kind === 'memory' ? 'memory' : cell.dim
+    index.set(key(cell.scenario, dim, cell.params, cell.adapter), cell)
+    ;((grouped[cell.scenario] ??= {})[dim] ??= new Set()).add(cell.params)
+  }
+
+  const runtime = {}
+  for (const scenario of SCENARIO_ORDER) {
+    if (!grouped[scenario]) continue
+    runtime[scenario] = {}
+    for (const dim of DIM_ORDER) {
+      const paramSet = grouped[scenario][dim]
+      if (!paramSet) continue
+      const params = [...paramSet].sort((a, b) => paramSize(a) - paramSize(b))
+      const smallest = params[0]
+      const byParam = {}
+      let unit = dim === 'memory' ? 'bytes' : null
+      for (const param of params) {
+        const baseCell = index.get(key(scenario, dim, param, BASELINE))
+        const baseValue = baseCell ? cellValue(baseCell) : 0
+        const built = []
+        for (const m of libOrder.keys()) {
+          const cell = index.get(key(scenario, dim, param, m))
+          if (!cell) continue
+          const row = rowOf(cell)
+          const value = cellValue(cell)
+          row.ratio = baseValue > 0 ? round2(value / baseValue) : null
+          const smallestCell = index.get(key(scenario, dim, smallest, m))
+          const smallestValue = smallestCell ? cellValue(smallestCell) : 0
+          row.slope = smallestValue > 0 ? round2(value / smallestValue) : 1
+          built.push(row)
+          if (unit === null && cell.kind === 'timed') {
+            // rerender mixes units (FormKit reports the dom-mutation proxy); the
+            // canonical column unit is renders, and each row keeps its own unit.
+            unit = dim === 'rerender' ? 'renders' : cell.unit
+          }
+        }
+        byParam[param] = built
+      }
+      runtime[scenario][dim] = { unit: unit ?? 'ms', byParam }
+    }
+  }
+  return runtime
+}
+
+async function main() {
+  const { grep } = parseArgs()
+  const smoke = grep !== null
+
+  const { status, reportPath } = runSpec(grep)
+  if (status !== 0) {
+    console.error(`\n[run-arena] the spec run failed (exit ${status}); not writing results.`)
+    exit(status)
+  }
+
+  const { cells, meta } = harvest(reportPath)
+  if (cells.length === 0) {
+    console.error('[run-arena] no cell measurements were harvested from the report.')
+    exit(1)
+  }
+  if (!meta && !smoke) {
+    console.error('[run-arena] the cohort meta attachment was missing from a full run.')
+    exit(1)
+  }
+
+  const libOrder = libOrderOf(meta, cells)
+  const cpus = os.cpus()
+  const runId = env.GITHUB_RUN_ID
+  const ciRunUrl =
+    runId && env.GITHUB_SERVER_URL && env.GITHUB_REPOSITORY
+      ? `${env.GITHUB_SERVER_URL}/${env.GITHUB_REPOSITORY}/actions/runs/${runId}`
+      : null
+
+  const results = {
+    schemaVersion: SCHEMA_VERSION,
+    provenance: {
+      source: runId ? 'ci' : 'local',
+      commit: env.GITHUB_SHA ?? null,
+      ciRunId: runId ?? null,
+      ciRunUrl,
+      runner: {
+        os: os.platform(),
+        arch: os.arch(),
+        cpuModel: cpus[0]?.model ?? 'unknown',
+        cpuCount: cpus.length,
+      },
+      node: nodeVersion,
+      timestamp: new Date().toISOString(),
+      libVersions: readInstalledVersions(LIB_VERSION_PKGS),
+    },
+    baseline: BASELINE,
+    capabilities: capabilitiesOf(meta),
+    bundle: await measureBundles(),
+    runtime: buildRuntime(cells, libOrder),
+  }
+
+  const outPath = join(PKG_ROOT, smoke ? 'results.smoke.json' : 'results.json')
+  writeFileSync(outPath, `${JSON.stringify(results, null, 2)}\n`)
+  console.log(
+    `\n[run-arena] wrote ${outPath} ` +
+      `(${cells.length} cells, ${results.bundle.length} bundle rows, source=${results.provenance.source})`
+  )
+}
+
+await main()

--- a/apps/bench-arena/scripts/run-arena.mjs
+++ b/apps/bench-arena/scripts/run-arena.mjs
@@ -12,8 +12,9 @@
  * only orchestrates, aggregates, and writes.
  *
  * Steps: run the spec (abort if it is red) -> harvest the cell + meta
- * attachments -> measure bundles -> compute ratios and slopes -> stamp
- * provenance -> write results.json.
+ * attachments -> measure bundles -> look up each library's OpenSSF Scorecard
+ * (best-effort) -> compute ratios and slopes -> stamp provenance -> write
+ * results.json.
  *
  * Run `pnpm prepack` at the repo root first so the Attaform rows measure the
  * real published dist. The committed results.json must always come from CI; a
@@ -30,8 +31,9 @@ import os from 'node:os'
 import { dirname, join } from 'node:path'
 import { argv, env, exit, version as nodeVersion } from 'node:process'
 import { fileURLToPath } from 'node:url'
-import { readInstalledVersions } from './installed-version.mjs'
+import { readInstalledRepoSlug, readInstalledVersions } from './installed-version.mjs'
 import { measureBundles } from './measure-bundles.mjs'
+import { fetchScorecards, scorecardViewerUrl } from './scorecards.mjs'
 
 const PKG_ROOT = dirname(dirname(fileURLToPath(import.meta.url)))
 const SCHEMA_VERSION = 1
@@ -73,6 +75,21 @@ const LIB_VERSION_PKGS = [
   'zod',
   'valibot',
 ]
+
+// Adapter id -> the npm package whose `repository` field locates its source, so
+// the Scorecard slug is derived from the lockfile-pinned package rather than
+// hardcoded (it self-corrects when a project moves orgs). Regle's two adapters
+// share one repository.
+const LIB_REPO_PKG = {
+  attaform: 'attaform',
+  'vee-validate': 'vee-validate',
+  tanstack: '@tanstack/vue-form',
+  formisch: '@formisch/vue',
+  'regle-schema': '@regle/core',
+  'regle-rules': '@regle/core',
+  formkit: '@formkit/vue',
+  vuelidate: '@vuelidate/core',
+}
 
 /** Round a ratio/slope to two decimals; medians keep their measured precision. */
 function round2(value) {
@@ -149,8 +166,13 @@ function harvest(reportPath) {
   return { cells, meta }
 }
 
-/** Capability matrix + display metadata, straight from the built adapters' meta. */
-function capabilitiesOf(meta) {
+/**
+ * Capability matrix + display metadata, straight from the built adapters' meta,
+ * plus each library's repository and (best-effort) OpenSSF Scorecard. A library
+ * with no published Scorecard carries scorecard: null; the docs render that as
+ * "not published" and link the repository instead.
+ */
+function capabilitiesOf(meta, scorecardInfo) {
   return (meta ?? []).map((m) => {
     const row = {
       lib: m.id,
@@ -161,8 +183,38 @@ function capabilitiesOf(meta) {
     }
     for (const scenario of SCENARIO_ORDER)
       row[scenario] = m.capabilities?.[scenario] ?? 'unsupported'
+    const info = scorecardInfo?.[m.id]
+    row.repo = info?.repo ?? null
+    row.repoUrl = info?.repoUrl ?? null
+    row.scorecardUrl = info?.viewerUrl ?? null
+    row.scorecard = info?.scorecard ?? null
     return row
   })
+}
+
+/**
+ * Per-adapter repository + OpenSSF Scorecard info. Derives each library's repo
+ * slug from its installed package, resolves the published scores in one
+ * best-effort batch, and returns adapter id -> { repo, repoUrl, viewerUrl,
+ * scorecard }. Never throws: a failed lookup leaves scorecard null.
+ */
+async function buildScorecardInfo(meta) {
+  const slugById = {}
+  for (const m of meta ?? []) {
+    const pkg = LIB_REPO_PKG[m.id]
+    slugById[m.id] = pkg ? readInstalledRepoSlug(pkg) : null
+  }
+  const scores = await fetchScorecards(Object.values(slugById))
+  const info = {}
+  for (const [id, slug] of Object.entries(slugById)) {
+    info[id] = {
+      repo: slug,
+      repoUrl: slug ? `https://${slug}` : null,
+      viewerUrl: slug ? scorecardViewerUrl(slug) : null,
+      scorecard: slug ? (scores[slug] ?? null) : null,
+    }
+  }
+  return info
 }
 
 /**
@@ -277,6 +329,7 @@ async function main() {
   }
 
   const libOrder = libOrderOf(meta, cells)
+  const scorecardInfo = await buildScorecardInfo(meta)
   const cpus = os.cpus()
   const runId = env.GITHUB_RUN_ID
   const ciRunUrl =
@@ -302,7 +355,7 @@ async function main() {
       libVersions: readInstalledVersions(LIB_VERSION_PKGS),
     },
     baseline: BASELINE,
-    capabilities: capabilitiesOf(meta),
+    capabilities: capabilitiesOf(meta, scorecardInfo),
     bundle: await measureBundles(),
     runtime: buildRuntime(cells, libOrder),
   }

--- a/apps/bench-arena/scripts/run-arena.mjs
+++ b/apps/bench-arena/scripts/run-arena.mjs
@@ -22,8 +22,10 @@
  * development only and stamps its provenance source as "local".
  *
  * CLI:
- *   node scripts/run-arena.mjs                 full run -> results.json
- *   node scripts/run-arena.mjs --grep <pat>    partial smoke run -> results.smoke.json
+ *   node scripts/run-arena.mjs                   full run -> results.json
+ *   node scripts/run-arena.mjs --grep <pat>      partial smoke run -> results.smoke.json
+ *   node scripts/run-arena.mjs --scorecards-only refresh only the supply-chain scores in
+ *                                                results.json, in place, with no browser run
  */
 import { spawnSync } from 'node:child_process'
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
@@ -121,7 +123,8 @@ function cellValue(cell) {
 function parseArgs() {
   const grepIndex = argv.indexOf('--grep')
   const grep = grepIndex >= 0 ? (argv[grepIndex + 1] ?? null) : null
-  return { grep }
+  const scorecardsOnly = argv.includes('--scorecards-only')
+  return { grep, scorecardsOnly }
 }
 
 /** Run the Playwright spec (live `list` output) and tee a JSON report to disk. */
@@ -166,11 +169,23 @@ function harvest(reportPath) {
   return { cells, meta }
 }
 
+/** The repository + Scorecard fields, stamped onto a capability row in one
+ *  canonical key order so the full-run and the --scorecards-only paths emit an
+ *  identical shape. scorecardStatus is the discriminant the docs render on:
+ *  'published' carries a score, 'not-published' is an opted-out project, and
+ *  'unavailable' is a lookup that did not complete (a gap on our side). */
+function stampScorecard(row, info) {
+  row.repo = info?.repo ?? null
+  row.repoUrl = info?.repoUrl ?? null
+  row.scorecardUrl = info?.viewerUrl ?? null
+  row.scorecardStatus = info?.status ?? 'unavailable'
+  row.scorecard = info?.scorecard ?? null
+  return row
+}
+
 /**
  * Capability matrix + display metadata, straight from the built adapters' meta,
- * plus each library's repository and (best-effort) OpenSSF Scorecard. A library
- * with no published Scorecard carries scorecard: null; the docs render that as
- * "not published" and link the repository instead.
+ * plus each library's repository and (best-effort) OpenSSF Scorecard.
  */
 function capabilitiesOf(meta, scorecardInfo) {
   return (meta ?? []).map((m) => {
@@ -183,38 +198,79 @@ function capabilitiesOf(meta, scorecardInfo) {
     }
     for (const scenario of SCENARIO_ORDER)
       row[scenario] = m.capabilities?.[scenario] ?? 'unsupported'
-    const info = scorecardInfo?.[m.id]
-    row.repo = info?.repo ?? null
-    row.repoUrl = info?.repoUrl ?? null
-    row.scorecardUrl = info?.viewerUrl ?? null
-    row.scorecard = info?.scorecard ?? null
-    return row
+    return stampScorecard(row, scorecardInfo?.[m.id])
   })
 }
 
 /**
- * Per-adapter repository + OpenSSF Scorecard info. Derives each library's repo
- * slug from its installed package, resolves the published scores in one
- * best-effort batch, and returns adapter id -> { repo, repoUrl, viewerUrl,
- * scorecard }. Never throws: a failed lookup leaves scorecard null.
+ * Per-adapter repository + OpenSSF Scorecard info for a list of adapter ids.
+ * Derives each library's repo slug from its installed package, resolves the
+ * Scorecards in one best-effort batch, and returns adapter id -> { repo,
+ * repoUrl, viewerUrl, status, scorecard }. status is 'published' |
+ * 'not-published' | 'unavailable'; scorecard carries { score, date } only when
+ * published. Never throws: a slug that cannot be derived, or a lookup that does
+ * not complete, both resolve to status 'unavailable'.
  */
-async function buildScorecardInfo(meta) {
+async function buildScorecardInfo(ids) {
   const slugById = {}
-  for (const m of meta ?? []) {
-    const pkg = LIB_REPO_PKG[m.id]
-    slugById[m.id] = pkg ? readInstalledRepoSlug(pkg) : null
+  for (const id of ids) {
+    const pkg = LIB_REPO_PKG[id]
+    slugById[id] = pkg ? readInstalledRepoSlug(pkg) : null
   }
-  const scores = await fetchScorecards(Object.values(slugById))
+  const results = await fetchScorecards(Object.values(slugById))
   const info = {}
   for (const [id, slug] of Object.entries(slugById)) {
+    const result = slug ? results[slug] : null
     info[id] = {
       repo: slug,
       repoUrl: slug ? `https://${slug}` : null,
       viewerUrl: slug ? scorecardViewerUrl(slug) : null,
-      scorecard: slug ? (scores[slug] ?? null) : null,
+      status: result?.status ?? 'unavailable',
+      scorecard: result?.status === 'published' ? { score: result.score, date: result.date } : null,
     }
   }
   return info
+}
+
+/**
+ * Refresh only the supply-chain (Scorecard) fields of the committed
+ * results.json, in place, without re-running the browser sweep. Supply-chain
+ * scores move on a different cadence than runtime performance, so this keeps the
+ * verified runtime numbers untouched and re-polls just the cohort's Scorecards:
+ * it picks up a newly published score, or refreshes an existing snapshot.
+ *
+ * Safety valve: if every lookup comes back 'unavailable' (the network is down,
+ * not the projects), it writes nothing and exits non-zero, so a flaky
+ * connection can never overwrite good committed scores with blanks.
+ */
+async function refreshScorecards() {
+  const outPath = join(PKG_ROOT, 'results.json')
+  const results = JSON.parse(readFileSync(outPath, 'utf8'))
+  const ids = results.capabilities.map((c) => c.lib)
+  const info = await buildScorecardInfo(ids)
+  const conclusive = Object.values(info).filter(
+    (i) => i.status === 'published' || i.status === 'not-published'
+  )
+  if (conclusive.length === 0) {
+    console.error(
+      '[run-arena] every Scorecard lookup was unavailable (the network looks down); ' +
+        'leaving the committed scores untouched.'
+    )
+    exit(1)
+  }
+  const scorecardKeys = ['repo', 'repoUrl', 'scorecardUrl', 'scorecardStatus', 'scorecard']
+  results.capabilities = results.capabilities.map((c) => {
+    const row = {}
+    for (const [k, v] of Object.entries(c)) if (!scorecardKeys.includes(k)) row[k] = v
+    return stampScorecard(row, info[c.lib])
+  })
+  writeFileSync(outPath, `${JSON.stringify(results, null, 2)}\n`)
+  const published = conclusive.filter((i) => i.status === 'published').length
+  console.log(
+    `[run-arena] refreshed Scorecards in ${outPath} ` +
+      `(${published} published, ${conclusive.length - published} not published, ` +
+      `${ids.length - conclusive.length} unavailable)`
+  )
 }
 
 /**
@@ -309,7 +365,11 @@ function buildRuntime(cells, libOrder) {
 }
 
 async function main() {
-  const { grep } = parseArgs()
+  const { grep, scorecardsOnly } = parseArgs()
+  if (scorecardsOnly) {
+    await refreshScorecards()
+    return
+  }
   const smoke = grep !== null
 
   const { status, reportPath } = runSpec(grep)
@@ -329,7 +389,7 @@ async function main() {
   }
 
   const libOrder = libOrderOf(meta, cells)
-  const scorecardInfo = await buildScorecardInfo(meta)
+  const scorecardInfo = await buildScorecardInfo((meta ?? []).map((m) => m.id))
   const cpus = os.cpus()
   const runId = env.GITHUB_RUN_ID
   const ciRunUrl =

--- a/apps/bench-arena/scripts/scorecards.mjs
+++ b/apps/bench-arena/scripts/scorecards.mjs
@@ -1,0 +1,56 @@
+/**
+ * Best-effort OpenSSF Scorecard lookups for the cohort.
+ *
+ * A published Scorecard (https://scorecard.dev) is a project's opt-in,
+ * point-in-time measurement of supply-chain best practices (branch
+ * protection, signed releases, pinned dependencies, CI hardening, and so
+ * on). The benchmark stamps each library's current score into results.json
+ * so the docs can show it alongside the size and runtime figures, since a
+ * library's supply-chain posture is part of the honest "what does adopting
+ * this cost me" picture, especially for an audited downstream consumer.
+ *
+ * The lookup is best-effort and never gates a run: a repository that has
+ * not published a Scorecard returns 404 (the common case), and a network
+ * error or timeout resolves to null. The docs render a null as "not
+ * published" and link the repository instead, and the monthly CI run
+ * refreshes whatever the API serves that day. The committed score is a
+ * snapshot; the viewer link always reflects the live result.
+ */
+const API = 'https://api.securityscorecards.dev/projects'
+const TIMEOUT_MS = 12_000
+
+/** The public viewer URL for a "github.com/owner/repo" slug (always live). */
+export function scorecardViewerUrl(slug) {
+  return `https://scorecard.dev/viewer/?uri=${slug}`
+}
+
+/** Fetch one repository's published score; null on 404, error, or timeout. */
+async function fetchOne(slug) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS)
+  try {
+    const res = await fetch(`${API}/${slug}`, {
+      signal: controller.signal,
+      headers: { accept: 'application/json' },
+    })
+    if (!res.ok) return null
+    const body = await res.json()
+    if (typeof body?.score !== 'number') return null
+    return { score: body.score, date: body.date ?? null }
+  } catch {
+    return null
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/**
+ * Resolve published scores for a set of "github.com/owner/repo" slugs in
+ * parallel. Returns a slug -> { score, date } | null map; falsy slugs are
+ * dropped. Never throws.
+ */
+export async function fetchScorecards(slugs) {
+  const unique = [...new Set(slugs.filter(Boolean))]
+  const entries = await Promise.all(unique.map(async (slug) => [slug, await fetchOne(slug)]))
+  return Object.fromEntries(entries)
+}

--- a/apps/bench-arena/scripts/scorecards.mjs
+++ b/apps/bench-arena/scripts/scorecards.mjs
@@ -9,12 +9,19 @@
  * library's supply-chain posture is part of the honest "what does adopting
  * this cost me" picture, especially for an audited downstream consumer.
  *
- * The lookup is best-effort and never gates a run: a repository that has
- * not published a Scorecard returns 404 (the common case), and a network
- * error or timeout resolves to null. The docs render a null as "not
- * published" and link the repository instead, and the monthly CI run
- * refreshes whatever the API serves that day. The committed score is a
- * snapshot; the viewer link always reflects the live result.
+ * A lookup resolves to one of three states, because an absent score has two
+ * very different meanings the docs must never conflate:
+ *   - 'published'      the API served a score (a fact about the project)
+ *   - 'not-published'  the API returned 404: the project has not opted into a
+ *                      Scorecard (a choice by the project, not a deficiency)
+ *   - 'unavailable'    the lookup did not complete: a timeout, a network
+ *                      error, a non-404 response, or a malformed body (a gap
+ *                      on our side this run, never a statement about the
+ *                      project)
+ *
+ * The lookup is best-effort and never gates a run. The monthly CI run
+ * refreshes whatever the API serves that day; the committed score is a
+ * snapshot, and the viewer link always reflects the live result.
  */
 const API = 'https://api.securityscorecards.dev/projects'
 const TIMEOUT_MS = 12_000
@@ -24,7 +31,13 @@ export function scorecardViewerUrl(slug) {
   return `https://scorecard.dev/viewer/?uri=${slug}`
 }
 
-/** Fetch one repository's published score; null on 404, error, or timeout. */
+/**
+ * Look up one repository's Scorecard. Returns a discriminated result:
+ * { status: 'published', score, date } when the API serves a score,
+ * { status: 'not-published' } on a 404 (the project opted out), or
+ * { status: 'unavailable' } on any timeout, network error, non-404 response,
+ * or malformed body. Never throws.
+ */
 async function fetchOne(slug) {
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), TIMEOUT_MS)
@@ -33,21 +46,22 @@ async function fetchOne(slug) {
       signal: controller.signal,
       headers: { accept: 'application/json' },
     })
-    if (!res.ok) return null
+    if (res.status === 404) return { status: 'not-published' }
+    if (!res.ok) return { status: 'unavailable' }
     const body = await res.json()
-    if (typeof body?.score !== 'number') return null
-    return { score: body.score, date: body.date ?? null }
+    if (typeof body?.score !== 'number') return { status: 'unavailable' }
+    return { status: 'published', score: body.score, date: body.date ?? null }
   } catch {
-    return null
+    return { status: 'unavailable' }
   } finally {
     clearTimeout(timer)
   }
 }
 
 /**
- * Resolve published scores for a set of "github.com/owner/repo" slugs in
- * parallel. Returns a slug -> { score, date } | null map; falsy slugs are
- * dropped. Never throws.
+ * Resolve Scorecard results for a set of "github.com/owner/repo" slugs in
+ * parallel. Returns a slug -> { status, ... } map (see fetchOne for the per-slug
+ * shape); falsy slugs are dropped. Never throws.
  */
 export async function fetchScorecards(slugs) {
   const unique = [...new Set(slugs.filter(Boolean))]

--- a/apps/bench-arena/src/adapters/attaform/ArrayRow.vue
+++ b/apps/bench-arena/src/adapters/attaform/ArrayRow.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+  import { computed, onUpdated } from 'vue'
+  import { recordRender } from '../../shared/render-count'
+  import type { AttaformForm } from './types'
+
+  /**
+   * An Attaform array row, wired the way the canonical `form.list` demo wires
+   * one: the row is keyed by its stable `row.key` (set by the parent v-for), and
+   * the input registers the CURRENT positional path. Re-deriving the binding
+   * from `props.path` on each render is exactly what the `v-register` directive
+   * does, so when a reorder moves this keyed row to a new slot, it rebinds to the
+   * new `rows.${i}.v` and shows that slot's value. The cached-in-setup binding of
+   * the flat/nested field would go stale across a reorder; an array row cannot.
+   */
+  const props = defineProps<{
+    form: AttaformForm
+    path: string
+    index: number
+    trigger: 'input' | 'blur'
+  }>()
+
+  onUpdated(() => recordRender(props.index))
+
+  const displayValue = computed(() => props.form.register(props.path).displayValue.value)
+
+  function onInput(event: Event): void {
+    props.form.setValue(props.path, (event.target as HTMLInputElement).value)
+  }
+
+  function onBlur(): void {
+    if (props.trigger === 'blur') props.form.validate(props.path)
+  }
+</script>
+
+<template>
+  <input :data-bench-field="index" :value="displayValue" @input="onInput" @blur="onBlur" />
+</template>

--- a/apps/bench-arena/src/adapters/attaform/Field.vue
+++ b/apps/bench-arena/src/adapters/attaform/Field.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+  import { onUpdated } from 'vue'
+  import { recordRender } from '../../shared/render-count'
+  import type { AttaformForm } from './types'
+
+  /**
+   * An Attaform field, wired the way the `v-register` directive wires one: the
+   * granular `register(path).displayValue` drives `:value` (exactly the string
+   * the compile-time `:value` injection reads), and the public `setValue` funnel
+   * takes the keystroke (the same funnel the directive's input listener and the
+   * render-isolation lock test drive). Reading `displayValue` and writing
+   * `setValue` is runtime-equivalent to the directive, so the measured keystroke
+   * and render-scope figures are Attaform's real ones, with no compiler-plugin
+   * magic in the harness.
+   *
+   * The keystroke cost reflects Attaform's subtree-scoped validation: under
+   * `validateOn: 'change'` with no root refine, a write validates only the
+   * changed leaf, not the whole form.
+   */
+  const props = defineProps<{
+    form: AttaformForm
+    path: string
+    index: number
+    trigger: 'input' | 'blur'
+  }>()
+
+  // register() returns a fresh binding per call; call once and reuse the
+  // granular read.
+  const rv = props.form.register(props.path)
+
+  // One-line render-scope instrumentation: fires once per re-render, off the
+  // reactive path. The template reads only `rv.displayValue`, so this field
+  // re-renders solely when its own value changes.
+  onUpdated(() => recordRender(props.index))
+
+  function onInput(event: Event): void {
+    props.form.setValue(props.path, (event.target as HTMLInputElement).value)
+  }
+
+  function onBlur(): void {
+    if (props.trigger === 'blur') props.form.validate(props.path)
+  }
+</script>
+
+<template>
+  <input :data-bench-field="index" :value="rv.displayValue.value" @input="onInput" @blur="onBlur" />
+</template>

--- a/apps/bench-arena/src/adapters/attaform/adapter.ts
+++ b/apps/bench-arena/src/adapters/attaform/adapter.ts
@@ -5,7 +5,8 @@ import { flush } from '../../shared/clock'
 import { domDriver } from '../../shared/dom-driver'
 import { resetRenderCounts, totalRenders } from '../../shared/render-count'
 import { shapeFor, zodSchemaFor } from '../../shared/scenarios'
-import type { BenchAdapter, MountHandle } from '../contract'
+import type { ArrayOp, BenchAdapter, MountHandle } from '../contract'
+import ArrayRow from './ArrayRow.vue'
 import Field from './Field.vue'
 import type { AttaformForm } from './types'
 
@@ -71,13 +72,35 @@ export const attaformAdapter: BenchAdapter = {
           debounceMs: 0,
         })
         form = f
-        return () =>
-          h(
+        const arrayPath = shape.arrayPath
+        const itemFields = shape.arrayItemFields ?? []
+        return () => {
+          // An array scenario renders reactively through `form.list`: reading it
+          // tracks the array length, so a row added or removed reflows the list,
+          // while a leaf edit (length unchanged) re-renders only its own row.
+          if (arrayPath !== undefined) {
+            return h(
+              'div',
+              f.list(arrayPath).flatMap((row, i) =>
+                itemFields.map((field, fIdx) =>
+                  h(ArrayRow, {
+                    key: `${row.key}.${field}`,
+                    form: f,
+                    path: `${arrayPath}.${i}.${field}`,
+                    index: i * itemFields.length + fIdx,
+                    trigger: opts.trigger,
+                  })
+                )
+              )
+            )
+          }
+          return h(
             'div',
             shape.paths.map((path, index) =>
               h(Field, { key: index, form: f, path, index, trigger: opts.trigger })
             )
           )
+        }
       },
     })
 
@@ -98,7 +121,17 @@ export const attaformAdapter: BenchAdapter = {
         await form?.validateAsync(shape.paths[index])
         await flush()
       },
-      arrayOp: () => Promise.resolve(unsupported('arrayOp')),
+      async arrayOp(op: ArrayOp, a?: number, b?: number) {
+        const path = shape.arrayPath ?? 'rows'
+        if (op === 'append') form?.append(path, shape.newRow?.() ?? {})
+        else if (op === 'remove') {
+          const len = form?.list(path).length ?? 0
+          const index = a ?? len - 1
+          if (index >= 0) form?.remove(path, index)
+        } else if (op === 'swap') form?.swap(path, a ?? 0, b ?? 0)
+        else unsupported(op)
+        await flush()
+      },
       flipVariant: () => Promise.resolve(unsupported('flipVariant')),
       stepTransition: () => Promise.resolve(unsupported('stepTransition')),
       getRenderCount: () => totalRenders(),

--- a/apps/bench-arena/src/adapters/attaform/adapter.ts
+++ b/apps/bench-arena/src/adapters/attaform/adapter.ts
@@ -94,11 +94,14 @@ export const attaformAdapter: BenchAdapter = {
           }
           // An array scenario renders reactively through `form.list`: reading it
           // tracks the array length, so a row added or removed reflows the list,
-          // while a leaf edit (length unchanged) re-renders only its own row.
+          // while a leaf edit (length unchanged) re-renders only its own row. The
+          // composite massive scenario appends its flat and nested leaves after
+          // the rows (`objectPaths`), each registered at an index past the cells.
           if (arrayPath !== undefined) {
-            return h(
-              'div',
-              f.list(arrayPath).flatMap((row, i) =>
+            const objectPaths = shape.objectPaths ?? []
+            const objBase = shape.paths.length - objectPaths.length
+            return h('div', [
+              ...f.list(arrayPath).flatMap((row, i) =>
                 itemFields.map((field, fIdx) =>
                   h(ArrayRow, {
                     key: `${row.key}.${field}`,
@@ -108,8 +111,17 @@ export const attaformAdapter: BenchAdapter = {
                     trigger: opts.trigger,
                   })
                 )
-              )
-            )
+              ),
+              ...objectPaths.map((path, j) =>
+                h(Field, {
+                  key: `obj-${path}`,
+                  form: f,
+                  path,
+                  index: objBase + j,
+                  trigger: opts.trigger,
+                })
+              ),
+            ])
           }
           return h(
             'div',

--- a/apps/bench-arena/src/adapters/attaform/adapter.ts
+++ b/apps/bench-arena/src/adapters/attaform/adapter.ts
@@ -1,5 +1,5 @@
 import { createAttaform } from 'attaform'
-import { useForm } from 'attaform/zod-v3'
+import { useForm, useWizard } from 'attaform/zod-v3'
 import { type App, type Ref, createApp, defineComponent, h, ref } from 'vue'
 import { flush } from '../../shared/clock'
 import { domDriver } from '../../shared/dom-driver'
@@ -24,6 +24,21 @@ type UseFormLoose = (config: {
   debounceMs: number
 }) => AttaformForm
 const useFormLoose = useForm as unknown as UseFormLoose
+
+/**
+ * useWizard composes a list of step forms into a multistep flow. The dynamic
+ * per-step schemas erase its generics, so it is called through a loose
+ * signature while the runtime call is the real one. `handleSubmit` on an
+ * intermediate step validates the active step's form and advances on success
+ * (the gated transition the stepTransition dimension measures); `back()` is a
+ * free retreat with no validation.
+ */
+interface WizardLoose {
+  readonly activeIndex: { readonly value: number }
+  back(): void
+  handleSubmit(onSuccess: (ctx: unknown) => void): (event?: Event) => Promise<void>
+}
+const useWizardLoose = useWizard as unknown as (config: { steps: unknown[] }) => WizardLoose
 
 let mountSeq = 0
 
@@ -57,7 +72,10 @@ export const attaformAdapter: BenchAdapter = {
     const key = `bench-attaform-${opts.scenario}-${opts.seed}-${mountSeq}`
 
     const union = shape.union
+    const wizardDesc = shape.wizard
     let form: AttaformForm | undefined
+    let stepForms: AttaformForm[] | undefined
+    let wizard: WizardLoose | undefined
     let activeTag: Ref<string> | undefined
 
     // The host renders the static field list and reads nothing reactive, so it
@@ -66,6 +84,53 @@ export const attaformAdapter: BenchAdapter = {
     const Host = defineComponent({
       name: 'AttaformHost',
       setup() {
+        // The wizard is the real useWizard idiom: each step is its own useForm
+        // over that step's sub-schema (sliced off the root object by key), and
+        // useWizard composes them into one flow. Only the active step's fields
+        // render, off `wizard.activeIndex`; an advance validates that step's
+        // form through `handleSubmit` (see the handle's stepTransition).
+        if (wizardDesc !== undefined) {
+          const rootShape = (schema as unknown as { shape: Record<string, unknown> }).shape
+          const forms = wizardDesc.stepKeys.map((stepK) =>
+            useFormLoose({
+              schema: rootShape[stepK],
+              key: `${key}-${stepK}`,
+              defaultValues: (shape.defaultValues[stepK] ?? {}) as Record<string, unknown>,
+              validateOn,
+              debounceMs: 0,
+            })
+          )
+          stepForms = forms
+          const wiz = useWizardLoose({ steps: forms })
+          wizard = wiz
+          const perStep = wizardDesc.steps[0]?.length ?? 0
+          // Render every step's fields at once (eager). The wizard's per-step
+          // forms all hold state regardless of which step shows, so an advance
+          // never mounts or unmounts an input: the transition cost is the
+          // active step's validation plus the wizard's own bookkeeping, nothing
+          // more. It also keeps the cohort's aggregate validate comparable, with
+          // every field mounted for every library (the hand-rolled adapters
+          // render the same full set through their default branch). `activeIndex`
+          // still tracks the gated position the advance walks; the render does
+          // not read it, so an advance triggers no host re-render.
+          return () =>
+            h(
+              'div',
+              wizardDesc.steps.flatMap((stepPaths, s) =>
+                stepPaths.map((path, j) =>
+                  h(Field, {
+                    key: path,
+                    form: forms[s] as AttaformForm,
+                    // Each step form's own field name (`f0`), not the dotted root
+                    // path; the data-bench-field index stays global for the driver.
+                    path: path.slice(path.indexOf('.') + 1),
+                    index: s * perStep + j,
+                    trigger: opts.trigger,
+                  })
+                )
+              )
+            )
+        }
         const f = useFormLoose({
           schema,
           key,
@@ -139,11 +204,19 @@ export const attaformAdapter: BenchAdapter = {
 
     const driver = domDriver(container, opts.trigger)
 
+    // The gated forward transition: validating the active step's form and
+    // advancing on success is exactly what useWizard's intermediate
+    // handleSubmit does. Built once after mount; the handler is stable.
+    const stepAdvance = wizard?.handleSubmit(() => {})
+
     return {
       typeChar: driver.typeChar,
       setFieldValue: driver.setFieldValue,
       async validateAll() {
-        await form?.validateAsync()
+        // A wizard's cross-step aggregate is every step's form validated (the
+        // same set a final-step submit runs); a single form validates itself.
+        if (stepForms !== undefined) await Promise.all(stepForms.map((sf) => sf.validateAsync()))
+        else await form?.validateAsync()
         await flush()
       },
       async validateField(index) {
@@ -171,7 +244,15 @@ export const attaformAdapter: BenchAdapter = {
         if (activeTag) activeTag.value = to
         await flush()
       },
-      stepTransition: () => Promise.resolve(unsupported('stepTransition')),
+      async stepTransition(dir: 1 | -1) {
+        if (!wizard || !stepAdvance) return unsupported('stepTransition')
+        // Forward is the gated advance (validate the active step, then move on);
+        // backward is a free retreat, the same asymmetry a hand-composed wizard
+        // carries (progress is gated, going back is not).
+        if (dir === 1) await stepAdvance()
+        else wizard.back()
+        await flush()
+      },
       getRenderCount: () => totalRenders(),
       resetRenderCount: () => resetRenderCounts(),
       teardown: () => app.unmount(),

--- a/apps/bench-arena/src/adapters/attaform/adapter.ts
+++ b/apps/bench-arena/src/adapters/attaform/adapter.ts
@@ -1,6 +1,6 @@
 import { createAttaform } from 'attaform'
 import { useForm } from 'attaform/zod-v3'
-import { type App, createApp, defineComponent, h } from 'vue'
+import { type App, type Ref, createApp, defineComponent, h, ref } from 'vue'
 import { flush } from '../../shared/clock'
 import { domDriver } from '../../shared/dom-driver'
 import { resetRenderCounts, totalRenders } from '../../shared/render-count'
@@ -56,7 +56,9 @@ export const attaformAdapter: BenchAdapter = {
     mountSeq += 1
     const key = `bench-attaform-${opts.scenario}-${opts.seed}-${mountSeq}`
 
+    const union = shape.union
     let form: AttaformForm | undefined
+    let activeTag: Ref<string> | undefined
 
     // The host renders the static field list and reads nothing reactive, so it
     // never re-renders; each Field subscribes only to its own value, which is
@@ -74,7 +76,22 @@ export const attaformAdapter: BenchAdapter = {
         form = f
         const arrayPath = shape.arrayPath
         const itemFields = shape.arrayItemFields ?? []
+        // The active variant is tracked off a local signal the flip keeps in
+        // sync (the same shape as the array's length signal): a flip writes the
+        // union value through setValue, then advances the signal so the host
+        // swaps to the new branch's fields. A keystroke never touches it.
+        const tag = ref(union?.variants[0]?.tag ?? '')
+        activeTag = tag
         return () => {
+          if (union !== undefined) {
+            const variant = union.variants.find((v) => v.tag === tag.value)
+            return h(
+              'div',
+              (variant?.fieldPaths ?? []).map((path, index) =>
+                h(Field, { key: path, form: f, path, index, trigger: opts.trigger })
+              )
+            )
+          }
           // An array scenario renders reactively through `form.list`: reading it
           // tracks the array length, so a row added or removed reflows the list,
           // while a leaf edit (length unchanged) re-renders only its own row.
@@ -132,7 +149,16 @@ export const attaformAdapter: BenchAdapter = {
         else unsupported(op)
         await flush()
       },
-      flipVariant: () => Promise.resolve(unsupported('flipVariant')),
+      async flipVariant(to: string) {
+        const variant = union?.variants.find((v) => v.tag === to)
+        if (!union || !variant) return unsupported('flipVariant')
+        // Replace the whole union value, then advance the local signal so the
+        // host swaps to the new branch's fields after the value has landed. A
+        // fresh clone per flip keeps repeated flips from sharing one object.
+        form?.setValue(union.unionPath, { ...variant.value })
+        if (activeTag) activeTag.value = to
+        await flush()
+      },
       stepTransition: () => Promise.resolve(unsupported('stepTransition')),
       getRenderCount: () => totalRenders(),
       resetRenderCount: () => resetRenderCounts(),

--- a/apps/bench-arena/src/adapters/attaform/adapter.ts
+++ b/apps/bench-arena/src/adapters/attaform/adapter.ts
@@ -1,0 +1,109 @@
+import { createAttaform } from 'attaform'
+import { useForm } from 'attaform/zod-v3'
+import { type App, createApp, defineComponent, h } from 'vue'
+import { flush } from '../../shared/clock'
+import { domDriver } from '../../shared/dom-driver'
+import { resetRenderCounts, totalRenders } from '../../shared/render-count'
+import { shapeFor, zodSchemaFor } from '../../shared/scenarios'
+import type { BenchAdapter, MountHandle } from '../contract'
+import Field from './Field.vue'
+import type { AttaformForm } from './types'
+
+/**
+ * The benchmark builds the schema dynamically, so `useForm`'s generics cannot
+ * derive the static `FlatPath` set and the inference blows the instantiation
+ * depth. Calling through a loose signature erases that derivation while leaving
+ * the runtime call identical (the same path the typed API resolves to).
+ */
+type UseFormLoose = (config: {
+  schema: unknown
+  key: string
+  defaultValues: Record<string, unknown>
+  validateOn: 'change' | 'blur'
+  debounceMs: number
+}) => AttaformForm
+const useFormLoose = useForm as unknown as UseFormLoose
+
+let mountSeq = 0
+
+const unsupported = (op: string): never => {
+  throw new Error(`bench: attaform adapter does not drive "${op}" in this scenario`)
+}
+
+export const attaformAdapter: BenchAdapter = {
+  meta: {
+    id: 'attaform',
+    displayName: 'Attaform',
+    layer: 'headless-form-state',
+    schemaLib: 'zod3',
+    ownsInputs: false,
+    capabilities: {
+      flat: 'native',
+      nested: 'native',
+      arrays: 'native',
+      grid: 'native',
+      'discriminated-union': 'native',
+      massive: 'native',
+      wizard: 'native',
+    },
+  },
+
+  async mount(container, opts): Promise<MountHandle> {
+    const shape = shapeFor(opts.scenario, opts.params)
+    const schema = zodSchemaFor(opts.scenario, opts.params)
+    const validateOn: 'change' | 'blur' = opts.trigger === 'blur' ? 'blur' : 'change'
+    mountSeq += 1
+    const key = `bench-attaform-${opts.scenario}-${opts.seed}-${mountSeq}`
+
+    let form: AttaformForm | undefined
+
+    // The host renders the static field list and reads nothing reactive, so it
+    // never re-renders; each Field subscribes only to its own value, which is
+    // what keeps the render-scope measurement honest.
+    const Host = defineComponent({
+      name: 'AttaformHost',
+      setup() {
+        const f = useFormLoose({
+          schema,
+          key,
+          defaultValues: shape.defaultValues,
+          validateOn,
+          debounceMs: 0,
+        })
+        form = f
+        return () =>
+          h(
+            'div',
+            shape.paths.map((path, index) =>
+              h(Field, { key: index, form: f, path, index, trigger: opts.trigger })
+            )
+          )
+      },
+    })
+
+    const app: App = createApp(Host).use(createAttaform())
+    app.mount(container)
+    await flush()
+
+    const driver = domDriver(container, opts.trigger)
+
+    return {
+      typeChar: driver.typeChar,
+      setFieldValue: driver.setFieldValue,
+      async validateAll() {
+        await form?.validateAsync()
+        await flush()
+      },
+      async validateField(index) {
+        await form?.validateAsync(shape.paths[index])
+        await flush()
+      },
+      arrayOp: () => Promise.resolve(unsupported('arrayOp')),
+      flipVariant: () => Promise.resolve(unsupported('flipVariant')),
+      stepTransition: () => Promise.resolve(unsupported('stepTransition')),
+      getRenderCount: () => totalRenders(),
+      resetRenderCount: () => resetRenderCounts(),
+      teardown: () => app.unmount(),
+    }
+  },
+}

--- a/apps/bench-arena/src/adapters/attaform/types.ts
+++ b/apps/bench-arena/src/adapters/attaform/types.ts
@@ -1,0 +1,21 @@
+/**
+ * The slice of Attaform's form surface the bench adapter drives. The benchmark
+ * builds the schema dynamically (`z.ZodTypeAny`), which erases the static
+ * per-path generics, so the precise `FlatPath` types collapse; this narrow
+ * shape keeps the binding honestly typed against the methods it actually calls.
+ */
+export interface AttaformForm {
+  /** register(path).displayValue is the granular string the compile-time
+   *  :value injection reads; used here purely for the per-field read. */
+  register(path: string): { readonly displayValue: { readonly value: string } }
+  /** The public write funnel (the same one v-register's input listener drives,
+   *  and the render-isolation lock test exercises) - it updates displayValue
+   *  reactively and validates per `validateOn`, so the edited field re-renders. */
+  setValue(path: string, value: unknown): unknown
+  /** Reactive validation status accessor; drives the blur-trigger keystroke. */
+  validate(path?: string): unknown
+  /** Awaitable whole-form (or subtree) validation that resolves when the pass
+   *  completes - the parity with the cohort's awaited validate() for the
+   *  validation-throughput dimension. */
+  validateAsync(path?: string): Promise<unknown>
+}

--- a/apps/bench-arena/src/adapters/attaform/types.ts
+++ b/apps/bench-arena/src/adapters/attaform/types.ts
@@ -18,4 +18,14 @@ export interface AttaformForm {
    *  completes - the parity with the cohort's awaited validate() for the
    *  validation-throughput dimension. */
   validateAsync(path?: string): Promise<unknown>
+  /** Append a fresh row to the array at `path` (the array add/remove dimension). */
+  append(path: string, value: unknown): unknown
+  /** Remove the row at `index` from the array at `path`. */
+  remove(path: string, index: number): unknown
+  /** Swap the rows at `a` and `b` in the array at `path` (the reorder dimension). */
+  swap(path: string, a: number, b: number): unknown
+  /** The array at `path` as one entry per element, each carrying a stable `key`
+   *  that follows its element across reorders. Reading it tracks the array
+   *  length, so the rendered list reflows when a row is added or removed. */
+  list(path: string): ReadonlyArray<{ readonly key: string | number }>
 }

--- a/apps/bench-arena/src/adapters/contract.ts
+++ b/apps/bench-arena/src/adapters/contract.ts
@@ -27,7 +27,8 @@ export type DimensionId =
   | 'mount'
   | 'validate'
   | 'rerender'
-  | 'arrayOp'
+  | 'arrayAdd'
+  | 'arrayReorder'
   | 'variantFlip'
   | 'stepTransition'
 
@@ -92,8 +93,13 @@ export interface MountHandle {
   validateAll(): Promise<void>
   /** Validate a single field. */
   validateField(index: number): Promise<void>
-  /** Mutate the active array (arrays/grid scenarios). */
-  arrayOp(op: ArrayOp, index?: number): Promise<void>
+  /**
+   * Mutate the active array through the library's own array primitive
+   * (arrays/grid scenarios). `append` adds a fresh valid row; `remove` with no
+   * index drops the last row, with an index drops that row; `swap` exchanges the
+   * rows at `a` and `b`. Awaits the shared settle so the DOM reflow is included.
+   */
+  arrayOp(op: ArrayOp, a?: number, b?: number): Promise<void>
   /** Flip a discriminated union to another variant (discriminated-union). */
   flipVariant(to: string): Promise<void>
   /** Advance or retreat a wizard step (wizard scenario). */

--- a/apps/bench-arena/src/adapters/contract.ts
+++ b/apps/bench-arena/src/adapters/contract.ts
@@ -31,6 +31,7 @@ export type DimensionId =
   | 'arrayReorder'
   | 'variantFlip'
   | 'stepTransition'
+  | 'memory'
 
 /** The design-point a library occupies; the fairness axis. */
 export type LayerId = 'headless-form-state' | 'headless-validation-only' | 'batteries-included'

--- a/apps/bench-arena/src/adapters/contract.ts
+++ b/apps/bench-arena/src/adapters/contract.ts
@@ -1,0 +1,114 @@
+/**
+ * The fairness device: one interface every library implements, so a single
+ * driver runs all of them identically. The three design-point layers
+ * (headless-form-state, headless-validation-only, batteries-included) are
+ * absorbed by WHAT an adapter owns, not by branching in the driver.
+ *
+ * The contract is scenario-parameterized: the same handle drives a flat form,
+ * a deep tree, a dynamic array, a discriminated union, or a wizard. A library
+ * that genuinely cannot express a scenario idiomatically declares it
+ * `unsupported` in its capability map (which feeds the docs capability matrix)
+ * and the driver skips it; it is NEVER hand-rigged into a misleading number.
+ */
+
+/** The practical form shapes the suite stress-tests. */
+export type ScenarioId =
+  | 'flat'
+  | 'nested'
+  | 'arrays'
+  | 'grid'
+  | 'discriminated-union'
+  | 'massive'
+  | 'wizard'
+
+/** What a given (scenario, dimension) cell measures. */
+export type DimensionId =
+  | 'keystroke'
+  | 'mount'
+  | 'validate'
+  | 'rerender'
+  | 'arrayOp'
+  | 'variantFlip'
+  | 'stepTransition'
+
+/** The design-point a library occupies; the fairness axis. */
+export type LayerId = 'headless-form-state' | 'headless-validation-only' | 'batteries-included'
+
+/** Which validator the adapter feeds. zod v3 is pinned across the zod cohort. */
+export type SchemaLib = 'zod3' | 'valibot' | 'native'
+
+/** Validation trigger under test. `input` is the primary (universal) pass. */
+export type TriggerMode = 'input' | 'blur'
+
+/** How well a library expresses a scenario; the capability-matrix vocabulary. */
+export type Capability = 'native' | 'hand-rolled' | 'unsupported'
+
+/** Dynamic-array mutations exercised by the arrays/grid scenarios. */
+export type ArrayOp = 'append' | 'prepend' | 'insert' | 'remove' | 'swap' | 'move'
+
+/** Scenario size knobs, e.g. `{ fields: 50 }`, `{ depth: 8 }`, `{ rows: 100 }`. */
+export type ScenarioParams = Readonly<Record<string, number>>
+
+export interface AdapterMeta {
+  readonly id: string
+  readonly displayName: string
+  readonly layer: LayerId
+  readonly schemaLib: SchemaLib
+  /**
+   * True when the library renders its own field components (FormKit). Such an
+   * adapter cannot drive the shared bare `<input>`, so it is measured in its
+   * idiomatic mode and labeled batteries-included, never placed silently
+   * beside the bare-input libraries.
+   */
+  readonly ownsInputs: boolean
+  /** Per-scenario expressiveness; rendered verbatim as the capability matrix. */
+  readonly capabilities: Readonly<Record<ScenarioId, Capability>>
+}
+
+export interface MountOpts {
+  readonly scenario: ScenarioId
+  readonly params: ScenarioParams
+  readonly trigger: TriggerMode
+  /** Deterministic seed so a re-run drives the identical sequence of edits. */
+  readonly seed: number
+}
+
+/**
+ * A mounted form under measurement. Edit/validation methods route through the
+ * library's real API; the driver clocks the wall-clock cost around each.
+ *
+ * Scenario-specific ops (arrayOp/flipVariant/stepTransition) are present on
+ * every handle for a uniform driver, but only invoked when the adapter's
+ * capability map says the library expresses that scenario. An adapter whose
+ * library lacks the primitive throws from the unused op (never reached under
+ * capability gating) rather than faking a number.
+ */
+export interface MountHandle {
+  /** One keystroke: set the input value, fire the native event, await settle. */
+  typeChar(index: number, value: string): Promise<void>
+  /** Set a field without timing it (warmup / pre-dirtying a valid baseline). */
+  setFieldValue(index: number, value: string): Promise<void>
+  /** Run a full-form validation pass to completion. */
+  validateAll(): Promise<void>
+  /** Validate a single field. */
+  validateField(index: number): Promise<void>
+  /** Mutate the active array (arrays/grid scenarios). */
+  arrayOp(op: ArrayOp, index?: number): Promise<void>
+  /** Flip a discriminated union to another variant (discriminated-union). */
+  flipVariant(to: string): Promise<void>
+  /** Advance or retreat a wizard step (wizard scenario). */
+  stepTransition(dir: 1 | -1): Promise<void>
+  /**
+   * Components re-rendered since the last reset. `null` for batteries-included
+   * libraries that own their inputs, where the driver falls back to a
+   * DOM-mutation proxy (explicitly caveated, not directly comparable).
+   */
+  getRenderCount(): number | null
+  resetRenderCount(): void
+  teardown(): void
+}
+
+export interface BenchAdapter {
+  readonly meta: AdapterMeta
+  mount(container: HTMLElement, opts: MountOpts): Promise<MountHandle>
+}

--- a/apps/bench-arena/src/adapters/formisch/ArrayRow.vue
+++ b/apps/bench-arena/src/adapters/formisch/ArrayRow.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+  import { useField } from '@formisch/vue'
+  import { onUpdated } from 'vue'
+  import { recordRender } from '../../shared/render-count'
+  import type { FormischField } from './types'
+
+  /**
+   * A formisch array row. formisch hands each row a stable key (the parent keys
+   * the v-for by it), so a reorder moves the DOM node. The row therefore binds to
+   * its CURRENT positional path through a getter config: useField takes a
+   * `MaybeRefOrGetter`, so re-deriving the array path from `props.path` re-points
+   * the field when a reorder moves this row to a new slot. The flat field caches
+   * its path in setup, which an identity-keyed reorderable row cannot.
+   */
+  const props = defineProps<{
+    form: unknown
+    path: string
+    index: number
+    trigger: 'input' | 'blur'
+  }>()
+
+  onUpdated(() => recordRender(props.index))
+
+  const field = useField(
+    props.form as never,
+    (() => ({
+      path: props.path.split('.').map((seg) => (/^\d+$/.test(seg) ? Number(seg) : seg)),
+    })) as never
+  ) as unknown as FormischField
+
+  function onInput(event: Event): void {
+    field.input = (event.target as HTMLInputElement).value
+  }
+
+  function onBlur(): void {
+    if (props.trigger === 'blur') field.props.onBlur()
+  }
+</script>
+
+<template>
+  <input :data-bench-field="index" :value="field.input" @input="onInput" @blur="onBlur" />
+</template>

--- a/apps/bench-arena/src/adapters/formisch/Field.vue
+++ b/apps/bench-arena/src/adapters/formisch/Field.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+  import { useField } from '@formisch/vue'
+  import { onUpdated } from 'vue'
+  import { recordRender } from '../../shared/render-count'
+  import type { FormischField } from './types'
+
+  /**
+   * A formisch field through the `useField` composable (formisch's `<Field>`
+   * render-prop is a wrapper over it). Binding `:value` to the reactive `input`
+   * getter makes the field controlled and granular: it re-renders only when its
+   * own value changes. Assigning `input` runs formisch's input-mode validation,
+   * so under the input-trigger pass the keystroke latency captures the valibot
+   * parse for this field.
+   */
+  const props = defineProps<{
+    form: unknown
+    path: string
+    index: number
+    trigger: 'input' | 'blur'
+  }>()
+
+  // formisch addresses fields by an array path (['a', 0, 'b']); the harness's
+  // dotted path maps to it, numeric segments coerced to array indices. useField
+  // takes the form store directly; the dynamic schema collapses its path
+  // generics, so the args are cast through to the call.
+  const fieldPath = props.path.split('.').map((seg) => (/^\d+$/.test(seg) ? Number(seg) : seg))
+  const field = useField(
+    props.form as never,
+    { path: fieldPath } as never
+  ) as unknown as FormischField
+
+  onUpdated(() => recordRender(props.index))
+
+  function onInput(event: Event): void {
+    field.input = (event.target as HTMLInputElement).value
+  }
+
+  function onBlur(): void {
+    if (props.trigger === 'blur') field.props.onBlur()
+  }
+</script>
+
+<template>
+  <input :data-bench-field="index" :value="field.input" @input="onInput" @blur="onBlur" />
+</template>

--- a/apps/bench-arena/src/adapters/formisch/adapter.ts
+++ b/apps/bench-arena/src/adapters/formisch/adapter.ts
@@ -52,8 +52,6 @@ const setInputAt = setInput as unknown as (
   config: { path: ArrayPath; input: unknown }
 ) => void
 
-let mountSeq = 0
-
 const unsupported = (op: string): never => {
   throw new Error(`bench: formisch adapter does not drive "${op}" in this scenario`)
 }
@@ -82,7 +80,6 @@ export const formischAdapter: BenchAdapter = {
     // Validate on the trigger under test; revalidate on the same event so a
     // dirtied field keeps re-checking as the cohort does.
     const mode = opts.trigger === 'blur' ? 'blur' : 'input'
-    mountSeq += 1
 
     const arrayPath = shape.arrayPath
     const itemFields = shape.arrayItemFields ?? []

--- a/apps/bench-arena/src/adapters/formisch/adapter.ts
+++ b/apps/bench-arena/src/adapters/formisch/adapter.ts
@@ -1,10 +1,11 @@
-import { useForm, validate } from '@formisch/vue'
+import { insert, remove, swap, useFieldArray, useForm, validate } from '@formisch/vue'
 import { type App, createApp, defineComponent, h } from 'vue'
 import { flush } from '../../shared/clock'
 import { domDriver } from '../../shared/dom-driver'
 import { resetRenderCounts, totalRenders } from '../../shared/render-count'
 import { shapeFor, valibotSchemaFor } from '../../shared/scenarios'
-import type { BenchAdapter, MountHandle } from '../contract'
+import type { ArrayOp, BenchAdapter, MountHandle } from '../contract'
+import ArrayRow from './ArrayRow.vue'
 import Field from './Field.vue'
 
 /**
@@ -23,6 +24,27 @@ type UseFormLoose = (config: {
 }) => FormStoreLoose
 const useFormLoose = useForm as unknown as UseFormLoose
 const validateForm = validate as unknown as (form: FormStoreLoose) => Promise<unknown>
+
+// formisch addresses a field array by its array path (`['rows']`); the dynamic
+// schema collapses the path generics, so the helpers are called through loose
+// signatures while the runtime calls are the real ones.
+type ArrayPath = ReadonlyArray<string | number>
+const useFieldArrayLoose = useFieldArray as unknown as (
+  form: FormStoreLoose,
+  config: { path: ArrayPath }
+) => { readonly items: readonly string[] }
+const insertRow = insert as unknown as (
+  form: FormStoreLoose,
+  config: { path: ArrayPath; initialInput?: unknown }
+) => void
+const removeRow = remove as unknown as (
+  form: FormStoreLoose,
+  config: { path: ArrayPath; at: number }
+) => void
+const swapRows = swap as unknown as (
+  form: FormStoreLoose,
+  config: { path: ArrayPath; at: number; and: number }
+) => void
 
 let mountSeq = 0
 
@@ -56,7 +78,10 @@ export const formischAdapter: BenchAdapter = {
     const mode = opts.trigger === 'blur' ? 'blur' : 'input'
     mountSeq += 1
 
+    const arrayPath = shape.arrayPath
+    const itemFields = shape.arrayItemFields ?? []
     let form: FormStoreLoose | undefined
+    let rows: { readonly items: readonly string[] } | undefined
 
     const Host = defineComponent({
       name: 'FormischHost',
@@ -68,13 +93,35 @@ export const formischAdapter: BenchAdapter = {
           revalidate: mode,
         })
         form = f
-        return () =>
-          h(
+        // useFieldArray is formisch's array primitive; its reactive `items` are
+        // the stable per-row keys, so iterating them reflows the list on an
+        // add/remove and a leaf edit (keys unchanged) touches only its own row.
+        const fieldArray = arrayPath ? useFieldArrayLoose(f, { path: [arrayPath] }) : undefined
+        rows = fieldArray
+        return () => {
+          if (fieldArray && arrayPath !== undefined) {
+            return h(
+              'div',
+              fieldArray.items.flatMap((key, i) =>
+                itemFields.map((field, fIdx) =>
+                  h(ArrayRow, {
+                    key: `${key}.${field}`,
+                    form: f,
+                    path: `${arrayPath}.${i}.${field}`,
+                    index: i * itemFields.length + fIdx,
+                    trigger: opts.trigger,
+                  })
+                )
+              )
+            )
+          }
+          return h(
             'div',
             shape.paths.map((path, index) =>
               h(Field, { key: index, form: f, path, index, trigger: opts.trigger })
             )
           )
+        }
       },
     })
 
@@ -96,7 +143,17 @@ export const formischAdapter: BenchAdapter = {
         if (form) await validateForm(form)
         await flush()
       },
-      arrayOp: () => Promise.resolve(unsupported('arrayOp')),
+      async arrayOp(op: ArrayOp, a?: number, b?: number) {
+        if (arrayPath === undefined || !form) return unsupported(op)
+        const path = [arrayPath]
+        if (op === 'append') insertRow(form, { path, initialInput: shape.newRow?.() ?? {} })
+        else if (op === 'remove') {
+          const at = a ?? (rows?.items.length ?? 0) - 1
+          if (at >= 0) removeRow(form, { path, at })
+        } else if (op === 'swap') swapRows(form, { path, at: a ?? 0, and: b ?? 0 })
+        else unsupported(op)
+        await flush()
+      },
       flipVariant: () => Promise.resolve(unsupported('flipVariant')),
       stepTransition: () => Promise.resolve(unsupported('stepTransition')),
       getRenderCount: () => totalRenders(),

--- a/apps/bench-arena/src/adapters/formisch/adapter.ts
+++ b/apps/bench-arena/src/adapters/formisch/adapter.ts
@@ -1,5 +1,5 @@
-import { insert, remove, swap, useFieldArray, useForm, validate } from '@formisch/vue'
-import { type App, createApp, defineComponent, h } from 'vue'
+import { insert, remove, setInput, swap, useFieldArray, useForm, validate } from '@formisch/vue'
+import { type App, type Ref, createApp, defineComponent, h, ref } from 'vue'
 import { flush } from '../../shared/clock'
 import { domDriver } from '../../shared/dom-driver'
 import { resetRenderCounts, totalRenders } from '../../shared/render-count'
@@ -45,6 +45,12 @@ const swapRows = swap as unknown as (
   form: FormStoreLoose,
   config: { path: ArrayPath; at: number; and: number }
 ) => void
+// setInput writes a value at a path; the flip writes the whole union object at
+// `['event']`. The dynamic schema collapses the path/input generics.
+const setInputAt = setInput as unknown as (
+  form: FormStoreLoose,
+  config: { path: ArrayPath; input: unknown }
+) => void
 
 let mountSeq = 0
 
@@ -80,8 +86,10 @@ export const formischAdapter: BenchAdapter = {
 
     const arrayPath = shape.arrayPath
     const itemFields = shape.arrayItemFields ?? []
+    const union = shape.union
     let form: FormStoreLoose | undefined
     let rows: { readonly items: readonly string[] } | undefined
+    let activeTag: Ref<string> | undefined
 
     const Host = defineComponent({
       name: 'FormischHost',
@@ -98,7 +106,21 @@ export const formischAdapter: BenchAdapter = {
         // add/remove and a leaf edit (keys unchanged) touches only its own row.
         const fieldArray = arrayPath ? useFieldArrayLoose(f, { path: [arrayPath] }) : undefined
         rows = fieldArray
+        // The active variant is tracked off a local signal the flip keeps in
+        // sync; a flip writes the union value through setInput, then advances the
+        // signal so the host swaps to the new branch's fields.
+        const tag = ref(union?.variants[0]?.tag ?? '')
+        activeTag = tag
         return () => {
+          if (union !== undefined) {
+            const variant = union.variants.find((v) => v.tag === tag.value)
+            return h(
+              'div',
+              (variant?.fieldPaths ?? []).map((path, index) =>
+                h(Field, { key: path, form: f, path, index, trigger: opts.trigger })
+              )
+            )
+          }
           if (fieldArray && arrayPath !== undefined) {
             return h(
               'div',
@@ -154,7 +176,15 @@ export const formischAdapter: BenchAdapter = {
         else unsupported(op)
         await flush()
       },
-      flipVariant: () => Promise.resolve(unsupported('flipVariant')),
+      async flipVariant(to: string) {
+        const variant = union?.variants.find((v) => v.tag === to)
+        if (!union || !variant || !form) return unsupported('flipVariant')
+        // Write the whole union value, then advance the local signal so the host
+        // swaps to the new branch's fields after the value has landed.
+        setInputAt(form, { path: [union.unionPath], input: { ...variant.value } })
+        if (activeTag) activeTag.value = to
+        await flush()
+      },
       stepTransition: () => Promise.resolve(unsupported('stepTransition')),
       getRenderCount: () => totalRenders(),
       resetRenderCount: () => resetRenderCounts(),

--- a/apps/bench-arena/src/adapters/formisch/adapter.ts
+++ b/apps/bench-arena/src/adapters/formisch/adapter.ts
@@ -122,9 +122,10 @@ export const formischAdapter: BenchAdapter = {
             )
           }
           if (fieldArray && arrayPath !== undefined) {
-            return h(
-              'div',
-              fieldArray.items.flatMap((key, i) =>
+            const objectPaths = shape.objectPaths ?? []
+            const objBase = shape.paths.length - objectPaths.length
+            return h('div', [
+              ...fieldArray.items.flatMap((key, i) =>
                 itemFields.map((field, fIdx) =>
                   h(ArrayRow, {
                     key: `${key}.${field}`,
@@ -134,8 +135,17 @@ export const formischAdapter: BenchAdapter = {
                     trigger: opts.trigger,
                   })
                 )
-              )
-            )
+              ),
+              ...objectPaths.map((path, j) =>
+                h(Field, {
+                  key: `obj-${path}`,
+                  form: f,
+                  path,
+                  index: objBase + j,
+                  trigger: opts.trigger,
+                })
+              ),
+            ])
           }
           return h(
             'div',

--- a/apps/bench-arena/src/adapters/formisch/adapter.ts
+++ b/apps/bench-arena/src/adapters/formisch/adapter.ts
@@ -1,0 +1,107 @@
+import { useForm, validate } from '@formisch/vue'
+import { type App, createApp, defineComponent, h } from 'vue'
+import { flush } from '../../shared/clock'
+import { domDriver } from '../../shared/dom-driver'
+import { resetRenderCounts, totalRenders } from '../../shared/render-count'
+import { shapeFor, valibotSchemaFor } from '../../shared/scenarios'
+import type { BenchAdapter, MountHandle } from '../contract'
+import Field from './Field.vue'
+
+/**
+ * formisch is a functional, valibot-native form store. The dynamic valibot
+ * schema collapses its generics, so `useForm` / `validate` are called through
+ * loose signatures; the runtime calls are the real ones. `validate(form)` runs
+ * the whole-schema parse, which is formisch's only public validation entry, so
+ * single-field validation maps to the same full-form pass (noted as such).
+ */
+type FormStoreLoose = object
+type UseFormLoose = (config: {
+  schema: unknown
+  initialInput: Record<string, unknown>
+  validate: string
+  revalidate: string
+}) => FormStoreLoose
+const useFormLoose = useForm as unknown as UseFormLoose
+const validateForm = validate as unknown as (form: FormStoreLoose) => Promise<unknown>
+
+let mountSeq = 0
+
+const unsupported = (op: string): never => {
+  throw new Error(`bench: formisch adapter does not drive "${op}" in this scenario`)
+}
+
+export const formischAdapter: BenchAdapter = {
+  meta: {
+    id: 'formisch',
+    displayName: '@formisch/vue',
+    layer: 'headless-form-state',
+    schemaLib: 'valibot',
+    ownsInputs: false,
+    capabilities: {
+      flat: 'native',
+      nested: 'native',
+      arrays: 'native',
+      grid: 'native',
+      'discriminated-union': 'hand-rolled',
+      massive: 'native',
+      wizard: 'hand-rolled',
+    },
+  },
+
+  async mount(container, opts): Promise<MountHandle> {
+    const shape = shapeFor(opts.scenario, opts.params)
+    const schema = valibotSchemaFor(opts.scenario, opts.params)
+    // Validate on the trigger under test; revalidate on the same event so a
+    // dirtied field keeps re-checking as the cohort does.
+    const mode = opts.trigger === 'blur' ? 'blur' : 'input'
+    mountSeq += 1
+
+    let form: FormStoreLoose | undefined
+
+    const Host = defineComponent({
+      name: 'FormischHost',
+      setup() {
+        const f = useFormLoose({
+          schema,
+          initialInput: { ...shape.defaultValues },
+          validate: mode,
+          revalidate: mode,
+        })
+        form = f
+        return () =>
+          h(
+            'div',
+            shape.paths.map((path, index) =>
+              h(Field, { key: index, form: f, path, index, trigger: opts.trigger })
+            )
+          )
+      },
+    })
+
+    const app: App = createApp(Host)
+    app.mount(container)
+    await flush()
+
+    const driver = domDriver(container, opts.trigger)
+
+    return {
+      typeChar: driver.typeChar,
+      setFieldValue: driver.setFieldValue,
+      async validateAll() {
+        if (form) await validateForm(form)
+        await flush()
+      },
+      // formisch exposes only whole-form validation; single-field maps to it.
+      async validateField() {
+        if (form) await validateForm(form)
+        await flush()
+      },
+      arrayOp: () => Promise.resolve(unsupported('arrayOp')),
+      flipVariant: () => Promise.resolve(unsupported('flipVariant')),
+      stepTransition: () => Promise.resolve(unsupported('stepTransition')),
+      getRenderCount: () => totalRenders(),
+      resetRenderCount: () => resetRenderCounts(),
+      teardown: () => app.unmount(),
+    }
+  },
+}

--- a/apps/bench-arena/src/adapters/formisch/adapter.ts
+++ b/apps/bench-arena/src/adapters/formisch/adapter.ts
@@ -87,9 +87,14 @@ export const formischAdapter: BenchAdapter = {
     const arrayPath = shape.arrayPath
     const itemFields = shape.arrayItemFields ?? []
     const union = shape.union
+    const wizardDesc = shape.wizard
     let form: FormStoreLoose | undefined
     let rows: { readonly items: readonly string[] } | undefined
     let activeTag: Ref<string> | undefined
+    // The hand-composed wizard's active step. formisch has no wizard primitive
+    // and exposes only whole-form validation, so a gated advance re-parses the
+    // whole schema; every step renders through the default branch.
+    let wizardStep = 0
 
     const Host = defineComponent({
       name: 'FormischHost',
@@ -195,7 +200,19 @@ export const formischAdapter: BenchAdapter = {
         if (activeTag) activeTag.value = to
         await flush()
       },
-      stepTransition: () => Promise.resolve(unsupported('stepTransition')),
+      async stepTransition(dir: 1 | -1) {
+        if (!wizardDesc || !form) return unsupported('stepTransition')
+        if (dir === 1) {
+          if (wizardStep < wizardDesc.steps.length - 1) {
+            // formisch validates the whole form (no per-field entry), so a gated
+            // step re-runs the full schema parse; that whole-form cost is the
+            // honest price of hand-composing a wizard without a step primitive.
+            await validateForm(form)
+            wizardStep += 1
+          }
+        } else if (wizardStep > 0) wizardStep -= 1
+        await flush()
+      },
       getRenderCount: () => totalRenders(),
       resetRenderCount: () => resetRenderCounts(),
       teardown: () => app.unmount(),

--- a/apps/bench-arena/src/adapters/formisch/types.ts
+++ b/apps/bench-arena/src/adapters/formisch/types.ts
@@ -1,0 +1,11 @@
+/**
+ * The slice of a formisch field store the adapter binds. `input` is a reactive
+ * getter whose setter writes the value AND runs the form's validation when the
+ * form is in `'input'` mode, so a controlled `:value` binding drives formisch's
+ * real per-keystroke valibot parse. `props.onBlur` is formisch's blur funnel,
+ * used only on the blur-trigger pass.
+ */
+export interface FormischField {
+  input: string
+  readonly props: { onBlur(): void }
+}

--- a/apps/bench-arena/src/adapters/formkit/adapter.ts
+++ b/apps/bench-arena/src/adapters/formkit/adapter.ts
@@ -53,20 +53,44 @@ function buildTrie(paths: readonly string[]): TrieNode {
   return root
 }
 
+/** A trie node whose every child key is numeric is an array: FormKit models it
+ *  as a `list` whose items are positional, not a `group` keyed by name. */
+function isArrayNode(node: TrieNode): boolean {
+  if (node.children.size === 0) return false
+  for (const key of node.children.keys()) if (!/^\d+$/.test(key)) return false
+  return true
+}
+
+function leafInput(
+  leaf: { index: number; path: string },
+  defaultValues: Record<string, unknown>,
+  name?: string
+): VNode {
+  return h(FormKitC, {
+    key: name ?? leaf.index,
+    type: 'text',
+    name,
+    value: leafSeed(defaultValues, leaf.path),
+    delay: 0,
+    'data-bench-field': leaf.index,
+  })
+}
+
 function renderNodes(node: TrieNode, defaultValues: Record<string, unknown>): VNode[] {
   const out: VNode[] = []
   for (const [seg, child] of node.children) {
     if (child.leaf) {
-      out.push(
-        h(FormKitC, {
-          key: seg,
-          type: 'text',
-          name: seg,
-          value: leafSeed(defaultValues, child.leaf.path),
-          delay: 0,
-          'data-bench-field': child.leaf.index,
-        })
-      )
+      out.push(leafInput(child.leaf, defaultValues, seg))
+    } else if (isArrayNode(child)) {
+      // A `list`: render its items in index order, each positional (no name).
+      const items = [...child.children.entries()]
+        .sort((a, b) => Number(a[0]) - Number(b[0]))
+        .map(([idx, item]) =>
+          item.leaf
+            ? leafInput(item.leaf, defaultValues)
+            : h(FormKitC, { key: idx, type: 'group' }, () => renderNodes(item, defaultValues))
+        )
+      out.push(h(FormKitC, { key: seg, type: 'list', name: seg }, () => items))
     } else {
       out.push(
         h(FormKitC, { key: seg, type: 'group', name: seg }, () => renderNodes(child, defaultValues))

--- a/apps/bench-arena/src/adapters/formkit/adapter.ts
+++ b/apps/bench-arena/src/adapters/formkit/adapter.ts
@@ -1,0 +1,168 @@
+import { FormKit, defaultConfig, plugin } from '@formkit/vue'
+import { createZodPlugin } from '@formkit/zod'
+import { type App, type Component, type VNode, createApp, defineComponent, h } from 'vue'
+import { flush } from '../../shared/clock'
+import { domDriver } from '../../shared/dom-driver'
+import { leafSeed, shapeFor, zodSchemaFor } from '../../shared/scenarios'
+import type { BenchAdapter, MountHandle } from '../contract'
+
+// FormKit accepts arbitrary attributes (type, name, delay, data-*), which its
+// typed component surface does not enumerate; bind through a loose Component.
+const FormKitC = FormKit as unknown as Component
+
+let mountSeq = 0
+
+const unsupported = (op: string): never => {
+  throw new Error(`bench: formkit adapter does not drive "${op}" in this scenario`)
+}
+
+interface FormNode {
+  submit(): void
+  settled: Promise<unknown>
+}
+
+/** A segment node in the FormKit field tree: a `group` if it has children, a
+ *  `text` input if it is a leaf (carrying its rendered index + full path). */
+interface TrieNode {
+  readonly children: Map<string, TrieNode>
+  leaf?: { index: number; path: string }
+}
+
+/**
+ * FormKit builds its data tree from the nesting of `group` nodes, so the flat
+ * dotted paths are folded into a segment trie the render mirrors: shared
+ * prefixes become nested groups, leaves become text inputs. Flat scenarios
+ * (single-segment paths) fold to a flat list of inputs, exactly the prior
+ * shape; nested scenarios produce the real group chain a FormKit author writes.
+ */
+function buildTrie(paths: readonly string[]): TrieNode {
+  const root: TrieNode = { children: new Map() }
+  paths.forEach((path, index) => {
+    const segs = path.split('.')
+    let node = root
+    segs.forEach((seg, i) => {
+      let child = node.children.get(seg)
+      if (!child) {
+        child = { children: new Map() }
+        node.children.set(seg, child)
+      }
+      node = child
+      if (i === segs.length - 1) node.leaf = { index, path }
+    })
+  })
+  return root
+}
+
+function renderNodes(node: TrieNode, defaultValues: Record<string, unknown>): VNode[] {
+  const out: VNode[] = []
+  for (const [seg, child] of node.children) {
+    if (child.leaf) {
+      out.push(
+        h(FormKitC, {
+          key: seg,
+          type: 'text',
+          name: seg,
+          value: leafSeed(defaultValues, child.leaf.path),
+          delay: 0,
+          'data-bench-field': child.leaf.index,
+        })
+      )
+    } else {
+      out.push(
+        h(FormKitC, { key: seg, type: 'group', name: seg }, () => renderNodes(child, defaultValues))
+      )
+    }
+  }
+  return out
+}
+
+/**
+ * FormKit is the batteries-included entry: it renders its own inputs, so it
+ * cannot drive the shared bare input and is always categorized separately. It is
+ * measured in its idiomatic mode (the zod plugin, `:delay="0"` to neutralize the
+ * input debounce). Validation is debounced inside the zod plugin, so a keystroke
+ * measures FormKit's commit + re-render, and the full-form validate pass forces
+ * an immediate validation via `node.submit()`. Render scope reports `null`
+ * (FormKit owns the components); the DOM-mutation proxy lands with the grid
+ * scenario, where render scope is the headline.
+ */
+export const formkitAdapter: BenchAdapter = {
+  meta: {
+    id: 'formkit',
+    displayName: 'FormKit',
+    layer: 'batteries-included',
+    schemaLib: 'zod3',
+    ownsInputs: true,
+    capabilities: {
+      flat: 'native',
+      nested: 'native',
+      arrays: 'native',
+      grid: 'native',
+      'discriminated-union': 'hand-rolled',
+      massive: 'native',
+      wizard: 'hand-rolled',
+    },
+  },
+
+  async mount(container, opts): Promise<MountHandle> {
+    const shape = shapeFor(opts.scenario, opts.params)
+    const schema = zodSchemaFor(opts.scenario, opts.params)
+    const [zodPlugin, submitHandler] = createZodPlugin(schema as never, () => {})
+    mountSeq += 1
+    const formId = `bench-formkit-${opts.scenario}-${opts.seed}-${mountSeq}`
+
+    // FormKit emits its root node on creation; capture it for the validate pass
+    // rather than reaching for a getNode import from @formkit/core.
+    let rootNode: FormNode | undefined
+
+    const trie = buildTrie(shape.paths)
+
+    const Host = defineComponent({
+      name: 'FormKitHost',
+      setup() {
+        return () =>
+          h(
+            FormKitC,
+            {
+              type: 'form',
+              id: formId,
+              plugins: [zodPlugin],
+              actions: false,
+              onSubmit: submitHandler,
+              onNode: (node: unknown) => {
+                rootNode = node as FormNode
+              },
+            },
+            () => renderNodes(trie, shape.defaultValues)
+          )
+      },
+    })
+
+    const app: App = createApp(Host).use(plugin, defaultConfig())
+    app.mount(container)
+    await flush()
+
+    const driver = domDriver(container, opts.trigger)
+
+    const validate = async (): Promise<void> => {
+      rootNode?.submit()
+      await rootNode?.settled
+      await flush()
+    }
+
+    return {
+      typeChar: driver.typeChar,
+      setFieldValue: driver.setFieldValue,
+      validateAll: validate,
+      validateField: validate,
+      arrayOp: () => Promise.resolve(unsupported('arrayOp')),
+      flipVariant: () => Promise.resolve(unsupported('flipVariant')),
+      stepTransition: () => Promise.resolve(unsupported('stepTransition')),
+      // FormKit owns its components; component render count is not applicable.
+      // The grid scenario adds a DOM-mutation proxy, explicitly caveated.
+      getRenderCount: () => null,
+      resetRenderCount: () => {},
+      teardown: () => app.unmount(),
+    }
+  },
+}

--- a/apps/bench-arena/src/adapters/formkit/adapter.ts
+++ b/apps/bench-arena/src/adapters/formkit/adapter.ts
@@ -226,12 +226,16 @@ export const formkitAdapter: BenchAdapter = {
             )
           }
         }
-        // An array scenario renders the `list` node's rows off a reactive count:
-        // appending or removing a row mounts/unmounts a group child, which FormKit
-        // grows/shrinks the list from. A keystroke (count unchanged) never reflows
-        // the list, so this is the performant idiomatic dynamic list (the repeater
-        // add-on, an extra package, is the only lighter authoring path).
-        if (arrayPath !== undefined) {
+        // A dynamic-array scenario renders the `list` node's rows off a reactive
+        // count: appending or removing a row mounts/unmounts a group child, which
+        // FormKit grows/shrinks the list from. A keystroke (count unchanged) never
+        // reflows the list, so this is the performant idiomatic dynamic list (the
+        // repeater add-on, an extra package, is the only lighter authoring path).
+        // The composite massive scenario carries `objectPaths`, so it falls
+        // through to the trie render below, which folds its flat, nested, and row
+        // paths into FormKit's groups, lists, and leaves in one pass (massive runs
+        // no array mutation, so it needs no reactive row count).
+        if (arrayPath !== undefined && (shape.objectPaths?.length ?? 0) === 0) {
           const count = ref(initialSeeds.length)
           rowCount = count
           return () =>

--- a/apps/bench-arena/src/adapters/formkit/adapter.ts
+++ b/apps/bench-arena/src/adapters/formkit/adapter.ts
@@ -164,12 +164,68 @@ export const formkitAdapter: BenchAdapter = {
     // The append row is the SAME row every adapter pushes (the shape's newRow),
     // so an appended FormKit row seeds to identical content as the cohort's.
     const appendSeed = shape.newRow?.() ?? {}
+    const union = shape.union
+    // FormKit addresses fields by name within a group, so the union renders as
+    // a `group` whose children are the discriminant input plus the active
+    // variant's inputs; the leaf segment is the FormKit `name`.
+    const discriminantSeg = union
+      ? union.discriminantPath.slice(union.discriminantPath.lastIndexOf('.') + 1)
+      : ''
     let listNode: ListNode | undefined
     let rowCount: Ref<number> | undefined
+    let activeTag: Ref<string> | undefined
 
     const Host = defineComponent({
       name: 'FormKitHost',
       setup() {
+        // A discriminated union renders as a `group` whose children are rebuilt
+        // when the discriminant flips. Keying the group by the active tag remounts
+        // it, so FormKit rebuilds the union value (the discriminant carried by its
+        // own input plus the new branch's fields) from the freshly mounted inputs:
+        // the idiomatic conditional-fields shape a FormKit union form takes.
+        if (union !== undefined) {
+          const tag = ref(union.variants[0]?.tag ?? '')
+          activeTag = tag
+          return () => {
+            const variant = union.variants.find((v) => v.tag === tag.value)
+            const fields = Object.entries(variant?.value ?? {}).filter(
+              ([key]) => key !== discriminantSeg
+            )
+            return h(
+              FormKitC,
+              {
+                type: 'form',
+                id: formId,
+                plugins: [zodPlugin],
+                actions: false,
+                onSubmit: submitHandler,
+                onNode: (node: unknown) => {
+                  rootNode = node as FormNode
+                },
+              },
+              () =>
+                h(FormKitC, { type: 'group', name: union.unionPath, key: tag.value }, () => [
+                  h(FormKitC, {
+                    key: '__discriminant',
+                    type: 'text',
+                    name: discriminantSeg,
+                    value: tag.value,
+                    delay: 0,
+                  }),
+                  ...fields.map(([seg, val], i) =>
+                    h(FormKitC, {
+                      key: seg,
+                      type: 'text',
+                      name: seg,
+                      value: val,
+                      delay: 0,
+                      'data-bench-field': i,
+                    })
+                  ),
+                ])
+            )
+          }
+        }
         // An array scenario renders the `list` node's rows off a reactive count:
         // appending or removing a row mounts/unmounts a group child, which FormKit
         // grows/shrinks the list from. A keystroke (count unchanged) never reflows
@@ -273,7 +329,15 @@ export const formkitAdapter: BenchAdapter = {
         } else unsupported(op)
         await flush()
       },
-      flipVariant: () => Promise.resolve(unsupported('flipVariant')),
+      async flipVariant(to: string) {
+        if (!union || !activeTag || !union.variants.some((v) => v.tag === to)) {
+          return unsupported('flipVariant')
+        }
+        // Advancing the tag remounts the keyed group, so FormKit rebuilds the
+        // union value from the new branch's inputs (no explicit value write).
+        activeTag.value = to
+        await flush()
+      },
       stepTransition: () => Promise.resolve(unsupported('stepTransition')),
       // FormKit owns its components; component render count is not applicable.
       // The grid scenario adds a DOM-mutation proxy, explicitly caveated.

--- a/apps/bench-arena/src/adapters/formkit/adapter.ts
+++ b/apps/bench-arena/src/adapters/formkit/adapter.ts
@@ -1,10 +1,19 @@
 import { FormKit, defaultConfig, plugin } from '@formkit/vue'
 import { createZodPlugin } from '@formkit/zod'
-import { type App, type Component, type VNode, createApp, defineComponent, h } from 'vue'
+import {
+  type App,
+  type Component,
+  type Ref,
+  type VNode,
+  createApp,
+  defineComponent,
+  h,
+  ref,
+} from 'vue'
 import { flush } from '../../shared/clock'
 import { domDriver } from '../../shared/dom-driver'
 import { leafSeed, shapeFor, zodSchemaFor } from '../../shared/scenarios'
-import type { BenchAdapter, MountHandle } from '../contract'
+import type { ArrayOp, BenchAdapter, MountHandle } from '../contract'
 
 // FormKit accepts arbitrary attributes (type, name, delay, data-*), which its
 // typed component surface does not enumerate; bind through a loose Component.
@@ -19,6 +28,13 @@ const unsupported = (op: string): never => {
 interface FormNode {
   submit(): void
   settled: Promise<unknown>
+}
+
+/** The FormKit `list` node the array scenario reorders through. Its value is the
+ *  array of row values; `input` commits a new array (used for the swap). */
+interface ListNode {
+  readonly value: readonly unknown[]
+  input(value: unknown): Promise<unknown>
 }
 
 /** A segment node in the FormKit field tree: a `group` if it has children, a
@@ -140,10 +156,68 @@ export const formkitAdapter: BenchAdapter = {
     let rootNode: FormNode | undefined
 
     const trie = buildTrie(shape.paths)
+    const arrayPath = shape.arrayPath
+    const itemFields = shape.arrayItemFields ?? []
+    const initialSeeds = arrayPath
+      ? ((shape.defaultValues[arrayPath] as Array<Record<string, unknown>>) ?? [])
+      : []
+    // The append row is the SAME row every adapter pushes (the shape's newRow),
+    // so an appended FormKit row seeds to identical content as the cohort's.
+    const appendSeed = shape.newRow?.() ?? {}
+    let listNode: ListNode | undefined
+    let rowCount: Ref<number> | undefined
 
     const Host = defineComponent({
       name: 'FormKitHost',
       setup() {
+        // An array scenario renders the `list` node's rows off a reactive count:
+        // appending or removing a row mounts/unmounts a group child, which FormKit
+        // grows/shrinks the list from. A keystroke (count unchanged) never reflows
+        // the list, so this is the performant idiomatic dynamic list (the repeater
+        // add-on, an extra package, is the only lighter authoring path).
+        if (arrayPath !== undefined) {
+          const count = ref(initialSeeds.length)
+          rowCount = count
+          return () =>
+            h(
+              FormKitC,
+              {
+                type: 'form',
+                id: formId,
+                plugins: [zodPlugin],
+                actions: false,
+                onSubmit: submitHandler,
+                onNode: (node: unknown) => {
+                  rootNode = node as FormNode
+                },
+              },
+              () =>
+                h(
+                  FormKitC,
+                  {
+                    type: 'list',
+                    name: arrayPath,
+                    onNode: (node: unknown) => {
+                      listNode = node as ListNode
+                    },
+                  },
+                  () =>
+                    Array.from({ length: count.value }, (_unused, i) =>
+                      h(FormKitC, { key: i, type: 'group' }, () =>
+                        itemFields.map((field, fIdx) =>
+                          h(FormKitC, {
+                            type: 'text',
+                            name: field,
+                            delay: 0,
+                            value: (initialSeeds[i] ?? appendSeed)[field],
+                            'data-bench-field': i * itemFields.length + fIdx,
+                          })
+                        )
+                      )
+                    )
+                )
+            )
+        }
         return () =>
           h(
             FormKitC,
@@ -179,7 +253,26 @@ export const formkitAdapter: BenchAdapter = {
       setFieldValue: driver.setFieldValue,
       validateAll: validate,
       validateField: validate,
-      arrayOp: () => Promise.resolve(unsupported('arrayOp')),
+      async arrayOp(op: ArrayOp, a?: number, b?: number) {
+        if (arrayPath === undefined || !rowCount) return unsupported(op)
+        // Add/remove a row by mounting/unmounting a group child (FormKit grows or
+        // shrinks the list to match). A reorder commits a reordered array to the
+        // list node, since the rendered groups carry no Vue-side array to swap.
+        if (op === 'append') rowCount.value += 1
+        else if (op === 'remove') {
+          if (rowCount.value > 0) rowCount.value -= 1
+        } else if (op === 'swap') {
+          if (!listNode) return unsupported(op)
+          const arr = [...listNode.value]
+          const i = a ?? 0
+          const j = b ?? 0
+          const tmp = arr[i]
+          arr[i] = arr[j]
+          arr[j] = tmp
+          await listNode.input(arr)
+        } else unsupported(op)
+        await flush()
+      },
       flipVariant: () => Promise.resolve(unsupported('flipVariant')),
       stepTransition: () => Promise.resolve(unsupported('stepTransition')),
       // FormKit owns its components; component render count is not applicable.

--- a/apps/bench-arena/src/adapters/formkit/adapter.ts
+++ b/apps/bench-arena/src/adapters/formkit/adapter.ts
@@ -171,9 +171,15 @@ export const formkitAdapter: BenchAdapter = {
     const discriminantSeg = union
       ? union.discriminantPath.slice(union.discriminantPath.lastIndexOf('.') + 1)
       : ''
+    const wizardDesc = shape.wizard
     let listNode: ListNode | undefined
     let rowCount: Ref<number> | undefined
     let activeTag: Ref<string> | undefined
+    // The hand-composed wizard's active step. FormKit has no wizard primitive
+    // without the multi-step add-on, and its submit validates the whole form,
+    // so a gated advance re-validates every field; every step's inputs render
+    // through the trie (the default branch).
+    let wizardStep = 0
 
     const Host = defineComponent({
       name: 'FormKitHost',
@@ -342,7 +348,20 @@ export const formkitAdapter: BenchAdapter = {
         activeTag.value = to
         await flush()
       },
-      stepTransition: () => Promise.resolve(unsupported('stepTransition')),
+      async stepTransition(dir: 1 | -1) {
+        if (!wizardDesc) return unsupported('stepTransition')
+        if (dir === 1) {
+          if (wizardStep < wizardDesc.steps.length - 1) {
+            // FormKit validates the whole form on submit (no per-step entry
+            // without the multi-step add-on), so a gated step re-validates every
+            // field; that whole-form cost is the honest price of a hand-composed
+            // FormKit wizard.
+            await validate()
+            wizardStep += 1
+          }
+        } else if (wizardStep > 0) wizardStep -= 1
+        await flush()
+      },
       // FormKit owns its components; component render count is not applicable.
       // The grid scenario adds a DOM-mutation proxy, explicitly caveated.
       getRenderCount: () => null,

--- a/apps/bench-arena/src/adapters/registry.ts
+++ b/apps/bench-arena/src/adapters/registry.ts
@@ -1,0 +1,26 @@
+import { attaformAdapter } from './attaform/adapter'
+import type { BenchAdapter } from './contract'
+import { formischAdapter } from './formisch/adapter'
+import { formkitAdapter } from './formkit/adapter'
+import { regleRulesAdapter } from './regle/rules-adapter'
+import { regleSchemaAdapter } from './regle/schema-adapter'
+import { tanstackAdapter } from './tanstack/adapter'
+import { veeValidateAdapter } from './vee-validate/adapter'
+import { vuelidateAdapter } from './vuelidate/adapter'
+
+/**
+ * Static adapter registry. The harness mounts exactly one adapter per page
+ * load, selected by the `?adapter` query param, so no two libraries ever share
+ * a heap. The full June 2026 cohort across all three fairness layers:
+ * headless-form-state, headless-validation-only, and batteries-included.
+ */
+export const adapters: Record<string, BenchAdapter> = {
+  [attaformAdapter.meta.id]: attaformAdapter,
+  [veeValidateAdapter.meta.id]: veeValidateAdapter,
+  [tanstackAdapter.meta.id]: tanstackAdapter,
+  [formischAdapter.meta.id]: formischAdapter,
+  [regleSchemaAdapter.meta.id]: regleSchemaAdapter,
+  [regleRulesAdapter.meta.id]: regleRulesAdapter,
+  [formkitAdapter.meta.id]: formkitAdapter,
+  [vuelidateAdapter.meta.id]: vuelidateAdapter,
+}

--- a/apps/bench-arena/src/adapters/regle/Field.vue
+++ b/apps/bench-arena/src/adapters/regle/Field.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+  import { onUpdated } from 'vue'
+  import { recordRender } from '../../shared/render-count'
+  import type { RegleField } from './types'
+
+  /**
+   * A Regle field. Regle is validation-only, so the harness owns the input and
+   * binds it to the field status's `$value` (the model reference Regle exposes for
+   * v-model). Reading `$value` subscribes to this field alone, so it re-renders
+   * granularly; assigning it marks the field dirty and runs Regle's reactive
+   * validation: a whole-schema re-parse in schema mode, this field's rules in
+   * rules mode. The same component serves both modes because the binding is
+   * identical; only the engine behind `r$` differs.
+   */
+  const props = defineProps<{
+    field: RegleField
+    index: number
+    trigger: 'input' | 'blur'
+  }>()
+
+  onUpdated(() => recordRender(props.index))
+
+  function onInput(event: Event): void {
+    props.field.$value = (event.target as HTMLInputElement).value
+  }
+
+  function onBlur(): void {
+    if (props.trigger === 'blur') props.field.$touch()
+  }
+</script>
+
+<template>
+  <input :data-bench-field="index" :value="field.$value" @input="onInput" @blur="onBlur" />
+</template>

--- a/apps/bench-arena/src/adapters/regle/rules-adapter.ts
+++ b/apps/bench-arena/src/adapters/regle/rules-adapter.ts
@@ -1,9 +1,15 @@
 import { useRegle } from '@regle/core'
 import { minLength } from '@regle/rules'
-import { nativeRulesFor, nestRules } from '../../shared/scenarios'
+import { nativeRulesFor, nestRules, shapeFor } from '../../shared/scenarios'
+import type { NativeRule } from '../../shared/scenarios'
 import type { BenchAdapter } from '../contract'
 import { mountRegle } from './shared'
 import type { RegleRoot } from './types'
+
+/** Map one scenario rule to Regle's native validator set. */
+function toRegleRule(rule: NativeRule): Record<string, unknown> {
+  return rule.minLength !== undefined ? { minLength: minLength(rule.minLength) } : {}
+}
 
 /**
  * Regle in rules mode: native validators ride on each field, so a keystroke
@@ -30,11 +36,18 @@ export const regleRulesAdapter: BenchAdapter = {
   },
 
   mount(container, opts) {
-    // Native rules nest to mirror the value tree (Regle keys rules by structure,
-    // not by dotted path), built from the scenario's flat rule description.
-    const rules = nestRules(nativeRulesFor(opts.scenario, opts.params), (rule) =>
-      rule.minLength !== undefined ? { minLength: minLength(rule.minLength) } : {}
-    )
+    const shape = shapeFor(opts.scenario, opts.params)
+    // Object-leaf rules nest to mirror the value tree (Regle keys rules by
+    // structure, not by dotted path), built from the scenario's flat rules.
+    const rules = nestRules(nativeRulesFor(opts.scenario, opts.params), toRegleRule)
+    // An array scenario adds a `$each` collection rule for the row field, the
+    // field-granular path Regle validates a list through.
+    if (shape.arrayPath && shape.arrayItemRules) {
+      const each: Record<string, unknown> = {}
+      for (const [field, rule] of Object.entries(shape.arrayItemRules))
+        each[field] = toRegleRule(rule)
+      rules[shape.arrayPath] = { $each: each }
+    }
     return mountRegle(container, opts, (state) => {
       const { r$ } = useRegle(state as never, rules as never) as unknown as { r$: RegleRoot }
       return r$

--- a/apps/bench-arena/src/adapters/regle/rules-adapter.ts
+++ b/apps/bench-arena/src/adapters/regle/rules-adapter.ts
@@ -1,0 +1,43 @@
+import { useRegle } from '@regle/core'
+import { minLength } from '@regle/rules'
+import { nativeRulesFor, nestRules } from '../../shared/scenarios'
+import type { BenchAdapter } from '../contract'
+import { mountRegle } from './shared'
+import type { RegleRoot } from './types'
+
+/**
+ * Regle in rules mode: native validators ride on each field, so a keystroke
+ * runs only the changed field's rules (the field-granular fast path), not a
+ * whole-tree parse. Shown next to schema mode so neither is strawmanned: same
+ * library, same binding, different validation strategy.
+ */
+export const regleRulesAdapter: BenchAdapter = {
+  meta: {
+    id: 'regle-rules',
+    displayName: 'Regle (rules)',
+    layer: 'headless-validation-only',
+    schemaLib: 'native',
+    ownsInputs: false,
+    capabilities: {
+      flat: 'native',
+      nested: 'native',
+      arrays: 'native',
+      grid: 'native',
+      'discriminated-union': 'hand-rolled',
+      massive: 'native',
+      wizard: 'hand-rolled',
+    },
+  },
+
+  mount(container, opts) {
+    // Native rules nest to mirror the value tree (Regle keys rules by structure,
+    // not by dotted path), built from the scenario's flat rule description.
+    const rules = nestRules(nativeRulesFor(opts.scenario, opts.params), (rule) =>
+      rule.minLength !== undefined ? { minLength: minLength(rule.minLength) } : {}
+    )
+    return mountRegle(container, opts, (state) => {
+      const { r$ } = useRegle(state as never, rules as never) as unknown as { r$: RegleRoot }
+      return r$
+    })
+  },
+}

--- a/apps/bench-arena/src/adapters/regle/schema-adapter.ts
+++ b/apps/bench-arena/src/adapters/regle/schema-adapter.ts
@@ -1,0 +1,38 @@
+import { useRegleSchema } from '@regle/schemas'
+import { zodSchemaFor } from '../../shared/scenarios'
+import type { BenchAdapter } from '../contract'
+import { mountRegle } from './shared'
+import type { RegleRoot } from './types'
+
+/**
+ * Regle in schema mode: a Standard Schema (zod v3) drives validation over the
+ * harness-owned reactive state. Every keystroke re-parses the whole schema, the
+ * trade-off for a single source of truth; the keystroke latency captures it.
+ * Shown alongside rules mode so the field-granular fast path is never strawmanned.
+ */
+export const regleSchemaAdapter: BenchAdapter = {
+  meta: {
+    id: 'regle-schema',
+    displayName: 'Regle (schema)',
+    layer: 'headless-validation-only',
+    schemaLib: 'zod3',
+    ownsInputs: false,
+    capabilities: {
+      flat: 'native',
+      nested: 'native',
+      arrays: 'native',
+      grid: 'native',
+      'discriminated-union': 'native',
+      massive: 'native',
+      wizard: 'hand-rolled',
+    },
+  },
+
+  mount(container, opts) {
+    const schema = zodSchemaFor(opts.scenario, opts.params)
+    return mountRegle(container, opts, (state) => {
+      const { r$ } = useRegleSchema(state as never, schema as never) as unknown as { r$: RegleRoot }
+      return r$
+    })
+  },
+}

--- a/apps/bench-arena/src/adapters/regle/shared.ts
+++ b/apps/bench-arena/src/adapters/regle/shared.ts
@@ -13,18 +13,22 @@ const unsupported = (op: string): never => {
 
 /**
  * Resolve a dotted leaf path to its Regle field status. Regle nests object
- * fields under `$fields`, so a deep path walks `$fields[seg]` at each level
- * (`r$.$fields.l0.$fields.l1.$fields.leaf`); a flat path is the single-segment
+ * fields under `$fields` and array items under `$each`, so a deep path walks
+ * `$fields[seg]` for an object segment and `$each[i]` for a numeric one
+ * (`r$.$fields.rows.$each[0].$fields.v`); a flat path is the single-segment
  * case. Returns undefined if the path is absent, so a missing input surfaces as
  * the driver's "no input mounted" rather than a silent miss.
  */
 function resolveField(root: RegleRoot, dotted: string): RegleField | undefined {
-  let fields: Record<string, RegleField> | undefined = root.$fields
+  let node: {
+    readonly $fields?: Record<string, RegleField>
+    readonly $each?: readonly RegleField[]
+  } = root
   let field: RegleField | undefined
   for (const seg of dotted.split('.')) {
-    field = fields?.[seg]
+    field = /^\d+$/.test(seg) ? node.$each?.[Number(seg)] : node.$fields?.[seg]
     if (!field) return undefined
-    fields = field.$fields
+    node = field
   }
   return field
 }

--- a/apps/bench-arena/src/adapters/regle/shared.ts
+++ b/apps/bench-arena/src/adapters/regle/shared.ts
@@ -1,4 +1,4 @@
-import { type App, createApp, defineComponent, h, reactive } from 'vue'
+import { type App, type Ref, createApp, defineComponent, h, nextTick, reactive, ref } from 'vue'
 import { flush } from '../../shared/clock'
 import { domDriver } from '../../shared/dom-driver'
 import { resetRenderCounts, totalRenders } from '../../shared/render-count'
@@ -47,8 +47,10 @@ export async function mountRegle(
   const shape = shapeFor(opts.scenario, opts.params)
   const arrayPath = shape.arrayPath
   const itemFields = shape.arrayItemFields ?? []
+  const union = shape.union
   let root: RegleRoot | undefined
   let state: Record<string, unknown> | undefined
+  let activeTag: Ref<string> | undefined
 
   const Host = defineComponent({
     name: 'RegleHost',
@@ -64,11 +66,30 @@ export async function mountRegle(
       state = s
       const r$ = createRoot(s)
       root = r$
+      // The active variant is tracked off a local signal the flip keeps in sync;
+      // a flip reassigns the harness state's union value and advances the signal,
+      // and Regle re-derives the active branch's field statuses from the state.
+      const tag = ref(union?.variants[0]?.tag ?? '')
+      activeTag = tag
       // Each field status is stable, so the host renders once; each Field
       // re-renders only on its own `$value`. An array scenario iterates the
       // harness-owned reactive array for length (an add/remove/reorder reflows
       // the list; a leaf edit, which never touches the array structure, does not).
       return () => {
+        if (union !== undefined) {
+          const variant = union.variants.find((v) => v.tag === tag.value)
+          // Skip a field that has not resolved yet: in schema mode Regle derives
+          // a union branch's field statuses from the schema and state, so a field
+          // briefly absent right after a flip is dropped rather than crashing the
+          // render (the flip lets the derivation settle before swapping).
+          return h(
+            'div',
+            (variant?.fieldPaths ?? []).flatMap((path, index) => {
+              const field = resolveField(r$, path)
+              return field ? [h(Field, { key: path, field, index, trigger: opts.trigger })] : []
+            })
+          )
+        }
         if (arrayPath !== undefined) {
           const list = (s[arrayPath] as unknown[]) ?? []
           return h(
@@ -138,7 +159,21 @@ export async function mountRegle(
       } else unsupported(op)
       await flush()
     },
-    flipVariant: () => Promise.resolve(unsupported('flipVariant')),
+    // Regle is validation-only, so the harness owns the union value; reassigning
+    // it lets Regle re-derive the active branch from the reactive state. The
+    // clone keeps repeated flips from sharing one object across the reactive tree.
+    async flipVariant(to: string) {
+      const variant = union?.variants.find((v) => v.tag === to)
+      if (!union || !variant || !state) return unsupported('flipVariant')
+      state[union.unionPath] = { ...variant.value }
+      // Let Regle re-derive the new branch's field statuses from the changed
+      // state before the host swaps to them; in schema mode the branch fields do
+      // not exist on `r$` until this settles. This two-phase update is the real
+      // cost of a Regle discriminated-union flip.
+      await nextTick()
+      if (activeTag) activeTag.value = to
+      await flush()
+    },
     stepTransition: () => Promise.resolve(unsupported('stepTransition')),
     getRenderCount: () => totalRenders(),
     resetRenderCount: () => resetRenderCounts(),

--- a/apps/bench-arena/src/adapters/regle/shared.ts
+++ b/apps/bench-arena/src/adapters/regle/shared.ts
@@ -1,0 +1,94 @@
+import { type App, createApp, defineComponent, h, reactive } from 'vue'
+import { flush } from '../../shared/clock'
+import { domDriver } from '../../shared/dom-driver'
+import { resetRenderCounts, totalRenders } from '../../shared/render-count'
+import { shapeFor } from '../../shared/scenarios'
+import type { MountHandle, MountOpts } from '../contract'
+import Field from './Field.vue'
+import type { RegleField, RegleRoot } from './types'
+
+const unsupported = (op: string): never => {
+  throw new Error(`bench: regle adapter does not drive "${op}" in this scenario`)
+}
+
+/**
+ * Resolve a dotted leaf path to its Regle field status. Regle nests object
+ * fields under `$fields`, so a deep path walks `$fields[seg]` at each level
+ * (`r$.$fields.l0.$fields.l1.$fields.leaf`); a flat path is the single-segment
+ * case. Returns undefined if the path is absent, so a missing input surfaces as
+ * the driver's "no input mounted" rather than a silent miss.
+ */
+function resolveField(root: RegleRoot, dotted: string): RegleField | undefined {
+  let fields: Record<string, RegleField> | undefined = root.$fields
+  let field: RegleField | undefined
+  for (const seg of dotted.split('.')) {
+    field = fields?.[seg]
+    if (!field) return undefined
+    fields = field.$fields
+  }
+  return field
+}
+
+/**
+ * Shared Regle mount. Both modes own identical wiring (a reactive state object,
+ * an `r$` root, and granular per-field bindings); only how `r$` is produced
+ * differs, so each mode passes a `createRoot` that calls `useRegleSchema` (zod)
+ * or `useRegle` (native rules) on the harness-owned reactive state.
+ */
+export async function mountRegle(
+  container: HTMLElement,
+  opts: MountOpts,
+  createRoot: (state: Record<string, unknown>) => RegleRoot
+): Promise<MountHandle> {
+  const shape = shapeFor(opts.scenario, opts.params)
+  let root: RegleRoot | undefined
+
+  const Host = defineComponent({
+    name: 'RegleHost',
+    setup() {
+      const state = reactive({ ...shape.defaultValues })
+      const r$ = createRoot(state)
+      root = r$
+      // Each field status is stable, so the host renders once; each Field
+      // re-renders only on its own `$value`.
+      return () =>
+        h(
+          'div',
+          shape.paths.map((path, index) =>
+            h(Field, {
+              key: index,
+              field: resolveField(r$, path) as RegleField,
+              index,
+              trigger: opts.trigger,
+            })
+          )
+        )
+    },
+  })
+
+  const app: App = createApp(Host)
+  app.mount(container)
+  await flush()
+
+  const driver = domDriver(container, opts.trigger)
+
+  return {
+    typeChar: driver.typeChar,
+    setFieldValue: driver.setFieldValue,
+    async validateAll() {
+      await root?.$validate()
+      await flush()
+    },
+    async validateField(index) {
+      const path = shape.paths[index]
+      if (path !== undefined && root) await resolveField(root, path)?.$validate()
+      await flush()
+    },
+    arrayOp: () => Promise.resolve(unsupported('arrayOp')),
+    flipVariant: () => Promise.resolve(unsupported('flipVariant')),
+    stepTransition: () => Promise.resolve(unsupported('stepTransition')),
+    getRenderCount: () => totalRenders(),
+    resetRenderCount: () => resetRenderCounts(),
+    teardown: () => app.unmount(),
+  }
+}

--- a/apps/bench-arena/src/adapters/regle/shared.ts
+++ b/apps/bench-arena/src/adapters/regle/shared.ts
@@ -92,9 +92,10 @@ export async function mountRegle(
         }
         if (arrayPath !== undefined) {
           const list = (s[arrayPath] as unknown[]) ?? []
-          return h(
-            'div',
-            list.flatMap((_row, i) =>
+          const objectPaths = shape.objectPaths ?? []
+          const objBase = shape.paths.length - objectPaths.length
+          return h('div', [
+            ...list.flatMap((_row, i) =>
               itemFields.map((field, fIdx) => {
                 const index = i * itemFields.length + fIdx
                 return h(Field, {
@@ -104,8 +105,16 @@ export async function mountRegle(
                   trigger: opts.trigger,
                 })
               })
-            )
-          )
+            ),
+            ...objectPaths.map((path, j) =>
+              h(Field, {
+                key: `obj-${path}`,
+                field: resolveField(r$, path) as RegleField,
+                index: objBase + j,
+                trigger: opts.trigger,
+              })
+            ),
+          ])
         }
         return h(
           'div',

--- a/apps/bench-arena/src/adapters/regle/shared.ts
+++ b/apps/bench-arena/src/adapters/regle/shared.ts
@@ -48,9 +48,15 @@ export async function mountRegle(
   const arrayPath = shape.arrayPath
   const itemFields = shape.arrayItemFields ?? []
   const union = shape.union
+  const wizardDesc = shape.wizard
   let root: RegleRoot | undefined
   let state: Record<string, unknown> | undefined
   let activeTag: Ref<string> | undefined
+  // The hand-composed wizard's active step. Regle has no wizard primitive, so
+  // the harness tracks the position and the gated advance validates the leaving
+  // step's field statuses ($validate per field); every step renders through the
+  // default branch.
+  let wizardStep = 0
 
   const Host = defineComponent({
     name: 'RegleHost',
@@ -183,7 +189,21 @@ export async function mountRegle(
       if (activeTag) activeTag.value = to
       await flush()
     },
-    stepTransition: () => Promise.resolve(unsupported('stepTransition')),
+    async stepTransition(dir: 1 | -1) {
+      if (!wizardDesc || !root) return unsupported('stepTransition')
+      const r$ = root
+      if (dir === 1) {
+        if (wizardStep < wizardDesc.steps.length - 1) {
+          // Gate the advance on the leaving step's field statuses, validated
+          // through Regle's per-field $validate; only this step's fields run.
+          await Promise.all(
+            (wizardDesc.steps[wizardStep] ?? []).map((p) => resolveField(r$, p)?.$validate())
+          )
+          wizardStep += 1
+        }
+      } else if (wizardStep > 0) wizardStep -= 1
+      await flush()
+    },
     getRenderCount: () => totalRenders(),
     resetRenderCount: () => resetRenderCounts(),
     teardown: () => app.unmount(),

--- a/apps/bench-arena/src/adapters/regle/shared.ts
+++ b/apps/bench-arena/src/adapters/regle/shared.ts
@@ -3,7 +3,7 @@ import { flush } from '../../shared/clock'
 import { domDriver } from '../../shared/dom-driver'
 import { resetRenderCounts, totalRenders } from '../../shared/render-count'
 import { shapeFor } from '../../shared/scenarios'
-import type { MountHandle, MountOpts } from '../contract'
+import type { ArrayOp, MountHandle, MountOpts } from '../contract'
 import Field from './Field.vue'
 import type { RegleField, RegleRoot } from './types'
 
@@ -45,18 +45,48 @@ export async function mountRegle(
   createRoot: (state: Record<string, unknown>) => RegleRoot
 ): Promise<MountHandle> {
   const shape = shapeFor(opts.scenario, opts.params)
+  const arrayPath = shape.arrayPath
+  const itemFields = shape.arrayItemFields ?? []
   let root: RegleRoot | undefined
+  let state: Record<string, unknown> | undefined
 
   const Host = defineComponent({
     name: 'RegleHost',
     setup() {
-      const state = reactive({ ...shape.defaultValues })
-      const r$ = createRoot(state)
+      // An array scenario owns a mutable array the ops splice and swap, so the
+      // seed tree is cloned per mount; sharing the shape's array across mounts
+      // would let one mount's op corrupt the next. Flat/nested never mutate, so
+      // a shallow spread is enough there.
+      const seed = arrayPath
+        ? (JSON.parse(JSON.stringify(shape.defaultValues)) as Record<string, unknown>)
+        : { ...shape.defaultValues }
+      const s = reactive(seed) as Record<string, unknown>
+      state = s
+      const r$ = createRoot(s)
       root = r$
       // Each field status is stable, so the host renders once; each Field
-      // re-renders only on its own `$value`.
-      return () =>
-        h(
+      // re-renders only on its own `$value`. An array scenario iterates the
+      // harness-owned reactive array for length (an add/remove/reorder reflows
+      // the list; a leaf edit, which never touches the array structure, does not).
+      return () => {
+        if (arrayPath !== undefined) {
+          const list = (s[arrayPath] as unknown[]) ?? []
+          return h(
+            'div',
+            list.flatMap((_row, i) =>
+              itemFields.map((field, fIdx) => {
+                const index = i * itemFields.length + fIdx
+                return h(Field, {
+                  key: index,
+                  field: resolveField(r$, `${arrayPath}.${i}.${field}`) as RegleField,
+                  index,
+                  trigger: opts.trigger,
+                })
+              })
+            )
+          )
+        }
+        return h(
           'div',
           shape.paths.map((path, index) =>
             h(Field, {
@@ -67,6 +97,7 @@ export async function mountRegle(
             })
           )
         )
+      }
     },
   })
 
@@ -88,7 +119,25 @@ export async function mountRegle(
       if (path !== undefined && root) await resolveField(root, path)?.$validate()
       await flush()
     },
-    arrayOp: () => Promise.resolve(unsupported('arrayOp')),
+    // Regle is validation-only, so the harness owns the array and mutates it;
+    // Regle re-derives its `$each` collection statuses from the reactive state.
+    // This is the shape a Regle array form actually takes (you own the array).
+    async arrayOp(op: ArrayOp, a?: number, b?: number) {
+      if (arrayPath === undefined || !state) return unsupported(op)
+      const list = state[arrayPath] as Array<Record<string, unknown>>
+      if (op === 'append') list.push(shape.newRow?.() ?? {})
+      else if (op === 'remove') {
+        const index = a ?? list.length - 1
+        if (index >= 0) list.splice(index, 1)
+      } else if (op === 'swap') {
+        const i = a ?? 0
+        const j = b ?? 0
+        const tmp = list[i] as Record<string, unknown>
+        list[i] = list[j] as Record<string, unknown>
+        list[j] = tmp
+      } else unsupported(op)
+      await flush()
+    },
     flipVariant: () => Promise.resolve(unsupported('flipVariant')),
     stepTransition: () => Promise.resolve(unsupported('stepTransition')),
     getRenderCount: () => totalRenders(),

--- a/apps/bench-arena/src/adapters/regle/types.ts
+++ b/apps/bench-arena/src/adapters/regle/types.ts
@@ -1,0 +1,22 @@
+/**
+ * The Regle field-status slice the bench binds. `$value` is the model reference
+ * Regle exposes for v-model: reading it subscribes to this field alone, and
+ * assigning it marks the field dirty and runs Regle's reactive validation.
+ * Common to schema mode (whole Standard Schema re-parse) and rules mode (this
+ * field's native rules only).
+ */
+export interface RegleField {
+  $value: string
+  $touch(): void
+  $validate(): Promise<unknown>
+  /** Present on nested-object field statuses; the children keyed by segment.
+   *  The path walker descends through these to reach a deep leaf status. */
+  readonly $fields?: Record<string, RegleField>
+}
+
+/** The `r$` root the adapter reaches through: its per-field status map + the
+ *  whole-form validate. */
+export interface RegleRoot {
+  readonly $fields: Record<string, RegleField>
+  $validate(): Promise<unknown>
+}

--- a/apps/bench-arena/src/adapters/regle/types.ts
+++ b/apps/bench-arena/src/adapters/regle/types.ts
@@ -12,6 +12,9 @@ export interface RegleField {
   /** Present on nested-object field statuses; the children keyed by segment.
    *  The path walker descends through these to reach a deep leaf status. */
   readonly $fields?: Record<string, RegleField>
+  /** Present on array (collection) field statuses; one item status per row.
+   *  A numeric path segment descends through this. */
+  readonly $each?: readonly RegleField[]
 }
 
 /** The `r$` root the adapter reaches through: its per-field status map + the

--- a/apps/bench-arena/src/adapters/tanstack/Field.vue
+++ b/apps/bench-arena/src/adapters/tanstack/Field.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+  import { useField } from '@tanstack/vue-form'
+  import { onUpdated } from 'vue'
+  import { recordRender } from '../../shared/render-count'
+  import type { TanstackField, TanstackForm } from './types'
+
+  /**
+   * A TanStack field through the `useField` composable: TanStack's first-class
+   * primitive for a custom field component (the `form.Field` render-prop is a thin
+   * wrapper over this exact call). useField subscribes to a granular slice of the
+   * form store keyed to this path, so the field re-renders only when its own value
+   * changes. The form-level `onChange` validator (the schema, attached as a
+   * Standard Schema, which is the recommended setup) runs on every edit; the
+   * keystroke latency captures that whole-schema pass honestly.
+   */
+  const props = defineProps<{
+    form: TanstackForm
+    name: string
+    index: number
+    trigger: 'input' | 'blur'
+  }>()
+
+  // useField takes the form instance directly (no provide/inject). The dynamic
+  // schema collapses its generics, so the opts are cast through to the call.
+  const field = useField({
+    form: props.form,
+    name: props.name,
+  } as never) as unknown as TanstackField
+
+  onUpdated(() => recordRender(props.index))
+
+  function onInput(event: Event): void {
+    field.api.handleChange((event.target as HTMLInputElement).value)
+  }
+
+  // Always funnel through handleBlur; whether a blur validates is decided by the
+  // adapter's validator config (onBlur attached only on the blur-trigger pass).
+  function onBlur(): void {
+    field.api.handleBlur()
+  }
+</script>
+
+<template>
+  <input :data-bench-field="index" :value="field.state.value" @input="onInput" @blur="onBlur" />
+</template>

--- a/apps/bench-arena/src/adapters/tanstack/adapter.ts
+++ b/apps/bench-arena/src/adapters/tanstack/adapter.ts
@@ -55,8 +55,10 @@ export const tanstackAdapter: BenchAdapter = {
     const arrayPath = shape.arrayPath
     const itemFields = shape.arrayItemFields ?? []
     const seedRows = arrayPath ? ((shape.defaultValues[arrayPath] as unknown[]) ?? []) : []
+    const union = shape.union
     let form: TanstackForm | undefined
     let rowCount: Ref<number> | undefined
+    let activeTag: Ref<string> | undefined
 
     const Host = defineComponent({
       name: 'TanstackHost',
@@ -69,7 +71,22 @@ export const tanstackAdapter: BenchAdapter = {
         // into a row never reflows the list, only an add/remove/reorder does.
         const count = ref(seedRows.length)
         rowCount = count
+        // The active variant is tracked off a local signal the flip keeps in
+        // sync (the same shape as the row-count signal); a flip writes the union
+        // value through setFieldValue, then advances the signal so the host
+        // swaps to the new branch's fields.
+        const tag = ref(union?.variants[0]?.tag ?? '')
+        activeTag = tag
         return () => {
+          if (union !== undefined) {
+            const variant = union.variants.find((v) => v.tag === tag.value)
+            return h(
+              'div',
+              (variant?.fieldPaths ?? []).map((path, index) =>
+                h(Field, { key: path, form: f, name: path, index, trigger: opts.trigger })
+              )
+            )
+          }
           if (arrayPath !== undefined) {
             return h(
               'div',
@@ -130,7 +147,15 @@ export const tanstackAdapter: BenchAdapter = {
         } else unsupported(op)
         await flush()
       },
-      flipVariant: () => Promise.resolve(unsupported('flipVariant')),
+      async flipVariant(to: string) {
+        const variant = union?.variants.find((v) => v.tag === to)
+        if (!union || !variant) return unsupported('flipVariant')
+        // Write the whole union value, then advance the local signal so the host
+        // swaps to the new branch's fields after the value has landed.
+        form?.setFieldValue(union.unionPath, { ...variant.value })
+        if (activeTag) activeTag.value = to
+        await flush()
+      },
       stepTransition: () => Promise.resolve(unsupported('stepTransition')),
       getRenderCount: () => totalRenders(),
       resetRenderCount: () => resetRenderCounts(),

--- a/apps/bench-arena/src/adapters/tanstack/adapter.ts
+++ b/apps/bench-arena/src/adapters/tanstack/adapter.ts
@@ -56,9 +56,15 @@ export const tanstackAdapter: BenchAdapter = {
     const itemFields = shape.arrayItemFields ?? []
     const seedRows = arrayPath ? ((shape.defaultValues[arrayPath] as unknown[]) ?? []) : []
     const union = shape.union
+    const wizardDesc = shape.wizard
     let form: TanstackForm | undefined
     let rowCount: Ref<number> | undefined
     let activeTag: Ref<string> | undefined
+    // The hand-composed wizard's active step. TanStack has no wizard primitive,
+    // so the harness tracks the position and the gated advance validates the
+    // leaving step's fields through the per-field API; every step renders
+    // through the default branch, so navigation never remounts a field.
+    let wizardStep = 0
 
     const Host = defineComponent({
       name: 'TanstackHost',
@@ -166,7 +172,20 @@ export const tanstackAdapter: BenchAdapter = {
         if (activeTag) activeTag.value = to
         await flush()
       },
-      stepTransition: () => Promise.resolve(unsupported('stepTransition')),
+      async stepTransition(dir: 1 | -1) {
+        if (!wizardDesc || !form) return unsupported('stepTransition')
+        if (dir === 1) {
+          if (wizardStep < wizardDesc.steps.length - 1) {
+            // Gate the advance on the leaving step's fields, validated through
+            // TanStack's per-field API; only this step's fields are checked.
+            await Promise.all(
+              (wizardDesc.steps[wizardStep] ?? []).map((p) => form?.validateField(p, 'change'))
+            )
+            wizardStep += 1
+          }
+        } else if (wizardStep > 0) wizardStep -= 1
+        await flush()
+      },
       getRenderCount: () => totalRenders(),
       resetRenderCount: () => resetRenderCounts(),
       teardown: () => app.unmount(),

--- a/apps/bench-arena/src/adapters/tanstack/adapter.ts
+++ b/apps/bench-arena/src/adapters/tanstack/adapter.ts
@@ -1,10 +1,10 @@
 import { useForm } from '@tanstack/vue-form'
-import { type App, createApp, defineComponent, h } from 'vue'
+import { type App, type Ref, createApp, defineComponent, h, ref } from 'vue'
 import { flush } from '../../shared/clock'
 import { domDriver } from '../../shared/dom-driver'
 import { resetRenderCounts, totalRenders } from '../../shared/render-count'
 import { shapeFor, zodSchemaFor } from '../../shared/scenarios'
-import type { BenchAdapter, MountHandle } from '../contract'
+import type { ArrayOp, BenchAdapter, MountHandle } from '../contract'
 import Field from './Field.vue'
 import type { TanstackForm } from './types'
 
@@ -52,20 +52,48 @@ export const tanstackAdapter: BenchAdapter = {
     const validators = opts.trigger === 'blur' ? { onBlur: schema } : { onChange: schema }
     mountSeq += 1
 
+    const arrayPath = shape.arrayPath
+    const itemFields = shape.arrayItemFields ?? []
+    const seedRows = arrayPath ? ((shape.defaultValues[arrayPath] as unknown[]) ?? []) : []
     let form: TanstackForm | undefined
+    let rowCount: Ref<number> | undefined
 
     const Host = defineComponent({
       name: 'TanstackHost',
       setup() {
         const f = useFormLoose({ defaultValues: { ...shape.defaultValues }, validators })
         form = f
-        return () =>
-          h(
+        // TanStack exposes no per-row key, so rows are positional. Rendering off
+        // a length signal the array ops keep in sync (rather than deep-reading
+        // the array value) is the most performant idiomatic shape: a keystroke
+        // into a row never reflows the list, only an add/remove/reorder does.
+        const count = ref(seedRows.length)
+        rowCount = count
+        return () => {
+          if (arrayPath !== undefined) {
+            return h(
+              'div',
+              Array.from({ length: count.value }, (_unused, i) =>
+                itemFields.map((field, fIdx) => {
+                  const index = i * itemFields.length + fIdx
+                  return h(Field, {
+                    key: index,
+                    form: f,
+                    name: `${arrayPath}.${i}.${field}`,
+                    index,
+                    trigger: opts.trigger,
+                  })
+                })
+              ).flat()
+            )
+          }
+          return h(
             'div',
             shape.paths.map((path, index) =>
               h(Field, { key: index, form: f, name: path, index, trigger: opts.trigger })
             )
           )
+        }
       },
     })
 
@@ -86,7 +114,22 @@ export const tanstackAdapter: BenchAdapter = {
         await form?.validateField(shape.paths[index] ?? '', 'change')
         await flush()
       },
-      arrayOp: () => Promise.resolve(unsupported('arrayOp')),
+      async arrayOp(op: ArrayOp, a?: number, b?: number) {
+        if (arrayPath === undefined || !rowCount) return unsupported(op)
+        if (op === 'append') {
+          form?.pushFieldValue(arrayPath, shape.newRow?.() ?? {})
+          rowCount.value += 1
+        } else if (op === 'remove') {
+          const index = a ?? rowCount.value - 1
+          if (index >= 0) {
+            await form?.removeFieldValue(arrayPath, index)
+            rowCount.value -= 1
+          }
+        } else if (op === 'swap') {
+          form?.swapFieldValues(arrayPath, a ?? 0, b ?? 0)
+        } else unsupported(op)
+        await flush()
+      },
       flipVariant: () => Promise.resolve(unsupported('flipVariant')),
       stepTransition: () => Promise.resolve(unsupported('stepTransition')),
       getRenderCount: () => totalRenders(),

--- a/apps/bench-arena/src/adapters/tanstack/adapter.ts
+++ b/apps/bench-arena/src/adapters/tanstack/adapter.ts
@@ -20,8 +20,6 @@ type UseFormLoose = (opts: {
 }) => TanstackForm
 const useFormLoose = useForm as unknown as UseFormLoose
 
-let mountSeq = 0
-
 const unsupported = (op: string): never => {
   throw new Error(`bench: tanstack adapter does not drive "${op}" in this scenario`)
 }
@@ -50,7 +48,6 @@ export const tanstackAdapter: BenchAdapter = {
     // Validate on the trigger under test: onChange for the input pass (a
     // keystroke does validation work), onBlur for the blur pass.
     const validators = opts.trigger === 'blur' ? { onBlur: schema } : { onChange: schema }
-    mountSeq += 1
 
     const arrayPath = shape.arrayPath
     const itemFields = shape.arrayItemFields ?? []

--- a/apps/bench-arena/src/adapters/tanstack/adapter.ts
+++ b/apps/bench-arena/src/adapters/tanstack/adapter.ts
@@ -88,9 +88,10 @@ export const tanstackAdapter: BenchAdapter = {
             )
           }
           if (arrayPath !== undefined) {
-            return h(
-              'div',
-              Array.from({ length: count.value }, (_unused, i) =>
+            const objectPaths = shape.objectPaths ?? []
+            const objBase = shape.paths.length - objectPaths.length
+            return h('div', [
+              ...Array.from({ length: count.value }, (_unused, i) =>
                 itemFields.map((field, fIdx) => {
                   const index = i * itemFields.length + fIdx
                   return h(Field, {
@@ -101,8 +102,17 @@ export const tanstackAdapter: BenchAdapter = {
                     trigger: opts.trigger,
                   })
                 })
-              ).flat()
-            )
+              ).flat(),
+              ...objectPaths.map((path, j) =>
+                h(Field, {
+                  key: `obj-${path}`,
+                  form: f,
+                  name: path,
+                  index: objBase + j,
+                  trigger: opts.trigger,
+                })
+              ),
+            ])
           }
           return h(
             'div',

--- a/apps/bench-arena/src/adapters/tanstack/adapter.ts
+++ b/apps/bench-arena/src/adapters/tanstack/adapter.ts
@@ -1,0 +1,97 @@
+import { useForm } from '@tanstack/vue-form'
+import { type App, createApp, defineComponent, h } from 'vue'
+import { flush } from '../../shared/clock'
+import { domDriver } from '../../shared/dom-driver'
+import { resetRenderCounts, totalRenders } from '../../shared/render-count'
+import { shapeFor, zodSchemaFor } from '../../shared/scenarios'
+import type { BenchAdapter, MountHandle } from '../contract'
+import Field from './Field.vue'
+import type { TanstackForm } from './types'
+
+/**
+ * The dynamic schema erases TanStack's form generics, so the call is made
+ * through a loose signature; the runtime config is exactly what the typed API
+ * resolves to. The schema rides along as a Standard Schema validator (zod v3
+ * implements the spec), which is TanStack's recommended whole-form setup.
+ */
+type UseFormLoose = (opts: {
+  defaultValues: Record<string, unknown>
+  validators: Record<string, unknown>
+}) => TanstackForm
+const useFormLoose = useForm as unknown as UseFormLoose
+
+let mountSeq = 0
+
+const unsupported = (op: string): never => {
+  throw new Error(`bench: tanstack adapter does not drive "${op}" in this scenario`)
+}
+
+export const tanstackAdapter: BenchAdapter = {
+  meta: {
+    id: 'tanstack',
+    displayName: '@tanstack/vue-form',
+    layer: 'headless-form-state',
+    schemaLib: 'zod3',
+    ownsInputs: false,
+    capabilities: {
+      flat: 'native',
+      nested: 'native',
+      arrays: 'native',
+      grid: 'native',
+      'discriminated-union': 'hand-rolled',
+      massive: 'native',
+      wizard: 'hand-rolled',
+    },
+  },
+
+  async mount(container, opts): Promise<MountHandle> {
+    const shape = shapeFor(opts.scenario, opts.params)
+    const schema = zodSchemaFor(opts.scenario, opts.params)
+    // Validate on the trigger under test: onChange for the input pass (a
+    // keystroke does validation work), onBlur for the blur pass.
+    const validators = opts.trigger === 'blur' ? { onBlur: schema } : { onChange: schema }
+    mountSeq += 1
+
+    let form: TanstackForm | undefined
+
+    const Host = defineComponent({
+      name: 'TanstackHost',
+      setup() {
+        const f = useFormLoose({ defaultValues: { ...shape.defaultValues }, validators })
+        form = f
+        return () =>
+          h(
+            'div',
+            shape.paths.map((path, index) =>
+              h(Field, { key: index, form: f, name: path, index, trigger: opts.trigger })
+            )
+          )
+      },
+    })
+
+    const app: App = createApp(Host)
+    app.mount(container)
+    await flush()
+
+    const driver = domDriver(container, opts.trigger)
+
+    return {
+      typeChar: driver.typeChar,
+      setFieldValue: driver.setFieldValue,
+      async validateAll() {
+        await form?.validateAllFields('change')
+        await flush()
+      },
+      async validateField(index) {
+        await form?.validateField(shape.paths[index] ?? '', 'change')
+        await flush()
+      },
+      arrayOp: () => Promise.resolve(unsupported('arrayOp')),
+      flipVariant: () => Promise.resolve(unsupported('flipVariant')),
+      stepTransition: () => Promise.resolve(unsupported('stepTransition')),
+      getRenderCount: () => totalRenders(),
+      resetRenderCount: () => resetRenderCounts(),
+      teardown: () => app.unmount(),
+    }
+  },
+}

--- a/apps/bench-arena/src/adapters/tanstack/types.ts
+++ b/apps/bench-arena/src/adapters/tanstack/types.ts
@@ -1,0 +1,22 @@
+/**
+ * The slices of TanStack Vue Form the bench adapter drives. The benchmark's
+ * schema is built dynamically (`z.ZodTypeAny`), which collapses TanStack's
+ * per-path generics and blows the instantiation depth, so the adapter binds
+ * against these narrow shapes while the runtime calls stay the real ones.
+ */
+export interface TanstackForm {
+  /** Validate every field with the given cause; the full-form pass. */
+  validateAllFields(cause: string): Promise<unknown[]>
+  /** Validate one field by path. */
+  validateField(name: string, cause: string): unknown
+}
+
+/**
+ * What `useField` returns: a reactive value read plus the change/blur funnels.
+ * `state` is a getter over a computed, so reading `field.state.value` in the
+ * template subscribes granularly to this field alone.
+ */
+export interface TanstackField {
+  readonly state: { readonly value: string }
+  readonly api: { handleChange(value: string): void; handleBlur(): void }
+}

--- a/apps/bench-arena/src/adapters/tanstack/types.ts
+++ b/apps/bench-arena/src/adapters/tanstack/types.ts
@@ -9,6 +9,12 @@ export interface TanstackForm {
   validateAllFields(cause: string): Promise<unknown[]>
   /** Validate one field by path. */
   validateField(name: string, cause: string): unknown
+  /** Append a row to the array field (the array add/remove dimension). */
+  pushFieldValue(name: string, value: unknown): void
+  /** Remove the row at `index` from the array field. */
+  removeFieldValue(name: string, index: number): Promise<void>
+  /** Swap the rows at `a` and `b` in the array field (the reorder dimension). */
+  swapFieldValues(name: string, a: number, b: number): void
 }
 
 /**

--- a/apps/bench-arena/src/adapters/tanstack/types.ts
+++ b/apps/bench-arena/src/adapters/tanstack/types.ts
@@ -9,6 +9,8 @@ export interface TanstackForm {
   validateAllFields(cause: string): Promise<unknown[]>
   /** Validate one field by path. */
   validateField(name: string, cause: string): unknown
+  /** Set a path's value, including a whole object at the union path (the flip). */
+  setFieldValue(name: string, value: unknown): void
   /** Append a row to the array field (the array add/remove dimension). */
   pushFieldValue(name: string, value: unknown): void
   /** Remove the row at `index` from the array field. */

--- a/apps/bench-arena/src/adapters/vee-validate/Field.vue
+++ b/apps/bench-arena/src/adapters/vee-validate/Field.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+  import { useField } from 'vee-validate'
+  import { onUpdated } from 'vue'
+  import { recordRender } from '../../shared/render-count'
+
+  /**
+   * A vee-validate field through its per-field-component composition API.
+   * `useField` injects the form context the host's `useForm` provides and
+   * returns a granular value ref plus a change handler scoped to this path, so
+   * the field re-renders only when its own value changes.
+   *
+   * The whole zod schema validates on each change. That is inherent to driving a
+   * single typed schema (the recommended, fastest-correct zod setup), not a
+   * strawman; the keystroke latency captures that cost honestly.
+   */
+  const props = defineProps<{ name: string; index: number; trigger: 'input' | 'blur' }>()
+
+  const { value, handleChange, validate } = useField<string>(() => props.name, undefined, {
+    validateOnValueUpdate: props.trigger === 'input',
+  })
+
+  onUpdated(() => recordRender(props.index))
+
+  function onInput(event: Event): void {
+    handleChange((event.target as HTMLInputElement).value, props.trigger === 'input')
+  }
+
+  function onBlur(): void {
+    if (props.trigger === 'blur') void validate()
+  }
+</script>
+
+<template>
+  <input :data-bench-field="index" :value="value" @input="onInput" @blur="onBlur" />
+</template>

--- a/apps/bench-arena/src/adapters/vee-validate/adapter.ts
+++ b/apps/bench-arena/src/adapters/vee-validate/adapter.ts
@@ -1,6 +1,6 @@
 import { toTypedSchema } from '@vee-validate/zod'
 import { useFieldArray, useForm } from 'vee-validate'
-import { type App, createApp, defineComponent, h } from 'vue'
+import { type App, type Ref, createApp, defineComponent, h, ref } from 'vue'
 import { flush } from '../../shared/clock'
 import { domDriver } from '../../shared/dom-driver'
 import { resetRenderCounts, totalRenders } from '../../shared/render-count'
@@ -12,6 +12,8 @@ import Field from './Field.vue'
 interface VeeForm {
   validate: () => Promise<unknown>
   validateField: (path: string) => Promise<unknown>
+  /** Set a path's value, including a whole object at the union path (the flip). */
+  setFieldValue: (path: string, value: unknown) => void
 }
 
 /**
@@ -58,8 +60,10 @@ export const veeValidateAdapter: BenchAdapter = {
 
     const arrayPath = shape.arrayPath
     const itemFields = shape.arrayItemFields ?? []
+    const union = shape.union
     let form: VeeForm | undefined
     let rows: VeeFieldArray | undefined
+    let activeTag: Ref<string> | undefined
 
     const Host = defineComponent({
       name: 'VeeValidateHost',
@@ -76,7 +80,21 @@ export const veeValidateAdapter: BenchAdapter = {
           ? (useFieldArray(arrayPath) as unknown as VeeFieldArray)
           : undefined
         rows = fieldArray
+        // The active variant is tracked off a local signal the flip keeps in
+        // sync; a flip writes the union value through setFieldValue, then
+        // advances the signal so the host swaps to the new branch's fields.
+        const tag = ref(union?.variants[0]?.tag ?? '')
+        activeTag = tag
         return () => {
+          if (union !== undefined) {
+            const variant = union.variants.find((v) => v.tag === tag.value)
+            return h(
+              'div',
+              (variant?.fieldPaths ?? []).map((path, index) =>
+                h(Field, { key: path, name: path, index, trigger: opts.trigger })
+              )
+            )
+          }
           if (fieldArray) {
             return h(
               'div',
@@ -127,7 +145,15 @@ export const veeValidateAdapter: BenchAdapter = {
         else unsupported(op)
         await flush()
       },
-      flipVariant: () => Promise.resolve(unsupported('flipVariant')),
+      async flipVariant(to: string) {
+        const variant = union?.variants.find((v) => v.tag === to)
+        if (!union || !variant) return unsupported('flipVariant')
+        // Write the whole union value, then advance the local signal so the host
+        // swaps to the new branch's fields after the value has landed.
+        form?.setFieldValue(union.unionPath, { ...variant.value })
+        if (activeTag) activeTag.value = to
+        await flush()
+      },
       stepTransition: () => Promise.resolve(unsupported('stepTransition')),
       getRenderCount: () => totalRenders(),
       resetRenderCount: () => resetRenderCounts(),

--- a/apps/bench-arena/src/adapters/vee-validate/adapter.ts
+++ b/apps/bench-arena/src/adapters/vee-validate/adapter.ts
@@ -1,17 +1,30 @@
 import { toTypedSchema } from '@vee-validate/zod'
-import { useForm } from 'vee-validate'
+import { useFieldArray, useForm } from 'vee-validate'
 import { type App, createApp, defineComponent, h } from 'vue'
 import { flush } from '../../shared/clock'
 import { domDriver } from '../../shared/dom-driver'
 import { resetRenderCounts, totalRenders } from '../../shared/render-count'
 import { shapeFor, zodSchemaFor } from '../../shared/scenarios'
-import type { BenchAdapter, MountHandle } from '../contract'
+import type { ArrayOp, BenchAdapter, MountHandle } from '../contract'
 import Field from './Field.vue'
 
 /** The slice of vee-validate's form context the adapter drives. */
 interface VeeForm {
   validate: () => Promise<unknown>
   validateField: (path: string) => Promise<unknown>
+}
+
+/**
+ * The slice of vee-validate's `useFieldArray` the adapter drives: the reactive
+ * `fields` (each entry carrying a stable `key` that follows its row across a
+ * reorder) plus the idiomatic mutators. This is vee-validate's first-class
+ * dynamic-array primitive.
+ */
+interface VeeFieldArray {
+  fields: { readonly value: ReadonlyArray<{ readonly key: string | number }> }
+  push(value: unknown): void
+  remove(index: number): void
+  swap(a: number, b: number): void
 }
 
 let mountSeq = 0
@@ -43,7 +56,10 @@ export const veeValidateAdapter: BenchAdapter = {
     const schema = zodSchemaFor(opts.scenario, opts.params)
     mountSeq += 1
 
+    const arrayPath = shape.arrayPath
+    const itemFields = shape.arrayItemFields ?? []
     let form: VeeForm | undefined
+    let rows: VeeFieldArray | undefined
 
     const Host = defineComponent({
       name: 'VeeValidateHost',
@@ -54,13 +70,35 @@ export const veeValidateAdapter: BenchAdapter = {
           initialValues: shape.defaultValues as Record<string, unknown>,
         })
         form = f as unknown as VeeForm
-        return () =>
-          h(
+        // useFieldArray is vee-validate's array primitive; its reactive `fields`
+        // drive the rendered rows so an add/remove/reorder reflows the list.
+        const fieldArray = arrayPath
+          ? (useFieldArray(arrayPath) as unknown as VeeFieldArray)
+          : undefined
+        rows = fieldArray
+        return () => {
+          if (fieldArray) {
+            return h(
+              'div',
+              fieldArray.fields.value.flatMap((entry, i) =>
+                itemFields.map((field, fIdx) =>
+                  h(Field, {
+                    key: `${entry.key}.${field}`,
+                    name: `${arrayPath}.${i}.${field}`,
+                    index: i * itemFields.length + fIdx,
+                    trigger: opts.trigger,
+                  })
+                )
+              )
+            )
+          }
+          return h(
             'div',
             shape.paths.map((path, index) =>
               h(Field, { key: index, name: path, index, trigger: opts.trigger })
             )
           )
+        }
       },
     })
 
@@ -81,7 +119,14 @@ export const veeValidateAdapter: BenchAdapter = {
         await form?.validateField(shape.paths[index] ?? '')
         await flush()
       },
-      arrayOp: () => Promise.resolve(unsupported('arrayOp')),
+      async arrayOp(op: ArrayOp, a?: number, b?: number) {
+        if (!rows) return unsupported(op)
+        if (op === 'append') rows.push(shape.newRow?.() ?? {})
+        else if (op === 'remove') rows.remove(a ?? rows.fields.value.length - 1)
+        else if (op === 'swap') rows.swap(a ?? 0, b ?? 0)
+        else unsupported(op)
+        await flush()
+      },
       flipVariant: () => Promise.resolve(unsupported('flipVariant')),
       stepTransition: () => Promise.resolve(unsupported('stepTransition')),
       getRenderCount: () => totalRenders(),

--- a/apps/bench-arena/src/adapters/vee-validate/adapter.ts
+++ b/apps/bench-arena/src/adapters/vee-validate/adapter.ts
@@ -29,8 +29,6 @@ interface VeeFieldArray {
   swap(a: number, b: number): void
 }
 
-let mountSeq = 0
-
 const unsupported = (op: string): never => {
   throw new Error(`bench: vee-validate adapter does not drive "${op}" in this scenario`)
 }
@@ -56,7 +54,6 @@ export const veeValidateAdapter: BenchAdapter = {
   async mount(container, opts): Promise<MountHandle> {
     const shape = shapeFor(opts.scenario, opts.params)
     const schema = zodSchemaFor(opts.scenario, opts.params)
-    mountSeq += 1
 
     const arrayPath = shape.arrayPath
     const itemFields = shape.arrayItemFields ?? []

--- a/apps/bench-arena/src/adapters/vee-validate/adapter.ts
+++ b/apps/bench-arena/src/adapters/vee-validate/adapter.ts
@@ -61,9 +61,15 @@ export const veeValidateAdapter: BenchAdapter = {
     const arrayPath = shape.arrayPath
     const itemFields = shape.arrayItemFields ?? []
     const union = shape.union
+    const wizardDesc = shape.wizard
     let form: VeeForm | undefined
     let rows: VeeFieldArray | undefined
     let activeTag: Ref<string> | undefined
+    // The hand-composed wizard's active step. vee-validate has no wizard
+    // primitive, so the harness tracks the position and the gated advance
+    // validates the leaving step's fields through the per-field API; every step
+    // renders through the default branch, so navigation never remounts a field.
+    let wizardStep = 0
 
     const Host = defineComponent({
       name: 'VeeValidateHost',
@@ -163,7 +169,21 @@ export const veeValidateAdapter: BenchAdapter = {
         if (activeTag) activeTag.value = to
         await flush()
       },
-      stepTransition: () => Promise.resolve(unsupported('stepTransition')),
+      async stepTransition(dir: 1 | -1) {
+        if (!wizardDesc || !form) return unsupported('stepTransition')
+        if (dir === 1) {
+          if (wizardStep < wizardDesc.steps.length - 1) {
+            // Gate the advance on the leaving step's fields, validated through
+            // vee-validate's per-field API (the granular path a hand-composed
+            // wizard reaches for; only this step's fields are checked).
+            await Promise.all(
+              (wizardDesc.steps[wizardStep] ?? []).map((p) => form?.validateField(p))
+            )
+            wizardStep += 1
+          }
+        } else if (wizardStep > 0) wizardStep -= 1
+        await flush()
+      },
       getRenderCount: () => totalRenders(),
       resetRenderCount: () => resetRenderCounts(),
       teardown: () => app.unmount(),

--- a/apps/bench-arena/src/adapters/vee-validate/adapter.ts
+++ b/apps/bench-arena/src/adapters/vee-validate/adapter.ts
@@ -96,9 +96,10 @@ export const veeValidateAdapter: BenchAdapter = {
             )
           }
           if (fieldArray) {
-            return h(
-              'div',
-              fieldArray.fields.value.flatMap((entry, i) =>
+            const objectPaths = shape.objectPaths ?? []
+            const objBase = shape.paths.length - objectPaths.length
+            return h('div', [
+              ...fieldArray.fields.value.flatMap((entry, i) =>
                 itemFields.map((field, fIdx) =>
                   h(Field, {
                     key: `${entry.key}.${field}`,
@@ -107,8 +108,16 @@ export const veeValidateAdapter: BenchAdapter = {
                     trigger: opts.trigger,
                   })
                 )
-              )
-            )
+              ),
+              ...objectPaths.map((path, j) =>
+                h(Field, {
+                  key: `obj-${path}`,
+                  name: path,
+                  index: objBase + j,
+                  trigger: opts.trigger,
+                })
+              ),
+            ])
           }
           return h(
             'div',

--- a/apps/bench-arena/src/adapters/vee-validate/adapter.ts
+++ b/apps/bench-arena/src/adapters/vee-validate/adapter.ts
@@ -1,0 +1,92 @@
+import { toTypedSchema } from '@vee-validate/zod'
+import { useForm } from 'vee-validate'
+import { type App, createApp, defineComponent, h } from 'vue'
+import { flush } from '../../shared/clock'
+import { domDriver } from '../../shared/dom-driver'
+import { resetRenderCounts, totalRenders } from '../../shared/render-count'
+import { shapeFor, zodSchemaFor } from '../../shared/scenarios'
+import type { BenchAdapter, MountHandle } from '../contract'
+import Field from './Field.vue'
+
+/** The slice of vee-validate's form context the adapter drives. */
+interface VeeForm {
+  validate: () => Promise<unknown>
+  validateField: (path: string) => Promise<unknown>
+}
+
+let mountSeq = 0
+
+const unsupported = (op: string): never => {
+  throw new Error(`bench: vee-validate adapter does not drive "${op}" in this scenario`)
+}
+
+export const veeValidateAdapter: BenchAdapter = {
+  meta: {
+    id: 'vee-validate',
+    displayName: 'vee-validate',
+    layer: 'headless-form-state',
+    schemaLib: 'zod3',
+    ownsInputs: false,
+    capabilities: {
+      flat: 'native',
+      nested: 'native',
+      arrays: 'native',
+      grid: 'native',
+      'discriminated-union': 'hand-rolled',
+      massive: 'native',
+      wizard: 'hand-rolled',
+    },
+  },
+
+  async mount(container, opts): Promise<MountHandle> {
+    const shape = shapeFor(opts.scenario, opts.params)
+    const schema = zodSchemaFor(opts.scenario, opts.params)
+    mountSeq += 1
+
+    let form: VeeForm | undefined
+
+    const Host = defineComponent({
+      name: 'VeeValidateHost',
+      setup() {
+        // useForm provides the field context useField injects in each child.
+        const f = useForm({
+          validationSchema: toTypedSchema(schema),
+          initialValues: shape.defaultValues as Record<string, unknown>,
+        })
+        form = f as unknown as VeeForm
+        return () =>
+          h(
+            'div',
+            shape.paths.map((path, index) =>
+              h(Field, { key: index, name: path, index, trigger: opts.trigger })
+            )
+          )
+      },
+    })
+
+    const app: App = createApp(Host)
+    app.mount(container)
+    await flush()
+
+    const driver = domDriver(container, opts.trigger)
+
+    return {
+      typeChar: driver.typeChar,
+      setFieldValue: driver.setFieldValue,
+      async validateAll() {
+        await form?.validate()
+        await flush()
+      },
+      async validateField(index) {
+        await form?.validateField(shape.paths[index] ?? '')
+        await flush()
+      },
+      arrayOp: () => Promise.resolve(unsupported('arrayOp')),
+      flipVariant: () => Promise.resolve(unsupported('flipVariant')),
+      stepTransition: () => Promise.resolve(unsupported('stepTransition')),
+      getRenderCount: () => totalRenders(),
+      resetRenderCount: () => resetRenderCounts(),
+      teardown: () => app.unmount(),
+    }
+  },
+}

--- a/apps/bench-arena/src/adapters/vuelidate/Field.vue
+++ b/apps/bench-arena/src/adapters/vuelidate/Field.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+  import { onUpdated } from 'vue'
+  import { recordRender } from '../../shared/render-count'
+  import type { VuelidateField } from './types'
+
+  /**
+   * A Vuelidate field. Vuelidate is validation-only and model-based, so the
+   * harness owns the input and binds it to the field's `$model` (the two-way model
+   * that writes state and marks the field dirty). Reading `$model` subscribes to
+   * this field alone, so it re-renders granularly.
+   *
+   * Vuelidate's validation is a lazy computed: it recomputes only when its result
+   * is read. Binding `:aria-invalid` to `$error` reads it on every re-render, so
+   * the per-keystroke validation actually runs and the latency reflects it. That
+   * is also the idiomatic display path, since a real form surfaces error state.
+   */
+  const props = defineProps<{
+    field: VuelidateField
+    index: number
+    trigger: 'input' | 'blur'
+  }>()
+
+  onUpdated(() => recordRender(props.index))
+
+  function onInput(event: Event): void {
+    props.field.$model = (event.target as HTMLInputElement).value
+  }
+
+  function onBlur(): void {
+    if (props.trigger === 'blur') props.field.$touch()
+  }
+</script>
+
+<template>
+  <input
+    :data-bench-field="index"
+    :value="field.$model"
+    :aria-invalid="field.$error"
+    @input="onInput"
+    @blur="onBlur"
+  />
+</template>

--- a/apps/bench-arena/src/adapters/vuelidate/adapter.ts
+++ b/apps/bench-arena/src/adapters/vuelidate/adapter.ts
@@ -175,9 +175,10 @@ export const vuelidateAdapter: BenchAdapter = {
           }
           if (arrayPath !== undefined) {
             const list = (state[arrayPath] as unknown[]) ?? []
-            return h(
-              'div',
-              list.flatMap((_row, i) =>
+            const objectPaths = shape.objectPaths ?? []
+            const objBase = shape.paths.length - objectPaths.length
+            return h('div', [
+              ...list.flatMap((_row, i) =>
                 itemFields.map((field, fIdx) => {
                   const index = i * itemFields.length + fIdx
                   return h(Field, {
@@ -187,8 +188,16 @@ export const vuelidateAdapter: BenchAdapter = {
                     trigger: opts.trigger,
                   })
                 })
-              )
-            )
+              ),
+              ...objectPaths.map((path, j) =>
+                h(Field, {
+                  key: `obj-${path}`,
+                  field: fieldFor(path) as VuelidateField,
+                  index: objBase + j,
+                  trigger: opts.trigger,
+                })
+              ),
+            ])
           }
           return h(
             'div',

--- a/apps/bench-arena/src/adapters/vuelidate/adapter.ts
+++ b/apps/bench-arena/src/adapters/vuelidate/adapter.ts
@@ -121,10 +121,16 @@ export const vuelidateAdapter: BenchAdapter = {
     const arrayPath = shape.arrayPath
     const itemFields = shape.arrayItemFields ?? []
     const union = shape.union
+    const wizardDesc = shape.wizard
     let root: VuelidateRoot | undefined
     let resolve: ((index: number) => VuelidateField | undefined) | undefined
     let stateRef: Record<string, unknown> | undefined
     let activeTag: Ref<string> | undefined
+    // The hand-composed wizard's active step. Vuelidate has no wizard primitive,
+    // so the harness tracks the position and the gated advance validates the
+    // leaving step's fields ($validate per field); every step renders through
+    // the default branch.
+    let wizardStep = 0
 
     const Host = defineComponent({
       name: 'VuelidateHost',
@@ -260,7 +266,23 @@ export const vuelidateAdapter: BenchAdapter = {
         if (activeTag) activeTag.value = to
         await flush()
       },
-      stepTransition: () => Promise.resolve(unsupported('stepTransition')),
+      async stepTransition(dir: 1 | -1) {
+        if (!wizardDesc || !resolve) return unsupported('stepTransition')
+        const resolveAt = resolve
+        if (dir === 1) {
+          if (wizardStep < wizardDesc.steps.length - 1) {
+            // Gate the advance on the leaving step's fields, each validated
+            // through its Vuelidate field status; only this step's fields run.
+            await Promise.all(
+              (wizardDesc.steps[wizardStep] ?? []).map((p) =>
+                resolveAt(shape.paths.indexOf(p))?.$validate()
+              )
+            )
+            wizardStep += 1
+          }
+        } else if (wizardStep > 0) wizardStep -= 1
+        await flush()
+      },
       getRenderCount: () => totalRenders(),
       resetRenderCount: () => resetRenderCounts(),
       teardown: () => app.unmount(),

--- a/apps/bench-arena/src/adapters/vuelidate/adapter.ts
+++ b/apps/bench-arena/src/adapters/vuelidate/adapter.ts
@@ -71,8 +71,6 @@ type VuelidateTree = VuelidateRoot & Record<string, VuelidateField>
 type UseVuelidateLoose = (rules: Record<string, unknown>, state: object) => { value: VuelidateTree }
 const useVuelidateLoose = useVuelidate as unknown as UseVuelidateLoose
 
-let mountSeq = 0
-
 const unsupported = (op: string): never => {
   throw new Error(`bench: vuelidate adapter does not drive "${op}" in this scenario`)
 }
@@ -116,7 +114,6 @@ export const vuelidateAdapter: BenchAdapter = {
       }
       rules[shape.arrayPath] = { $each: helpers.forEach(itemRules) }
     }
-    mountSeq += 1
 
     const arrayPath = shape.arrayPath
     const itemFields = shape.arrayItemFields ?? []

--- a/apps/bench-arena/src/adapters/vuelidate/adapter.ts
+++ b/apps/bench-arena/src/adapters/vuelidate/adapter.ts
@@ -5,7 +5,7 @@ import { flush } from '../../shared/clock'
 import { domDriver } from '../../shared/dom-driver'
 import { resetRenderCounts, totalRenders } from '../../shared/render-count'
 import { nativeRulesFor, nestRules, shapeFor } from '../../shared/scenarios'
-import type { BenchAdapter, MountHandle } from '../contract'
+import type { ArrayOp, BenchAdapter, MountHandle } from '../contract'
 import Field from './Field.vue'
 import type { VuelidateField, VuelidateRoot } from './types'
 
@@ -118,16 +118,25 @@ export const vuelidateAdapter: BenchAdapter = {
     }
     mountSeq += 1
 
+    const arrayPath = shape.arrayPath
+    const itemFields = shape.arrayItemFields ?? []
     let root: VuelidateRoot | undefined
     let resolve: ((index: number) => VuelidateField | undefined) | undefined
+    let stateRef: Record<string, unknown> | undefined
 
     const Host = defineComponent({
       name: 'VuelidateHost',
       setup() {
-        const state = reactive({ ...shape.defaultValues }) as Record<string, unknown>
+        // An array scenario owns a mutable array the ops splice and swap, so the
+        // seed tree is cloned per mount; sharing the shape's array would let one
+        // mount's op corrupt the next. Flat/nested never mutate.
+        const seed = arrayPath
+          ? (JSON.parse(JSON.stringify(shape.defaultValues)) as Record<string, unknown>)
+          : { ...shape.defaultValues }
+        const state = reactive(seed) as Record<string, unknown>
+        stateRef = state
         const v$ = useVuelidateLoose(rules, state)
         root = v$.value
-        const arrayPath = shape.arrayPath
         // An array path resolves to a per-row façade; an object path walks the
         // nested validation tree by key.
         const fieldFor = (path: string): VuelidateField | undefined => {
@@ -142,8 +151,25 @@ export const vuelidateAdapter: BenchAdapter = {
           const path = shape.paths[index]
           return path === undefined ? undefined : fieldFor(path)
         }
-        return () =>
-          h(
+        return () => {
+          if (arrayPath !== undefined) {
+            const list = (state[arrayPath] as unknown[]) ?? []
+            return h(
+              'div',
+              list.flatMap((_row, i) =>
+                itemFields.map((field, fIdx) => {
+                  const index = i * itemFields.length + fIdx
+                  return h(Field, {
+                    key: index,
+                    field: fieldFor(`${arrayPath}.${i}.${field}`) as VuelidateField,
+                    index,
+                    trigger: opts.trigger,
+                  })
+                })
+              )
+            )
+          }
+          return h(
             'div',
             shape.paths.map((path, index) =>
               h(Field, {
@@ -154,6 +180,7 @@ export const vuelidateAdapter: BenchAdapter = {
               })
             )
           )
+        }
       },
     })
 
@@ -174,7 +201,25 @@ export const vuelidateAdapter: BenchAdapter = {
         await resolve?.(index)?.$validate()
         await flush()
       },
-      arrayOp: () => Promise.resolve(unsupported('arrayOp')),
+      // Vuelidate is validation-only, so the harness owns the array and mutates
+      // it; Vuelidate's `forEach` collection rule re-validates the rows from the
+      // reactive state. This is the shape a Vuelidate array form actually takes.
+      async arrayOp(op: ArrayOp, a?: number, b?: number) {
+        if (arrayPath === undefined || !stateRef) return unsupported(op)
+        const list = stateRef[arrayPath] as Array<Record<string, unknown>>
+        if (op === 'append') list.push(shape.newRow?.() ?? {})
+        else if (op === 'remove') {
+          const index = a ?? list.length - 1
+          if (index >= 0) list.splice(index, 1)
+        } else if (op === 'swap') {
+          const i = a ?? 0
+          const j = b ?? 0
+          const tmp = list[i] as Record<string, unknown>
+          list[i] = list[j] as Record<string, unknown>
+          list[j] = tmp
+        } else unsupported(op)
+        await flush()
+      },
       flipVariant: () => Promise.resolve(unsupported('flipVariant')),
       stepTransition: () => Promise.resolve(unsupported('stepTransition')),
       getRenderCount: () => totalRenders(),

--- a/apps/bench-arena/src/adapters/vuelidate/adapter.ts
+++ b/apps/bench-arena/src/adapters/vuelidate/adapter.ts
@@ -1,5 +1,5 @@
 import { useVuelidate } from '@vuelidate/core'
-import { minLength } from '@vuelidate/validators'
+import { helpers, minLength } from '@vuelidate/validators'
 import { type App, createApp, defineComponent, h, reactive } from 'vue'
 import { flush } from '../../shared/clock'
 import { domDriver } from '../../shared/dom-driver'
@@ -21,6 +21,45 @@ function resolveField(root: Record<string, unknown>, dotted: string): VuelidateF
     node = (node as Record<string, unknown>)[seg]
   }
   return node as VuelidateField | undefined
+}
+
+/**
+ * A per-row field façade for an array scenario. Vuelidate's `forEach` validates
+ * the collection as a whole and exposes no per-item `$model`, so the row binds
+ * its value to the raw reactive state cell (granular: only this row re-renders on
+ * its own edit) and routes validation through the collection status. That is the
+ * honest hand-rolled shape a Vuelidate array form takes; reading the collection
+ * `$error` on render forces the whole-collection revalidation per keystroke.
+ */
+function arrayFacade(
+  state: Record<string, unknown>,
+  coll: VuelidateField,
+  arrayPath: string,
+  index: number,
+  fieldSegs: readonly string[]
+): VuelidateField {
+  const row = (): Record<string, unknown> =>
+    (state[arrayPath] as Array<Record<string, unknown>>)[index] ?? {}
+  const last = fieldSegs[fieldSegs.length - 1] ?? ''
+  return {
+    get $model(): string {
+      let node: unknown = row()
+      for (const seg of fieldSegs) node = (node as Record<string, unknown> | undefined)?.[seg]
+      return node as string
+    },
+    set $model(val: string) {
+      let node = row()
+      for (let k = 0; k < fieldSegs.length - 1; k++) {
+        node = node[fieldSegs[k] ?? ''] as Record<string, unknown>
+      }
+      node[last] = val
+    },
+    get $error(): boolean {
+      return coll.$error
+    },
+    $touch: () => coll.$touch(),
+    $validate: () => coll.$validate(),
+  }
 }
 
 /**
@@ -69,25 +108,47 @@ export const vuelidateAdapter: BenchAdapter = {
     const rules = nestRules(nativeRulesFor(opts.scenario, opts.params), (rule) =>
       rule.minLength !== undefined ? { minLength: minLength(rule.minLength) } : {}
     )
+    if (shape.arrayPath && shape.arrayItemRules) {
+      const itemRules: Record<string, unknown> = {}
+      for (const [field, rule] of Object.entries(shape.arrayItemRules)) {
+        itemRules[field] =
+          rule.minLength !== undefined ? { minLength: minLength(rule.minLength) } : {}
+      }
+      rules[shape.arrayPath] = { $each: helpers.forEach(itemRules) }
+    }
     mountSeq += 1
 
     let root: VuelidateRoot | undefined
-    let tree: Record<string, unknown> | undefined
+    let resolve: ((index: number) => VuelidateField | undefined) | undefined
 
     const Host = defineComponent({
       name: 'VuelidateHost',
       setup() {
-        const state = reactive({ ...shape.defaultValues })
+        const state = reactive({ ...shape.defaultValues }) as Record<string, unknown>
         const v$ = useVuelidateLoose(rules, state)
         root = v$.value
-        tree = v$.value
+        const arrayPath = shape.arrayPath
+        // An array path resolves to a per-row façade; an object path walks the
+        // nested validation tree by key.
+        const fieldFor = (path: string): VuelidateField | undefined => {
+          if (arrayPath && path.startsWith(`${arrayPath}.`)) {
+            const rest = path.slice(arrayPath.length + 1).split('.')
+            const coll = (v$.value as Record<string, unknown>)[arrayPath] as VuelidateField
+            return arrayFacade(state, coll, arrayPath, Number(rest[0]), rest.slice(1))
+          }
+          return resolveField(v$.value, path)
+        }
+        resolve = (index) => {
+          const path = shape.paths[index]
+          return path === undefined ? undefined : fieldFor(path)
+        }
         return () =>
           h(
             'div',
             shape.paths.map((path, index) =>
               h(Field, {
                 key: index,
-                field: resolveField(v$.value, path) as VuelidateField,
+                field: fieldFor(path) as VuelidateField,
                 index,
                 trigger: opts.trigger,
               })
@@ -110,8 +171,7 @@ export const vuelidateAdapter: BenchAdapter = {
         await flush()
       },
       async validateField(index) {
-        const path = shape.paths[index]
-        if (path !== undefined && tree) await resolveField(tree, path)?.$validate()
+        await resolve?.(index)?.$validate()
         await flush()
       },
       arrayOp: () => Promise.resolve(unsupported('arrayOp')),

--- a/apps/bench-arena/src/adapters/vuelidate/adapter.ts
+++ b/apps/bench-arena/src/adapters/vuelidate/adapter.ts
@@ -1,6 +1,6 @@
 import { useVuelidate } from '@vuelidate/core'
 import { helpers, minLength } from '@vuelidate/validators'
-import { type App, createApp, defineComponent, h, reactive } from 'vue'
+import { type App, type Ref, createApp, defineComponent, h, reactive, ref } from 'vue'
 import { flush } from '../../shared/clock'
 import { domDriver } from '../../shared/dom-driver'
 import { resetRenderCounts, totalRenders } from '../../shared/render-count'
@@ -120,9 +120,11 @@ export const vuelidateAdapter: BenchAdapter = {
 
     const arrayPath = shape.arrayPath
     const itemFields = shape.arrayItemFields ?? []
+    const union = shape.union
     let root: VuelidateRoot | undefined
     let resolve: ((index: number) => VuelidateField | undefined) | undefined
     let stateRef: Record<string, unknown> | undefined
+    let activeTag: Ref<string> | undefined
 
     const Host = defineComponent({
       name: 'VuelidateHost',
@@ -151,7 +153,26 @@ export const vuelidateAdapter: BenchAdapter = {
           const path = shape.paths[index]
           return path === undefined ? undefined : fieldFor(path)
         }
+        // The active variant is tracked off a local signal the flip keeps in
+        // sync; a flip reassigns the harness state's union value, and Vuelidate
+        // re-validates the active branch through its union-covering rules.
+        const tag = ref(union?.variants[0]?.tag ?? '')
+        activeTag = tag
         return () => {
+          if (union !== undefined) {
+            const variant = union.variants.find((v) => v.tag === tag.value)
+            return h(
+              'div',
+              (variant?.fieldPaths ?? []).map((path, index) =>
+                h(Field, {
+                  key: path,
+                  field: fieldFor(path) as VuelidateField,
+                  index,
+                  trigger: opts.trigger,
+                })
+              )
+            )
+          }
           if (arrayPath !== undefined) {
             const list = (state[arrayPath] as unknown[]) ?? []
             return h(
@@ -220,7 +241,16 @@ export const vuelidateAdapter: BenchAdapter = {
         } else unsupported(op)
         await flush()
       },
-      flipVariant: () => Promise.resolve(unsupported('flipVariant')),
+      // Vuelidate is validation-only, so the harness owns the union value;
+      // reassigning it revalidates the active branch through the union-covering
+      // rules. The clone keeps repeated flips from sharing one reactive object.
+      async flipVariant(to: string) {
+        const variant = union?.variants.find((v) => v.tag === to)
+        if (!union || !variant || !stateRef) return unsupported('flipVariant')
+        stateRef[union.unionPath] = { ...variant.value }
+        if (activeTag) activeTag.value = to
+        await flush()
+      },
       stepTransition: () => Promise.resolve(unsupported('stepTransition')),
       getRenderCount: () => totalRenders(),
       resetRenderCount: () => resetRenderCounts(),

--- a/apps/bench-arena/src/adapters/vuelidate/adapter.ts
+++ b/apps/bench-arena/src/adapters/vuelidate/adapter.ts
@@ -1,0 +1,125 @@
+import { useVuelidate } from '@vuelidate/core'
+import { minLength } from '@vuelidate/validators'
+import { type App, createApp, defineComponent, h, reactive } from 'vue'
+import { flush } from '../../shared/clock'
+import { domDriver } from '../../shared/dom-driver'
+import { resetRenderCounts, totalRenders } from '../../shared/render-count'
+import { nativeRulesFor, nestRules, shapeFor } from '../../shared/scenarios'
+import type { BenchAdapter, MountHandle } from '../contract'
+import Field from './Field.vue'
+import type { VuelidateField, VuelidateRoot } from './types'
+
+/**
+ * Resolve a dotted leaf path to its Vuelidate field validation. Vuelidate's
+ * validation tree mirrors the nested rules/state by key, so a deep path walks
+ * `v$.value.l0.l1.leaf`; a flat path is the single-segment case.
+ */
+function resolveField(root: Record<string, unknown>, dotted: string): VuelidateField | undefined {
+  let node: unknown = root
+  for (const seg of dotted.split('.')) {
+    if (node == null || typeof node !== 'object') return undefined
+    node = (node as Record<string, unknown>)[seg]
+  }
+  return node as VuelidateField | undefined
+}
+
+/**
+ * The dynamic rules object erases Vuelidate's `Validation` generics, so the call
+ * is made through a loose signature; the runtime call is the real one. `v$.value`
+ * is the validation tree, indexable by field path.
+ */
+type VuelidateTree = VuelidateRoot & Record<string, VuelidateField>
+type UseVuelidateLoose = (rules: Record<string, unknown>, state: object) => { value: VuelidateTree }
+const useVuelidateLoose = useVuelidate as unknown as UseVuelidateLoose
+
+let mountSeq = 0
+
+const unsupported = (op: string): never => {
+  throw new Error(`bench: vuelidate adapter does not drive "${op}" in this scenario`)
+}
+
+/**
+ * Vuelidate is the model-based old-guard baseline (clearly labeled
+ * unmaintained / LTS on the page). Native validators ride on a rules object
+ * mirroring the cohort's constraint, and the reactive state is the model the
+ * fields bind to through `$model`.
+ */
+export const vuelidateAdapter: BenchAdapter = {
+  meta: {
+    id: 'vuelidate',
+    displayName: 'Vuelidate',
+    layer: 'headless-validation-only',
+    schemaLib: 'native',
+    ownsInputs: false,
+    capabilities: {
+      flat: 'native',
+      nested: 'native',
+      arrays: 'hand-rolled',
+      grid: 'hand-rolled',
+      'discriminated-union': 'hand-rolled',
+      massive: 'native',
+      wizard: 'hand-rolled',
+    },
+  },
+
+  async mount(container, opts): Promise<MountHandle> {
+    const shape = shapeFor(opts.scenario, opts.params)
+    // Rules nest to mirror the value tree (Vuelidate keys validations by
+    // structure), built from the scenario's flat rule description.
+    const rules = nestRules(nativeRulesFor(opts.scenario, opts.params), (rule) =>
+      rule.minLength !== undefined ? { minLength: minLength(rule.minLength) } : {}
+    )
+    mountSeq += 1
+
+    let root: VuelidateRoot | undefined
+    let tree: Record<string, unknown> | undefined
+
+    const Host = defineComponent({
+      name: 'VuelidateHost',
+      setup() {
+        const state = reactive({ ...shape.defaultValues })
+        const v$ = useVuelidateLoose(rules, state)
+        root = v$.value
+        tree = v$.value
+        return () =>
+          h(
+            'div',
+            shape.paths.map((path, index) =>
+              h(Field, {
+                key: index,
+                field: resolveField(v$.value, path) as VuelidateField,
+                index,
+                trigger: opts.trigger,
+              })
+            )
+          )
+      },
+    })
+
+    const app: App = createApp(Host)
+    app.mount(container)
+    await flush()
+
+    const driver = domDriver(container, opts.trigger)
+
+    return {
+      typeChar: driver.typeChar,
+      setFieldValue: driver.setFieldValue,
+      async validateAll() {
+        await root?.$validate()
+        await flush()
+      },
+      async validateField(index) {
+        const path = shape.paths[index]
+        if (path !== undefined && tree) await resolveField(tree, path)?.$validate()
+        await flush()
+      },
+      arrayOp: () => Promise.resolve(unsupported('arrayOp')),
+      flipVariant: () => Promise.resolve(unsupported('flipVariant')),
+      stepTransition: () => Promise.resolve(unsupported('stepTransition')),
+      getRenderCount: () => totalRenders(),
+      resetRenderCount: () => resetRenderCounts(),
+      teardown: () => app.unmount(),
+    }
+  },
+}

--- a/apps/bench-arena/src/adapters/vuelidate/types.ts
+++ b/apps/bench-arena/src/adapters/vuelidate/types.ts
@@ -1,0 +1,18 @@
+/**
+ * The Vuelidate field slice the bench binds. `$model` is Vuelidate's two-way
+ * model: reading it subscribes to this field, assigning it writes the state and
+ * marks the field dirty. `$error` is read in the template so Vuelidate's
+ * lazy-computed validation actually runs each keystroke (and mirrors the
+ * idiomatic error-display path).
+ */
+export interface VuelidateField {
+  $model: string
+  readonly $error: boolean
+  $touch(): void
+  $validate(): Promise<boolean>
+}
+
+/** The `v$.value` root the adapter reaches through. */
+export interface VuelidateRoot {
+  $validate(): Promise<boolean>
+}

--- a/apps/bench-arena/src/main.ts
+++ b/apps/bench-arena/src/main.ts
@@ -8,7 +8,7 @@ import type {
   TriggerMode,
 } from './adapters/contract'
 import { adapters } from './adapters/registry'
-import { calibrate, frame, type Summary, summarize, timed } from './shared/clock'
+import { calibrate, frame, settle, type Summary, summarize, timed } from './shared/clock'
 import { shapeFor } from './shared/scenarios'
 import type { ScenarioShape } from './shared/scenarios/types'
 
@@ -19,6 +19,12 @@ import type { ScenarioShape } from './shared/scenarios/types'
  * the Playwright boundary), and signals completion via `body[data-bench-done]`.
  *
  *   /?adapter=attaform&scenario=flat&params=F50&trigger=input&dim=keystroke
+ *
+ * The memory dimension is the one exception: a precise heap reading is only
+ * available through the privileged CDP protocol (driver-side), so for `memory`
+ * the page installs `window.__BENCH_MEM__` mount/type/teardown hooks and the
+ * driver brackets them with CDP garbage collection and heap reads. See
+ * `setupMemoryHooks`.
  */
 
 interface BenchPayload {
@@ -29,10 +35,12 @@ interface BenchPayload {
   dimension: string
   /**
    * Summary unit: milliseconds for timed dims, component renders for the
-   * rerender dim, or DOM mutations for the rerender dim of a library that owns
-   * its inputs (FormKit), where the driver falls back to a mutation proxy.
+   * rerender dim, DOM mutations for the rerender dim of a library that owns its
+   * inputs (FormKit), where the driver falls back to a mutation proxy, or bytes
+   * for the memory dim (whose figures the driver fills in via CDP; the in-page
+   * payload is a readiness placeholder).
    */
-  unit: 'ms' | 'renders' | 'dom-mutations'
+  unit: 'ms' | 'renders' | 'dom-mutations' | 'bytes'
   summary: Summary
   /** Machine-speed proxy so absolute numbers normalize across runners. */
   calibrationMs: number
@@ -41,9 +49,26 @@ interface BenchPayload {
   error?: string
 }
 
+/**
+ * The hooks the memory driver calls between its CDP heap reads. One `mount`
+ * stands up a fresh form (held alive); `typeBurst` drives `burst` keystrokes
+ * into it without an intervening collection (so the driver can read allocation
+ * churn); `teardown` unmounts so the driver can read the post-teardown residual.
+ * `cycles` and `burst` come from the sample plan, so the page stays the single
+ * source for the counts.
+ */
+interface MemoryHooks {
+  readonly cycles: number
+  readonly burst: number
+  mount(): Promise<void>
+  typeBurst(): Promise<void>
+  teardown(): Promise<void>
+}
+
 declare global {
   interface Window {
     __BENCH_RESULTS__?: BenchPayload
+    __BENCH_MEM__?: MemoryHooks
   }
 }
 
@@ -64,6 +89,7 @@ interface SamplePlan {
   readonly arrayOpRuns: number
   readonly variantFlipRuns: number
   readonly stepTransitionRuns: number
+  readonly memoryRuns: number
 }
 
 const DEFAULT_PLAN: SamplePlan = {
@@ -75,6 +101,11 @@ const DEFAULT_PLAN: SamplePlan = {
   arrayOpRuns: 50,
   variantFlipRuns: 50,
   stepTransitionRuns: 50,
+  // Memory cycles: each is a full mount, keystroke burst, and teardown bracketed
+  // by CDP collections, so it costs more than a timed mount; the per-cycle heap
+  // deltas have low relative variance, so a smaller count still yields a stable
+  // median.
+  memoryRuns: 12,
 }
 
 const MASSIVE_PLAN: SamplePlan = {
@@ -90,6 +121,10 @@ const MASSIVE_PLAN: SamplePlan = {
   arrayOpRuns: 50,
   variantFlipRuns: 50,
   stepTransitionRuns: 50,
+  // Each memory cycle re-mounts thousands of inputs, so the count stays low to
+  // keep the cell in budget; a many-thousand-leaf heap is large, so a few
+  // cycles already give a stable median.
+  memoryRuns: 5,
 }
 
 function planFor(scenario: ScenarioId): SamplePlan {
@@ -97,6 +132,9 @@ function planFor(scenario: ScenarioId): SamplePlan {
 }
 
 const ZERO: Summary = { median: 0, p95: 0, iqr: 0, count: 0, trimmed: 0 }
+
+/** Keystrokes the memory dimension drives per cycle to expose allocation churn. */
+const MEMORY_BURST = 50
 
 // Compact param labels (F50, D8, N1000, ...) decode to the scenario knobs.
 const CODE_TO_KEY: Record<string, string> = {
@@ -381,6 +419,63 @@ async function measureMount(
   return summarize(samples)
 }
 
+/**
+ * Install the memory hooks the CDP driver brackets with heap reads, rather than
+ * measuring in-page. The in-page `performance.memory` is quantized so heavily
+ * (tens-of-MB buckets that ignore real allocations, even under cross-origin
+ * isolation) that a delta reads zero for every library at every size, and
+ * `measureUserAgentSpecificMemory` is unavailable under automation. The driver
+ * instead reads the byte-exact heap through CDP (HeapProfiler.collectGarbage +
+ * Runtime.getHeapUsage), collecting before and after each hook call.
+ *
+ * One mount/teardown cycle yields three drift-robust deltas: with `s0` the
+ * collected baseline, `s1` the collected heap of the live mount, `s2` the heap
+ * after a keystroke burst (no collection), and `s3` the collected heap after
+ * teardown, the driver records retained `s1 - s0` (live-form heap), churn
+ * `s2 - s1` (the burst's allocation pressure), and leak `s3 - s0` (residual a
+ * mount/unmount leaves behind). A leak that makes `s0` creep upward across
+ * cycles leaves every per-cycle delta correct, so retained and leak stay honest
+ * even as the page accumulates.
+ *
+ * The DOM is held constant for the bare-input cohort, so the figures isolate the
+ * library's own reactive and validation state; the compiled schema (zod/valibot)
+ * and, for a library that owns its inputs (FormKit), its component tree ride
+ * along, which is fair, since that is what the library needs to do its job.
+ */
+function setupMemoryHooks(
+  adapter: BenchAdapter,
+  opts: MountOpts,
+  shape: ScenarioShape,
+  plan: SamplePlan
+): void {
+  const fieldCount = shape.paths.length
+  let container: HTMLElement | undefined
+  let handle: MountHandle | undefined
+  window.__BENCH_MEM__ = {
+    cycles: plan.memoryRuns,
+    burst: MEMORY_BURST,
+    async mount() {
+      container = makeContainer()
+      handle = await adapter.mount(container, opts)
+      await settle()
+    },
+    async typeBurst() {
+      if (!handle) return
+      for (let i = 0; i < MEMORY_BURST; i++) await handle.typeChar(i % fieldCount, `m${i}`)
+    },
+    async teardown() {
+      handle?.teardown()
+      container?.remove()
+      handle = undefined
+      container = undefined
+      // Let the unmount's async cleanup run before the driver collects, so the
+      // detached tree is actually reclaimable; without this the post-teardown
+      // heap still looks live and the leak reads as the whole retained heap.
+      await settle()
+    },
+  }
+}
+
 async function run(): Promise<BenchPayload> {
   // Collect before this cell allocates anything, so the previous cell's heap
   // cannot skew the measurement. The driver reuses one browser process across
@@ -422,6 +517,14 @@ async function run(): Promise<BenchPayload> {
       summary: await measureMount(adapter, opts, plan),
       supported: true,
     }
+  }
+
+  // Memory is measured driver-side: install the hooks the CDP driver brackets
+  // with heap reads, then report readiness. The summary here is a placeholder;
+  // the driver fills in the real retained/churn/leak figures.
+  if (q.dim === 'memory') {
+    setupMemoryHooks(adapter, opts, shape, plan)
+    return { ...base, unit: 'bytes', summary: ZERO, supported: true }
   }
 
   const container = makeContainer()

--- a/apps/bench-arena/src/main.ts
+++ b/apps/bench-arena/src/main.ts
@@ -1,4 +1,5 @@
 import type {
+  AdapterMeta,
   BenchAdapter,
   DimensionId,
   MountHandle,
@@ -69,6 +70,13 @@ declare global {
   interface Window {
     __BENCH_RESULTS__?: BenchPayload
     __BENCH_MEM__?: MemoryHooks
+    /**
+     * Every adapter's static meta, exposed on the `?meta=1` page so the
+     * orchestrator can build the capability matrix and display metadata from
+     * the real built adapters (a single source of truth, never a hand-kept
+     * copy). No adapter is mounted on this page; it only reads the registry.
+     */
+    __BENCH_META__?: readonly AdapterMeta[]
   }
 }
 
@@ -586,25 +594,35 @@ async function run(): Promise<BenchPayload> {
   }
 }
 
-run()
-  .then((payload) => {
-    window.__BENCH_RESULTS__ = payload
-  })
-  .catch((err: unknown) => {
-    const q = readQuery()
-    window.__BENCH_RESULTS__ = {
-      adapter: q.adapter,
-      scenario: q.scenario,
-      params: q.params,
-      trigger: q.trigger,
-      dimension: q.dim,
-      unit: 'ms',
-      summary: ZERO,
-      calibrationMs: 0,
-      supported: false,
-      error: err instanceof Error ? err.message : String(err),
-    }
-  })
-  .finally(() => {
-    document.body.dataset['benchDone'] = '1'
-  })
+/** Expose every adapter's meta for the orchestrator; mounts nothing. */
+function exposeMeta(): void {
+  window.__BENCH_META__ = Object.values(adapters).map((adapter) => adapter.meta)
+  document.body.dataset['benchDone'] = '1'
+}
+
+if (new URLSearchParams(window.location.search).get('meta') === '1') {
+  exposeMeta()
+} else {
+  run()
+    .then((payload) => {
+      window.__BENCH_RESULTS__ = payload
+    })
+    .catch((err: unknown) => {
+      const q = readQuery()
+      window.__BENCH_RESULTS__ = {
+        adapter: q.adapter,
+        scenario: q.scenario,
+        params: q.params,
+        trigger: q.trigger,
+        dimension: q.dim,
+        unit: 'ms',
+        summary: ZERO,
+        calibrationMs: 0,
+        supported: false,
+        error: err instanceof Error ? err.message : String(err),
+      }
+    })
+    .finally(() => {
+      document.body.dataset['benchDone'] = '1'
+    })
+}

--- a/apps/bench-arena/src/main.ts
+++ b/apps/bench-arena/src/main.ts
@@ -48,6 +48,7 @@ const MEASURE = 200
 const MOUNT_RUNS = 15
 const VALIDATE_RUNS = 100
 const RERENDER_RUNS = 30
+const ARRAYOP_RUNS = 50
 
 const ZERO: Summary = { median: 0, p95: 0, iqr: 0, count: 0, trimmed: 0 }
 
@@ -135,6 +136,48 @@ async function measureRerender(handle: MountHandle, shape: ScenarioShape): Promi
   return summarize(counts)
 }
 
+/**
+ * Add-a-row then remove-the-last (a size-stable rotation): the cost of the
+ * library's array insert + delete at the scenario's row count, including the
+ * reactive reflow of the rendered list. Size-stable so every sample starts from
+ * the same N, and the appended row is valid so no error state churns.
+ */
+async function measureArrayAdd(handle: MountHandle): Promise<Summary> {
+  for (let i = 0; i < 5; i++) {
+    await handle.arrayOp('append')
+    await handle.arrayOp('remove')
+  }
+  const samples: number[] = []
+  for (let i = 0; i < ARRAYOP_RUNS; i++) {
+    samples.push(
+      await timed(async () => {
+        await handle.arrayOp('append')
+        await handle.arrayOp('remove')
+      })
+    )
+    await frame()
+  }
+  return summarize(samples)
+}
+
+/**
+ * Reorder: swap the first and last rows. An identity-keyed list moves the two
+ * DOM nodes and rebinds them to their new positional paths; an index-keyed list
+ * re-renders the two changed positions. Either way the cost is the library's
+ * array swap plus the reactive settle. Each sample swaps back, so the array
+ * alternates between two orderings of equal cost.
+ */
+async function measureArrayReorder(handle: MountHandle, shape: ScenarioShape): Promise<Summary> {
+  const last = shape.paths.length - 1
+  for (let i = 0; i < 5; i++) await handle.arrayOp('swap', 0, last)
+  const samples: number[] = []
+  for (let i = 0; i < ARRAYOP_RUNS; i++) {
+    samples.push(await timed(() => handle.arrayOp('swap', 0, last)))
+    await frame()
+  }
+  return summarize(samples)
+}
+
 /** Mount/init cost over fresh mounts; the only dim that re-mounts per sample. */
 async function measureMount(adapter: BenchAdapter, opts: MountOpts): Promise<Summary> {
   const samples: number[] = []
@@ -199,6 +242,15 @@ async function run(): Promise<BenchPayload> {
           ? { ...base, unit: 'renders', summary: ZERO, supported: false }
           : { ...base, unit: 'renders', summary, supported: true }
       }
+      case 'arrayAdd':
+        return { ...base, unit: 'ms', summary: await measureArrayAdd(handle), supported: true }
+      case 'arrayReorder':
+        return {
+          ...base,
+          unit: 'ms',
+          summary: await measureArrayReorder(handle, shape),
+          supported: true,
+        }
       default:
         throw new Error(`bench: dimension "${q.dim}" is not implemented yet`)
     }

--- a/apps/bench-arena/src/main.ts
+++ b/apps/bench-arena/src/main.ts
@@ -63,6 +63,7 @@ interface SamplePlan {
   readonly rerenderRuns: number
   readonly arrayOpRuns: number
   readonly variantFlipRuns: number
+  readonly stepTransitionRuns: number
 }
 
 const DEFAULT_PLAN: SamplePlan = {
@@ -73,6 +74,7 @@ const DEFAULT_PLAN: SamplePlan = {
   rerenderRuns: 30,
   arrayOpRuns: 50,
   variantFlipRuns: 50,
+  stepTransitionRuns: 50,
 }
 
 const MASSIVE_PLAN: SamplePlan = {
@@ -87,6 +89,7 @@ const MASSIVE_PLAN: SamplePlan = {
   rerenderRuns: 30,
   arrayOpRuns: 50,
   variantFlipRuns: 50,
+  stepTransitionRuns: 50,
 }
 
 function planFor(scenario: ScenarioId): SamplePlan {
@@ -102,6 +105,7 @@ const CODE_TO_KEY: Record<string, string> = {
   N: 'rows',
   M: 'cols',
   L: 'leaves',
+  S: 'steps',
 }
 
 function parseParams(label: string): ScenarioParams {
@@ -315,6 +319,46 @@ async function measureVariantFlip(
   return summarize(samples)
 }
 
+/**
+ * Wizard step transition: the gated forward advance, where a step is validated
+ * before the next is revealed. Each measured sample advances one step from a
+ * non-final step (the leaving step is validated, then the wizard moves on); on
+ * reaching the final step the wizard retreats to the first through unmeasured
+ * free back-steps, so every measured sample is the identical intermediate gated
+ * advance. A library with a wizard primitive (Attaform's useWizard) validates
+ * only the active step on an advance; a hand-composed wizard validates the step
+ * the way its engine allows, so this is where a wizard primitive earns its keep.
+ */
+async function measureStepTransition(
+  handle: MountHandle,
+  shape: ScenarioShape,
+  plan: SamplePlan
+): Promise<Summary> {
+  const steps = shape.wizard?.steps.length ?? 0
+  if (steps < 2)
+    throw new Error('bench: stepTransition needs a wizard scenario with two or more steps')
+  // Retreat to the first step through free (ungated) back-steps; called only
+  // from the final step, so it walks exactly `steps - 1` positions to step 0.
+  const rewind = async (): Promise<void> => {
+    for (let s = 0; s < steps - 1; s++) await handle.stepTransition(-1)
+  }
+  // Warm up one full forward sweep, then rewind to the first step.
+  for (let i = 0; i < steps - 1; i++) await handle.stepTransition(1)
+  await rewind()
+  const samples: number[] = []
+  let pos = 0
+  for (let i = 0; i < plan.stepTransitionRuns; i++) {
+    samples.push(await timed(() => handle.stepTransition(1)))
+    pos += 1
+    await frame()
+    if (pos >= steps - 1) {
+      await rewind()
+      pos = 0
+    }
+  }
+  return summarize(samples)
+}
+
 /** Mount/init cost over fresh mounts; the only dim that re-mounts per sample. */
 async function measureMount(
   adapter: BenchAdapter,
@@ -421,6 +465,13 @@ async function run(): Promise<BenchPayload> {
           ...base,
           unit: 'ms',
           summary: await measureVariantFlip(handle, shape, plan),
+          supported: true,
+        }
+      case 'stepTransition':
+        return {
+          ...base,
+          unit: 'ms',
+          summary: await measureStepTransition(handle, shape, plan),
           supported: true,
         }
       default:

--- a/apps/bench-arena/src/main.ts
+++ b/apps/bench-arena/src/main.ts
@@ -27,8 +27,12 @@ interface BenchPayload {
   params: ScenarioParams
   trigger: string
   dimension: string
-  /** Summary unit: milliseconds for timed dims, component renders for rerender. */
-  unit: 'ms' | 'renders'
+  /**
+   * Summary unit: milliseconds for timed dims, component renders for the
+   * rerender dim, or DOM mutations for the rerender dim of a library that owns
+   * its inputs (FormKit), where the driver falls back to a mutation proxy.
+   */
+  unit: 'ms' | 'renders' | 'dom-mutations'
   summary: Summary
   /** Machine-speed proxy so absolute numbers normalize across runners. */
   calibrationMs: number
@@ -121,19 +125,68 @@ async function measureValidate(handle: MountHandle): Promise<Summary> {
   return summarize(samples)
 }
 
-/** Components re-rendered per keystroke. Null render count => unsupported here. */
-async function measureRerender(handle: MountHandle, shape: ScenarioShape): Promise<Summary | null> {
+/** The rerender result plus which unit it is measured in. */
+interface RerenderResult {
+  summary: Summary
+  unit: 'renders' | 'dom-mutations'
+}
+
+/**
+ * Re-render scope per keystroke. For the bare-input cohort this is the count of
+ * field components whose render function ran (Attaform ~ 1, an O(F) library up
+ * to F). FormKit owns its inputs, so `getRenderCount` is null; the driver then
+ * falls back to a DOM-mutation proxy: a MutationObserver over the mounted
+ * subtree counts the attribute, child-list, and text mutations one keystroke
+ * produces. That is a DIFFERENT unit, not a component-render count, and is
+ * reported as such (the page caveats it, never placed numerically beside the
+ * render counts), but it answers the same real question the grid scenario asks:
+ * does editing one field churn DOM beyond that field?
+ *
+ * The proxy splits its count between the records the observer callback has
+ * already received during the settle (`delivered`) and the records still queued
+ * but undelivered (`takeRecords()`); the two sets are disjoint, so their sum is
+ * the keystroke's full mutation count with no double counting.
+ */
+async function measureRerender(
+  handle: MountHandle,
+  shape: ScenarioShape,
+  container: HTMLElement
+): Promise<RerenderResult> {
   const fieldCount = shape.paths.length
-  const counts: number[] = []
+  const renderCounts: number[] = []
+  const mutationCounts: number[] = []
+  let usesProxy = false
+
+  let delivered = 0
+  const observer = new MutationObserver((records) => {
+    delivered += records.length
+  })
+  observer.observe(container, {
+    subtree: true,
+    childList: true,
+    attributes: true,
+    characterData: true,
+  })
+
   for (let i = 0; i < RERENDER_RUNS; i++) {
     handle.resetRenderCount()
+    observer.takeRecords()
+    delivered = 0
     await handle.typeChar(i % fieldCount, `r${i}`)
     const count = handle.getRenderCount()
-    if (count === null) return null
-    counts.push(count)
+    if (count === null) {
+      usesProxy = true
+      mutationCounts.push(delivered + observer.takeRecords().length)
+    } else {
+      renderCounts.push(count)
+    }
     await frame()
   }
-  return summarize(counts)
+  observer.disconnect()
+
+  return usesProxy
+    ? { summary: summarize(mutationCounts), unit: 'dom-mutations' }
+    : { summary: summarize(renderCounts), unit: 'renders' }
 }
 
 /**
@@ -168,7 +221,13 @@ async function measureArrayAdd(handle: MountHandle): Promise<Summary> {
  * alternates between two orderings of equal cost.
  */
 async function measureArrayReorder(handle: MountHandle, shape: ScenarioShape): Promise<Summary> {
-  const last = shape.paths.length - 1
+  // The swap exchanges two ROWS (array elements), so the index lives in row
+  // space, not the flat input index. For a multi-column grid the input count
+  // (paths.length) is rows x columns, so divide by the column count to recover
+  // the row count; for a single-column array the two coincide.
+  const cols = shape.arrayItemFields?.length ?? 1
+  const rowCount = Math.floor(shape.paths.length / cols)
+  const last = Math.max(0, rowCount - 1)
   for (let i = 0; i < 5; i++) await handle.arrayOp('swap', 0, last)
   const samples: number[] = []
   for (let i = 0; i < ARRAYOP_RUNS; i++) {
@@ -237,10 +296,8 @@ async function run(): Promise<BenchPayload> {
       case 'validate':
         return { ...base, unit: 'ms', summary: await measureValidate(handle), supported: true }
       case 'rerender': {
-        const summary = await measureRerender(handle, shape)
-        return summary === null
-          ? { ...base, unit: 'renders', summary: ZERO, supported: false }
-          : { ...base, unit: 'renders', summary, supported: true }
+        const result = await measureRerender(handle, shape, container)
+        return { ...base, unit: result.unit, summary: result.summary, supported: true }
       }
       case 'arrayAdd':
         return { ...base, unit: 'ms', summary: await measureArrayAdd(handle), supported: true }

--- a/apps/bench-arena/src/main.ts
+++ b/apps/bench-arena/src/main.ts
@@ -79,7 +79,11 @@ const MASSIVE_PLAN: SamplePlan = {
   warmup: 10,
   measure: 120,
   mountRuns: 7,
-  validateRuns: 40,
+  // A single full-form validate at 5,000 leaves is seconds on the heaviest
+  // library (TanStack, ~2.8s), so the run count stays low to keep the cell
+  // inside its budget under runner variance; the median is stable regardless,
+  // since a whole-form validate at this scale has low relative variance.
+  validateRuns: 25,
   rerenderRuns: 30,
   arrayOpRuns: 50,
   variantFlipRuns: 50,

--- a/apps/bench-arena/src/main.ts
+++ b/apps/bench-arena/src/main.ts
@@ -334,6 +334,16 @@ async function measureMount(
 }
 
 async function run(): Promise<BenchPayload> {
+  // Collect before this cell allocates anything, so the previous cell's heap
+  // cannot skew the measurement. The driver reuses one browser process across
+  // every cell of every scenario, so a heavy cell leaves residue that slows the
+  // next one: an isolated FormKit validate measured ~65s but ~240s when it
+  // followed heavy mount cells with no collection between them. This runs for
+  // every cell uniformly; the driver also collects after each cell, so the heap
+  // is clean at both ends. Requires --expose-gc (the driver passes it); a safe
+  // no-op without it.
+  ;(globalThis as { gc?: () => void }).gc?.()
+
   const q = readQuery()
   const adapter = adapters[q.adapter]
   if (!adapter) throw new Error(`bench: unknown adapter "${q.adapter}"`)

--- a/apps/bench-arena/src/main.ts
+++ b/apps/bench-arena/src/main.ts
@@ -53,6 +53,7 @@ const MOUNT_RUNS = 15
 const VALIDATE_RUNS = 100
 const RERENDER_RUNS = 30
 const ARRAYOP_RUNS = 50
+const VARIANTFLIP_RUNS = 50
 
 const ZERO: Summary = { median: 0, p95: 0, iqr: 0, count: 0, trimmed: 0 }
 
@@ -237,6 +238,26 @@ async function measureArrayReorder(handle: MountHandle, shape: ScenarioShape): P
   return summarize(samples)
 }
 
+/**
+ * Cross-variant flip: cycle the discriminant through every variant, replacing
+ * the whole union value each time. The library re-resolves the now-active
+ * branch (its discriminated-union handling) and the rendered field set swaps to
+ * the new variant. Each sample is one flip to the next variant in the cycle, so
+ * the union rotates through all of its shapes, every one of them valid.
+ */
+async function measureVariantFlip(handle: MountHandle, shape: ScenarioShape): Promise<Summary> {
+  const tags = shape.union?.variants.map((variant) => variant.tag) ?? []
+  if (tags.length === 0) throw new Error('bench: variantFlip needs a discriminated-union scenario')
+  const at = (i: number): string => tags[i % tags.length] as string
+  for (let i = 0; i < 5; i++) await handle.flipVariant(at(i))
+  const samples: number[] = []
+  for (let i = 0; i < VARIANTFLIP_RUNS; i++) {
+    samples.push(await timed(() => handle.flipVariant(at(5 + i))))
+    await frame()
+  }
+  return summarize(samples)
+}
+
 /** Mount/init cost over fresh mounts; the only dim that re-mounts per sample. */
 async function measureMount(adapter: BenchAdapter, opts: MountOpts): Promise<Summary> {
   const samples: number[] = []
@@ -306,6 +327,13 @@ async function run(): Promise<BenchPayload> {
           ...base,
           unit: 'ms',
           summary: await measureArrayReorder(handle, shape),
+          supported: true,
+        }
+      case 'variantFlip':
+        return {
+          ...base,
+          unit: 'ms',
+          summary: await measureVariantFlip(handle, shape),
           supported: true,
         }
       default:

--- a/apps/bench-arena/src/main.ts
+++ b/apps/bench-arena/src/main.ts
@@ -1,0 +1,232 @@
+import type {
+  BenchAdapter,
+  DimensionId,
+  MountHandle,
+  MountOpts,
+  ScenarioId,
+  ScenarioParams,
+  TriggerMode,
+} from './adapters/contract'
+import { adapters } from './adapters/registry'
+import { calibrate, frame, type Summary, summarize, timed } from './shared/clock'
+import { shapeFor } from './shared/scenarios'
+import type { ScenarioShape } from './shared/scenarios/types'
+
+/**
+ * The harness entry. It reads one (adapter, scenario, params, trigger,
+ * dimension) cell from the URL, mounts that single adapter, runs the
+ * dimension's protocol entirely in-page (only the final scalar summary crosses
+ * the Playwright boundary), and signals completion via `body[data-bench-done]`.
+ *
+ *   /?adapter=attaform&scenario=flat&params=F50&trigger=input&dim=keystroke
+ */
+
+interface BenchPayload {
+  adapter: string
+  scenario: string
+  params: ScenarioParams
+  trigger: string
+  dimension: string
+  /** Summary unit: milliseconds for timed dims, component renders for rerender. */
+  unit: 'ms' | 'renders'
+  summary: Summary
+  /** Machine-speed proxy so absolute numbers normalize across runners. */
+  calibrationMs: number
+  /** False when the library cannot express this scenario; summary is then zero. */
+  supported: boolean
+  error?: string
+}
+
+declare global {
+  interface Window {
+    __BENCH_RESULTS__?: BenchPayload
+  }
+}
+
+const WARMUP = 30
+const MEASURE = 200
+const MOUNT_RUNS = 15
+const VALIDATE_RUNS = 100
+const RERENDER_RUNS = 30
+
+const ZERO: Summary = { median: 0, p95: 0, iqr: 0, count: 0, trimmed: 0 }
+
+// Compact param labels (F50, D8, N1000, ...) decode to the scenario knobs.
+const CODE_TO_KEY: Record<string, string> = { F: 'fields', D: 'depth', N: 'rows', M: 'cols' }
+
+function parseParams(label: string): ScenarioParams {
+  const out: Record<string, number> = {}
+  const re = /([A-Za-z]+)(\d+)/g
+  let match: RegExpExecArray | null
+  while ((match = re.exec(label)) !== null) {
+    const code = match[1] ?? ''
+    out[CODE_TO_KEY[code] ?? code.toLowerCase()] = Number(match[2])
+  }
+  return out
+}
+
+interface Query {
+  adapter: string
+  scenario: ScenarioId
+  paramsLabel: string
+  params: ScenarioParams
+  trigger: TriggerMode
+  dim: DimensionId
+  seed: number
+}
+
+function readQuery(): Query {
+  const p = new URLSearchParams(window.location.search)
+  const paramsLabel = p.get('params') ?? 'F10'
+  return {
+    adapter: p.get('adapter') ?? 'attaform',
+    scenario: (p.get('scenario') ?? 'flat') as ScenarioId,
+    paramsLabel,
+    params: parseParams(paramsLabel),
+    trigger: (p.get('trigger') ?? 'input') as TriggerMode,
+    dim: (p.get('dim') ?? 'keystroke') as DimensionId,
+    seed: Number(p.get('seed') ?? '1'),
+  }
+}
+
+function makeContainer(): HTMLElement {
+  const host = document.getElementById('app') ?? document.body
+  const el = document.createElement('div')
+  host.appendChild(el)
+  return el
+}
+
+/** Keystroke latency: warm up, then time MEASURE round-robin keystrokes. */
+async function measureKeystroke(handle: MountHandle, shape: ScenarioShape): Promise<Summary> {
+  const fieldCount = shape.paths.length
+  for (let i = 0; i < WARMUP; i++) await handle.setFieldValue(i % fieldCount, `s${i}`)
+  const samples: number[] = []
+  for (let i = 0; i < MEASURE; i++) {
+    const index = i % fieldCount
+    samples.push(await timed(() => handle.typeChar(index, `s${WARMUP + i}`)))
+    await frame()
+  }
+  return summarize(samples)
+}
+
+/** Full-form validation throughput. */
+async function measureValidate(handle: MountHandle): Promise<Summary> {
+  for (let i = 0; i < 5; i++) await handle.validateAll()
+  const samples: number[] = []
+  for (let i = 0; i < VALIDATE_RUNS; i++) {
+    samples.push(await timed(() => handle.validateAll()))
+    await frame()
+  }
+  return summarize(samples)
+}
+
+/** Components re-rendered per keystroke. Null render count => unsupported here. */
+async function measureRerender(handle: MountHandle, shape: ScenarioShape): Promise<Summary | null> {
+  const fieldCount = shape.paths.length
+  const counts: number[] = []
+  for (let i = 0; i < RERENDER_RUNS; i++) {
+    handle.resetRenderCount()
+    await handle.typeChar(i % fieldCount, `r${i}`)
+    const count = handle.getRenderCount()
+    if (count === null) return null
+    counts.push(count)
+    await frame()
+  }
+  return summarize(counts)
+}
+
+/** Mount/init cost over fresh mounts; the only dim that re-mounts per sample. */
+async function measureMount(adapter: BenchAdapter, opts: MountOpts): Promise<Summary> {
+  const samples: number[] = []
+  for (let i = 0; i < MOUNT_RUNS; i++) {
+    const container = makeContainer()
+    let handle: MountHandle | undefined
+    samples.push(
+      await timed(async () => {
+        handle = await adapter.mount(container, opts)
+      })
+    )
+    handle?.teardown()
+    container.remove()
+    await frame()
+  }
+  return summarize(samples)
+}
+
+async function run(): Promise<BenchPayload> {
+  const q = readQuery()
+  const adapter = adapters[q.adapter]
+  if (!adapter) throw new Error(`bench: unknown adapter "${q.adapter}"`)
+
+  const shape = shapeFor(q.scenario, q.params)
+  const opts: MountOpts = {
+    scenario: q.scenario,
+    params: q.params,
+    trigger: q.trigger,
+    seed: q.seed,
+  }
+  const calibrationMs = calibrate()
+
+  const base = {
+    adapter: q.adapter,
+    scenario: q.scenario,
+    params: q.params,
+    trigger: q.trigger,
+    dimension: q.dim,
+    calibrationMs,
+  }
+
+  if (q.dim === 'mount') {
+    return { ...base, unit: 'ms', summary: await measureMount(adapter, opts), supported: true }
+  }
+
+  const container = makeContainer()
+  const handle = await adapter.mount(container, opts)
+  try {
+    switch (q.dim) {
+      case 'keystroke':
+        return {
+          ...base,
+          unit: 'ms',
+          summary: await measureKeystroke(handle, shape),
+          supported: true,
+        }
+      case 'validate':
+        return { ...base, unit: 'ms', summary: await measureValidate(handle), supported: true }
+      case 'rerender': {
+        const summary = await measureRerender(handle, shape)
+        return summary === null
+          ? { ...base, unit: 'renders', summary: ZERO, supported: false }
+          : { ...base, unit: 'renders', summary, supported: true }
+      }
+      default:
+        throw new Error(`bench: dimension "${q.dim}" is not implemented yet`)
+    }
+  } finally {
+    handle.teardown()
+    container.remove()
+  }
+}
+
+run()
+  .then((payload) => {
+    window.__BENCH_RESULTS__ = payload
+  })
+  .catch((err: unknown) => {
+    const q = readQuery()
+    window.__BENCH_RESULTS__ = {
+      adapter: q.adapter,
+      scenario: q.scenario,
+      params: q.params,
+      trigger: q.trigger,
+      dimension: q.dim,
+      unit: 'ms',
+      summary: ZERO,
+      calibrationMs: 0,
+      supported: false,
+      error: err instanceof Error ? err.message : String(err),
+    }
+  })
+  .finally(() => {
+    document.body.dataset['benchDone'] = '1'
+  })

--- a/apps/bench-arena/src/main.ts
+++ b/apps/bench-arena/src/main.ts
@@ -160,7 +160,13 @@ function parseParams(label: string): ScenarioParams {
   let match: RegExpExecArray | null
   while ((match = re.exec(label)) !== null) {
     const code = match[1] ?? ''
-    out[CODE_TO_KEY[code] ?? code.toLowerCase()] = Number(match[2])
+    // Only the fixed scenario knobs (F/D/N/M/L/S) are valid keys. A code
+    // outside the allowlist is skipped rather than used as a property
+    // name, so the URL `params` query can never write an arbitrary
+    // property (CodeQL js/remote-property-injection).
+    const key = CODE_TO_KEY[code]
+    if (key === undefined) continue
+    out[key] = Number(match[2])
   }
   return out
 }

--- a/apps/bench-arena/src/main.ts
+++ b/apps/bench-arena/src/main.ts
@@ -47,18 +47,58 @@ declare global {
   }
 }
 
-const WARMUP = 30
-const MEASURE = 200
-const MOUNT_RUNS = 15
-const VALIDATE_RUNS = 100
-const RERENDER_RUNS = 30
-const ARRAYOP_RUNS = 50
-const VARIANTFLIP_RUNS = 50
+/**
+ * Per-cell sample counts. The massive scenario mounts thousands of inputs, so a
+ * single fresh mount runs on the order of seconds for the heavier libraries; its
+ * counts are trimmed (uniformly across the whole cohort, so the comparison stays
+ * fair) to keep each cell inside the driver's per-cell time budget. Mount and
+ * validation cost at that scale have low relative variance, so the smaller
+ * median is still stable. Every other scenario keeps the full counts.
+ */
+interface SamplePlan {
+  readonly warmup: number
+  readonly measure: number
+  readonly mountRuns: number
+  readonly validateRuns: number
+  readonly rerenderRuns: number
+  readonly arrayOpRuns: number
+  readonly variantFlipRuns: number
+}
+
+const DEFAULT_PLAN: SamplePlan = {
+  warmup: 30,
+  measure: 200,
+  mountRuns: 15,
+  validateRuns: 100,
+  rerenderRuns: 30,
+  arrayOpRuns: 50,
+  variantFlipRuns: 50,
+}
+
+const MASSIVE_PLAN: SamplePlan = {
+  warmup: 10,
+  measure: 120,
+  mountRuns: 7,
+  validateRuns: 40,
+  rerenderRuns: 30,
+  arrayOpRuns: 50,
+  variantFlipRuns: 50,
+}
+
+function planFor(scenario: ScenarioId): SamplePlan {
+  return scenario === 'massive' ? MASSIVE_PLAN : DEFAULT_PLAN
+}
 
 const ZERO: Summary = { median: 0, p95: 0, iqr: 0, count: 0, trimmed: 0 }
 
 // Compact param labels (F50, D8, N1000, ...) decode to the scenario knobs.
-const CODE_TO_KEY: Record<string, string> = { F: 'fields', D: 'depth', N: 'rows', M: 'cols' }
+const CODE_TO_KEY: Record<string, string> = {
+  F: 'fields',
+  D: 'depth',
+  N: 'rows',
+  M: 'cols',
+  L: 'leaves',
+}
 
 function parseParams(label: string): ScenarioParams {
   const out: Record<string, number> = {}
@@ -102,24 +142,28 @@ function makeContainer(): HTMLElement {
   return el
 }
 
-/** Keystroke latency: warm up, then time MEASURE round-robin keystrokes. */
-async function measureKeystroke(handle: MountHandle, shape: ScenarioShape): Promise<Summary> {
+/** Keystroke latency: warm up, then time `plan.measure` round-robin keystrokes. */
+async function measureKeystroke(
+  handle: MountHandle,
+  shape: ScenarioShape,
+  plan: SamplePlan
+): Promise<Summary> {
   const fieldCount = shape.paths.length
-  for (let i = 0; i < WARMUP; i++) await handle.setFieldValue(i % fieldCount, `s${i}`)
+  for (let i = 0; i < plan.warmup; i++) await handle.setFieldValue(i % fieldCount, `s${i}`)
   const samples: number[] = []
-  for (let i = 0; i < MEASURE; i++) {
+  for (let i = 0; i < plan.measure; i++) {
     const index = i % fieldCount
-    samples.push(await timed(() => handle.typeChar(index, `s${WARMUP + i}`)))
+    samples.push(await timed(() => handle.typeChar(index, `s${plan.warmup + i}`)))
     await frame()
   }
   return summarize(samples)
 }
 
 /** Full-form validation throughput. */
-async function measureValidate(handle: MountHandle): Promise<Summary> {
+async function measureValidate(handle: MountHandle, plan: SamplePlan): Promise<Summary> {
   for (let i = 0; i < 5; i++) await handle.validateAll()
   const samples: number[] = []
-  for (let i = 0; i < VALIDATE_RUNS; i++) {
+  for (let i = 0; i < plan.validateRuns; i++) {
     samples.push(await timed(() => handle.validateAll()))
     await frame()
   }
@@ -151,7 +195,8 @@ interface RerenderResult {
 async function measureRerender(
   handle: MountHandle,
   shape: ScenarioShape,
-  container: HTMLElement
+  container: HTMLElement,
+  plan: SamplePlan
 ): Promise<RerenderResult> {
   const fieldCount = shape.paths.length
   const renderCounts: number[] = []
@@ -169,7 +214,7 @@ async function measureRerender(
     characterData: true,
   })
 
-  for (let i = 0; i < RERENDER_RUNS; i++) {
+  for (let i = 0; i < plan.rerenderRuns; i++) {
     handle.resetRenderCount()
     observer.takeRecords()
     delivered = 0
@@ -196,13 +241,13 @@ async function measureRerender(
  * reactive reflow of the rendered list. Size-stable so every sample starts from
  * the same N, and the appended row is valid so no error state churns.
  */
-async function measureArrayAdd(handle: MountHandle): Promise<Summary> {
+async function measureArrayAdd(handle: MountHandle, plan: SamplePlan): Promise<Summary> {
   for (let i = 0; i < 5; i++) {
     await handle.arrayOp('append')
     await handle.arrayOp('remove')
   }
   const samples: number[] = []
-  for (let i = 0; i < ARRAYOP_RUNS; i++) {
+  for (let i = 0; i < plan.arrayOpRuns; i++) {
     samples.push(
       await timed(async () => {
         await handle.arrayOp('append')
@@ -221,7 +266,11 @@ async function measureArrayAdd(handle: MountHandle): Promise<Summary> {
  * array swap plus the reactive settle. Each sample swaps back, so the array
  * alternates between two orderings of equal cost.
  */
-async function measureArrayReorder(handle: MountHandle, shape: ScenarioShape): Promise<Summary> {
+async function measureArrayReorder(
+  handle: MountHandle,
+  shape: ScenarioShape,
+  plan: SamplePlan
+): Promise<Summary> {
   // The swap exchanges two ROWS (array elements), so the index lives in row
   // space, not the flat input index. For a multi-column grid the input count
   // (paths.length) is rows x columns, so divide by the column count to recover
@@ -231,7 +280,7 @@ async function measureArrayReorder(handle: MountHandle, shape: ScenarioShape): P
   const last = Math.max(0, rowCount - 1)
   for (let i = 0; i < 5; i++) await handle.arrayOp('swap', 0, last)
   const samples: number[] = []
-  for (let i = 0; i < ARRAYOP_RUNS; i++) {
+  for (let i = 0; i < plan.arrayOpRuns; i++) {
     samples.push(await timed(() => handle.arrayOp('swap', 0, last)))
     await frame()
   }
@@ -245,13 +294,17 @@ async function measureArrayReorder(handle: MountHandle, shape: ScenarioShape): P
  * the new variant. Each sample is one flip to the next variant in the cycle, so
  * the union rotates through all of its shapes, every one of them valid.
  */
-async function measureVariantFlip(handle: MountHandle, shape: ScenarioShape): Promise<Summary> {
+async function measureVariantFlip(
+  handle: MountHandle,
+  shape: ScenarioShape,
+  plan: SamplePlan
+): Promise<Summary> {
   const tags = shape.union?.variants.map((variant) => variant.tag) ?? []
   if (tags.length === 0) throw new Error('bench: variantFlip needs a discriminated-union scenario')
   const at = (i: number): string => tags[i % tags.length] as string
   for (let i = 0; i < 5; i++) await handle.flipVariant(at(i))
   const samples: number[] = []
-  for (let i = 0; i < VARIANTFLIP_RUNS; i++) {
+  for (let i = 0; i < plan.variantFlipRuns; i++) {
     samples.push(await timed(() => handle.flipVariant(at(5 + i))))
     await frame()
   }
@@ -259,9 +312,13 @@ async function measureVariantFlip(handle: MountHandle, shape: ScenarioShape): Pr
 }
 
 /** Mount/init cost over fresh mounts; the only dim that re-mounts per sample. */
-async function measureMount(adapter: BenchAdapter, opts: MountOpts): Promise<Summary> {
+async function measureMount(
+  adapter: BenchAdapter,
+  opts: MountOpts,
+  plan: SamplePlan
+): Promise<Summary> {
   const samples: number[] = []
-  for (let i = 0; i < MOUNT_RUNS; i++) {
+  for (let i = 0; i < plan.mountRuns; i++) {
     const container = makeContainer()
     let handle: MountHandle | undefined
     samples.push(
@@ -289,6 +346,7 @@ async function run(): Promise<BenchPayload> {
     seed: q.seed,
   }
   const calibrationMs = calibrate()
+  const plan = planFor(q.scenario)
 
   const base = {
     adapter: q.adapter,
@@ -300,7 +358,12 @@ async function run(): Promise<BenchPayload> {
   }
 
   if (q.dim === 'mount') {
-    return { ...base, unit: 'ms', summary: await measureMount(adapter, opts), supported: true }
+    return {
+      ...base,
+      unit: 'ms',
+      summary: await measureMount(adapter, opts, plan),
+      supported: true,
+    }
   }
 
   const container = makeContainer()
@@ -311,29 +374,39 @@ async function run(): Promise<BenchPayload> {
         return {
           ...base,
           unit: 'ms',
-          summary: await measureKeystroke(handle, shape),
+          summary: await measureKeystroke(handle, shape, plan),
           supported: true,
         }
       case 'validate':
-        return { ...base, unit: 'ms', summary: await measureValidate(handle), supported: true }
+        return {
+          ...base,
+          unit: 'ms',
+          summary: await measureValidate(handle, plan),
+          supported: true,
+        }
       case 'rerender': {
-        const result = await measureRerender(handle, shape, container)
+        const result = await measureRerender(handle, shape, container, plan)
         return { ...base, unit: result.unit, summary: result.summary, supported: true }
       }
       case 'arrayAdd':
-        return { ...base, unit: 'ms', summary: await measureArrayAdd(handle), supported: true }
+        return {
+          ...base,
+          unit: 'ms',
+          summary: await measureArrayAdd(handle, plan),
+          supported: true,
+        }
       case 'arrayReorder':
         return {
           ...base,
           unit: 'ms',
-          summary: await measureArrayReorder(handle, shape),
+          summary: await measureArrayReorder(handle, shape, plan),
           supported: true,
         }
       case 'variantFlip':
         return {
           ...base,
           unit: 'ms',
-          summary: await measureVariantFlip(handle, shape),
+          summary: await measureVariantFlip(handle, shape, plan),
           supported: true,
         }
       default:

--- a/apps/bench-arena/src/shared/clock.ts
+++ b/apps/bench-arena/src/shared/clock.ts
@@ -58,7 +58,7 @@ export async function timed(op: () => Promise<void>): Promise<number> {
 }
 
 export interface Summary {
-  /** Median over the kept samples, in milliseconds. */
+  /** Median over the kept samples, in the dimension's unit. */
   median: number
   /** 95th percentile over the kept samples. */
   p95: number

--- a/apps/bench-arena/src/shared/clock.ts
+++ b/apps/bench-arena/src/shared/clock.ts
@@ -1,0 +1,119 @@
+import { nextTick } from 'vue'
+
+/**
+ * Reactive-settle barriers, applied identically after every edit so they
+ * cannot bias one library over another.
+ *
+ * A form library can defer per-keystroke work to three places:
+ *   1. a macrotask (`setTimeout(0)`) - Attaform's 0ms validation debounce,
+ *      FormKit's commit. Our timer is queued AFTER the edit dispatched the
+ *      library's, so it fires once that work has run;
+ *   2. the Vue scheduler (microtasks) - component updates the edit queued. Two
+ *      `nextTick` waves: the first flushes them, the second catches updates a
+ *      watcher scheduled during that first flush;
+ *   3. an animation frame - paint-adjacent commits.
+ *
+ * `flush()` drains (1) and (2): it is the barrier the keystroke clock measures
+ * to, because folding rAF's frame latency into a sub-millisecond keystroke
+ * would swamp the signal. `settle()` adds the frame and is used between
+ * samples and for non-latency dimensions, so a library that commits on rAF is
+ * fully caught before the next sample begins.
+ */
+export function flush(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      void nextTick()
+        .then(() => nextTick())
+        .then(() => resolve())
+    }, 0)
+  })
+}
+
+/** One animation frame; the unmeasured paint gate between samples. */
+export function frame(): Promise<void> {
+  return new Promise((resolve) => {
+    requestAnimationFrame(() => resolve())
+  })
+}
+
+/** The full barrier: drain async reactive work, then wait one paint frame. */
+export async function settle(): Promise<void> {
+  await flush()
+  await frame()
+}
+
+/**
+ * Wall-clock milliseconds for one already-self-settling operation.
+ *
+ * Every `MountHandle` method does its work and then awaits the shared
+ * `flush()` before resolving, so the settle barrier is identical across the
+ * whole cohort (no adapter can substitute its own). The driver times the
+ * awaited call directly: the figure is the library's per-edit cost plus the
+ * single, constant `setTimeout(0)` floor every adapter pays equally.
+ */
+export async function timed(op: () => Promise<void>): Promise<number> {
+  const start = performance.now()
+  await op()
+  return performance.now() - start
+}
+
+export interface Summary {
+  /** Median over the kept samples, in milliseconds. */
+  median: number
+  /** 95th percentile over the kept samples. */
+  p95: number
+  /** Interquartile range of the raw samples (the trim ceiling input). */
+  iqr: number
+  /** Samples kept after trimming. */
+  count: number
+  /** Samples dropped as GC-suspect (above median + 3 x IQR). */
+  trimmed: number
+}
+
+function quantile(sorted: readonly number[], q: number): number {
+  if (sorted.length === 0) return 0
+  const pos = q * (sorted.length - 1)
+  const lo = Math.floor(pos)
+  const hi = Math.ceil(pos)
+  const loV = sorted[lo] ?? 0
+  const hiV = sorted[hi] ?? loV
+  return loV + (hiV - loV) * (pos - lo)
+}
+
+/**
+ * Median + p95 + IQR over samples, trimming GC-suspect outliers (anything
+ * above median + 3 x IQR) and recording how many were dropped. The robust
+ * statistics keep a stray garbage-collection pause from moving the headline.
+ */
+export function summarize(samples: readonly number[]): Summary {
+  const sorted = [...samples].sort((a, b) => a - b)
+  const q1 = quantile(sorted, 0.25)
+  const q3 = quantile(sorted, 0.75)
+  const iqr = q3 - q1
+  const ceiling = quantile(sorted, 0.5) + 3 * iqr
+  const kept = sorted.filter((s) => s <= ceiling)
+  return {
+    median: quantile(kept, 0.5),
+    p95: quantile(kept, 0.95),
+    iqr,
+    count: kept.length,
+    trimmed: sorted.length - kept.length,
+  }
+}
+
+/**
+ * A fixed, allocation-light arithmetic workload timed once per run. Its
+ * wall-clock duration is a proxy for the machine's single-core speed, so the
+ * docs can normalize absolute milliseconds across runners (a fast laptop and a
+ * slower CI box differ by this factor). Pure compute: no DOM, no GC churn.
+ */
+export function calibrate(): number {
+  const start = performance.now()
+  let acc = 0
+  for (let r = 0; r < 4000; r++) {
+    for (let i = 1; i < 1000; i++) acc += Math.sqrt(i) * 1.0000001
+  }
+  // Consume the accumulator so the loop cannot be optimized away.
+  if (!Number.isFinite(acc)) throw new Error('calibration diverged')
+  return performance.now() - start
+}

--- a/apps/bench-arena/src/shared/dom-driver.ts
+++ b/apps/bench-arena/src/shared/dom-driver.ts
@@ -1,0 +1,47 @@
+import type { TriggerMode } from '../adapters/contract'
+import { flush } from './clock'
+
+/** Locate a rendered bare input by its stable index. */
+function inputAt(container: HTMLElement, index: number): HTMLInputElement {
+  const el = container.querySelector<HTMLInputElement>(`[data-bench-field="${index}"]`)
+  if (!el) throw new Error(`bench: no input [data-bench-field="${index}"] mounted`)
+  return el
+}
+
+/** Set the value and fire the native `input` event a real keystroke produces. */
+export function domType(container: HTMLElement, index: number, value: string): void {
+  const el = inputAt(container, index)
+  el.value = value
+  el.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
+/** Fire the native `blur` event (the on-blur trigger pass). */
+export function domBlur(container: HTMLElement, index: number): void {
+  inputAt(container, index).dispatchEvent(new Event('blur', { bubbles: true }))
+}
+
+/**
+ * The shared keystroke path every bare-input adapter reuses, so the DOM event
+ * sequence is identical across the cohort: a keystroke is a value set plus a
+ * native `input`, with an added `blur` when the trigger under test is on-blur.
+ * It awaits the shared `flush()`, so the settle barrier is the same everywhere
+ * and the driver simply times the awaited call.
+ *
+ * `typeChar` (measured) and `setFieldValue` (unmeasured warmup / seeding) take
+ * the same path; only the driver's choice to time one and not the other
+ * distinguishes them.
+ */
+export function domDriver(
+  container: HTMLElement,
+  trigger: TriggerMode
+): {
+  typeChar: (index: number, value: string) => Promise<void>
+  setFieldValue: (index: number, value: string) => Promise<void>
+} {
+  const keystroke = async (index: number, value: string): Promise<void> => {
+    domType(container, index, value)
+    if (trigger === 'blur') domBlur(container, index)
+    await flush()
+  }
+  return { typeChar: keystroke, setFieldValue: keystroke }
+}

--- a/apps/bench-arena/src/shared/render-count.ts
+++ b/apps/bench-arena/src/shared/render-count.ts
@@ -1,0 +1,31 @@
+/**
+ * Per-field render counter shared by the bare-input field component.
+ *
+ * The harness mounts exactly one adapter per page load, so a module-global
+ * counter never crosses library boundaries. The driver resets it, drives one
+ * edit, settles, and reads how many field components re-rendered: the
+ * render-scope signal. A granular library re-renders only the edited field
+ * (total ~ 1); an O(F) library wakes every sibling (total ~ F).
+ *
+ * This counts ACTUAL render-function invocations (bumped in the render body),
+ * not scheduler triggers, so coalesced updates are never double-counted.
+ */
+const counts = new Map<number, number>()
+
+export function recordRender(index: number): void {
+  counts.set(index, (counts.get(index) ?? 0) + 1)
+}
+
+export function resetRenderCounts(): void {
+  counts.clear()
+}
+
+export function totalRenders(): number {
+  let total = 0
+  for (const n of counts.values()) total += n
+  return total
+}
+
+export function renderCountFor(index: number): number {
+  return counts.get(index) ?? 0
+}

--- a/apps/bench-arena/src/shared/scenarios/arrays.ts
+++ b/apps/bench-arena/src/shared/scenarios/arrays.ts
@@ -17,6 +17,18 @@ const MIN_LENGTH = 2
 /** A valid seed value (length >= MIN_LENGTH) so every row validates. */
 const SEED = 'seed'
 
+/**
+ * Each row seeds to a DISTINCT valid value (`seed-0`, `seed-1`, ...). Distinct
+ * row content is what makes the reorder dimension meaningful: swapping two rows
+ * changes the value displayed at each, which forces an index-keyed list to
+ * re-render the two positions and an identity-keyed list to move the two DOM
+ * nodes. Identical rows would mask that cost, so a swap would measure almost
+ * nothing for every library.
+ */
+function seedFor(index: number): string {
+  return `${SEED}-${index}`
+}
+
 /** Row count, defaulted defensively. */
 function rowsOf(params: ScenarioParams): number {
   return params.rows ?? 100
@@ -28,7 +40,7 @@ export function arraysShape(params: ScenarioParams): ScenarioShape {
   const rows: Array<{ v: string }> = []
   for (let i = 0; i < n; i++) {
     paths.push(`rows.${i}.v`)
-    rows.push({ v: SEED })
+    rows.push({ v: seedFor(i) })
   }
   return {
     paths,
@@ -38,6 +50,8 @@ export function arraysShape(params: ScenarioParams): ScenarioShape {
     keystrokeIndex: Math.max(0, n - 1),
     arrayPath: 'rows',
     arrayItemRules: { v: { minLength: MIN_LENGTH } },
+    arrayItemFields: ['v'],
+    newRow: () => ({ v: SEED }),
   }
 }
 

--- a/apps/bench-arena/src/shared/scenarios/arrays.ts
+++ b/apps/bench-arena/src/shared/scenarios/arrays.ts
@@ -1,0 +1,63 @@
+/**
+ * Dynamic-array scenario: one array of N single-field row objects (`rows[i].v`),
+ * swept over N. The headline is array behavior at scale: how a library's
+ * per-keystroke cost into a row, its mount cost, and (the arrayOp dimension) its
+ * reorder cost grow with row count, and how widely a single row edit re-renders
+ * (granular libraries re-render one row, whole-form libraries re-render all N).
+ * One text field per row keeps the DOM identical across the cohort.
+ */
+import * as v from 'valibot'
+import { z } from 'zod'
+import type { ScenarioParams } from '../../adapters/contract'
+import { type NativeRule, type ScenarioShape } from './types'
+
+/** Minimum length each row's field must satisfy; the uniform constraint. */
+const MIN_LENGTH = 2
+
+/** A valid seed value (length >= MIN_LENGTH) so every row validates. */
+const SEED = 'seed'
+
+/** Row count, defaulted defensively. */
+function rowsOf(params: ScenarioParams): number {
+  return params.rows ?? 100
+}
+
+export function arraysShape(params: ScenarioParams): ScenarioShape {
+  const n = rowsOf(params)
+  const paths: string[] = []
+  const rows: Array<{ v: string }> = []
+  for (let i = 0; i < n; i++) {
+    paths.push(`rows.${i}.v`)
+    rows.push({ v: SEED })
+  }
+  return {
+    paths,
+    defaultValues: { rows },
+    // The last row: a single-row edit costs the same wherever it lands, and a
+    // fixed index keeps path resolution constant across the sweep.
+    keystrokeIndex: Math.max(0, n - 1),
+    arrayPath: 'rows',
+    arrayItemRules: { v: { minLength: MIN_LENGTH } },
+  }
+}
+
+/** zod v3 schema shared by every zod-capable adapter. */
+export function arraysZod3(_params: ScenarioParams): z.ZodTypeAny {
+  return z.object({ rows: z.array(z.object({ v: z.string().min(MIN_LENGTH) })) })
+}
+
+/** valibot mirror for formisch. */
+export function arraysValibot(_params: ScenarioParams): v.GenericSchema {
+  return v.object({
+    rows: v.array(v.object({ v: v.pipe(v.string(), v.minLength(MIN_LENGTH)) })),
+  })
+}
+
+/**
+ * Native-rule mirror for object leaves. An array scenario has none (its per-item
+ * constraint travels on the shape's `arrayItemRules`, which the native-validator
+ * adapters turn into a `$each` collection rule), so this is empty.
+ */
+export function arraysNative(_params: ScenarioParams): Record<string, NativeRule> {
+  return {}
+}

--- a/apps/bench-arena/src/shared/scenarios/discriminated-union.ts
+++ b/apps/bench-arena/src/shared/scenarios/discriminated-union.ts
@@ -1,0 +1,125 @@
+/**
+ * Discriminated-union scenario: an `event` object that is one of three
+ * variants, each tagged by a `kind` discriminant (`click` / `scroll` /
+ * `keypress`) and carrying its own text fields. Only the active variant's
+ * fields are rendered, so the headline is how a library handles writing into
+ * and flipping between branches: a discriminant-aware library resolves the path
+ * within the active branch alone, while a plain union walks every option. The
+ * default active variant is `click`, so the keystroke and re-render dimensions
+ * drive its fields; the variantFlip dimension cycles the discriminant through
+ * all three. Every field is a uniform-constraint text input, so the DOM stays
+ * identical across the cohort.
+ */
+import * as v from 'valibot'
+import { z } from 'zod'
+import type { ScenarioParams } from '../../adapters/contract'
+import { type NativeRule, type ScenarioShape } from './types'
+
+/** Minimum length each variant field must satisfy; the uniform constraint. */
+const MIN_LENGTH = 2
+
+/** A valid seed value (length >= MIN_LENGTH) so every variant validates. */
+const SEED = 'seed'
+
+/** The object the union occupies; a flip replaces this whole value. */
+const UNION_PATH = 'event'
+
+/** The discriminant key within the union object. */
+const DISCRIMINANT = 'kind'
+
+/** The default active variant (first rendered, and what keystroke drives). */
+const DEFAULT_VARIANT = { tag: 'click', fields: ['x', 'y'] }
+
+/**
+ * The variants, each its discriminant value plus its own non-discriminant text
+ * fields. The shapes deliberately differ in field count (2 / 1 / 2), so a flip
+ * genuinely swaps the rendered field set rather than relabeling a fixed one.
+ */
+const VARIANTS: ReadonlyArray<{ tag: string; fields: readonly string[] }> = [
+  DEFAULT_VARIANT,
+  { tag: 'scroll', fields: ['delta'] },
+  { tag: 'keypress', fields: ['code', 'meta'] },
+]
+
+/** A full valid value for one variant (`{ kind, ...fields: SEED }`). */
+function variantValue(tag: string, fields: readonly string[]): Record<string, unknown> {
+  const value: Record<string, unknown> = { [DISCRIMINANT]: tag }
+  for (const f of fields) value[f] = SEED
+  return value
+}
+
+export function discriminatedUnionShape(_params: ScenarioParams): ScenarioShape {
+  const variants = VARIANTS.map((variant) => ({
+    tag: variant.tag,
+    fieldPaths: variant.fields.map((f) => `${UNION_PATH}.${f}`),
+    value: variantValue(variant.tag, variant.fields),
+  }))
+  return {
+    paths: DEFAULT_VARIANT.fields.map((f) => `${UNION_PATH}.${f}`),
+    defaultValues: { [UNION_PATH]: variantValue(DEFAULT_VARIANT.tag, DEFAULT_VARIANT.fields) },
+    keystrokeIndex: 0,
+    union: {
+      unionPath: UNION_PATH,
+      discriminantPath: `${UNION_PATH}.${DISCRIMINANT}`,
+      variants,
+    },
+  }
+}
+
+/**
+ * zod v3 schema shared by every zod-capable adapter. The discriminated union is
+ * spelled out literally: zod keys the branch by the `kind` literal, so the
+ * options cannot be built from a loop without losing the literal types.
+ */
+export function discriminatedUnionZod3(_params: ScenarioParams): z.ZodTypeAny {
+  return z.object({
+    [UNION_PATH]: z.discriminatedUnion(DISCRIMINANT, [
+      z.object({
+        kind: z.literal('click'),
+        x: z.string().min(MIN_LENGTH),
+        y: z.string().min(MIN_LENGTH),
+      }),
+      z.object({ kind: z.literal('scroll'), delta: z.string().min(MIN_LENGTH) }),
+      z.object({
+        kind: z.literal('keypress'),
+        code: z.string().min(MIN_LENGTH),
+        meta: z.string().min(MIN_LENGTH),
+      }),
+    ]),
+  })
+}
+
+/** valibot mirror for formisch (`v.variant` is its discriminated union). */
+export function discriminatedUnionValibot(_params: ScenarioParams): v.GenericSchema {
+  return v.object({
+    [UNION_PATH]: v.variant(DISCRIMINANT, [
+      v.object({
+        kind: v.literal('click'),
+        x: v.pipe(v.string(), v.minLength(MIN_LENGTH)),
+        y: v.pipe(v.string(), v.minLength(MIN_LENGTH)),
+      }),
+      v.object({ kind: v.literal('scroll'), delta: v.pipe(v.string(), v.minLength(MIN_LENGTH)) }),
+      v.object({
+        kind: v.literal('keypress'),
+        code: v.pipe(v.string(), v.minLength(MIN_LENGTH)),
+        meta: v.pipe(v.string(), v.minLength(MIN_LENGTH)),
+      }),
+    ]),
+  })
+}
+
+/**
+ * Native-rule mirror for the headless-validation-only libraries (Regle rules
+ * mode, Vuelidate), which have no schema and so hand-roll the union. Every
+ * variant's field carries the same minimum-length rule across the whole union;
+ * a rule whose field is absent under the current variant stays dormant
+ * (minimum-length passes an empty/absent optional value), so the active
+ * variant's fields validate and the inactive ones never raise a false error.
+ */
+export function discriminatedUnionNative(_params: ScenarioParams): Record<string, NativeRule> {
+  const rules: Record<string, NativeRule> = {}
+  for (const variant of VARIANTS) {
+    for (const f of variant.fields) rules[`${UNION_PATH}.${f}`] = { minLength: MIN_LENGTH }
+  }
+  return rules
+}

--- a/apps/bench-arena/src/shared/scenarios/flat.ts
+++ b/apps/bench-arena/src/shared/scenarios/flat.ts
@@ -1,0 +1,63 @@
+/**
+ * Flat scenario: F sibling string leaves at depth 1. The headline shape, swept
+ * over F to expose how each library's per-keystroke cost and render scope scale
+ * with field count.
+ *
+ * Every leaf carries the SAME light constraint (a minimum length), so the
+ * validation work is uniform across fields and the DOM is identical (all text
+ * inputs). A flat baseline deliberately avoids mixed types: per-field type
+ * coercion differs library to library and would smuggle an unfair asymmetry
+ * into the simplest comparison. Genuine mixed types live in the massive
+ * scenario, where the realism is the point and coercion is handled evenly.
+ */
+import * as v from 'valibot'
+import { z } from 'zod'
+import type { ScenarioParams } from '../../adapters/contract'
+import { fieldCount, type NativeRule, type ScenarioShape } from './types'
+
+/** Minimum length every flat leaf must satisfy; the uniform constraint. */
+const MIN_LENGTH = 2
+
+/** A valid seed value (length >= MIN_LENGTH) so the baseline tree validates. */
+const SEED = 'seed'
+
+export function flatShape(params: ScenarioParams): ScenarioShape {
+  const F = fieldCount(params)
+  const paths: string[] = []
+  const defaultValues: Record<string, unknown> = {}
+  for (let i = 0; i < F; i++) {
+    paths.push(`f${i}`)
+    defaultValues[`f${i}`] = SEED
+  }
+  return {
+    paths,
+    defaultValues,
+    // The last field: for a flat object a single-scalar write costs the same
+    // wherever it lands, and a fixed index keeps path resolution constant.
+    keystrokeIndex: Math.max(0, F - 1),
+  }
+}
+
+/** zod v3 schema shared by Attaform, vee-validate, TanStack, FormKit, Regle (schema). */
+export function flatZod3(params: ScenarioParams): z.ZodTypeAny {
+  const F = fieldCount(params)
+  const shape: Record<string, z.ZodTypeAny> = {}
+  for (let i = 0; i < F; i++) shape[`f${i}`] = z.string().min(MIN_LENGTH)
+  return z.object(shape)
+}
+
+/** valibot mirror for formisch. */
+export function flatValibot(params: ScenarioParams): v.GenericSchema {
+  const F = fieldCount(params)
+  const entries: Record<string, v.GenericSchema> = {}
+  for (let i = 0; i < F; i++) entries[`f${i}`] = v.pipe(v.string(), v.minLength(MIN_LENGTH))
+  return v.object(entries)
+}
+
+/** Native-rule mirror for Regle (rules mode) and Vuelidate. */
+export function flatNative(params: ScenarioParams): Record<string, NativeRule> {
+  const F = fieldCount(params)
+  const rules: Record<string, NativeRule> = {}
+  for (let i = 0; i < F; i++) rules[`f${i}`] = { minLength: MIN_LENGTH }
+  return rules
+}

--- a/apps/bench-arena/src/shared/scenarios/grid.ts
+++ b/apps/bench-arena/src/shared/scenarios/grid.ts
@@ -1,0 +1,108 @@
+/**
+ * Grid scenario: an array of N row objects, each with M text columns
+ * (`rows.{i}.c{j}`), the line-items editor every invoice, order, or timesheet
+ * form is. Swept over rows (N) and columns (M). It folds an array's length
+ * reactivity together with a row's object nesting, so the headline is
+ * edit-one-cell render scope: typing into a single cell should wake only that
+ * cell, not its row siblings and not the other rows. A granular library
+ * re-renders one cell; a whole-form library re-renders the whole grid. The
+ * grid reuses the array machinery (one `arrayPath` with M `arrayItemFields`),
+ * so every adapter renders it through the same reactive row path it uses for
+ * the single-column array. One text input per cell keeps the DOM identical
+ * across the cohort.
+ */
+import * as v from 'valibot'
+import { z } from 'zod'
+import type { ScenarioParams } from '../../adapters/contract'
+import { type NativeRule, type ScenarioShape } from './types'
+
+/** Minimum length each cell must satisfy; the uniform constraint. */
+const MIN_LENGTH = 2
+
+/** A valid seed value (length >= MIN_LENGTH) so every cell validates. */
+const SEED = 'seed'
+
+/** Row count, defaulted defensively. */
+function rowsOf(params: ScenarioParams): number {
+  return params.rows ?? 20
+}
+
+/** Column count, defaulted defensively. */
+function colsOf(params: ScenarioParams): number {
+  return params.cols ?? 8
+}
+
+/** The M column field names `[c0, ..., c{M-1}]`. */
+function columns(cols: number): string[] {
+  const out: string[] = []
+  for (let c = 0; c < cols; c++) out.push(`c${c}`)
+  return out
+}
+
+/**
+ * Each cell seeds to a DISTINCT valid value (`seed-{row}-{col}`). Distinct
+ * content keeps an edited cell's new value distinguishable from its neighbors'
+ * and makes a row reorder meaningful (a swap changes what each moved row
+ * displays). Identical cells would mask the cost the render-scope and reorder
+ * dimensions are measuring.
+ */
+function seedFor(row: number, col: number): string {
+  return `${SEED}-${row}-${col}`
+}
+
+export function gridShape(params: ScenarioParams): ScenarioShape {
+  const n = rowsOf(params)
+  const fields = columns(colsOf(params))
+  const paths: string[] = []
+  const rows: Array<Record<string, string>> = []
+  for (let i = 0; i < n; i++) {
+    const row: Record<string, string> = {}
+    fields.forEach((field, c) => {
+      paths.push(`rows.${i}.${field}`)
+      row[field] = seedFor(i, c)
+    })
+    rows.push(row)
+  }
+  const itemRules: Record<string, NativeRule> = {}
+  for (const field of fields) itemRules[field] = { minLength: MIN_LENGTH }
+  return {
+    paths,
+    defaultValues: { rows },
+    // The last cell of the last row: a single-cell edit costs the same wherever
+    // it lands, and a fixed cell keeps path resolution constant across the sweep.
+    keystrokeIndex: Math.max(0, paths.length - 1),
+    arrayPath: 'rows',
+    arrayItemRules: itemRules,
+    arrayItemFields: fields,
+    newRow: () => {
+      const row: Record<string, string> = {}
+      for (const field of fields) row[field] = SEED
+      return row
+    },
+  }
+}
+
+/** zod v3 schema shared by every zod-capable adapter. */
+export function gridZod3(params: ScenarioParams): z.ZodTypeAny {
+  const shape: Record<string, z.ZodTypeAny> = {}
+  for (const field of columns(colsOf(params))) shape[field] = z.string().min(MIN_LENGTH)
+  return z.object({ rows: z.array(z.object(shape)) })
+}
+
+/** valibot mirror for formisch. */
+export function gridValibot(params: ScenarioParams): v.GenericSchema {
+  const entries: Record<string, v.GenericSchema> = {}
+  for (const field of columns(colsOf(params))) {
+    entries[field] = v.pipe(v.string(), v.minLength(MIN_LENGTH))
+  }
+  return v.object({ rows: v.array(v.object(entries)) })
+}
+
+/**
+ * Native-rule mirror for object leaves. A grid scenario has none (its per-cell
+ * constraint travels on the shape's `arrayItemRules`, which the native-validator
+ * adapters turn into a `$each` collection rule), so this is empty.
+ */
+export function gridNative(_params: ScenarioParams): Record<string, NativeRule> {
+  return {}
+}

--- a/apps/bench-arena/src/shared/scenarios/index.ts
+++ b/apps/bench-arena/src/shared/scenarios/index.ts
@@ -1,0 +1,70 @@
+import type { ScenarioId, ScenarioParams } from '../../adapters/contract'
+import type * as v from 'valibot'
+import type { z } from 'zod'
+import { flatNative, flatShape, flatValibot, flatZod3 } from './flat'
+import { nestedNative, nestedShape, nestedValibot, nestedZod3 } from './nested'
+import type { NativeRule, ScenarioShape } from './types'
+
+export { leafSeed, nestRules } from './types'
+export type { NativeRule, ScenarioShape } from './types'
+
+/**
+ * Per-scenario builders, dispatched once here so every adapter stays
+ * scenario-agnostic: an adapter asks for the shape plus whichever validator
+ * flavor it feeds, never knowing which scenario it is driving. New scenarios
+ * extend these switches (Phase 3); the adapters do not change.
+ */
+
+function notYet(scenario: ScenarioId, kind: string): never {
+  throw new Error(`bench: ${kind} for scenario "${scenario}" is not implemented yet`)
+}
+
+export function shapeFor(scenario: ScenarioId, params: ScenarioParams): ScenarioShape {
+  switch (scenario) {
+    case 'flat':
+      return flatShape(params)
+    case 'nested':
+      return nestedShape(params)
+    default:
+      return notYet(scenario, 'shape')
+  }
+}
+
+/** zod v3 schema shared by every zod-capable adapter (the common denominator). */
+export function zodSchemaFor(scenario: ScenarioId, params: ScenarioParams): z.ZodTypeAny {
+  switch (scenario) {
+    case 'flat':
+      return flatZod3(params)
+    case 'nested':
+      return nestedZod3(params)
+    default:
+      return notYet(scenario, 'zod schema')
+  }
+}
+
+/** valibot schema for formisch. */
+export function valibotSchemaFor(scenario: ScenarioId, params: ScenarioParams): v.GenericSchema {
+  switch (scenario) {
+    case 'flat':
+      return flatValibot(params)
+    case 'nested':
+      return nestedValibot(params)
+    default:
+      return notYet(scenario, 'valibot schema')
+  }
+}
+
+/** Native-rule mirror for Regle (rules mode) and Vuelidate. */
+export function nativeRulesFor(
+  scenario: ScenarioId,
+  params: ScenarioParams
+): Record<string, NativeRule> {
+  switch (scenario) {
+    case 'flat':
+      return flatNative(params)
+    case 'nested':
+      return nestedNative(params)
+    default:
+      return notYet(scenario, 'native rules')
+  }
+}

--- a/apps/bench-arena/src/shared/scenarios/index.ts
+++ b/apps/bench-arena/src/shared/scenarios/index.ts
@@ -3,6 +3,7 @@ import type * as v from 'valibot'
 import type { z } from 'zod'
 import { arraysNative, arraysShape, arraysValibot, arraysZod3 } from './arrays'
 import { flatNative, flatShape, flatValibot, flatZod3 } from './flat'
+import { gridNative, gridShape, gridValibot, gridZod3 } from './grid'
 import { nestedNative, nestedShape, nestedValibot, nestedZod3 } from './nested'
 import type { NativeRule, ScenarioShape } from './types'
 
@@ -28,6 +29,8 @@ export function shapeFor(scenario: ScenarioId, params: ScenarioParams): Scenario
       return nestedShape(params)
     case 'arrays':
       return arraysShape(params)
+    case 'grid':
+      return gridShape(params)
     default:
       return notYet(scenario, 'shape')
   }
@@ -42,6 +45,8 @@ export function zodSchemaFor(scenario: ScenarioId, params: ScenarioParams): z.Zo
       return nestedZod3(params)
     case 'arrays':
       return arraysZod3(params)
+    case 'grid':
+      return gridZod3(params)
     default:
       return notYet(scenario, 'zod schema')
   }
@@ -56,6 +61,8 @@ export function valibotSchemaFor(scenario: ScenarioId, params: ScenarioParams): 
       return nestedValibot(params)
     case 'arrays':
       return arraysValibot(params)
+    case 'grid':
+      return gridValibot(params)
     default:
       return notYet(scenario, 'valibot schema')
   }
@@ -73,6 +80,8 @@ export function nativeRulesFor(
       return nestedNative(params)
     case 'arrays':
       return arraysNative(params)
+    case 'grid':
+      return gridNative(params)
     default:
       return notYet(scenario, 'native rules')
   }

--- a/apps/bench-arena/src/shared/scenarios/index.ts
+++ b/apps/bench-arena/src/shared/scenarios/index.ts
@@ -2,6 +2,12 @@ import type { ScenarioId, ScenarioParams } from '../../adapters/contract'
 import type * as v from 'valibot'
 import type { z } from 'zod'
 import { arraysNative, arraysShape, arraysValibot, arraysZod3 } from './arrays'
+import {
+  discriminatedUnionNative,
+  discriminatedUnionShape,
+  discriminatedUnionValibot,
+  discriminatedUnionZod3,
+} from './discriminated-union'
 import { flatNative, flatShape, flatValibot, flatZod3 } from './flat'
 import { gridNative, gridShape, gridValibot, gridZod3 } from './grid'
 import { nestedNative, nestedShape, nestedValibot, nestedZod3 } from './nested'
@@ -31,6 +37,8 @@ export function shapeFor(scenario: ScenarioId, params: ScenarioParams): Scenario
       return arraysShape(params)
     case 'grid':
       return gridShape(params)
+    case 'discriminated-union':
+      return discriminatedUnionShape(params)
     default:
       return notYet(scenario, 'shape')
   }
@@ -47,6 +55,8 @@ export function zodSchemaFor(scenario: ScenarioId, params: ScenarioParams): z.Zo
       return arraysZod3(params)
     case 'grid':
       return gridZod3(params)
+    case 'discriminated-union':
+      return discriminatedUnionZod3(params)
     default:
       return notYet(scenario, 'zod schema')
   }
@@ -63,6 +73,8 @@ export function valibotSchemaFor(scenario: ScenarioId, params: ScenarioParams): 
       return arraysValibot(params)
     case 'grid':
       return gridValibot(params)
+    case 'discriminated-union':
+      return discriminatedUnionValibot(params)
     default:
       return notYet(scenario, 'valibot schema')
   }
@@ -82,6 +94,8 @@ export function nativeRulesFor(
       return arraysNative(params)
     case 'grid':
       return gridNative(params)
+    case 'discriminated-union':
+      return discriminatedUnionNative(params)
     default:
       return notYet(scenario, 'native rules')
   }

--- a/apps/bench-arena/src/shared/scenarios/index.ts
+++ b/apps/bench-arena/src/shared/scenarios/index.ts
@@ -1,6 +1,7 @@
 import type { ScenarioId, ScenarioParams } from '../../adapters/contract'
 import type * as v from 'valibot'
 import type { z } from 'zod'
+import { arraysNative, arraysShape, arraysValibot, arraysZod3 } from './arrays'
 import { flatNative, flatShape, flatValibot, flatZod3 } from './flat'
 import { nestedNative, nestedShape, nestedValibot, nestedZod3 } from './nested'
 import type { NativeRule, ScenarioShape } from './types'
@@ -25,6 +26,8 @@ export function shapeFor(scenario: ScenarioId, params: ScenarioParams): Scenario
       return flatShape(params)
     case 'nested':
       return nestedShape(params)
+    case 'arrays':
+      return arraysShape(params)
     default:
       return notYet(scenario, 'shape')
   }
@@ -37,6 +40,8 @@ export function zodSchemaFor(scenario: ScenarioId, params: ScenarioParams): z.Zo
       return flatZod3(params)
     case 'nested':
       return nestedZod3(params)
+    case 'arrays':
+      return arraysZod3(params)
     default:
       return notYet(scenario, 'zod schema')
   }
@@ -49,6 +54,8 @@ export function valibotSchemaFor(scenario: ScenarioId, params: ScenarioParams): 
       return flatValibot(params)
     case 'nested':
       return nestedValibot(params)
+    case 'arrays':
+      return arraysValibot(params)
     default:
       return notYet(scenario, 'valibot schema')
   }
@@ -64,6 +71,8 @@ export function nativeRulesFor(
       return flatNative(params)
     case 'nested':
       return nestedNative(params)
+    case 'arrays':
+      return arraysNative(params)
     default:
       return notYet(scenario, 'native rules')
   }

--- a/apps/bench-arena/src/shared/scenarios/index.ts
+++ b/apps/bench-arena/src/shared/scenarios/index.ts
@@ -10,6 +10,7 @@ import {
 } from './discriminated-union'
 import { flatNative, flatShape, flatValibot, flatZod3 } from './flat'
 import { gridNative, gridShape, gridValibot, gridZod3 } from './grid'
+import { massiveNative, massiveShape, massiveValibot, massiveZod3 } from './massive'
 import { nestedNative, nestedShape, nestedValibot, nestedZod3 } from './nested'
 import type { NativeRule, ScenarioShape } from './types'
 
@@ -39,6 +40,8 @@ export function shapeFor(scenario: ScenarioId, params: ScenarioParams): Scenario
       return gridShape(params)
     case 'discriminated-union':
       return discriminatedUnionShape(params)
+    case 'massive':
+      return massiveShape(params)
     default:
       return notYet(scenario, 'shape')
   }
@@ -57,6 +60,8 @@ export function zodSchemaFor(scenario: ScenarioId, params: ScenarioParams): z.Zo
       return gridZod3(params)
     case 'discriminated-union':
       return discriminatedUnionZod3(params)
+    case 'massive':
+      return massiveZod3(params)
     default:
       return notYet(scenario, 'zod schema')
   }
@@ -75,6 +80,8 @@ export function valibotSchemaFor(scenario: ScenarioId, params: ScenarioParams): 
       return gridValibot(params)
     case 'discriminated-union':
       return discriminatedUnionValibot(params)
+    case 'massive':
+      return massiveValibot(params)
     default:
       return notYet(scenario, 'valibot schema')
   }
@@ -96,6 +103,8 @@ export function nativeRulesFor(
       return gridNative(params)
     case 'discriminated-union':
       return discriminatedUnionNative(params)
+    case 'massive':
+      return massiveNative(params)
     default:
       return notYet(scenario, 'native rules')
   }

--- a/apps/bench-arena/src/shared/scenarios/index.ts
+++ b/apps/bench-arena/src/shared/scenarios/index.ts
@@ -13,6 +13,7 @@ import { gridNative, gridShape, gridValibot, gridZod3 } from './grid'
 import { massiveNative, massiveShape, massiveValibot, massiveZod3 } from './massive'
 import { nestedNative, nestedShape, nestedValibot, nestedZod3 } from './nested'
 import type { NativeRule, ScenarioShape } from './types'
+import { wizardNative, wizardShape, wizardValibot, wizardZod3 } from './wizard'
 
 export { leafSeed, nestRules } from './types'
 export type { NativeRule, ScenarioShape } from './types'
@@ -42,6 +43,8 @@ export function shapeFor(scenario: ScenarioId, params: ScenarioParams): Scenario
       return discriminatedUnionShape(params)
     case 'massive':
       return massiveShape(params)
+    case 'wizard':
+      return wizardShape(params)
     default:
       return notYet(scenario, 'shape')
   }
@@ -62,6 +65,8 @@ export function zodSchemaFor(scenario: ScenarioId, params: ScenarioParams): z.Zo
       return discriminatedUnionZod3(params)
     case 'massive':
       return massiveZod3(params)
+    case 'wizard':
+      return wizardZod3(params)
     default:
       return notYet(scenario, 'zod schema')
   }
@@ -82,6 +87,8 @@ export function valibotSchemaFor(scenario: ScenarioId, params: ScenarioParams): 
       return discriminatedUnionValibot(params)
     case 'massive':
       return massiveValibot(params)
+    case 'wizard':
+      return wizardValibot(params)
     default:
       return notYet(scenario, 'valibot schema')
   }
@@ -105,6 +112,8 @@ export function nativeRulesFor(
       return discriminatedUnionNative(params)
     case 'massive':
       return massiveNative(params)
+    case 'wizard':
+      return wizardNative(params)
     default:
       return notYet(scenario, 'native rules')
   }

--- a/apps/bench-arena/src/shared/scenarios/massive.ts
+++ b/apps/bench-arena/src/shared/scenarios/massive.ts
@@ -1,0 +1,188 @@
+/**
+ * Massive scenario: one form mixing all three structural shapes at scale, swept
+ * over the total leaf count L (~2,000 to ~5,000 inputs). A real enterprise form
+ * is not a thousand flat fields; it is sections of flat fields, a deep object or
+ * two, and repeating line-item rows, all in one form. Massive composes exactly
+ * that: a flat block, one deeply nested block, and one array of rows, sharing a
+ * single schema and validated in one pass.
+ *
+ * The headline is the ceiling: mount, one keystroke, and full-form validation at
+ * a field count where the cost of doing work proportional to the whole form (a
+ * keystroke that re-parses every leaf) diverges sharply from work proportional
+ * to the one field that changed. The keystroke targets a flat leaf so the number
+ * isolates that whole-form overhead at scale; deep-path cost is the nested
+ * scenario's job, and array behavior is the arrays and grid scenarios'.
+ *
+ * Every leaf is a text input carrying the same minimum-length constraint, so the
+ * DOM and the validation work are uniform across the cohort. The array section
+ * reuses the array machinery (`arrayPath` / `arrayItemFields` / `arrayItemRules`),
+ * so the native-validator adapters build their collection rule exactly as they do
+ * for the arrays scenario; the flat and nested leaves travel on `objectPaths`,
+ * which each adapter renders alongside the rows. Massive runs no array mutation,
+ * so the rows are static (no reorder or add dimension here).
+ */
+import * as v from 'valibot'
+import { z } from 'zod'
+import type { ScenarioParams } from '../../adapters/contract'
+import { type NativeRule, type ScenarioShape } from './types'
+
+/** Minimum length every leaf must satisfy; the uniform constraint. */
+const MIN_LENGTH = 2
+
+/** A valid seed value (length >= MIN_LENGTH) so the whole tree validates. */
+const SEED = 'seed'
+
+/** Fields per array row (an invoice-line-item width). */
+const COLS = 4
+
+/** Wrapper-object depth above the nested-leaf cluster (the deep block). */
+const NEST_DEPTH = 8
+
+/** Share of the leaf budget given to the flat block and the array block; the
+ *  remainder is the nested block. */
+const FLAT_FRACTION = 0.3
+const ARRAY_FRACTION = 0.4
+
+/** Total leaf count, defaulted defensively. */
+function leavesOf(params: ScenarioParams): number {
+  return params.leaves ?? 2000
+}
+
+/** The wrapper segments `[l0, ..., l{NEST_DEPTH-1}]` above the nested leaves. */
+function wrappers(): string[] {
+  const out: string[] = []
+  for (let d = 0; d < NEST_DEPTH; d++) out.push(`l${d}`)
+  return out
+}
+
+/**
+ * Resolve the leaf budget L into the three blocks. The counts are a
+ * deterministic function of L, so a label (`L5000`) always produces the same
+ * structure: an array of `rows` x `COLS` cells, `flatCount` flat leaves, and
+ * `nestedCount` leaves clustered at the bottom of the wrapper chain.
+ */
+interface MassiveLayout {
+  readonly flatCount: number
+  readonly rows: number
+  readonly cols: number
+  readonly arrayLeaves: number
+  readonly nestedCount: number
+}
+
+function layout(params: ScenarioParams): MassiveLayout {
+  const L = leavesOf(params)
+  const cols = COLS
+  const rows = Math.max(1, Math.floor((L * ARRAY_FRACTION) / cols))
+  const arrayLeaves = rows * cols
+  const flatCount = Math.floor(L * FLAT_FRACTION)
+  const nestedCount = Math.max(0, L - flatCount - arrayLeaves)
+  return { flatCount, rows, cols, arrayLeaves, nestedCount }
+}
+
+/** The dotted prefix above the nested leaves (`deep.l0.l1.....l{NEST_DEPTH-1}`). */
+function nestPrefix(): string {
+  return ['deep', ...wrappers()].join('.')
+}
+
+export function massiveShape(params: ScenarioParams): ScenarioShape {
+  const { flatCount, rows, cols, arrayLeaves, nestedCount } = layout(params)
+
+  // The rendered input order: every array cell first (row-major, the existing
+  // array-branch index formula), then the flat leaves, then the nested leaves.
+  // The object leaves carry indices continuing past the array cells, so the flat
+  // and nested blocks render at `arrayLeaves + their position in objectPaths`.
+  const paths: string[] = []
+  for (let i = 0; i < rows; i++) {
+    for (let c = 0; c < cols; c++) paths.push(`rows.${i}.c${c}`)
+  }
+  const objectPaths: string[] = []
+  for (let i = 0; i < flatCount; i++) objectPaths.push(`s${i}`)
+  const prefix = nestPrefix()
+  for (let i = 0; i < nestedCount; i++) objectPaths.push(`${prefix}.n${i}`)
+  paths.push(...objectPaths)
+
+  // The seed tree: flat leaves, the nested cluster wrapped to depth, and the row
+  // array. Cloned per mount by the adapters that own a mutable array.
+  const defaultValues: Record<string, unknown> = {}
+  for (let i = 0; i < flatCount; i++) defaultValues[`s${i}`] = SEED
+  let nested: Record<string, unknown> = {}
+  for (let i = 0; i < nestedCount; i++) nested[`n${i}`] = SEED
+  for (const seg of [...wrappers()].reverse()) nested = { [seg]: nested }
+  defaultValues['deep'] = nested
+  defaultValues['rows'] = Array.from({ length: rows }, () => newRow(cols))
+
+  const arrayItemFields: string[] = []
+  const arrayItemRules: Record<string, NativeRule> = {}
+  for (let c = 0; c < cols; c++) {
+    arrayItemFields.push(`c${c}`)
+    arrayItemRules[`c${c}`] = { minLength: MIN_LENGTH }
+  }
+
+  return {
+    paths,
+    defaultValues,
+    // The last flat leaf: a shallow scalar write whose cost is the library's
+    // per-keystroke overhead at this scale, undiluted by deep-path resolution.
+    keystrokeIndex: arrayLeaves + Math.max(0, flatCount - 1),
+    arrayPath: 'rows',
+    arrayItemRules,
+    arrayItemFields,
+    newRow: () => newRow(cols),
+    objectPaths,
+  }
+}
+
+/** A fresh all-seed row of `cols` fields. */
+function newRow(cols: number): Record<string, unknown> {
+  const row: Record<string, unknown> = {}
+  for (let c = 0; c < cols; c++) row[`c${c}`] = SEED
+  return row
+}
+
+/** zod v3 schema shared by every zod-capable adapter. */
+export function massiveZod3(params: ScenarioParams): z.ZodTypeAny {
+  const { flatCount, cols, nestedCount } = layout(params)
+  const shape: Record<string, z.ZodTypeAny> = {}
+  for (let i = 0; i < flatCount; i++) shape[`s${i}`] = z.string().min(MIN_LENGTH)
+  const bottom: Record<string, z.ZodTypeAny> = {}
+  for (let i = 0; i < nestedCount; i++) bottom[`n${i}`] = z.string().min(MIN_LENGTH)
+  let nested: z.ZodTypeAny = z.object(bottom)
+  for (const seg of [...wrappers()].reverse()) nested = z.object({ [seg]: nested })
+  shape['deep'] = nested
+  const row: Record<string, z.ZodTypeAny> = {}
+  for (let c = 0; c < cols; c++) row[`c${c}`] = z.string().min(MIN_LENGTH)
+  shape['rows'] = z.array(z.object(row))
+  return z.object(shape)
+}
+
+/** valibot mirror for formisch. */
+export function massiveValibot(params: ScenarioParams): v.GenericSchema {
+  const { flatCount, cols, nestedCount } = layout(params)
+  const entries: Record<string, v.GenericSchema> = {}
+  for (let i = 0; i < flatCount; i++) entries[`s${i}`] = v.pipe(v.string(), v.minLength(MIN_LENGTH))
+  const bottom: Record<string, v.GenericSchema> = {}
+  for (let i = 0; i < nestedCount; i++)
+    bottom[`n${i}`] = v.pipe(v.string(), v.minLength(MIN_LENGTH))
+  let nested: v.GenericSchema = v.object(bottom)
+  for (const seg of [...wrappers()].reverse()) nested = v.object({ [seg]: nested })
+  entries['deep'] = nested
+  const row: Record<string, v.GenericSchema> = {}
+  for (let c = 0; c < cols; c++) row[`c${c}`] = v.pipe(v.string(), v.minLength(MIN_LENGTH))
+  entries['rows'] = v.array(v.object(row))
+  return v.object(entries)
+}
+
+/**
+ * Native-rule mirror for the object leaves (flat + nested), keyed by dotted path
+ * for `nestRules` to de-flatten. The array section's per-row rules travel on the
+ * shape's `arrayItemRules`, which the native-validator adapters turn into a
+ * collection rule, so the rows are absent here.
+ */
+export function massiveNative(params: ScenarioParams): Record<string, NativeRule> {
+  const { flatCount, nestedCount } = layout(params)
+  const rules: Record<string, NativeRule> = {}
+  for (let i = 0; i < flatCount; i++) rules[`s${i}`] = { minLength: MIN_LENGTH }
+  const prefix = nestPrefix()
+  for (let i = 0; i < nestedCount; i++) rules[`${prefix}.n${i}`] = { minLength: MIN_LENGTH }
+  return rules
+}

--- a/apps/bench-arena/src/shared/scenarios/nested.ts
+++ b/apps/bench-arena/src/shared/scenarios/nested.ts
@@ -1,0 +1,65 @@
+/**
+ * Deeply-nested scenario: a single object chain `l0.l1.....l{D-1}.leaf`, D
+ * wrapper objects deep, swept over D. One leaf, so the headline is not render
+ * scope but path resolution and deep reactivity: how a library's per-keystroke
+ * cost and mount cost grow as the edited value sinks deeper into the tree
+ * (Attaform's depth story). The single uniform constraint (minimum length) and
+ * the single text input keep the DOM identical across the cohort.
+ */
+import * as v from 'valibot'
+import { z } from 'zod'
+import type { ScenarioParams } from '../../adapters/contract'
+import { type NativeRule, type ScenarioShape } from './types'
+
+/** Minimum length the deep leaf must satisfy; the uniform constraint. */
+const MIN_LENGTH = 2
+
+/** A valid seed value (length >= MIN_LENGTH) so the chain validates. */
+const SEED = 'seed'
+
+/** Wrapper-object depth, defaulted defensively. */
+function depthOf(params: ScenarioParams): number {
+  return params.depth ?? 8
+}
+
+/** The wrapper segments `[l0, ..., l{D-1}]` above the `leaf`. */
+function wrappers(depth: number): string[] {
+  const out: string[] = []
+  for (let d = 0; d < depth; d++) out.push(`l${d}`)
+  return out
+}
+
+export function nestedShape(params: ScenarioParams): ScenarioShape {
+  const segs = wrappers(depthOf(params))
+  let tree: Record<string, unknown> = { leaf: SEED }
+  for (const seg of [...segs].reverse()) tree = { [seg]: tree }
+  return {
+    paths: [[...segs, 'leaf'].join('.')],
+    defaultValues: tree,
+    keystrokeIndex: 0,
+  }
+}
+
+/** zod v3 schema shared by every zod-capable adapter. */
+export function nestedZod3(params: ScenarioParams): z.ZodTypeAny {
+  let schema: z.ZodTypeAny = z.object({ leaf: z.string().min(MIN_LENGTH) })
+  for (const seg of [...wrappers(depthOf(params))].reverse()) {
+    schema = z.object({ [seg]: schema })
+  }
+  return schema
+}
+
+/** valibot mirror for formisch. */
+export function nestedValibot(params: ScenarioParams): v.GenericSchema {
+  let schema: v.GenericSchema = v.object({ leaf: v.pipe(v.string(), v.minLength(MIN_LENGTH)) })
+  for (const seg of [...wrappers(depthOf(params))].reverse()) {
+    schema = v.object({ [seg]: schema })
+  }
+  return schema
+}
+
+/** Native-rule mirror (flat dotted leaf path) for Regle (rules) and Vuelidate. */
+export function nestedNative(params: ScenarioParams): Record<string, NativeRule> {
+  const path = [...wrappers(depthOf(params)), 'leaf'].join('.')
+  return { [path]: { minLength: MIN_LENGTH } }
+}

--- a/apps/bench-arena/src/shared/scenarios/types.ts
+++ b/apps/bench-arena/src/shared/scenarios/types.ts
@@ -51,6 +51,16 @@ export interface ScenarioShape {
    */
   readonly newRow?: () => Record<string, unknown>
   /**
+   * Non-array leaf paths rendered alongside the rows, present only for the
+   * composite massive scenario (flat + nested leaves; the array cells travel on
+   * `paths` ahead of these). An array scenario renders the rows through its
+   * array primitive and then these object leaves through its plain field
+   * binding, each at an index continuing past the last array cell
+   * (`paths.length - objectPaths.length + position`). Absent for the
+   * single-shape scenarios, where the array branch renders only rows.
+   */
+  readonly objectPaths?: readonly string[]
+  /**
    * Discriminated-union descriptor, present only for the discriminated-union
    * scenario. Adapters render only the ACTIVE variant's fields (the one the
    * current discriminant selects), and the variantFlip dimension cycles the

--- a/apps/bench-arena/src/shared/scenarios/types.ts
+++ b/apps/bench-arena/src/shared/scenarios/types.ts
@@ -24,6 +24,19 @@ export interface ScenarioShape {
   readonly defaultValues: Record<string, unknown>
   /** Index into `paths` that the keystroke dimension types into. */
   readonly keystrokeIndex: number
+  /**
+   * Dotted path of the array under test, present only for array-shaped
+   * scenarios (arrays, grid). The arrayOp dimension reorders this array, and
+   * the native-validator adapters build their collection rule against it.
+   */
+  readonly arrayPath?: string
+  /**
+   * Per-item field rules for an array scenario, keyed by the item's own field
+   * name (`{ v: { minLength: 2 } }`). The schema-based libraries express arrays
+   * through their schema; the native-validator libraries (Regle rules, Vuelidate)
+   * build their `$each` collection rule from this.
+   */
+  readonly arrayItemRules?: Record<string, NativeRule>
 }
 
 /**

--- a/apps/bench-arena/src/shared/scenarios/types.ts
+++ b/apps/bench-arena/src/shared/scenarios/types.ts
@@ -83,6 +83,23 @@ export interface ScenarioShape {
       readonly value: Record<string, unknown>
     }>
   }
+  /**
+   * Multi-step wizard descriptor, present only for the wizard scenario. The
+   * steps partition `paths` in order (`steps[i]` holds step i's leaf paths), and
+   * only the active step's fields are rendered. The stepTransition dimension
+   * advances through them: a library with a wizard primitive (Attaform's
+   * useWizard) makes each step its own form, so a gated advance validates only
+   * that step; a library without one hand-composes the flow off a step signal.
+   * `stepKeys` names each step's object key (`step0`), so an adapter that builds
+   * a form per step slices the per-step schema and defaults out of the root by
+   * key.
+   */
+  readonly wizard?: {
+    /** Each step's object key (`step0`, `step1`, ...), in step order. */
+    readonly stepKeys: readonly string[]
+    /** Each step's leaf paths (`['step0.f0', ...]`), partitioning `paths`. */
+    readonly steps: readonly (readonly string[])[]
+  }
 }
 
 /**

--- a/apps/bench-arena/src/shared/scenarios/types.ts
+++ b/apps/bench-arena/src/shared/scenarios/types.ts
@@ -50,6 +50,29 @@ export interface ScenarioShape {
    * immediately and the add/remove rotation never churns error state.
    */
   readonly newRow?: () => Record<string, unknown>
+  /**
+   * Discriminated-union descriptor, present only for the discriminated-union
+   * scenario. Adapters render only the ACTIVE variant's fields (the one the
+   * current discriminant selects), and the variantFlip dimension cycles the
+   * discriminant, replacing the whole value at `unionPath` with the target
+   * variant's `value`. The default active variant is the first in `variants`,
+   * so its `fieldPaths` are what the keystroke and re-render dimensions drive.
+   */
+  readonly union?: {
+    /** Dotted path of the object the union occupies; a flip writes here. */
+    readonly unionPath: string
+    /** Dotted path of the discriminant leaf (`event.kind`). */
+    readonly discriminantPath: string
+    /** The variants, keyed by their discriminant value. */
+    readonly variants: ReadonlyArray<{
+      /** The discriminant value (`click`). */
+      readonly tag: string
+      /** This variant's non-discriminant leaf paths, rendered as inputs. */
+      readonly fieldPaths: readonly string[]
+      /** A full valid value for this variant, written verbatim on a flip. */
+      readonly value: Record<string, unknown>
+    }>
+  }
 }
 
 /**

--- a/apps/bench-arena/src/shared/scenarios/types.ts
+++ b/apps/bench-arena/src/shared/scenarios/types.ts
@@ -1,0 +1,90 @@
+import type { ScenarioParams } from '../../adapters/contract'
+
+/**
+ * The library-agnostic shape of a scenario at given params: the ordered leaf
+ * paths (one per rendered input), a valid seed tree, and which leaf the
+ * keystroke dimension drives. Every adapter renders this identically and binds
+ * its own validation engine behind it, so the DOM is held constant and only
+ * the engine differs.
+ */
+export interface ScenarioShape {
+  /**
+   * Ordered dotted leaf paths; array index === rendered input index. Nested
+   * scenarios use dot segments (`l0.l1.leaf`) and array scenarios numeric ones
+   * (`rows.3.qty`); every adapter resolves these against its own model.
+   */
+  readonly paths: readonly string[]
+  /**
+   * The valid seed tree (all leaves pass) passed verbatim to a form-state
+   * library's `defaultValues` / `initialValues` and to the harness-owned
+   * reactive state the validation-only libraries bind. For flat scenarios it is
+   * a flat object; for nested/array scenarios it is the real nested tree, so
+   * read an individual leaf via `leafSeed`, never `defaultValues[path]`.
+   */
+  readonly defaultValues: Record<string, unknown>
+  /** Index into `paths` that the keystroke dimension types into. */
+  readonly keystrokeIndex: number
+}
+
+/**
+ * A field's validation as native (non-schema) rules, so the
+ * headless-validation-only libraries (Regle rules mode, Vuelidate) can mirror
+ * the exact constraint the zod and valibot entries express. Each adapter maps
+ * these to its own rule helpers.
+ */
+export interface NativeRule {
+  /** Minimum string length; an empty string fails it (mirrors `.min(n)`). */
+  readonly minLength?: number
+}
+
+/** Field count for flat-like scenarios, defaulted defensively. */
+export function fieldCount(params: ScenarioParams, fallback = 10): number {
+  return params.fields ?? fallback
+}
+
+/** Coerce an all-digits path segment to an array index, else keep the key. */
+function segKey(seg: string): string | number {
+  return /^\d+$/.test(seg) ? Number(seg) : seg
+}
+
+/**
+ * Read a single leaf's seed value out of a nested default tree by dotted path,
+ * coercing numeric segments to array indices. The adapters that need a per-leaf
+ * initial value (FormKit, which seeds each rendered input) read it here rather
+ * than indexing the tree by the dotted string, which only works when flat.
+ */
+export function leafSeed(tree: Record<string, unknown>, dottedPath: string): unknown {
+  let node: unknown = tree
+  for (const seg of dottedPath.split('.')) {
+    if (node == null || typeof node !== 'object') return undefined
+    node = (node as Record<string | number, unknown>)[segKey(seg)]
+  }
+  return node
+}
+
+/**
+ * De-flatten the scenario's flat dotted native-rule map into a nested rules
+ * object mirroring the value tree, applying `map` to each leaf rule. The
+ * headless-validation libraries (Regle rules mode, Vuelidate) take rules nested
+ * to match the state they validate, so they build their engine-specific rules
+ * from the scenario's flat description through this one helper. Object segments
+ * only; array scenarios validate per item through each engine's own primitive.
+ */
+export function nestRules<T>(
+  flat: Record<string, NativeRule>,
+  map: (rule: NativeRule) => T
+): Record<string, unknown> {
+  const root: Record<string, unknown> = {}
+  for (const [dotted, rule] of Object.entries(flat)) {
+    const segs = dotted.split('.')
+    const leaf = segs.pop()
+    if (leaf === undefined) continue
+    let node = root
+    for (const seg of segs) {
+      node[seg] ??= {}
+      node = node[seg] as Record<string, unknown>
+    }
+    node[leaf] = map(rule)
+  }
+  return root
+}

--- a/apps/bench-arena/src/shared/scenarios/types.ts
+++ b/apps/bench-arena/src/shared/scenarios/types.ts
@@ -37,6 +37,19 @@ export interface ScenarioShape {
    * build their `$each` collection rule from this.
    */
   readonly arrayItemRules?: Record<string, NativeRule>
+  /**
+   * The field name(s) within each array row (`['v']`), present only for
+   * array-shaped scenarios. The adapters render a row reactively through their
+   * own array primitive and build each leaf path as `${arrayPath}.${i}.${field}`,
+   * so a reorder rebinds the moved row to its new positional path.
+   */
+  readonly arrayItemFields?: readonly string[]
+  /**
+   * Build a fresh valid row for the append op (arrays/grid scenarios). It
+   * returns the same shape as a seed row, so an appended row validates
+   * immediately and the add/remove rotation never churns error state.
+   */
+  readonly newRow?: () => Record<string, unknown>
 }
 
 /**

--- a/apps/bench-arena/src/shared/scenarios/wizard.ts
+++ b/apps/bench-arena/src/shared/scenarios/wizard.ts
@@ -1,0 +1,113 @@
+/**
+ * Wizard scenario: a linear multi-step flow whose fields are partitioned into
+ * ordered steps, one step shown at a time. The headline is how a library
+ * advances a gated step: validate the leaving step, then reveal the next. A
+ * library with a wizard primitive (Attaform's useWizard) makes each step its
+ * own form, so gating an advance validates only that step; a library without
+ * one hand-composes the flow off a step signal and validates the step the way
+ * its engine allows. Every field is a uniform-constraint text input, so the DOM
+ * stays identical across the cohort, and the steps are uniform (same field
+ * count each), so a transition cost reflects navigation and gating rather than a
+ * lopsided step.
+ *
+ * Branching across steps (a discriminator selecting later steps) is deliberately
+ * out of scope here: the discriminated-union scenario already measures branch
+ * resolution, and a linear flow isolates the step-transition cost without a
+ * per-library branching shape to express differently. The genuinely comparable
+ * operations are the gated forward advance (stepTransition) and the cross-step
+ * aggregate validation (the validate dimension over every step).
+ */
+import * as v from 'valibot'
+import { z } from 'zod'
+import type { ScenarioParams } from '../../adapters/contract'
+import { type NativeRule, type ScenarioShape } from './types'
+
+/** Minimum length each field must satisfy; the uniform constraint. */
+const MIN_LENGTH = 2
+
+/** A valid seed value (length >= MIN_LENGTH) so every step validates. */
+const SEED = 'seed'
+
+/** Steps when the param omits a count; the default multi-step flow. */
+const DEFAULT_STEPS = 4
+
+/** Text fields per step; uniform so a transition cost is step-independent. */
+const FIELDS_PER_STEP = 3
+
+/** Step count for the scenario, from the `steps` param (label `S4`). */
+function stepCount(params: ScenarioParams): number {
+  return Math.max(2, params.steps ?? DEFAULT_STEPS)
+}
+
+/** The object key for step `i` (`step0`); each step occupies its own object. */
+function stepKey(i: number): string {
+  return `step${i}`
+}
+
+/** The field name for position `j` within a step (`f0`). */
+function fieldName(j: number): string {
+  return `f${j}`
+}
+
+export function wizardShape(params: ScenarioParams): ScenarioShape {
+  const steps = stepCount(params)
+  const stepKeys = Array.from({ length: steps }, (_unused, i) => stepKey(i))
+  const stepPaths = stepKeys.map((key) =>
+    Array.from({ length: FIELDS_PER_STEP }, (_unused, j) => `${key}.${fieldName(j)}`)
+  )
+  const defaultValues: Record<string, unknown> = {}
+  for (const key of stepKeys) {
+    const obj: Record<string, unknown> = {}
+    for (let j = 0; j < FIELDS_PER_STEP; j++) obj[fieldName(j)] = SEED
+    defaultValues[key] = obj
+  }
+  return {
+    paths: stepPaths.flat(),
+    defaultValues,
+    keystrokeIndex: 0,
+    wizard: { stepKeys, steps: stepPaths },
+  }
+}
+
+/**
+ * zod v3 schema shared by every zod-capable adapter: an object of per-step
+ * objects (`{ step0: { f0, f1, f2 }, ... }`). A single-form library validates
+ * the whole object; an adapter that builds a form per step (useWizard) reads
+ * each step's sub-object off the root shape by key.
+ */
+export function wizardZod3(params: ScenarioParams): z.ZodTypeAny {
+  const shape: Record<string, z.ZodTypeAny> = {}
+  for (let i = 0; i < stepCount(params); i++) {
+    const fields: Record<string, z.ZodTypeAny> = {}
+    for (let j = 0; j < FIELDS_PER_STEP; j++) fields[fieldName(j)] = z.string().min(MIN_LENGTH)
+    shape[stepKey(i)] = z.object(fields)
+  }
+  return z.object(shape)
+}
+
+/** valibot mirror for formisch. */
+export function wizardValibot(params: ScenarioParams): v.GenericSchema {
+  const entries: Record<string, v.GenericSchema> = {}
+  for (let i = 0; i < stepCount(params); i++) {
+    const fields: Record<string, v.GenericSchema> = {}
+    for (let j = 0; j < FIELDS_PER_STEP; j++) {
+      fields[fieldName(j)] = v.pipe(v.string(), v.minLength(MIN_LENGTH))
+    }
+    entries[stepKey(i)] = v.object(fields)
+  }
+  return v.object(entries)
+}
+
+/**
+ * Native-rule mirror for the headless-validation-only libraries (Regle rules
+ * mode, Vuelidate), one minimum-length rule per leaf keyed by dotted path.
+ */
+export function wizardNative(params: ScenarioParams): Record<string, NativeRule> {
+  const rules: Record<string, NativeRule> = {}
+  for (let i = 0; i < stepCount(params); i++) {
+    for (let j = 0; j < FIELDS_PER_STEP; j++) {
+      rules[`${stepKey(i)}.${fieldName(j)}`] = { minLength: MIN_LENGTH }
+    }
+  }
+  return rules
+}

--- a/apps/bench-arena/tests/arena.spec.ts
+++ b/apps/bench-arena/tests/arena.spec.ts
@@ -49,6 +49,11 @@ const CASES: readonly ScenarioCase[] = [
     params: ['N20M8', 'N100M8'],
     dims: ['keystroke', 'mount', 'validate', 'rerender', 'arrayAdd', 'arrayReorder'],
   },
+  {
+    scenario: 'discriminated-union',
+    params: ['DU'],
+    dims: ['keystroke', 'mount', 'validate', 'rerender', 'variantFlip'],
+  },
 ]
 
 /**

--- a/apps/bench-arena/tests/arena.spec.ts
+++ b/apps/bench-arena/tests/arena.spec.ts
@@ -154,13 +154,17 @@ type MemoryWindow = Window & {
   __BENCH_RESULTS__?: { error?: string }
 }
 
-/** The three retained/churn/leak medians (bytes) plus the cycle count driven. */
+/**
+ * The three retained/churn/leak medians (bytes) and the cycle count driven, plus
+ * the raw per-cycle series the orchestrator keeps for the leak-creep sparkline.
+ */
 interface MemoryResult {
   error?: string
   cycles: number
   retained: number
   churn: number
   leak: number
+  series: { retained: number[]; churn: number[]; leak: number[] }
 }
 
 /**
@@ -188,7 +192,13 @@ async function runMemoryCell(
   await page.waitForFunction(() => document.body.dataset['benchDone'] === '1', undefined, {
     timeout: timeoutMs,
   })
-  const empty = { cycles: 0, retained: 0, churn: 0, leak: 0 }
+  const empty = {
+    cycles: 0,
+    retained: 0,
+    churn: 0,
+    leak: 0,
+    series: { retained: [], churn: [], leak: [] },
+  }
   const setupError = await page.evaluate(() => (window as MemoryWindow).__BENCH_RESULTS__?.error)
   if (setupError) return { ...empty, error: setupError }
   const cycles = await page.evaluate(() => (window as MemoryWindow).__BENCH_MEM__?.cycles ?? 0)
@@ -229,6 +239,7 @@ async function runMemoryCell(
     retained: median(retained),
     churn: median(churn),
     leak: median(leak),
+    series: { retained, churn, leak },
   }
 }
 
@@ -237,7 +248,7 @@ for (const { scenario, params: paramSet, dims, skip } of CASES) {
     for (const adapter of ADAPTERS) {
       for (const params of paramSet) {
         for (const dim of dims) {
-          test(`${adapter} · ${params} · ${dim}`, async ({ page }) => {
+          test(`${adapter} · ${params} · ${dim}`, async ({ page }, testInfo) => {
             test.skip(skip?.(params, dim) ?? false, 'cell exceeds the per-cell measurement budget')
             // The massive scenario mounts thousands of inputs, so a single mount
             // or full-form validate runs for seconds on the heavier libraries;
@@ -280,6 +291,23 @@ for (const { scenario, params: paramSet, dims, skip } of CASES) {
                 `${adapter.padEnd(14)} ${scenario.padEnd(8)} ${params.padEnd(4)} memory     ` +
                   `retained=${kb(m.retained)} churn=${kb(m.churn)} leak=${kb(m.leak)} n=${m.cycles}`
               )
+              // Hand the cell's measurement to the orchestrator: it harvests
+              // these attachments from the same green run that asserts them, so
+              // the published numbers and the gate can never diverge.
+              await testInfo.attach('cell', {
+                body: JSON.stringify({
+                  kind: 'memory',
+                  adapter,
+                  scenario,
+                  params,
+                  cycles: m.cycles,
+                  retained: m.retained,
+                  churn: m.churn,
+                  leak: m.leak,
+                  series: m.series,
+                }),
+                contentType: 'application/json',
+              })
               return
             }
 
@@ -323,9 +351,43 @@ for (const { scenario, params: paramSet, dims, skip } of CASES) {
                 `median=${r.summary.median.toFixed(3)}${unitLabel} p95=${r.summary.p95.toFixed(3)} ` +
                 `n=${r.summary.count} trim=${r.summary.trimmed} calib=${r.calibrationMs.toFixed(1)}ms`
             )
+            await testInfo.attach('cell', {
+              body: JSON.stringify({
+                kind: 'timed',
+                adapter,
+                scenario,
+                params,
+                dim,
+                summary: r.summary,
+                unit: r.unit,
+                supported: r.supported,
+                calibrationMs: r.calibrationMs,
+              }),
+              contentType: 'application/json',
+            })
           })
         }
       }
     }
   })
 }
+
+test.describe('cohort metadata', () => {
+  test('capability and display metadata', async ({ page }, testInfo) => {
+    await page.goto('/?meta=1')
+    await page.waitForFunction(() => document.body.dataset['benchDone'] === '1', undefined, {
+      timeout: 60_000,
+    })
+    const meta = await page.evaluate(
+      () => (window as unknown as { __BENCH_META__?: readonly unknown[] }).__BENCH_META__
+    )
+    expect(meta, 'adapter meta was not exposed on ?meta=1').toBeTruthy()
+    expect(Array.isArray(meta), 'adapter meta is not an array').toBe(true)
+    expect((meta as readonly unknown[]).length, 'meta count does not match the cohort').toBe(
+      ADAPTERS.length
+    )
+    // The orchestrator builds the capability matrix and display metadata from
+    // this attachment, so both come from the real built adapters, not a copy.
+    await testInfo.attach('meta', { body: JSON.stringify(meta), contentType: 'application/json' })
+  })
+})

--- a/apps/bench-arena/tests/arena.spec.ts
+++ b/apps/bench-arena/tests/arena.spec.ts
@@ -39,47 +39,50 @@ const CASES: readonly ScenarioCase[] = [
   {
     scenario: 'flat',
     params: ['F10', 'F50'],
-    dims: ['keystroke', 'mount', 'validate', 'rerender'],
+    dims: ['keystroke', 'mount', 'validate', 'rerender', 'memory'],
   },
   {
     scenario: 'nested',
     params: ['D4', 'D8', 'D16'],
-    dims: ['keystroke', 'mount', 'validate', 'rerender'],
+    dims: ['keystroke', 'mount', 'validate', 'rerender', 'memory'],
   },
   {
     scenario: 'arrays',
     params: ['N10', 'N100'],
-    dims: ['keystroke', 'mount', 'validate', 'rerender', 'arrayAdd', 'arrayReorder'],
+    dims: ['keystroke', 'mount', 'validate', 'rerender', 'arrayAdd', 'arrayReorder', 'memory'],
   },
   {
     scenario: 'grid',
     params: ['N20M8', 'N100M8'],
-    dims: ['keystroke', 'mount', 'validate', 'rerender', 'arrayAdd', 'arrayReorder'],
+    dims: ['keystroke', 'mount', 'validate', 'rerender', 'arrayAdd', 'arrayReorder', 'memory'],
   },
   {
     scenario: 'discriminated-union',
     params: ['DU'],
-    dims: ['keystroke', 'mount', 'validate', 'rerender', 'variantFlip'],
+    dims: ['keystroke', 'mount', 'validate', 'rerender', 'variantFlip', 'memory'],
   },
   {
     scenario: 'massive',
     params: ['L2000', 'L5000'],
-    dims: ['keystroke', 'mount', 'validate'],
+    dims: ['keystroke', 'mount', 'validate', 'memory'],
     // Mounting thousands of inputs is seconds per single mount on the heavier
-    // libraries, so a stable mount median at L5000 exceeds any practical cell
-    // budget; the L2000 mount already exposes the mount-cost divergence (a one
+    // libraries, so a stable median over repeated fresh mounts at L5000 exceeds
+    // any practical cell budget. That hits both mount and memory (a retained
+    // heap sample is itself a fresh mount), so both are skipped at L5000; the
+    // L2000 mount and heap already expose the per-field cost and slope (a one
     // time cost), while L5000 carries keystroke and full-form validate, where
     // the whole-form-versus-granular gap is the headline and both complete.
-    skip: (params, dim) => params === 'L5000' && dim === 'mount',
+    skip: (params, dim) => params === 'L5000' && (dim === 'mount' || dim === 'memory'),
   },
   {
     // A linear multi-step flow. The two genuinely comparable operations are the
     // gated forward advance (stepTransition: validate the leaving step, move on)
-    // and the cross-step aggregate validate. Keystroke/mount/rerender add no
+    // and the cross-step aggregate validate, plus the cross-cutting memory dim
+    // (the per-step forms' retained heap). Keystroke/mount/rerender add no
     // wizard-specific signal over flat/nested, so they are not swept here.
     scenario: 'wizard',
     params: ['S4'],
-    dims: ['stepTransition', 'validate'],
+    dims: ['stepTransition', 'validate', 'memory'],
   },
 ]
 
@@ -132,6 +135,103 @@ async function runCell(
   return payload
 }
 
+/** Median of a sample set (the memory cell's summary; p95/iqr land in Phase 4). */
+function median(samples: readonly number[]): number {
+  if (samples.length === 0) return 0
+  const sorted = [...samples].sort((a, b) => a - b)
+  return sorted[Math.floor((sorted.length - 1) / 2)] ?? 0
+}
+
+/** The page window once the memory hooks are installed. */
+type MemoryWindow = Window & {
+  __BENCH_MEM__?: {
+    cycles: number
+    burst: number
+    mount(): Promise<void>
+    typeBurst(): Promise<void>
+    teardown(): Promise<void>
+  }
+  __BENCH_RESULTS__?: { error?: string }
+}
+
+/** The three retained/churn/leak medians (bytes) plus the cycle count driven. */
+interface MemoryResult {
+  error?: string
+  cycles: number
+  retained: number
+  churn: number
+  leak: number
+}
+
+/**
+ * Drive the memory dimension. The page only installs mount/type/teardown hooks;
+ * a precise heap is read driver-side through CDP, since the in-page
+ * performance.memory is quantized to uselessness (tens-of-MB buckets that ignore
+ * real allocations). Per cycle, with `s0` the collected baseline, `s1` the
+ * collected live mount, `s2` the heap after a keystroke burst (uncollected), and
+ * `s3` the collected heap after teardown: retained = s1 - s0 (live-form heap),
+ * churn = s2 - s1 (the burst's allocation), leak = s3 - s0 (post-teardown
+ * residual). A leak that makes the baseline creep leaves every per-cycle delta
+ * correct. Production preview only: a dev build's HMR registry retains every
+ * mount and swamps the signal (leak then reads as the whole retained heap).
+ */
+async function runMemoryCell(
+  page: Page,
+  adapter: string,
+  scenario: string,
+  params: string,
+  timeoutMs: number
+): Promise<MemoryResult> {
+  await page.goto(
+    `/?adapter=${adapter}&scenario=${scenario}&params=${params}&trigger=input&dim=memory`
+  )
+  await page.waitForFunction(() => document.body.dataset['benchDone'] === '1', undefined, {
+    timeout: timeoutMs,
+  })
+  const empty = { cycles: 0, retained: 0, churn: 0, leak: 0 }
+  const setupError = await page.evaluate(() => (window as MemoryWindow).__BENCH_RESULTS__?.error)
+  if (setupError) return { ...empty, error: setupError }
+  const cycles = await page.evaluate(() => (window as MemoryWindow).__BENCH_MEM__?.cycles ?? 0)
+  if (!cycles) return { ...empty, error: 'memory hooks were not installed' }
+
+  const client = await page.context().newCDPSession(page)
+  await client.send('HeapProfiler.enable')
+  // Two collection passes: a single full GC can leave a large heap (FormKit at
+  // thousands of fields holds hundreds of MB) partly uncollected, which would
+  // overstate the leak; the second pass reclaims what the first left pending, so
+  // a reported leak is real, not collection lag. Symmetric across s0/s1/s3.
+  const gc = async (): Promise<void> => {
+    await client.send('HeapProfiler.collectGarbage')
+    await client.send('HeapProfiler.collectGarbage')
+  }
+  const used = async (): Promise<number> => (await client.send('Runtime.getHeapUsage')).usedSize
+  const retained: number[] = []
+  const churn: number[] = []
+  const leak: number[] = []
+  for (let i = 0; i < cycles; i++) {
+    await gc()
+    const s0 = await used()
+    await page.evaluate(() => (window as MemoryWindow).__BENCH_MEM__?.mount())
+    await gc()
+    const s1 = await used()
+    retained.push(Math.max(0, s1 - s0))
+    await page.evaluate(() => (window as MemoryWindow).__BENCH_MEM__?.typeBurst())
+    const s2 = await used()
+    churn.push(Math.max(0, s2 - s1))
+    await page.evaluate(() => (window as MemoryWindow).__BENCH_MEM__?.teardown())
+    await gc()
+    const s3 = await used()
+    leak.push(Math.max(0, s3 - s0))
+  }
+  await client.detach()
+  return {
+    cycles,
+    retained: median(retained),
+    churn: median(churn),
+    leak: median(leak),
+  }
+}
+
 for (const { scenario, params: paramSet, dims, skip } of CASES) {
   test.describe(`${scenario} scenario · full cohort`, () => {
     for (const adapter of ADAPTERS) {
@@ -145,7 +245,45 @@ for (const { scenario, params: paramSet, dims, skip } of CASES) {
             // genuine hang still fails). Every other cell keeps the default.
             const wide = scenario === 'massive'
             if (wide) test.setTimeout(360_000)
-            const r = await runCell(page, adapter, scenario, params, dim, wide ? 320_000 : 60_000)
+            const waitMs = wide ? 320_000 : 60_000
+
+            // Memory is driver-measured via CDP, so it reports three byte
+            // figures (retained/churn/leak) rather than one timed summary; it
+            // takes its own path. Every adapter mounts, so none is unsupported.
+            if (dim === 'memory') {
+              const m = await runMemoryCell(page, adapter, scenario, params, waitMs)
+              expect(
+                m.error,
+                `error in ${adapter}/${scenario}/${params}/memory: ${m.error ?? ''}`
+              ).toBeUndefined()
+              expect(
+                m.cycles,
+                `${adapter}/${scenario}/${params}/memory ran no cycles`
+              ).toBeGreaterThan(0)
+              for (const [facet, value] of [
+                ['retained', m.retained],
+                ['churn', m.churn],
+                ['leak', m.leak],
+              ] as const) {
+                expect(
+                  Number.isFinite(value),
+                  `${adapter}/${scenario}/${params}/memory ${facet} not finite`
+                ).toBe(true)
+                expect(
+                  value,
+                  `${adapter}/${scenario}/${params}/memory ${facet} negative`
+                ).toBeGreaterThanOrEqual(0)
+              }
+              const kb = (n: number): string => `${(n / 1024).toFixed(1)}KB`
+              // eslint-disable-next-line no-console
+              console.log(
+                `${adapter.padEnd(14)} ${scenario.padEnd(8)} ${params.padEnd(4)} memory     ` +
+                  `retained=${kb(m.retained)} churn=${kb(m.churn)} leak=${kb(m.leak)} n=${m.cycles}`
+              )
+              return
+            }
+
+            const r = await runCell(page, adapter, scenario, params, dim, waitMs)
             expect(r, `no payload for ${adapter}/${scenario}/${params}/${dim}`).toBeTruthy()
             expect(
               r.error,

--- a/apps/bench-arena/tests/arena.spec.ts
+++ b/apps/bench-arena/tests/arena.spec.ts
@@ -39,6 +39,11 @@ const CASES: readonly ScenarioCase[] = [
     params: ['D4', 'D8', 'D16'],
     dims: ['keystroke', 'mount', 'validate', 'rerender'],
   },
+  {
+    scenario: 'arrays',
+    params: ['N10', 'N100'],
+    dims: ['keystroke', 'mount', 'validate', 'rerender'],
+  },
 ]
 
 /**

--- a/apps/bench-arena/tests/arena.spec.ts
+++ b/apps/bench-arena/tests/arena.spec.ts
@@ -115,7 +115,9 @@ async function runCell(
   const payload = await page.evaluate(
     () => (window as unknown as { __BENCH_RESULTS__: Payload }).__BENCH_RESULTS__
   )
-  // Collect between cells so one library's garbage cannot skew the next.
+  // Collect after every cell of every scenario so one library's garbage cannot
+  // skew the next (the harness also collects before it measures, so the heap is
+  // clean at both ends of each cell).
   await page.evaluate(() => (globalThis as { gc?: () => void }).gc?.())
   return payload
 }

--- a/apps/bench-arena/tests/arena.spec.ts
+++ b/apps/bench-arena/tests/arena.spec.ts
@@ -26,6 +26,13 @@ interface ScenarioCase {
   readonly scenario: string
   readonly params: readonly string[]
   readonly dims: readonly string[]
+  /**
+   * A (param, dim) cell to skip for a library-agnostic measurement-budget
+   * reason (never a per-library one). Applied uniformly across the whole
+   * cohort, so it never biases a comparison: it removes a cell no library
+   * reports, not a number a slow library would lose on.
+   */
+  readonly skip?: (params: string, dim: string) => boolean
 }
 
 const CASES: readonly ScenarioCase[] = [
@@ -54,6 +61,17 @@ const CASES: readonly ScenarioCase[] = [
     params: ['DU'],
     dims: ['keystroke', 'mount', 'validate', 'rerender', 'variantFlip'],
   },
+  {
+    scenario: 'massive',
+    params: ['L2000', 'L5000'],
+    dims: ['keystroke', 'mount', 'validate'],
+    // Mounting thousands of inputs is seconds per single mount on the heavier
+    // libraries, so a stable mount median at L5000 exceeds any practical cell
+    // budget; the L2000 mount already exposes the mount-cost divergence (a one
+    // time cost), while L5000 carries keystroke and full-form validate, where
+    // the whole-form-versus-granular gap is the headline and both complete.
+    skip: (params, dim) => params === 'L5000' && dim === 'mount',
+  },
 ]
 
 /**
@@ -63,11 +81,12 @@ const CASES: readonly ScenarioCase[] = [
  * number where a gap belongs, or a skipped cell that should have measured).
  */
 function expectUnsupported(_adapter: string, _scenario: string, _dim: string): boolean {
-  // Every adapter expresses every dimension of the object, array, and grid
-  // scenarios. FormKit owns its inputs, so its render scope falls back to the
+  // Every adapter expresses every dimension of the object, array, grid, and
+  // massive scenarios (massive composes those same supported primitives at
+  // scale). FormKit owns its inputs, so its render scope falls back to the
   // caveated DOM-mutation proxy (asserted below) rather than reporting
-  // unsupported. The discriminated-union and wizard scenarios (later Phase 3
-  // commits) introduce the first genuine capability gaps this gate will assert.
+  // unsupported. The wizard scenario (a later Phase 3 commit) introduces the
+  // first genuine capability gaps this gate will assert.
   return false
 }
 
@@ -84,13 +103,14 @@ async function runCell(
   adapter: string,
   scenario: string,
   params: string,
-  dim: string
+  dim: string,
+  timeoutMs: number
 ): Promise<Payload> {
   await page.goto(
     `/?adapter=${adapter}&scenario=${scenario}&params=${params}&trigger=input&dim=${dim}`
   )
   await page.waitForFunction(() => document.body.dataset['benchDone'] === '1', undefined, {
-    timeout: 60_000,
+    timeout: timeoutMs,
   })
   const payload = await page.evaluate(
     () => (window as unknown as { __BENCH_RESULTS__: Payload }).__BENCH_RESULTS__
@@ -100,13 +120,20 @@ async function runCell(
   return payload
 }
 
-for (const { scenario, params: paramSet, dims } of CASES) {
+for (const { scenario, params: paramSet, dims, skip } of CASES) {
   test.describe(`${scenario} scenario · full cohort`, () => {
     for (const adapter of ADAPTERS) {
       for (const params of paramSet) {
         for (const dim of dims) {
           test(`${adapter} · ${params} · ${dim}`, async ({ page }) => {
-            const r = await runCell(page, adapter, scenario, params, dim)
+            test.skip(skip?.(params, dim) ?? false, 'cell exceeds the per-cell measurement budget')
+            // The massive scenario mounts thousands of inputs, so a single mount
+            // or full-form validate runs for seconds on the heavier libraries;
+            // give those cells a wide test + wait budget (still bounded, so a
+            // genuine hang still fails). Every other cell keeps the default.
+            const wide = scenario === 'massive'
+            if (wide) test.setTimeout(360_000)
+            const r = await runCell(page, adapter, scenario, params, dim, wide ? 320_000 : 60_000)
             expect(r, `no payload for ${adapter}/${scenario}/${params}/${dim}`).toBeTruthy()
             expect(
               r.error,

--- a/apps/bench-arena/tests/arena.spec.ts
+++ b/apps/bench-arena/tests/arena.spec.ts
@@ -72,6 +72,15 @@ const CASES: readonly ScenarioCase[] = [
     // the whole-form-versus-granular gap is the headline and both complete.
     skip: (params, dim) => params === 'L5000' && dim === 'mount',
   },
+  {
+    // A linear multi-step flow. The two genuinely comparable operations are the
+    // gated forward advance (stepTransition: validate the leaving step, move on)
+    // and the cross-step aggregate validate. Keystroke/mount/rerender add no
+    // wizard-specific signal over flat/nested, so they are not swept here.
+    scenario: 'wizard',
+    params: ['S4'],
+    dims: ['stepTransition', 'validate'],
+  },
 ]
 
 /**
@@ -81,12 +90,13 @@ const CASES: readonly ScenarioCase[] = [
  * number where a gap belongs, or a skipped cell that should have measured).
  */
 function expectUnsupported(_adapter: string, _scenario: string, _dim: string): boolean {
-  // Every adapter expresses every dimension of the object, array, grid, and
-  // massive scenarios (massive composes those same supported primitives at
-  // scale). FormKit owns its inputs, so its render scope falls back to the
-  // caveated DOM-mutation proxy (asserted below) rather than reporting
-  // unsupported. The wizard scenario (a later Phase 3 commit) introduces the
-  // first genuine capability gaps this gate will assert.
+  // Every adapter expresses every dimension of the object, array, grid,
+  // massive, and wizard scenarios. The wizard's expressiveness gap is
+  // native-versus-hand-rolled (the capability matrix column), not a measurement
+  // one: Attaform has a wizard primitive, the rest hand-compose the flow, but
+  // all of them advance steps and validate, so none reports a wizard dimension
+  // unsupported. FormKit owns its inputs, so its render scope falls back to the
+  // caveated DOM-mutation proxy (asserted below) rather than unsupported.
   return false
 }
 

--- a/apps/bench-arena/tests/arena.spec.ts
+++ b/apps/bench-arena/tests/arena.spec.ts
@@ -44,6 +44,11 @@ const CASES: readonly ScenarioCase[] = [
     params: ['N10', 'N100'],
     dims: ['keystroke', 'mount', 'validate', 'rerender', 'arrayAdd', 'arrayReorder'],
   },
+  {
+    scenario: 'grid',
+    params: ['N20M8', 'N100M8'],
+    dims: ['keystroke', 'mount', 'validate', 'rerender', 'arrayAdd', 'arrayReorder'],
+  },
 ]
 
 /**
@@ -52,15 +57,18 @@ const CASES: readonly ScenarioCase[] = [
  * SHOULD do, so a disagreement fails the test in either direction (a rigged
  * number where a gap belongs, or a skipped cell that should have measured).
  */
-function expectUnsupported(adapter: string, _scenario: string, dim: string): boolean {
-  // FormKit owns its inputs, so component render scope is not applicable on any
-  // scenario; it reports unsupported (the DOM-mutation proxy lands later).
-  return dim === 'rerender' && adapter === 'formkit'
+function expectUnsupported(_adapter: string, _scenario: string, _dim: string): boolean {
+  // Every adapter expresses every dimension of the object, array, and grid
+  // scenarios. FormKit owns its inputs, so its render scope falls back to the
+  // caveated DOM-mutation proxy (asserted below) rather than reporting
+  // unsupported. The discriminated-union and wizard scenarios (later Phase 3
+  // commits) introduce the first genuine capability gaps this gate will assert.
+  return false
 }
 
 interface Payload {
   summary: { median: number; p95: number; iqr: number; count: number; trimmed: number }
-  unit: 'ms' | 'renders'
+  unit: 'ms' | 'renders' | 'dom-mutations'
   supported: boolean
   calibrationMs: number
   error?: string
@@ -115,11 +123,22 @@ for (const { scenario, params: paramSet, dims } of CASES) {
               expect(r.summary.count).toBeGreaterThan(0)
             }
 
-            const unit = r.unit === 'renders' ? ' renders' : 'ms'
+            // Lock the render-scope unit: the bare-input cohort reports
+            // component renders; FormKit owns its inputs, so its rerender cell
+            // falls back to the caveated DOM-mutation proxy. Both are
+            // well-formed numbers; only the unit distinguishes them.
+            if (dim === 'rerender') {
+              expect(r.unit, `${adapter}/${scenario}/${params}/rerender unit`).toBe(
+                adapter === 'formkit' ? 'dom-mutations' : 'renders'
+              )
+            }
+
+            const unitLabel =
+              r.unit === 'renders' ? ' renders' : r.unit === 'dom-mutations' ? ' dom-mut' : 'ms'
             // eslint-disable-next-line no-console
             console.log(
               `${adapter.padEnd(14)} ${scenario.padEnd(8)} ${params.padEnd(4)} ${dim.padEnd(10)} ` +
-                `median=${r.summary.median.toFixed(3)}${unit} p95=${r.summary.p95.toFixed(3)} ` +
+                `median=${r.summary.median.toFixed(3)}${unitLabel} p95=${r.summary.p95.toFixed(3)} ` +
                 `n=${r.summary.count} trim=${r.summary.trimmed} calib=${r.calibrationMs.toFixed(1)}ms`
             )
           })

--- a/apps/bench-arena/tests/arena.spec.ts
+++ b/apps/bench-arena/tests/arena.spec.ts
@@ -42,7 +42,7 @@ const CASES: readonly ScenarioCase[] = [
   {
     scenario: 'arrays',
     params: ['N10', 'N100'],
-    dims: ['keystroke', 'mount', 'validate', 'rerender'],
+    dims: ['keystroke', 'mount', 'validate', 'rerender', 'arrayAdd', 'arrayReorder'],
   },
 ]
 

--- a/apps/bench-arena/tests/arena.spec.ts
+++ b/apps/bench-arena/tests/arena.spec.ts
@@ -1,0 +1,125 @@
+import { type Page, expect, test } from '@playwright/test'
+
+/**
+ * The cohort driver: loop every adapter across the scenario suite and every
+ * dimension, read each in-page measurement, and assert it is well-formed and
+ * sane. The numbers themselves are logged for human inspection; this spec's job
+ * is to prove every adapter mounts, drives, validates, and reports through the
+ * one uniform contract, and that an adapter which cannot express a (scenario,
+ * dimension) reports it unsupported rather than faking a number.
+ * Provenance-stamped `results.json` writing is Phase 4.
+ */
+
+const ADAPTERS = [
+  'attaform',
+  'vee-validate',
+  'tanstack',
+  'formisch',
+  'regle-schema',
+  'regle-rules',
+  'formkit',
+  'vuelidate',
+] as const
+
+/** A scenario plus the param labels and dimensions it is swept across. */
+interface ScenarioCase {
+  readonly scenario: string
+  readonly params: readonly string[]
+  readonly dims: readonly string[]
+}
+
+const CASES: readonly ScenarioCase[] = [
+  {
+    scenario: 'flat',
+    params: ['F10', 'F50'],
+    dims: ['keystroke', 'mount', 'validate', 'rerender'],
+  },
+  {
+    scenario: 'nested',
+    params: ['D4', 'D8', 'D16'],
+    dims: ['keystroke', 'mount', 'validate', 'rerender'],
+  },
+]
+
+/**
+ * Whether an adapter legitimately reports a (scenario, dimension) as
+ * unsupported. The page reports what the adapter actually does; this is what it
+ * SHOULD do, so a disagreement fails the test in either direction (a rigged
+ * number where a gap belongs, or a skipped cell that should have measured).
+ */
+function expectUnsupported(adapter: string, _scenario: string, dim: string): boolean {
+  // FormKit owns its inputs, so component render scope is not applicable on any
+  // scenario; it reports unsupported (the DOM-mutation proxy lands later).
+  return dim === 'rerender' && adapter === 'formkit'
+}
+
+interface Payload {
+  summary: { median: number; p95: number; iqr: number; count: number; trimmed: number }
+  unit: 'ms' | 'renders'
+  supported: boolean
+  calibrationMs: number
+  error?: string
+}
+
+async function runCell(
+  page: Page,
+  adapter: string,
+  scenario: string,
+  params: string,
+  dim: string
+): Promise<Payload> {
+  await page.goto(
+    `/?adapter=${adapter}&scenario=${scenario}&params=${params}&trigger=input&dim=${dim}`
+  )
+  await page.waitForFunction(() => document.body.dataset['benchDone'] === '1', undefined, {
+    timeout: 60_000,
+  })
+  const payload = await page.evaluate(
+    () => (window as unknown as { __BENCH_RESULTS__: Payload }).__BENCH_RESULTS__
+  )
+  // Collect between cells so one library's garbage cannot skew the next.
+  await page.evaluate(() => (globalThis as { gc?: () => void }).gc?.())
+  return payload
+}
+
+for (const { scenario, params: paramSet, dims } of CASES) {
+  test.describe(`${scenario} scenario · full cohort`, () => {
+    for (const adapter of ADAPTERS) {
+      for (const params of paramSet) {
+        for (const dim of dims) {
+          test(`${adapter} · ${params} · ${dim}`, async ({ page }) => {
+            const r = await runCell(page, adapter, scenario, params, dim)
+            expect(r, `no payload for ${adapter}/${scenario}/${params}/${dim}`).toBeTruthy()
+            expect(
+              r.error,
+              `error in ${adapter}/${scenario}/${params}/${dim}: ${r.error ?? ''}`
+            ).toBeUndefined()
+
+            if (expectUnsupported(adapter, scenario, dim)) {
+              expect(
+                r.supported,
+                `${adapter}/${scenario}/${params}/${dim} should be unsupported`
+              ).toBe(false)
+            } else {
+              expect(
+                r.supported,
+                `${adapter}/${scenario}/${params}/${dim} reported unsupported`
+              ).toBe(true)
+              expect(Number.isFinite(r.summary.median)).toBe(true)
+              expect(r.summary.median).toBeGreaterThanOrEqual(0)
+              expect(r.summary.count).toBeGreaterThan(0)
+            }
+
+            const unit = r.unit === 'renders' ? ' renders' : 'ms'
+            // eslint-disable-next-line no-console
+            console.log(
+              `${adapter.padEnd(14)} ${scenario.padEnd(8)} ${params.padEnd(4)} ${dim.padEnd(10)} ` +
+                `median=${r.summary.median.toFixed(3)}${unit} p95=${r.summary.p95.toFixed(3)} ` +
+                `n=${r.summary.count} trim=${r.summary.trimmed} calib=${r.calibrationMs.toFixed(1)}ms`
+            )
+          })
+        }
+      }
+    }
+  })
+}

--- a/apps/bench-arena/tsconfig.json
+++ b/apps/bench-arena/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "useUnknownInCatchVariables": true,
+    "allowUnreachableCode": false,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src", "entries", "tests", "vite.config.ts"],
+  "exclude": ["node_modules", "dist", ".vite"]
+}

--- a/apps/bench-arena/vite.config.ts
+++ b/apps/bench-arena/vite.config.ts
@@ -1,0 +1,44 @@
+import vue from '@vitejs/plugin-vue'
+import { defineConfig } from 'vite'
+
+/**
+ * Harness build for the benchmark arena.
+ *
+ * Fairness spine: this app consumes the REAL published Attaform build
+ * (`dist/*.mjs`, resolved through the package `exports` by the
+ * `workspace:*` dependency), never the `attaform -> src/*.ts` alias the
+ * docs site uses for dev. Run `pnpm prepack` at the repo root before
+ * building or serving this app so `dist` is current. Every library in the
+ * cohort, Attaform included, is bundled and minified the same way a
+ * consumer would install it, so no entry gets an unearned advantage.
+ *
+ * The driver measures against a production `build` + `preview` (stable,
+ * representative of shipped code); `dev` exists only for manual probing.
+ */
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    // Force a single copy of each shared runtime. Attaform is a symlinked
+    // workspace package, so without this its internal `import 'zod'` (and
+    // `vue`) hoist to the repo ROOT's versions (zod v4, for Attaform's own v4
+    // adapter dev) while the arena resolves its OWN deps (zod v3). That split
+    // feeds the v3 adapter v4 schemas and silently breaks it. A real consumer
+    // installs ONE zod, so deduping to the arena's copies faithfully mirrors
+    // them and keeps every library on the exact version the bundle measures.
+    dedupe: ['vue', 'zod', 'valibot'],
+  },
+  build: {
+    target: 'es2020',
+    // Keep everything in one chunk: the arena mounts one adapter per page
+    // load, so code-splitting would only add fetch latency to the timing.
+    modulePreload: false,
+  },
+  server: {
+    port: 4173,
+    strictPort: true,
+  },
+  preview: {
+    port: 4174,
+    strictPort: true,
+  },
+})

--- a/apps/site/components/content/BenchArena.vue
+++ b/apps/site/components/content/BenchArena.vue
@@ -94,13 +94,35 @@
   const props = defineProps<{ dimension: string; scenario?: string }>()
 
   const results = rawResults as Results
-  if (results.schemaVersion !== 1) {
+  const isDev = import.meta.dev
+  // The Actions page for the monthly refresh workflow. Doubles as the
+  // always-available provenance link (before any CI run has stamped a
+  // specific run URL) and the production fallback when data is missing.
+  const BENCH_WORKFLOW_URL =
+    'https://github.com/attaform/Attaform/actions/workflows/bench-arena.yml'
+  const BENCH_SOURCE_URL = 'https://github.com/attaform/Attaform/tree/main/apps/bench-arena'
+
+  // A present-but-incompatible schema is real drift and still fails the
+  // build loudly, so a shape change can never render a stale table. An
+  // absent or empty dataset is a different condition: a regen that never
+  // ran, or wrote nothing, should degrade to a friendly notice rather than
+  // crash every page that embeds a block. `datasetReady` separates the two.
+  const hasUsableShape =
+    !!results &&
+    typeof results === 'object' &&
+    typeof results.schemaVersion === 'number' &&
+    !!results.runtime &&
+    Object.keys(results.runtime).length > 0 &&
+    Array.isArray(results.capabilities) &&
+    results.capabilities.length > 0
+  if (hasUsableShape && results.schemaVersion !== 1) {
     throw new Error(
       `[BenchArena] results.json schemaVersion ${results.schemaVersion} is unsupported ` +
         `(this component renders schemaVersion 1). Update BenchArena.vue to the new shape ` +
         `or re-run the bench-arena orchestrator to emit a compatible results.json.`
     )
   }
+  const datasetReady = hasUsableShape && results.schemaVersion === 1
 
   const SCENARIO_LABEL: Record<string, string> = {
     flat: 'Flat',
@@ -273,6 +295,118 @@
     return `${s}: ${DIMENSION_LABEL[props.dimension] ?? props.dimension}`
   })
 
+  // --- Attaform standing (data-driven, never hard-coded) ------------------
+  // The page asserts no rank in prose; this derives Attaform's standing for
+  // the selected block straight from the numbers, so the sentence under a
+  // table can never drift from the table itself. The comparison set is
+  // Attaform's own layer, the form-state libraries: a validation-only engine
+  // that owns no input binding is not a faster form library, only a smaller
+  // one, exactly as the methodology note says. Ranking is by the largest
+  // size in the block (the most-stressed, fairest read) and combines rank
+  // with the gap to the leader, so "second of four but eight times behind"
+  // reads as trailing, not as front-of-pack.
+  const FORM_STATE_LAYER = 'headless-form-state'
+  const layerOf = (lib: string) => results.capabilities.find((c) => c.lib === lib)?.layer ?? ''
+
+  type StandingTone = 'lead' | 'plain'
+  interface Standing {
+    text: string
+    tone: StandingTone
+  }
+
+  // One pool per standing. Every line in a pool is interchangeably true for
+  // that standing, so any selection stays honest; the selection only varies
+  // the phrasing. Scoped to "form-state libraries", names Attaform, no
+  // competitor naming, no superlative the data does not earn.
+  const STANDING_POOLS: Record<string, string[]> = {
+    leads: [
+      'Fastest of the form-state libraries here, with daylight to the next.',
+      'Out in front of the form-state pack on this shape.',
+      'The quickest form-state library on this run, comfortably ahead.',
+    ],
+    edges: [
+      'Narrowly the fastest form-state library on this shape.',
+      'At the head of the form-state pack, by a step.',
+      'Just ahead of its form-state peers here.',
+    ],
+    matches: [
+      'Level with the fastest form-state libraries, at the floor this shape allows.',
+      'Matches the best of the form-state pack, with no lower number left to reach.',
+      'Even with the front of the form-state field on this run.',
+    ],
+    front: [
+      'Among the faster form-state libraries on this shape.',
+      'Near the front of the form-state pack here.',
+      'In the leading group of form-state libraries on this run.',
+    ],
+    mid: [
+      'Mid-pack among the form-state libraries here.',
+      'Holds the middle of the form-state field on this shape.',
+      'Squarely in the form-state pack, neither out front nor at the back.',
+    ],
+    trails: [
+      'Behind the form-state pack on this shape, and the run shows it plainly.',
+      'Off the lead here among the form-state libraries, a line we are actively sharpening.',
+      'Toward the back of the form-state field on this run, honest data we would rather show than hide.',
+    ],
+    renderScope: [
+      'One render per keystroke, whatever the form size. That is the design target, and the run holds it.',
+      'Editing one field re-renders one field, flat across every size measured.',
+      'Render scope stays at one, the floor, however large the form grows.',
+    ],
+  }
+
+  // Deterministic pick: stable across builds (no Math.random in SSG) but
+  // varied across sections, so neighbouring blocks do not repeat a sentence.
+  const pickFor = (key: string, pool: string[]): string => {
+    // Multiplier 33 (not 31): it keeps adjacent same-bucket blocks on the page
+    // (the two array ops, mount next to memory) from drawing the same sentence.
+    let h = 0
+    for (let i = 0; i < key.length; i += 1) h = (h * 33 + key.charCodeAt(i)) >>> 0
+    return pool[h % pool.length] ?? pool[0] ?? ''
+  }
+
+  const standing = computed<Standing | null>(() => {
+    const b = block.value
+    if (mode.value !== 'runtime' || !b) return null
+    const orderedParams = Object.keys(b.byParam)
+    const largest = orderedParams[orderedParams.length - 1]
+    if (!largest) return null
+    const valueOf = (r: RuntimeRow) => ('retained' in r ? r.retained.median : r.median)
+    const peers = (b.byParam[largest] ?? []).filter(
+      (r) => r.supported && layerOf(r.lib) === FORM_STATE_LAYER
+    )
+    const me = peers.find((r) => r.lib === results.baseline)
+    if (!me || peers.length < 2) return null
+    const sorted = [...peers].sort((a, c) => valueOf(a) - valueOf(c))
+    const leader = sorted[0]
+    if (!leader) return null
+    const rank = sorted.findIndex((r) => r.lib === results.baseline) + 1
+    const n = peers.length
+    const key = `${props.scenario}:${props.dimension}`
+
+    // Render scope has an architectural floor of one render per keystroke.
+    // When Attaform holds it (rank one), celebrate the constant scope rather
+    // than a rank; if it ever regresses, fall through to the honest buckets.
+    if (props.dimension === 'rerender' && rank === 1) {
+      return { text: pickFor(key, STANDING_POOLS.renderScope ?? []), tone: 'lead' }
+    }
+
+    const meValue = valueOf(me)
+    if (rank === 1) {
+      const secondRow = sorted[1]
+      const margin = secondRow && meValue > 0 ? valueOf(secondRow) / meValue : 1
+      const pool = margin >= 1.15 ? 'leads' : margin >= 1.04 ? 'edges' : 'matches'
+      return { text: pickFor(key, STANDING_POOLS[pool] ?? []), tone: 'lead' }
+    }
+    const leaderValue = valueOf(leader)
+    const gap = leaderValue > 0 ? meValue / leaderValue : 1
+    if (rank === n || gap > 4)
+      return { text: pickFor(key, STANDING_POOLS.trails ?? []), tone: 'plain' }
+    if (gap <= 1.5) return { text: pickFor(key, STANDING_POOLS.front ?? []), tone: 'lead' }
+    return { text: pickFor(key, STANDING_POOLS.mid ?? []), tone: 'plain' }
+  })
+
   // --- provenance ---------------------------------------------------------
   const prov = results.provenance
   const provDate = computed(() => shortDate(prov.timestamp))
@@ -280,8 +414,45 @@
 
 <template>
   <div class="not-prose my-6 overflow-hidden rounded-xl border border-border bg-bg shadow-sm">
+    <!-- ===================== Data unavailable (graceful) ===================== -->
+    <!-- Heads the v-if chain: if results.json is missing or empty, every block
+         renders this instead of crashing the build. Dev points at how to
+         regenerate; production names the gap and links the live resources. -->
+    <div v-if="!datasetReady" class="px-4 py-5 text-sm text-fg-muted">
+      <p class="font-medium text-fg">Benchmark data is not available in this build.</p>
+      <p v-if="isDev" class="mt-2">
+        Generate it from the repo root: build Attaform's real
+        <code class="rounded bg-surface px-1 py-0.5 font-mono text-xs text-fg">dist</code> with
+        <code class="rounded bg-surface px-1 py-0.5 font-mono text-xs text-fg">pnpm prepack</code>,
+        then run
+        <code class="rounded bg-surface px-1 py-0.5 font-mono text-xs text-fg"
+          >pnpm --filter attaform-bench-arena run arena</code
+        >, which writes
+        <code class="rounded bg-surface px-1 py-0.5 font-mono text-xs text-fg"
+          >apps/bench-arena/results.json</code
+        >.
+      </p>
+      <p v-else class="mt-2">
+        The benchmark results are being refreshed. See the latest runs on the
+        <a
+          :href="BENCH_WORKFLOW_URL"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-accent hover:underline"
+          >bench-arena workflow</a
+        >, or browse the
+        <a
+          :href="BENCH_SOURCE_URL"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-accent hover:underline"
+          >harness source</a
+        >.
+      </p>
+    </div>
+
     <!-- ===================== Capability matrix ===================== -->
-    <div v-if="mode === 'capabilities'" class="overflow-x-auto">
+    <div v-else-if="mode === 'capabilities'" class="overflow-x-auto">
       <table class="w-full text-sm">
         <thead>
           <tr class="border-b border-border bg-surface/40 text-left">
@@ -468,6 +639,20 @@
           caption
         }}</span>
       </div>
+      <!-- Where Attaform lands, derived from the numbers below, never asserted
+           by hand. See the `standing` classifier for the buckets. -->
+      <p
+        v-if="standing"
+        class="flex items-center gap-2 border-b border-border/60 px-3 py-2 text-sm"
+        :class="standing.tone === 'lead' ? 'text-fg' : 'text-fg-muted'"
+      >
+        <span
+          class="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+          :class="standing.tone === 'lead' ? 'bg-accent' : 'bg-fg-subtle/50'"
+          aria-hidden="true"
+        />
+        {{ standing.text }}
+      </p>
       <table v-if="isMemory" class="w-full text-sm">
         <thead>
           <tr class="border-b border-border text-left">
@@ -569,7 +754,11 @@
     </div>
 
     <!-- ===================== Provenance footer ===================== -->
+    <!-- Every block traces to where its numbers came from. A CI run links the
+         exact run; a local seed links the workflow that supersedes it, so a
+         reader is never left without a destination. -->
     <div
+      v-if="datasetReady"
       class="flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-border bg-surface/30 px-3 py-2 text-xs text-fg-subtle"
     >
       <span v-if="prov.source === 'ci' && prov.ciRunUrl">
@@ -582,7 +771,16 @@
           >CI run #{{ prov.ciRunId }}</a
         >
       </span>
-      <span v-else>Source: local run (illustrative shape data; superseded by CI)</span>
+      <span v-else>
+        Source: local run, superseded by the
+        <a
+          :href="BENCH_WORKFLOW_URL"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-accent hover:underline"
+          >monthly CI refresh</a
+        >
+      </span>
       <span>{{ prov.runner.cpuModel }}</span>
       <span>Node {{ prov.node }}</span>
       <span>{{ provDate }}</span>

--- a/apps/site/components/content/BenchArena.vue
+++ b/apps/site/components/content/BenchArena.vue
@@ -1,0 +1,575 @@
+<script setup lang="ts">
+  // Renders one slice of the cross-library benchmark from the committed
+  // results.json. Each `::bench-arena{dimension=... scenario=...}` block in the
+  // Benchmarks page selects a view: the capability matrix, the supply-chain
+  // (OpenSSF Scorecard) table, the bundle table, or a per-scenario runtime
+  // table. The data is the single source of truth produced by the bench-arena
+  // orchestrator; this component only renders it, so a number on the page can
+  // never disagree with the run that produced it.
+  //
+  // Build-time invariant (mirrors DocsDemo's missing-slug throw): an unknown
+  // schemaVersion, or a runtime view whose scenario or dimension is absent from
+  // the data, throws at render. That fails Nuxt's prerender for the page and
+  // surfaces in CI before reaching production, so a typo in a content block can
+  // never ship a blank or stale table.
+  import { computed } from 'vue'
+  import { ArrowUpRight, Github } from 'lucide-vue-next'
+  import rawResults from 'attaform-bench-arena/results.json'
+
+  type Support = 'native' | 'hand-rolled' | 'unsupported'
+  interface Scorecard {
+    score: number
+    date: string | null
+  }
+  interface Capability {
+    lib: string
+    displayName: string
+    layer: string
+    schemaLib: string
+    ownsInputs: boolean
+    repo: string | null
+    repoUrl: string | null
+    scorecardUrl: string | null
+    scorecard: Scorecard | null
+    [scenario: string]: unknown
+  }
+  interface BundleRow {
+    id: string
+    lib: string
+    version: string
+    validator: string
+    gzBytes: number
+    ratio: number
+  }
+  interface TimedRow {
+    lib: string
+    median: number
+    p95: number
+    unit: string
+    supported: boolean
+    ratio: number | null
+    slope: number
+  }
+  interface MemoryStat {
+    median: number
+    p95: number
+    count: number
+  }
+  interface MemoryRow {
+    lib: string
+    retained: MemoryStat
+    churn: MemoryStat
+    leak: MemoryStat
+    series: { retained: number[]; churn: number[]; leak: number[] }
+    supported: boolean
+    ratio: number | null
+    slope: number
+  }
+  type RuntimeRow = TimedRow | MemoryRow
+  interface DimBlock {
+    unit: string
+    byParam: Record<string, RuntimeRow[]>
+  }
+  interface Provenance {
+    source: 'ci' | 'local'
+    commit: string | null
+    ciRunId: string | null
+    ciRunUrl: string | null
+    runner: { os: string; arch: string; cpuModel: string; cpuCount: number }
+    node: string
+    timestamp: string
+    libVersions: Record<string, string>
+  }
+  interface Results {
+    schemaVersion: number
+    provenance: Provenance
+    baseline: string
+    capabilities: Capability[]
+    bundle: BundleRow[]
+    runtime: Record<string, Record<string, DimBlock>>
+  }
+
+  const props = defineProps<{ dimension: string; scenario?: string }>()
+
+  const results = rawResults as Results
+  if (results.schemaVersion !== 1) {
+    throw new Error(
+      `[BenchArena] results.json schemaVersion ${results.schemaVersion} is unsupported ` +
+        `(this component renders schemaVersion 1). Update BenchArena.vue to the new shape ` +
+        `or re-run the bench-arena orchestrator to emit a compatible results.json.`
+    )
+  }
+
+  const SCENARIO_LABEL: Record<string, string> = {
+    flat: 'Flat',
+    nested: 'Deeply nested',
+    arrays: 'Dynamic arrays',
+    grid: 'Grid',
+    'discriminated-union': 'Discriminated union',
+    massive: 'Massive',
+    wizard: 'Wizard',
+  }
+  const DIMENSION_LABEL: Record<string, string> = {
+    keystroke: 'Keystroke latency',
+    mount: 'Mount',
+    validate: 'Full-form validation',
+    rerender: 'Re-render scope per keystroke',
+    arrayAdd: 'Array append',
+    arrayReorder: 'Array reorder',
+    variantFlip: 'Variant flip',
+    stepTransition: 'Step transition',
+    memory: 'Retained heap',
+  }
+  const LAYER_LABEL: Record<string, string> = {
+    'headless-form-state': 'Form state',
+    'headless-validation-only': 'Validation only',
+    'batteries-included': 'Batteries included',
+  }
+  const SCHEMA_LABEL: Record<string, string> = {
+    zod3: 'Zod 3',
+    valibot: 'Valibot',
+    native: 'native rules',
+  }
+  const UNIT_LABEL: Record<string, string> = {
+    ms: 'ms',
+    renders: 'renders',
+    'dom-mutations': 'DOM mutations',
+    bytes: 'bytes',
+  }
+
+  const mode = computed<'capabilities' | 'scorecard' | 'bundle' | 'runtime'>(() => {
+    if (props.dimension === 'capabilities') return 'capabilities'
+    if (props.dimension === 'scorecard') return 'scorecard'
+    if (props.dimension === 'bundle') return 'bundle'
+    return 'runtime'
+  })
+
+  const displayName = (lib: string) =>
+    results.capabilities.find((c) => c.lib === lib)?.displayName ?? lib
+  const isBaseline = (lib: string) => lib === results.baseline
+
+  // --- formatting ---------------------------------------------------------
+  const fmtMs = (n: number) => (n >= 100 ? n.toFixed(0) : n >= 10 ? n.toFixed(1) : n.toFixed(2))
+  const fmtCount = (n: number) => (Number.isInteger(n) ? String(n) : n.toFixed(1))
+  const fmtKb = (bytes: number) => `${(bytes / 1024).toFixed(1)} kB`
+  // Heap is quantized by the engine, so retained bytes show as whole kB; false
+  // decimals would imply a precision the measurement does not have.
+  const fmtHeapKb = (bytes: number) => `${Math.round(bytes / 1024)} kB`
+  const fmtRatio = (r: number | null) => (r == null ? '' : `${r}×`)
+  const shortDate = (iso: string | null) => (iso ? iso.slice(0, 10) : '')
+  const fmtTimed = (value: number, unit: string) =>
+    unit === 'ms' ? `${fmtMs(value)} ms` : `${fmtCount(value)} ${UNIT_LABEL[unit] ?? unit}`
+  const barPct = (value: number, max: number) => (max > 0 ? Math.max(2, (value / max) * 100) : 0)
+
+  // --- capability matrix --------------------------------------------------
+  const SCENARIOS = Object.keys(SCENARIO_LABEL)
+  const supportOf = (cap: Capability, scenario: string) => cap[scenario] as Support | undefined
+  const SUPPORT_GLYPH: Record<Support, string> = {
+    native: 'Native',
+    'hand-rolled': 'Hand-rolled',
+    unsupported: '—',
+  }
+
+  // --- bundle -------------------------------------------------------------
+  // Smallest first, so Attaform's heaviest-in-cohort figure reads honestly at
+  // the foot of the table rather than being buried.
+  const bundleRows = computed(() => [...results.bundle].sort((a, b) => a.gzBytes - b.gzBytes))
+  const bundleMax = computed(() => Math.max(...results.bundle.map((r) => r.gzBytes)))
+
+  // --- scorecard ----------------------------------------------------------
+  const hasAnyScorecard = computed(() => results.capabilities.some((c) => c.scorecard != null))
+
+  // --- runtime tables -----------------------------------------------------
+  // Resolve the selected scenario/dimension; throw with a helpful message if it
+  // is absent, so a bad content block fails the build rather than rendering blank.
+  const block = computed<DimBlock | null>(() => {
+    if (mode.value !== 'runtime') return null
+    if (!props.scenario) {
+      throw new Error(
+        `[BenchArena] dimension "${props.dimension}" needs a scenario ` +
+          `(e.g. ::bench-arena{scenario="flat" dimension="${props.dimension}"}).`
+      )
+    }
+    const found = results.runtime[props.scenario]?.[props.dimension]
+    if (!found) {
+      const have = Object.keys(results.runtime[props.scenario] ?? {}).join(', ') || 'none'
+      throw new Error(
+        `[BenchArena] no data for scenario "${props.scenario}" dimension "${props.dimension}". ` +
+          `Available for that scenario: ${have}.`
+      )
+    }
+    return found
+  })
+  const params = computed(() => (block.value ? Object.keys(block.value.byParam) : []))
+  const runtimeLibs = computed(() => {
+    const b = block.value
+    const first = params.value[0]
+    if (!b || !first) return []
+    return (b.byParam[first] ?? []).map((r) => r.lib)
+  })
+  const isMemory = computed(() => props.dimension === 'memory')
+
+  // Per-column bar scale, over supported rows only.
+  const colMax = (param: string) => {
+    const rows = block.value?.byParam[param] ?? []
+    const vals = rows
+      .filter((r) => r.supported)
+      .map((r) => ('retained' in r ? r.retained.median : r.median))
+    return vals.length ? Math.max(...vals) : 0
+  }
+  const findRow = (param: string, lib: string) =>
+    block.value?.byParam[param]?.find((r) => r.lib === lib)
+
+  // Pivot the byParam arrays into lib rows x param cells, typed for the view so
+  // the template narrows with a plain v-if and needs no casts.
+  const timedGrid = computed(() => {
+    const b = block.value
+    if (!b || isMemory.value) return []
+    return runtimeLibs.value.map((lib) => ({
+      lib,
+      displayName: displayName(lib),
+      baseline: isBaseline(lib),
+      cells: params.value.map((param) => {
+        const row = findRow(param, lib) as TimedRow | undefined
+        return {
+          param,
+          row,
+          max: colMax(param),
+          proxy: !!row && row.unit !== b.unit,
+        }
+      }),
+    }))
+  })
+  const memoryGrid = computed(() => {
+    if (!block.value || !isMemory.value) return []
+    return runtimeLibs.value.map((lib) => ({
+      lib,
+      displayName: displayName(lib),
+      baseline: isBaseline(lib),
+      cells: params.value.map((param) => ({
+        param,
+        row: findRow(param, lib) as MemoryRow | undefined,
+        max: colMax(param),
+      })),
+    }))
+  })
+  const mixedUnits = computed(() => timedGrid.value.some((r) => r.cells.some((c) => c.proxy)))
+
+  // Inline sparkline of the per-cycle retained-heap series (leak creep across
+  // the measured mounts), normalized into a small viewBox.
+  const sparkline = (values: number[], w = 64, h = 18) => {
+    if (values.length < 2) return ''
+    const min = Math.min(...values)
+    const max = Math.max(...values)
+    const span = max - min || 1
+    const step = w / (values.length - 1)
+    return values
+      .map((v, i) => `${(i * step).toFixed(1)},${(h - ((v - min) / span) * h).toFixed(1)}`)
+      .join(' ')
+  }
+
+  const caption = computed(() => {
+    if (mode.value !== 'runtime') return ''
+    const s = SCENARIO_LABEL[props.scenario ?? ''] ?? props.scenario
+    return `${s}: ${DIMENSION_LABEL[props.dimension] ?? props.dimension}`
+  })
+
+  // --- provenance ---------------------------------------------------------
+  const prov = results.provenance
+  const provDate = computed(() => shortDate(prov.timestamp))
+</script>
+
+<template>
+  <div class="not-prose my-6 overflow-hidden rounded-xl border border-border bg-bg shadow-sm">
+    <!-- ===================== Capability matrix ===================== -->
+    <div v-if="mode === 'capabilities'" class="overflow-x-auto">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="border-b border-border bg-surface/40 text-left">
+            <th class="px-3 py-2 font-semibold text-fg">Library</th>
+            <th class="px-3 py-2 font-semibold text-fg-subtle">Layer</th>
+            <th
+              v-for="s in SCENARIOS"
+              :key="s"
+              class="px-3 py-2 text-center text-xs font-semibold text-fg-subtle"
+            >
+              {{ SCENARIO_LABEL[s] }}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="cap in results.capabilities"
+            :key="cap.lib"
+            class="border-b border-border/60 last:border-0"
+            :class="isBaseline(cap.lib) ? 'bg-accent/5' : ''"
+          >
+            <td class="px-3 py-2 font-medium whitespace-nowrap text-fg">
+              {{ cap.displayName }}
+              <span class="ml-1 text-xs text-fg-subtle">{{ SCHEMA_LABEL[cap.schemaLib] }}</span>
+            </td>
+            <td class="px-3 py-2 text-xs whitespace-nowrap text-fg-muted">
+              {{ LAYER_LABEL[cap.layer] ?? cap.layer }}
+            </td>
+            <td v-for="s in SCENARIOS" :key="s" class="px-3 py-2 text-center text-xs">
+              <span
+                :class="
+                  supportOf(cap, s) === 'native'
+                    ? 'font-medium text-accent'
+                    : supportOf(cap, s) === 'hand-rolled'
+                      ? 'text-fg-muted'
+                      : 'text-fg-subtle'
+                "
+              >
+                {{ SUPPORT_GLYPH[supportOf(cap, s) ?? 'unsupported'] }}
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p class="px-3 py-2 text-xs text-fg-subtle">
+        Native: a first-class primitive. Hand-rolled: composed from lower-level pieces. Dash: not
+        expressed, which the runtime tables read as no number, never a slow one.
+      </p>
+    </div>
+
+    <!-- ===================== Scorecard (supply chain) ===================== -->
+    <div v-else-if="mode === 'scorecard'" class="overflow-x-auto">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="border-b border-border bg-surface/40 text-left">
+            <th class="px-3 py-2 font-semibold text-fg">Library</th>
+            <th class="px-3 py-2 font-semibold text-fg-subtle">OpenSSF Scorecard</th>
+            <th class="px-3 py-2 font-semibold text-fg-subtle">As of</th>
+            <th class="px-3 py-2 font-semibold text-fg-subtle">Link</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="cap in results.capabilities"
+            :key="cap.lib"
+            class="border-b border-border/60 last:border-0"
+            :class="isBaseline(cap.lib) ? 'bg-accent/5' : ''"
+          >
+            <td class="px-3 py-2 font-medium whitespace-nowrap text-fg">{{ cap.displayName }}</td>
+            <td class="px-3 py-2 whitespace-nowrap">
+              <template v-if="cap.scorecard">
+                <span class="font-mono font-semibold text-fg">{{
+                  cap.scorecard.score.toFixed(1)
+                }}</span>
+                <span class="text-xs text-fg-subtle"> / 10</span>
+                <span class="ml-2 inline-block h-1.5 w-24 rounded-full bg-surface align-middle">
+                  <span
+                    class="block h-full rounded-full bg-accent/70"
+                    :style="{ width: `${(cap.scorecard.score / 10) * 100}%` }"
+                  />
+                </span>
+              </template>
+              <span v-else class="text-xs text-fg-subtle">Not published</span>
+            </td>
+            <td class="px-3 py-2 text-xs whitespace-nowrap text-fg-muted">
+              {{ cap.scorecard ? shortDate(cap.scorecard.date) : '—' }}
+            </td>
+            <td class="px-3 py-2 whitespace-nowrap">
+              <a
+                v-if="cap.scorecard && cap.scorecardUrl"
+                :href="cap.scorecardUrl"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="inline-flex items-center gap-1 text-xs text-accent hover:underline"
+              >
+                Scorecard <ArrowUpRight class="h-3 w-3" :stroke-width="2" />
+              </a>
+              <a
+                v-else-if="cap.repoUrl"
+                :href="cap.repoUrl"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="inline-flex items-center gap-1 text-xs text-fg-muted hover:text-fg"
+              >
+                <Github class="h-3 w-3" :stroke-width="2" /> Repository
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p v-if="hasAnyScorecard" class="px-3 py-2 text-xs text-fg-subtle">
+        The OpenSSF Scorecard rates a project's adoption of supply-chain practices out of 10.
+        Publishing one is opt-in, so an absent score means the project has not published a
+        Scorecard, not that it is deficient. Scores are point-in-time; the link shows the current
+        result.
+      </p>
+    </div>
+
+    <!-- ===================== Bundle size ===================== -->
+    <div v-else-if="mode === 'bundle'" class="overflow-x-auto">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="border-b border-border bg-surface/40 text-left">
+            <th class="px-3 py-2 font-semibold text-fg">Library</th>
+            <th class="px-3 py-2 font-semibold text-fg-subtle">Gzipped</th>
+            <th class="px-3 py-2 font-semibold text-fg-subtle">vs Attaform</th>
+            <th class="px-3 py-2 font-semibold text-fg-subtle">Validator</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="row in bundleRows"
+            :key="row.id"
+            class="border-b border-border/60 last:border-0"
+            :class="isBaseline(row.id) ? 'bg-accent/5' : ''"
+          >
+            <td class="px-3 py-2 font-medium whitespace-nowrap text-fg">{{ row.lib }}</td>
+            <td class="px-3 py-2 whitespace-nowrap">
+              <div class="flex items-center gap-2">
+                <span class="inline-block h-1.5 w-28 rounded-full bg-surface">
+                  <span
+                    class="block h-full rounded-full"
+                    :class="isBaseline(row.id) ? 'bg-accent/80' : 'bg-fg-subtle/40'"
+                    :style="{ width: `${barPct(row.gzBytes, bundleMax)}%` }"
+                  />
+                </span>
+                <span class="font-mono text-fg">{{ fmtKb(row.gzBytes) }}</span>
+              </div>
+            </td>
+            <td class="px-3 py-2 font-mono text-xs text-fg-muted">{{ fmtRatio(row.ratio) }}</td>
+            <td class="px-3 py-2 text-xs whitespace-nowrap text-fg-muted">{{ row.validator }}</td>
+          </tr>
+        </tbody>
+      </table>
+      <p class="px-3 py-2 text-xs text-fg-subtle">
+        Each row is the same minimal real form (one text field, one email field, schema-validated, a
+        submit handler) in that library's idiomatic API, with its validator weighed in. Vue is
+        external, since every app ships it once. Attaform's figure is its full bundle; with
+        route-level code-splitting a first paint pulls less.
+      </p>
+    </div>
+
+    <!-- ===================== Runtime: memory triad ===================== -->
+    <div v-else-if="block" class="overflow-x-auto">
+      <div class="border-b border-border bg-surface/40 px-3 py-2">
+        <span class="text-xs font-semibold tracking-wide text-fg-subtle uppercase">{{
+          caption
+        }}</span>
+      </div>
+      <table v-if="isMemory" class="w-full text-sm">
+        <thead>
+          <tr class="border-b border-border text-left">
+            <th class="px-3 py-2 font-semibold text-fg">Library</th>
+            <th v-for="p in params" :key="p" class="px-3 py-2 font-semibold text-fg-subtle">
+              {{ p }}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="r in memoryGrid"
+            :key="r.lib"
+            class="border-b border-border/60 align-top last:border-0"
+            :class="r.baseline ? 'bg-accent/5' : ''"
+          >
+            <td class="px-3 py-2 font-medium whitespace-nowrap text-fg">{{ r.displayName }}</td>
+            <td v-for="c in r.cells" :key="c.param" class="px-3 py-2">
+              <div v-if="c.row && c.row.supported" class="flex flex-col gap-1">
+                <div class="flex items-center gap-2">
+                  <span class="inline-block h-1.5 w-20 rounded-full bg-surface">
+                    <span
+                      class="block h-full rounded-full"
+                      :class="r.baseline ? 'bg-accent/80' : 'bg-fg-subtle/40'"
+                      :style="{ width: `${barPct(c.row.retained.median, c.max)}%` }"
+                    />
+                  </span>
+                  <span class="font-mono text-fg">{{ fmtHeapKb(c.row.retained.median) }}</span>
+                  <span class="font-mono text-xs text-fg-subtle">{{ fmtRatio(c.row.ratio) }}</span>
+                </div>
+                <div class="text-xs text-fg-subtle">
+                  churn {{ fmtHeapKb(c.row.churn.median) }} &middot; leak
+                  {{ fmtHeapKb(c.row.leak.median) }}
+                </div>
+                <svg
+                  viewBox="0 0 64 18"
+                  class="h-4 w-16 text-fg-subtle/70"
+                  preserveAspectRatio="none"
+                  role="img"
+                  aria-label="retained heap across mount cycles"
+                >
+                  <polyline
+                    :points="sparkline(c.row.series.retained)"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1"
+                    vector-effect="non-scaling-stroke"
+                  />
+                </svg>
+              </div>
+              <span v-else class="text-fg-subtle">&mdash;</span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <!-- ===================== Runtime: timed dimensions ===================== -->
+      <table v-else class="w-full text-sm">
+        <thead>
+          <tr class="border-b border-border text-left">
+            <th class="px-3 py-2 font-semibold text-fg">Library</th>
+            <th v-for="p in params" :key="p" class="px-3 py-2 font-semibold text-fg-subtle">
+              {{ p }}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="r in timedGrid"
+            :key="r.lib"
+            class="border-b border-border/60 last:border-0"
+            :class="r.baseline ? 'bg-accent/5' : ''"
+          >
+            <td class="px-3 py-2 font-medium whitespace-nowrap text-fg">{{ r.displayName }}</td>
+            <td v-for="c in r.cells" :key="c.param" class="px-3 py-2">
+              <div v-if="c.row && c.row.supported" class="flex items-center gap-2">
+                <span class="inline-block h-1.5 w-20 rounded-full bg-surface">
+                  <span
+                    class="block h-full rounded-full"
+                    :class="r.baseline ? 'bg-accent/80' : 'bg-fg-subtle/40'"
+                    :style="{ width: `${barPct(c.row.median, c.max)}%` }"
+                  />
+                </span>
+                <span class="font-mono whitespace-nowrap text-fg">
+                  {{ fmtTimed(c.row.median, c.row.unit) }}
+                  <sup v-if="c.proxy" class="text-accent">&dagger;</sup>
+                </span>
+                <span class="font-mono text-xs text-fg-subtle">{{ fmtRatio(c.row.ratio) }}</span>
+              </div>
+              <span v-else class="text-fg-subtle">&mdash;</span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p v-if="mixedUnits" class="px-3 py-2 text-xs text-fg-subtle">
+        &dagger; Reported as DOM mutations, a proxy for a library that owns its inputs rather than
+        binding the shared bare field. Not directly comparable to a Vue render count.
+      </p>
+    </div>
+
+    <!-- ===================== Provenance footer ===================== -->
+    <div
+      class="flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-border bg-surface/30 px-3 py-2 text-xs text-fg-subtle"
+    >
+      <span v-if="prov.source === 'ci' && prov.ciRunUrl">
+        Source:
+        <a
+          :href="prov.ciRunUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-accent hover:underline"
+          >CI run #{{ prov.ciRunId }}</a
+        >
+      </span>
+      <span v-else>Source: local run (illustrative shape data; superseded by CI)</span>
+      <span>{{ prov.runner.cpuModel }}</span>
+      <span>Node {{ prov.node }}</span>
+      <span>{{ provDate }}</span>
+    </div>
+  </div>
+</template>

--- a/apps/site/components/content/BenchArena.vue
+++ b/apps/site/components/content/BenchArena.vue
@@ -17,6 +17,7 @@
   import rawResults from 'attaform-bench-arena/results.json'
 
   type Support = 'native' | 'hand-rolled' | 'unsupported'
+  type ScorecardStatus = 'published' | 'not-published' | 'unavailable'
   interface Scorecard {
     score: number
     date: string | null
@@ -30,6 +31,7 @@
     repo: string | null
     repoUrl: string | null
     scorecardUrl: string | null
+    scorecardStatus: ScorecardStatus
     scorecard: Scorecard | null
     [scenario: string]: unknown
   }
@@ -175,9 +177,6 @@
   // the foot of the table rather than being buried.
   const bundleRows = computed(() => [...results.bundle].sort((a, b) => a.gzBytes - b.gzBytes))
   const bundleMax = computed(() => Math.max(...results.bundle.map((r) => r.gzBytes)))
-
-  // --- scorecard ----------------------------------------------------------
-  const hasAnyScorecard = computed(() => results.capabilities.some((c) => c.scorecard != null))
 
   // --- runtime tables -----------------------------------------------------
   // Resolve the selected scenario/dimension; throw with a helpful message if it
@@ -353,7 +352,7 @@
           >
             <td class="px-3 py-2 font-medium whitespace-nowrap text-fg">{{ cap.displayName }}</td>
             <td class="px-3 py-2 whitespace-nowrap">
-              <template v-if="cap.scorecard">
+              <template v-if="cap.scorecardStatus === 'published' && cap.scorecard">
                 <span class="font-mono font-semibold text-fg">{{
                   cap.scorecard.score.toFixed(1)
                 }}</span>
@@ -365,14 +364,28 @@
                   />
                 </span>
               </template>
-              <span v-else class="text-xs text-fg-subtle">Not published</span>
+              <span
+                v-else-if="cap.scorecardStatus === 'not-published'"
+                class="text-xs text-fg-subtle"
+                >Not published</span
+              >
+              <span
+                v-else
+                class="text-xs text-fg-subtle italic"
+                title="The Scorecard lookup did not complete on this run; the linked viewer shows the live result."
+                >Unavailable</span
+              >
             </td>
             <td class="px-3 py-2 text-xs whitespace-nowrap text-fg-muted">
-              {{ cap.scorecard ? shortDate(cap.scorecard.date) : '—' }}
+              {{
+                cap.scorecardStatus === 'published' && cap.scorecard
+                  ? shortDate(cap.scorecard.date)
+                  : '—'
+              }}
             </td>
             <td class="px-3 py-2 whitespace-nowrap">
               <a
-                v-if="cap.scorecard && cap.scorecardUrl"
+                v-if="cap.scorecardStatus !== 'not-published' && cap.scorecardUrl"
                 :href="cap.scorecardUrl"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -393,11 +406,14 @@
           </tr>
         </tbody>
       </table>
-      <p v-if="hasAnyScorecard" class="px-3 py-2 text-xs text-fg-subtle">
-        The OpenSSF Scorecard rates a project's adoption of supply-chain practices out of 10.
-        Publishing one is opt-in, so an absent score means the project has not published a
-        Scorecard, not that it is deficient. Scores are point-in-time; the link shows the current
-        result.
+      <p class="px-3 py-2 text-xs text-fg-subtle">
+        The OpenSSF Scorecard rates a project's adoption of supply-chain practices out of 10. An
+        absent score has two meanings, kept distinct here.
+        <span class="font-medium text-fg-muted">Not published</span> means the project has not opted
+        into a Scorecard, which is a choice, not a deficiency.
+        <span class="font-medium text-fg-muted">Unavailable</span> means the lookup did not complete
+        on this run, a network gap on our side and never a statement about the project. Scores are
+        point-in-time; the linked viewer shows the live result.
       </p>
     </div>
 

--- a/apps/site/composables/useDocsNavigation.ts
+++ b/apps/site/composables/useDocsNavigation.ts
@@ -177,6 +177,10 @@ export const docsNavigation: DocsSection[] = [
       { title: 'Entry-point reference', to: '/docs/reference/entry-points' },
     ],
   },
+  {
+    heading: 'Comparison',
+    links: [{ title: 'Benchmarks', to: '/docs/comparison/benchmarks' }],
+  },
 ]
 
 // All links in canonical reading order. Used by the pager (prev/next)

--- a/apps/site/composables/useDocsNavigation.ts
+++ b/apps/site/composables/useDocsNavigation.ts
@@ -39,6 +39,14 @@ export const docsNavigation: DocsSection[] = [
       { title: 'Demos', to: '/demos' },
     ],
   },
+  // Comparison sits second, right after the introduction: how Attaform
+  // stacks up against the field is a first-visit question, not a footnote,
+  // so the scoreboard rides near the top rather than at the bottom of the
+  // sidebar where it read as buried.
+  {
+    heading: 'Comparison',
+    links: [{ title: 'Benchmarks', to: '/docs/comparison/benchmarks' }],
+  },
   // Phase 1 fills in the remaining categories below as each page
   // lands. Empty `links` arrays render the heading as a disabled
   // sidebar group — visually placeholding the IA without surfacing
@@ -176,10 +184,6 @@ export const docsNavigation: DocsSection[] = [
       { title: 'Errors reference', to: '/docs/reference/errors' },
       { title: 'Entry-point reference', to: '/docs/reference/entry-points' },
     ],
-  },
-  {
-    heading: 'Comparison',
-    links: [{ title: 'Benchmarks', to: '/docs/comparison/benchmarks' }],
   },
 ]
 

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -25,6 +25,7 @@
     "@tailwindcss/typography": "^0.5.19",
     "@vue/repl": "^4.7.2",
     "attaform": "workspace:*",
+    "attaform-bench-arena": "workspace:*",
     "better-sqlite3": "^12.9.0",
     "lucide-vue-next": "^1.0.0",
     "satori": "^0.26.0",

--- a/apps/site/pages/index.vue
+++ b/apps/site/pages/index.vue
@@ -475,9 +475,13 @@
           </div>
         </div>
 
-        <div class="mt-12">
+        <div class="mt-12 flex flex-wrap gap-x-8 gap-y-3">
           <UiButton to="/docs/getting-started/why-attaform" variant="link">
             <span>Read the full case for Attaform</span>
+            <ArrowRight class="h-4 w-4" :stroke-width="2.25" />
+          </UiButton>
+          <UiButton to="/docs/comparison/benchmarks" variant="link">
+            <span>See how it compares</span>
             <ArrowRight class="h-4 w-4" :stroke-width="2.25" />
           </UiButton>
         </div>

--- a/apps/site/types/bench-arena.d.ts
+++ b/apps/site/types/bench-arena.d.ts
@@ -1,0 +1,10 @@
+// The benchmark results ship as a single JSON artifact produced by the
+// bench-arena orchestrator. Typing the import as `unknown` (rather than letting
+// resolveJsonModule deep-infer a ~300 KB literal on every typecheck) keeps
+// vue-tsc fast; BenchArena.vue casts it to a hand-written `Results` interface
+// and guards `schemaVersion` at runtime, so the shape is validated where it is
+// consumed, not inferred from the data.
+declare module 'attaform-bench-arena/results.json' {
+  const results: unknown
+  export default results
+}

--- a/docs/comparison/benchmarks.md
+++ b/docs/comparison/benchmarks.md
@@ -133,7 +133,7 @@ The methodology is only as good as what it admits.
 - **FormKit owns its inputs.** It cannot drive the shared bare field, so its re-render figure is a DOM-mutation proxy, marked in the tables, and its mount and memory figures include its own component tree. It is labeled batteries-included throughout and never placed silently beside bare-input libraries.
 - **Heap is Chromium-quantized.** `usedJSHeapSize` reports rounded magnitudes, not byte-exact values, so memory figures show whole kilobytes and the slope across sizes carries more signal than any single number.
 - **Bundle is total, not first-paint.** Every figure is the full minified and gzipped cost with the validator weighed in. Vue is external, since every app ships it once. Code-splitting changes what a first paint actually pulls.
-- **A Scorecard is opt-in.** An absent score means a project has not published a Scorecard, not that it is deficient. Scores are point-in-time; the link on each row shows the current result.
+- **An absent score has two distinct meanings.** "Not published" means a project has not opted into a Scorecard, which is a choice and not a deficiency. "Unavailable" means the lookup did not complete on that run, a network gap on our side and never a statement about the project. The viewer linked on each row shows the live result either way, and scores are point-in-time.
 - **Local versus CI.** The committed numbers come from CI on a fixed runner. A figure stamped "local run" is illustrative shape data from a developer machine, superseded the next time CI refreshes the page.
 
 ## Reproduce it yourself

--- a/docs/comparison/benchmarks.md
+++ b/docs/comparison/benchmarks.md
@@ -65,14 +65,14 @@ The headline interaction. A keystroke runs the value write, validation, and the 
 ::bench-arena{scenario="flat" dimension="keystroke"}
 ::
 
-At five thousand fields the picture is more competitive, and Attaform sits mid-pack rather than ahead. The harness reports it plainly; it is a scenario worth a future look.
+At five thousand fields the picture tightens. The harness reports where Attaform lands plainly, and it is a scenario worth a future look.
 
 ::bench-arena{scenario="massive" dimension="keystroke"}
 ::
 
 ### Re-render scope
 
-Editing one cell of a large grid should re-render one field, not the form. Configured optimally, the modern headless cohort all reach that bound. Attaform matches the best of them at one render per keystroke; it does not need to beat them, because there is no lower number to reach.
+Editing one cell of a large grid should re-render one field, not the form. Configured optimally, the modern headless cohort all reaches that bound, and there is no lower number to beat.
 
 ::bench-arena{scenario="grid" dimension="rerender"}
 ::
@@ -81,7 +81,7 @@ Editing one cell of a large grid should re-render one field, not the form. Confi
 
 ### Mounting a large form
 
-Building a two-thousand-field form from scratch is where the form-state libraries separate. Attaform mounts the whole reactive tree, validation wiring included, and is the fastest full form-state library in the cohort by a wide margin.
+Building a two-thousand-field form from scratch is where the form-state libraries separate. Attaform mounts the whole reactive tree, validation wiring included, every value and validation path live before the first paint.
 
 ::bench-arena{scenario="massive" dimension="mount"}
 ::

--- a/docs/comparison/benchmarks.md
+++ b/docs/comparison/benchmarks.md
@@ -1,0 +1,147 @@
+---
+title: Benchmarks
+description: How Attaform compares across the Vue form-library field: bundle size, supply-chain scores, and per-scenario runtime measured in a real browser, every number traced to the run that produced it.
+metaRows:
+  - label: Category
+    value: Comparison
+  - label: Method
+    value: Playwright, real Chromium
+  - label: Provenance
+    value: committed results.json
+---
+
+# Benchmarks
+
+> How Attaform holds up across the Vue form-library field on the same demanding forms, measured in a real browser. Bundle size, supply-chain health, and per-scenario runtime, with every number traced to the run that produced it.
+
+::docs-meta-table
+::
+
+This page is an honest scoreboard. The numbers come from `apps/bench-arena`, a self-contained harness that drives every library through identical scenarios in real Chromium via Playwright, then writes one provenance-stamped `results.json` that this page renders directly. Nothing is hand-entered. Where Attaform leads, the run says so; where it pays a cost, the run says that too. Both ship from the same green run.
+
+## How to read this
+
+A fair cross-library comparison has to account for the fact that these libraries do different amounts of work. The harness handles that with a few rules:
+
+- **Layers are the fairness axis.** Form-state libraries (Attaform among them) own reactive values, validation, and input binding. Validation-only libraries own validation against state you wire yourself. A batteries-included library renders its own inputs. Each row is labeled with its layer, so a validation-only engine mounting faster than a full form-state library is read as owning less, not as winning.
+- **The DOM is held constant.** Every headless library drives the same bare `<input>` markup over the same field count and the same schema, so a runtime number reflects the library's own machinery, not its choice of components.
+- **Every library runs in its fastest idiomatic configuration.** Debounces are neutralized, validation triggers are normalized, and array and union primitives use each library's native fast path. Attaform is measured on its shipping default, strict mode, never a relaxed setting.
+- **Real builds, pinned validators.** Attaform is consumed as its published `dist`, the same artifact an installer gets, minified in the same build as every other library. Zod v3 is pinned across the Zod-capable cohort.
+- **Numbers normalize two ways.** A _ratio_ compares each library to Attaform at the same size. A _slope_ compares a library to itself at the scenario's smallest size, so the shape of growth survives a change of machine.
+
+The harness, every adapter, and the scenario generators live in [`apps/bench-arena`](https://github.com/attaform/Attaform/tree/main/apps/bench-arena). Found a fairer configuration for a library? The adapters are small and the README invites a pull request.
+
+## What it costs to adopt
+
+Before any runtime number, three figures decide whether a library is worth reaching for: what it can express, what it adds to your bundle, and how its supply chain scores.
+
+### Capability coverage
+
+What each library expresses as a first-class primitive versus composes by hand. A gap here becomes honest expressiveness data, never a rigged timing loss: a shape a library cannot express idiomatically is left out of its runtime rows rather than forced into a slow number.
+
+::bench-arena{dimension="capabilities"}
+::
+
+### Bundle size
+
+Attaform is the heaviest in the cohort. That is the cost of shipping reactive form state, schema validation binding, persistence, undo and redo, and a multi-step wizard in one zero-dependency package, and it is the honest price of admission. The figure is the full bundle; an app that route-splits its forms pulls less on a first paint.
+
+::bench-arena{dimension="bundle"}
+::
+
+### Supply-chain health
+
+The [OpenSSF Scorecard](https://scorecard.dev) rates a project's adoption of supply-chain practices: branch protection, signed releases, pinned dependencies, CI hardening, and more. For a form library headed into an audited setting, that posture is part of the cost of adoption, so the benchmark stamps each project's current score alongside the size and runtime figures.
+
+::bench-arena{dimension="scorecard"}
+::
+
+## Typing into a form
+
+### Keystroke latency
+
+The headline interaction. A keystroke runs the value write, validation, and the re-render it triggers. On a flat form Attaform clears a 60 fps frame budget with room to spare.
+
+::bench-arena{scenario="flat" dimension="keystroke"}
+::
+
+At five thousand fields the picture is more competitive, and Attaform sits mid-pack rather than ahead. The harness reports it plainly; it is a scenario worth a future look.
+
+::bench-arena{scenario="massive" dimension="keystroke"}
+::
+
+### Re-render scope
+
+Editing one cell of a large grid should re-render one field, not the form. Configured optimally, the modern headless cohort all reach that bound. Attaform matches the best of them at one render per keystroke; it does not need to beat them, because there is no lower number to reach.
+
+::bench-arena{scenario="grid" dimension="rerender"}
+::
+
+## Standing up a form
+
+### Mounting a large form
+
+Building a two-thousand-field form from scratch is where the form-state libraries separate. Attaform mounts the whole reactive tree, validation wiring included, and is the fastest full form-state library in the cohort by a wide margin.
+
+::bench-arena{scenario="massive" dimension="mount"}
+::
+
+### Memory
+
+Retained heap after mount, the library's reactive and validation state at scenario size. Churn is the per-cycle allocation pressure, and leak is the residual across mount and teardown cycles. The sparkline traces retained heap across the measured cycles.
+
+::bench-arena{scenario="massive" dimension="memory"}
+::
+
+## Working the harder shapes
+
+### Validation throughput
+
+A full-form validation pass over a massive form, the cost of a submit on the largest shape in the suite.
+
+::bench-arena{scenario="massive" dimension="validate"}
+::
+
+### Discriminated unions
+
+Writing into and flipping between variants of a discriminated union. Attaform walks only the active branch, so a variant flip touches the branch in play rather than every alternative.
+
+::bench-arena{scenario="discriminated-union" dimension="variantFlip"}
+::
+
+### Dynamic arrays
+
+Appending and reordering rows in a growing list. Attaform's array helpers copy the target array before mutating, which keeps reads fast and identity stable but shows up as real cost on a reorder at a hundred rows. It is an honest line on the board.
+
+::bench-arena{scenario="arrays" dimension="arrayAdd"}
+::
+
+::bench-arena{scenario="arrays" dimension="arrayReorder"}
+::
+
+### Multi-step wizard
+
+Most of the cohort has no wizard primitive and composes a multi-step flow by hand, so this is an expressiveness comparison as much as a timing one. Where a comparable step transition exists, here is its cost; Attaform's `useWizard` ships the flow as a first-class shape.
+
+::bench-arena{scenario="wizard" dimension="stepTransition"}
+::
+
+## Caveats
+
+The methodology is only as good as what it admits.
+
+- **FormKit owns its inputs.** It cannot drive the shared bare field, so its re-render figure is a DOM-mutation proxy, marked in the tables, and its mount and memory figures include its own component tree. It is labeled batteries-included throughout and never placed silently beside bare-input libraries.
+- **Heap is Chromium-quantized.** `usedJSHeapSize` reports rounded magnitudes, not byte-exact values, so memory figures show whole kilobytes and the slope across sizes carries more signal than any single number.
+- **Bundle is total, not first-paint.** Every figure is the full minified and gzipped cost with the validator weighed in. Vue is external, since every app ships it once. Code-splitting changes what a first paint actually pulls.
+- **A Scorecard is opt-in.** An absent score means a project has not published a Scorecard, not that it is deficient. Scores are point-in-time; the link on each row shows the current result.
+- **Local versus CI.** The committed numbers come from CI on a fixed runner. A figure stamped "local run" is illustrative shape data from a developer machine, superseded the next time CI refreshes the page.
+
+## Reproduce it yourself
+
+The harness is meant to be run by hand. Clone the repo, build Attaform's real `dist` with `pnpm prepack`, then from `apps/bench-arena` install the browser and run the arena. The full instructions live in the [bench-arena README](https://github.com/attaform/Attaform/tree/main/apps/bench-arena). Every adapter mounts by query parameter, so you can also open a single library and scenario in a browser and watch it work.
+
+## Where to next
+
+- [Performance](/docs/server-and-ssr/performance): Attaform's own hot-path numbers, measured against a per-PR regression gate.
+- [How values are stored](/docs/schemas/storage-shape): the slim write shape behind the keystroke and validation figures.
+- [Field-array mutations](/docs/writing-and-mutating/field-arrays): the array-helper characteristics behind the dynamic-array rows.

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -15,4 +15,4 @@ Type-safe end to end. Errors surface at compile time, and the runtime keeps ever
 
 The sidebar walks top to bottom as a learning narrative: install, schema, bind, validate, submit, persist. Drop in anywhere. Every concept is its own URL, its own definition, its own demo.
 
-If you're new, start with the [Quick start](/docs/getting-started/quick-start). If you want our philosophy first, read [Why Attaform](/docs/getting-started/why-attaform). If you're hunting a specific surface, the sidebar's last category, **Reference**, is alphabetical and indexed.
+If you're new, start with the [Quick start](/docs/getting-started/quick-start). If you want our philosophy first, read [Why Attaform](/docs/getting-started/why-attaform); if you want the receipts, [Benchmarks](/docs/comparison/benchmarks) measures Attaform against the Vue form-library field in a real browser. If you're hunting a specific surface, the sidebar's last category, **Reference**, is alphabetical and indexed.

--- a/docs/getting-started/why-attaform.md
+++ b/docs/getting-started/why-attaform.md
@@ -90,3 +90,4 @@ These ship with the core, typed and orchestrated as first-class features:
 - [Type safety](/docs/reading-the-form/type-safety): wide while typing, tight inside `handleSubmit`, by design.
 - [When validation runs](/docs/validation/when-validation-runs): the moment errors appear.
 - [The `v-register` directive](/docs/binding-inputs/v-register): how Attaform binds inputs.
+- [Benchmarks](/docs/comparison/benchmarks): how Attaform measures up across the Vue form-library field, in a real browser.

--- a/docs/server-and-ssr/performance.md
+++ b/docs/server-and-ssr/performance.md
@@ -21,6 +21,8 @@ metaRows:
 
 This page is reference material; no demo. CI runs the benchmark suite under [`bench/`](https://github.com/attaform/Attaform/tree/main/bench) on every PR, so the numbers below come from a known-good environment and ride alongside the code.
 
+For how Attaform compares across the Vue form-library field on the same scenarios, in a real browser, see [Benchmarks](/docs/comparison/benchmarks).
+
 ## Measured numbers
 
 Real-browser numbers from `pnpm bench`, single-threaded on contemporary hardware. Your machine will land elsewhere on the number line; the orders of magnitude won't.
@@ -128,6 +130,7 @@ Per-PR CI covers Node 18 / 20 / 22 / LTS against the devDep-pinned peer versions
 
 ## Where to next
 
+- [Benchmarks](/docs/comparison/benchmarks): the same scenarios run across the Vue form-library field, with bundle size, supply-chain scores, and per-scenario runtime tables.
 - [Field-array mutations](/docs/writing-and-mutating/field-arrays): the O(N) characteristics in full, including amortized analysis.
 - [How values are stored](/docs/schemas/storage-shape): the slim write shape that keeps reads fast.
 - [SSR hydration: Nuxt](/docs/server-and-ssr/ssr-nuxt): hydration costs depend on form size; pair this page with the SSR pages when sizing.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -439,6 +439,9 @@ export default [
       'apps/site/public/_pagefind/**',
       // Site-local build scripts — same rationale as repo-root scripts/**.
       'apps/site/scripts/**',
+      // Bench-arena build scripts (the orchestrator, bundle and version
+      // helpers) — Node tooling, same rationale as repo-root scripts/**.
+      'apps/bench-arena/scripts/**',
       '.prettierrc.cjs',
       'scripts/**',
       // Bundled-types regression fixture imports from `dist/*` to

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -223,6 +223,19 @@ export default [
     },
   },
 
+  // Bench-arena harness components are path-namespaced inside each adapter
+  // directory (`tanstack/Field.vue`, `vee-validate/Field.vue`, ...) and
+  // deliberately mirror the name of each library's own field-rendering
+  // surface. They are internal to the benchmark, never public tags, so the
+  // multi-word rule's clarity heuristic does not apply here either — the same
+  // exemption the site components above carry.
+  {
+    files: ['apps/bench-arena/src/**/*.vue'],
+    rules: {
+      'vue/multi-word-component-names': 'off',
+    },
+  },
+
   // Playground-only `toast` global. Injected at runtime by
   // `DemoReplEditor.client.vue`'s `previewOptions.customCode.useCode`
   // and exposed in demos under `apps/site/docs-demos/` and

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,7 +38,7 @@ importers:
         version: 4.4.6
       '@nuxt/test-utils':
         specifier: ^4.0.2
-        version: 4.0.3(crossws@0.4.5(srvx@0.11.16))(jsdom@29.1.1)(magicast@0.5.3)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.8)
+        version: 4.0.3(@playwright/test@1.60.0)(crossws@0.4.5(srvx@0.11.16))(jsdom@29.1.1)(magicast@0.5.3)(playwright-core@1.60.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.8)
       '@rollup/plugin-alias':
         specifier: ^6.0.0
         version: 6.0.0(rollup@4.61.1)
@@ -113,7 +113,7 @@ importers:
         version: 17.0.7
       nuxt:
         specifier: ^4.4.2
-        version: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0)
+        version: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0)
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
@@ -154,6 +154,70 @@ importers:
         specifier: npm:zod@^3.24
         version: zod@3.25.76
 
+  apps/bench-arena:
+    dependencies:
+      attaform:
+        specifier: workspace:*
+        version: link:../..
+    devDependencies:
+      '@formisch/vue':
+        specifier: ^0.8.0
+        version: 0.8.0(typescript@6.0.3)(valibot@1.4.1(typescript@6.0.3))(vue@3.5.35(typescript@6.0.3))
+      '@formkit/vue':
+        specifier: ^2.0.0
+        version: 2.0.0(vue@3.5.35(typescript@6.0.3))
+      '@formkit/zod':
+        specifier: ^2.0.0
+        version: 2.0.0(zod@3.25.76)
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
+      '@regle/core':
+        specifier: ^1.26.1
+        version: 1.26.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))
+      '@regle/rules':
+        specifier: ^1.26.1
+        version: 1.26.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))
+      '@regle/schemas':
+        specifier: ^1.26.1
+        version: 1.26.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(valibot@1.4.1(typescript@6.0.3))(vue@3.5.35(typescript@6.0.3))(zod@3.25.76)
+      '@tanstack/vue-form':
+        specifier: ^1.33.0
+        version: 1.33.0(vue@3.5.35(typescript@6.0.3))
+      '@vee-validate/zod':
+        specifier: ^4.15.1
+        version: 4.15.1(vue@3.5.35(typescript@6.0.3))(zod@3.25.76)
+      '@vitejs/plugin-vue':
+        specifier: ^6.0.7
+        version: 6.0.7(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
+      '@vuelidate/core':
+        specifier: ^2.0.3
+        version: 2.0.3(vue@3.5.35(typescript@6.0.3))
+      '@vuelidate/validators':
+        specifier: ^2.0.4
+        version: 2.0.4(vue@3.5.35(typescript@6.0.3))
+      pinia:
+        specifier: ^3.0.4
+        version: 3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3))
+      valibot:
+        specifier: ^1.4.1
+        version: 1.4.1(typescript@6.0.3)
+      vee-validate:
+        specifier: ^4.15.1
+        version: 4.15.1(vue@3.5.35(typescript@6.0.3))
+      vite:
+        specifier: ^8.0.10
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
+      vue:
+        specifier: ^3.5.33
+        version: 3.5.35(typescript@6.0.3)
+      vue-tsc:
+        specifier: ^3.2.7
+        version: 3.3.3(typescript@6.0.3)
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
+
   apps/site:
     dependencies:
       '@nuxt/content':
@@ -164,7 +228,7 @@ importers:
         version: 4.0.0(magicast@0.5.3)
       '@nuxtjs/seo':
         specifier: ^5.1.3
-        version: 5.1.3(812b8aaf6d84c73eda28d1c9be5df7d7)
+        version: 5.1.3(127cb3337c735f977f287e36311083a9)
       '@resvg/resvg-js':
         specifier: ^2.6.2
         version: 2.6.2
@@ -194,7 +258,7 @@ importers:
         version: 4.1.0
       vue-sonner:
         specifier: ^2.0.9
-        version: 2.0.9(@nuxt/kit@4.4.6(magicast@0.5.3))(@nuxt/schema@4.4.7)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))
+        version: 2.0.9(@nuxt/kit@4.4.6(magicast@0.5.3))(@nuxt/schema@4.4.7)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.2.4
@@ -213,7 +277,7 @@ importers:
         version: 18.0.4
       nuxt:
         specifier: ^4.4.2
-        version: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0)
+        version: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0)
       pagefind:
         specifier: ^1.5.0
         version: 1.5.2
@@ -1156,6 +1220,53 @@ packages:
 
   '@floating-ui/vue@1.1.11':
     resolution: {integrity: sha512-HzHKCNVxnGS35r9fCHBc3+uCnjw9IWIlCPL683cGgM9Kgj2BiAl8x1mS7vtvP6F9S/e/q4O6MApwSHj8hNLGfw==}
+
+  '@formisch/vue@0.8.0':
+    resolution: {integrity: sha512-+01RxYsV9nlCcuCZGfpimSWDFw6E/eroEHYngptx8uLqSyeCkgyvI58axTzqIQCqD0rx4txRasieFksOBhnGpw==}
+    peerDependencies:
+      typescript: '>=5'
+      valibot: ^1.4.1
+      vue: ^3.3.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@formkit/core@2.0.0':
+    resolution: {integrity: sha512-y56SDriprtH44wJEPsEcsGXMZkBHzOT7gKJwX1uSmeM1aXnzMn86SEm5RIwNrDW7MVAgCjPPry/YAZxGgt2peA==}
+
+  '@formkit/dev@2.0.0':
+    resolution: {integrity: sha512-AFoRoFmoZjywfrRcbjyvuCSHeWS1lADn4tTuyx1nW1ZXw40G4T6ZoTW+ooiZKALpT2FpoKEnktbnQh97crozBw==}
+
+  '@formkit/i18n@2.0.0':
+    resolution: {integrity: sha512-crUPI5vNyubvOJek24FAMQ2T2wVTaFrisnf9GudI3oj9+Gu73sUZZBH7cQ3Mhf3WpE0QimMEhmDknYIaxoVwXA==}
+
+  '@formkit/inputs@2.0.0':
+    resolution: {integrity: sha512-RK5KRtMg3YHTCOZ0z83yzFTCb9im1n4gAq/YFUs51jzWthzOdpSSTTOpmQBYq2WhHehC4JZuCuDsVc7UasC3yw==}
+
+  '@formkit/observer@2.0.0':
+    resolution: {integrity: sha512-1DSKS28XCRSzRFHN+OVBe/6tKup6Tc1VtEvy2sGXfRsNRRo6my62pAB7EhcRcp+zu2keTkWhOcLx/ncz4GBgug==}
+
+  '@formkit/rules@2.0.0':
+    resolution: {integrity: sha512-JXxG5SdSDdlI2X9u/hNzK/7kQXR8o9+9HCvivhsBOquc52YcQ1uvfwT08wRRkYhRcO0IkXLIIW4fKCWuDsEVpw==}
+
+  '@formkit/themes@2.0.0':
+    resolution: {integrity: sha512-Rtad6OPtOFYF8C8FdR/BrUCkIoDY55ixRMxSQ0r3On/R2ERf3ub7YmyTWUUcoIG/cgITOEFloLz+yKRlyTkFQg==}
+
+  '@formkit/utils@2.0.0':
+    resolution: {integrity: sha512-9ql3QKsJvdhHY/lFVaXlML0kXTYhv/v/pKytrT3Oby5zIOuUOV/11+25rU+YkpnZePZ8AIhc0INW1iUGr4nF8w==}
+
+  '@formkit/validation@2.0.0':
+    resolution: {integrity: sha512-hAB2koAF9BPw3b2PnqQ4wyZa9QJ1X/T0r8ixBBuvgJpQFJM1YUBGM1FjuI7YmAEzrjghflriegbZK9IAFqTRcw==}
+
+  '@formkit/vue@2.0.0':
+    resolution: {integrity: sha512-mn0K+Gj2a6YZTCsL3rQk8F2AzOJTzWG7GwSgGJU1PmItMlzcKFkCC+kjqS4HpVCeSLRq5nUPlVsoxeSd2/pLNg==}
+    peerDependencies:
+      vue: ^3.4.0
+
+  '@formkit/zod@2.0.0':
+    resolution: {integrity: sha512-THNMk1qSPbUsYSff1+ZfwRF4UaBsv2rYIaeFYnivZH6zWpgbmEQSwo7K9j8xcbWNL01pt4EtmakBjQdv+RlGpQ==}
+    peerDependencies:
+      zod: ^3.0.0
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -2562,6 +2673,11 @@ packages:
     resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
@@ -2576,6 +2692,32 @@ packages:
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
+
+  '@regle/core@1.26.1':
+    resolution: {integrity: sha512-hGOjAjb9IhjaVB1ET9zxaonWooj3sQr6hjTH+CT+Jg4YKoIyX13mBAvX2dlI01nCX3w9l6hr9YnSTVxL8cDkKA==}
+    peerDependencies:
+      pinia: '>=2.2.5'
+      vue: '>=3.3.0'
+    peerDependenciesMeta:
+      pinia:
+        optional: true
+
+  '@regle/rules@1.26.1':
+    resolution: {integrity: sha512-ajIE+omS+R/L0PZy5kgvH4vjk88qs02tPzf+g0cjhwaUkEEID3PKWjyzOWjsAQULm0OrGKUvoaVO9woL+ZIaVA==}
+
+  '@regle/schemas@1.26.1':
+    resolution: {integrity: sha512-cYYPoEsMxpKKfeMUy3X+eWcLjrz1OFQTRgwwOMwp0cdCYYw/hSwI4lhc6FXoBO+/D7pgtnG6jgSX/KFBtkqnjg==}
+    peerDependencies:
+      arktype: ^2.1.0
+      valibot: ^1.0.0
+      zod: ^3.24.0 || ^4.0.0
+    peerDependenciesMeta:
+      arktype:
+        optional: true
+      valibot:
+        optional: true
+      zod:
+        optional: true
 
   '@resvg/resvg-js-android-arm-eabi@2.6.2':
     resolution: {integrity: sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==}
@@ -3190,12 +3332,41 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@tanstack/devtools-event-client@0.4.3':
+    resolution: {integrity: sha512-OZI6QyULw0FI0wjgmeYzCIfbgPsOEzwJtCpa69XrfLMtNXLGnz3d/dIabk7frg0TmHo+Ah49w5I4KC7Tufwsvw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@tanstack/form-core@1.33.0':
+    resolution: {integrity: sha512-AV4Pw9Dk4orFsuPBcDssfWMJFs+yMYBae7zZ4oTqrCf4ftNGQKxvrQRZeqKHG6A4TkiLeSvf2kzIjcVkrW7E6w==}
+
+  '@tanstack/pacer-lite@0.1.1':
+    resolution: {integrity: sha512-y/xtNPNt/YeyoVxE/JCx+T7yjEzpezmbb+toK8DDD1P4m7Kzs5YR956+7OKexG3f8aXgC3rLZl7b1V+yNUSy5w==}
+    engines: {node: '>=18'}
+
+  '@tanstack/store@0.11.0':
+    resolution: {integrity: sha512-WlzzCt3xi0G6pCAJu1U+2jiECwabETDpQDi3hfkFZvJii9AuZqEKbOiVarX1/bWhTNjU486yQtJCCasi/0q+Cw==}
+
   '@tanstack/table-core@8.21.3':
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
 
   '@tanstack/virtual-core@3.15.0':
     resolution: {integrity: sha512-0AwPGx0I8QxPYjAxShT/+z+ZOe9u8mW5rsXvivCTjRfRmz9a43+3mRyi4wwlyoUqOC56q/jatKa0Bh9M99BEHQ==}
+
+  '@tanstack/vue-form@1.33.0':
+    resolution: {integrity: sha512-ZdVDo4W2ohL27bCjsuNy/eQ8PHm9mOzCFNfI7d6GfhS5KHqehZ8TiR/y1eRJR/c1y3nucgSi6RfY6iLHBMVhAQ==}
+    peerDependencies:
+      vue: ^3.4.0
+
+  '@tanstack/vue-store@0.11.0':
+    resolution: {integrity: sha512-w1lE4D7oo6nIUhTQvL/RoTgcvoYJw+KvttWPNJd/Xu+MvNxMnjxFF/LgFp9vwmbNbiGhGCg3ZoPJptwjrfwNYw==}
+    peerDependencies:
+      '@vue/composition-api': ^1.2.1
+      vue: ^2.5.0 || ^3.0.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
 
   '@tanstack/vue-table@8.21.3':
     resolution: {integrity: sha512-rusRyd77c5tDPloPskctMyPLFEQUeBzxdQ+2Eow4F7gDPlPOB1UnnhzfpdvqZ8ZyX2rRNGmqNnQWm87OI2OQPw==}
@@ -3610,6 +3781,11 @@ packages:
     peerDependencies:
       valibot: ^1.4.0
 
+  '@vee-validate/zod@4.15.1':
+    resolution: {integrity: sha512-329Z4TDBE5Vx0FdbA8S4eR9iGCFFUNGbxjpQ20ff5b5wGueScjocUIx9JHPa79LTG06RnlUR4XogQsjN4tecKA==}
+    peerDependencies:
+      zod: ^3.24.0
+
   '@vercel/nft@1.5.0':
     resolution: {integrity: sha512-IWTDeIoWhQ7ZtRO/JRKH+jhmeQvZYhtGPmzw/QGDY+wDCQqfm25P9yIdoAFagu4fWsK4IwZXDFIjrmp5rRm/sA==}
     engines: {node: '>=20'}
@@ -3730,6 +3906,9 @@ packages:
   '@vue/compiler-ssr@3.5.35':
     resolution: {integrity: sha512-rGhAeXgdM7/ffTJGXT69rCCdTmjDewnFuUZfBQQHTdcEBeWdT5HCGY60y2ytLJr9/Dsu7IntUi5z/w0h6Rjnzw==}
 
+  '@vue/devtools-api@7.7.9':
+    resolution: {integrity: sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==}
+
   '@vue/devtools-api@8.1.2':
     resolution: {integrity: sha512-vA0O112YqyDuNA1s7Yb2gCgToQ/OxOWiFDO5ThLCcDy0ldHnSd1dUTaSYhOldbqoNgumE4dxtGAoAaSUKUD1Zg==}
 
@@ -3738,8 +3917,14 @@ packages:
     peerDependencies:
       vue: ^3.0.0
 
+  '@vue/devtools-kit@7.7.9':
+    resolution: {integrity: sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==}
+
   '@vue/devtools-kit@8.1.2':
     resolution: {integrity: sha512-f75/upc+GCyjXErpgPGz4582ujS0L/adAltGy+tqXMGUJpgAcfGr6CxnnhpZY8BHuMYt6KpbF8uaFrrQG66rGQ==}
+
+  '@vue/devtools-shared@7.7.9':
+    resolution: {integrity: sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==}
 
   '@vue/devtools-shared@8.1.2':
     resolution: {integrity: sha512-X9RyVFYAdkBe4IUf5v48TxBF/6QPmF8CmWrDAjXzfUHrgQ/HGfTC1A6TqgXqZ03ye66l3AD51BAGD69IvKM9sw==}
@@ -3784,6 +3969,24 @@ packages:
 
   '@vue/typescript-plugin@3.3.3':
     resolution: {integrity: sha512-FyT1EKeGZZJk4ZEMOv70sMYoEbiROm5xXFjfFCUK2wRmrB/hvYq/+zIbGWoH11Tox6wZc4AQoHHOabWdZatg8w==}
+
+  '@vuelidate/core@2.0.3':
+    resolution: {integrity: sha512-AN6l7KF7+mEfyWG0doT96z+47ljwPpZfi9/JrNMkOGLFv27XVZvKzRLXlmDPQjPl/wOB1GNnHuc54jlCLRNqGA==}
+    peerDependencies:
+      '@vue/composition-api': ^1.0.0-rc.1
+      vue: ^2.0.0 || >=3.0.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+
+  '@vuelidate/validators@2.0.4':
+    resolution: {integrity: sha512-odTxtUZ2JpwwiQ10t0QWYJkkYrfd0SyFYhdHH44QQ1jDatlZgTh/KRzrWVmn/ib9Gq7H4hFD4e8ahoo5YlUlDw==}
+    peerDependencies:
+      '@vue/composition-api': ^1.0.0-rc.1
+      vue: ^2.0.0 || >=3.0.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
 
   '@vueuse/core@10.11.1':
     resolution: {integrity: sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==}
@@ -4333,6 +4536,10 @@ packages:
 
   cookie-es@3.1.1:
     resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
+
+  copy-anything@4.0.5:
+    resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
+    engines: {node: '>=18'}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -5080,6 +5287,11 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -5514,6 +5726,10 @@ packages:
   is-typed-array@1.1.15:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
+
+  is-what@5.5.0:
+    resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
+    engines: {node: '>=18'}
 
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
@@ -6058,6 +6274,9 @@ packages:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
 
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
@@ -6546,6 +6765,9 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  perfect-debounce@1.0.0:
+    resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
+
   perfect-debounce@2.1.0:
     resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
 
@@ -6564,11 +6786,30 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
+  pinia@3.0.4:
+    resolution: {integrity: sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==}
+    peerDependencies:
+      typescript: '>=4.5.0'
+      vue: ^3.5.11
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -7394,6 +7635,10 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  speakingurl@14.0.1:
+    resolution: {integrity: sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==}
+    engines: {node: '>=0.10.0'}
+
   srvx@0.11.16:
     resolution: {integrity: sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw==}
     engines: {node: '>=20.16.0'}
@@ -7491,6 +7736,10 @@ packages:
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
       postcss: ^8.5.14
+
+  superjson@2.2.6:
+    resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
+    engines: {node: '>=16'}
 
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
@@ -7667,6 +7916,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
 
   type-fest@5.6.0:
     resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
@@ -7938,6 +8191,11 @@ packages:
     peerDependencies:
       reka-ui: ^2.0.0
       vue: ^3.3.0
+
+  vee-validate@4.15.1:
+    resolution: {integrity: sha512-DkFsiTwEKau8VIxyZBGdO6tOudD+QoUBPuHj3e6QFqmbfCRj1ArmYWue9lEp6jLSWBIw4XPlDLjFIZNLdRAMSg==}
+    peerDependencies:
+      vue: ^3.4.26
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -8249,6 +8507,17 @@ packages:
 
   vue-component-type-helpers@3.3.1:
     resolution: {integrity: sha512-pu58kqxmVyEH6VfNYW1UyEfR3XAnJ27ZXT3yzXxxpjLxVzAbyC35Zk/nm/RMs7ijWnJNSd9fWkeex2OhUsx3MA==}
+
+  vue-demi@0.13.11:
+    resolution: {integrity: sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==}
+    engines: {node: '>=12'}
+    hasBin: true
+    peerDependencies:
+      '@vue/composition-api': ^1.0.0-rc.1
+      vue: ^3.0.0-0 || ^2.6.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -9306,6 +9575,74 @@ snapshots:
       - '@vue/composition-api'
       - vue
 
+  '@formisch/vue@0.8.0(typescript@6.0.3)(valibot@1.4.1(typescript@6.0.3))(vue@3.5.35(typescript@6.0.3))':
+    dependencies:
+      valibot: 1.4.1(typescript@6.0.3)
+      vue: 3.5.35(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@formkit/core@2.0.0':
+    dependencies:
+      '@formkit/utils': 2.0.0
+
+  '@formkit/dev@2.0.0':
+    dependencies:
+      '@formkit/core': 2.0.0
+      '@formkit/utils': 2.0.0
+
+  '@formkit/i18n@2.0.0':
+    dependencies:
+      '@formkit/core': 2.0.0
+      '@formkit/utils': 2.0.0
+      '@formkit/validation': 2.0.0
+
+  '@formkit/inputs@2.0.0':
+    dependencies:
+      '@formkit/core': 2.0.0
+      '@formkit/utils': 2.0.0
+
+  '@formkit/observer@2.0.0':
+    dependencies:
+      '@formkit/core': 2.0.0
+      '@formkit/utils': 2.0.0
+
+  '@formkit/rules@2.0.0':
+    dependencies:
+      '@formkit/core': 2.0.0
+      '@formkit/utils': 2.0.0
+      '@formkit/validation': 2.0.0
+
+  '@formkit/themes@2.0.0':
+    dependencies:
+      '@formkit/core': 2.0.0
+
+  '@formkit/utils@2.0.0': {}
+
+  '@formkit/validation@2.0.0':
+    dependencies:
+      '@formkit/core': 2.0.0
+      '@formkit/observer': 2.0.0
+      '@formkit/utils': 2.0.0
+
+  '@formkit/vue@2.0.0(vue@3.5.35(typescript@6.0.3))':
+    dependencies:
+      '@formkit/core': 2.0.0
+      '@formkit/dev': 2.0.0
+      '@formkit/i18n': 2.0.0
+      '@formkit/inputs': 2.0.0
+      '@formkit/observer': 2.0.0
+      '@formkit/rules': 2.0.0
+      '@formkit/themes': 2.0.0
+      '@formkit/utils': 2.0.0
+      '@formkit/validation': 2.0.0
+      vue: 3.5.35(typescript@6.0.3)
+
+  '@formkit/zod@2.0.0(zod@3.25.76)':
+    dependencies:
+      '@formkit/core': 2.0.0
+      zod: 3.25.76
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -9797,7 +10134,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@4.4.6(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(better-sqlite3@12.10.0)(db0@0.3.4(better-sqlite3@12.10.0))(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(oxc-parser@0.131.0)(rolldown@1.0.3)(srvx@0.11.16)(typescript@6.0.3)':
+  '@nuxt/nitro-server@4.4.6(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(better-sqlite3@12.10.0)(db0@0.3.4(better-sqlite3@12.10.0))(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(oxc-parser@0.131.0)(rolldown@1.0.3)(srvx@0.11.16)(typescript@6.0.3)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
@@ -9815,7 +10152,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.13.4(better-sqlite3@12.10.0)(oxc-parser@0.131.0)(rolldown@1.0.3)(srvx@0.11.16)
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0)
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0)
       nypm: 0.6.6
       ohash: 2.0.11
       pathe: 2.0.3
@@ -9892,7 +10229,7 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.1.0
 
-  '@nuxt/test-utils@4.0.3(crossws@0.4.5(srvx@0.11.16))(jsdom@29.1.1)(magicast@0.5.3)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.8)':
+  '@nuxt/test-utils@4.0.3(@playwright/test@1.60.0)(crossws@0.4.5(srvx@0.11.16))(jsdom@29.1.1)(magicast@0.5.3)(playwright-core@1.60.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.8)':
     dependencies:
       '@clack/prompts': 1.2.0
       '@nuxt/devtools-kit': 2.7.0(magicast@0.5.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
@@ -9921,10 +10258,12 @@ snapshots:
       tinyexec: 1.2.2
       ufo: 1.6.4
       unplugin: 3.0.0
-      vitest-environment-nuxt: 2.0.0(crossws@0.4.5(srvx@0.11.16))(jsdom@29.1.1)(magicast@0.5.3)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.8)
+      vitest-environment-nuxt: 2.0.0(@playwright/test@1.60.0)(crossws@0.4.5(srvx@0.11.16))(jsdom@29.1.1)(magicast@0.5.3)(playwright-core@1.60.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.8)
       vue: 3.5.35(typescript@6.0.3)
     optionalDependencies:
+      '@playwright/test': 1.60.0
       jsdom: 29.1.1
+      playwright-core: 1.60.0
       vitest: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - crossws
@@ -9932,7 +10271,7 @@ snapshots:
       - typescript
       - vite
 
-  '@nuxt/ui@4.8.0(@internationalized/date@3.12.1)(@internationalized/number@3.6.6)(@nuxt/content@3.14.0(@valibot/to-json-schema@1.7.0(valibot@1.4.1(typescript@6.0.3)))(better-sqlite3@12.10.0)(magicast@0.5.3)(valibot@1.4.1(typescript@6.0.3)))(@tiptap/extensions@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(db0@0.3.4(better-sqlite3@12.10.0))(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.3)(tailwindcss@4.3.0)(typescript@6.0.3)(valibot@1.4.1(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-router@5.0.7(@vue/compiler-sfc@3.5.35)(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))(yjs@13.6.30)(zod@4.4.3)':
+  '@nuxt/ui@4.8.0(@internationalized/date@3.12.1)(@internationalized/number@3.6.6)(@nuxt/content@3.14.0(@valibot/to-json-schema@1.7.0(valibot@1.4.1(typescript@6.0.3)))(better-sqlite3@12.10.0)(magicast@0.5.3)(valibot@1.4.1(typescript@6.0.3)))(@tiptap/extensions@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(db0@0.3.4(better-sqlite3@12.10.0))(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.3)(tailwindcss@4.3.0)(typescript@6.0.3)(valibot@1.4.1(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-router@5.0.7(@vue/compiler-sfc@3.5.35)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))(yjs@13.6.30)(zod@4.4.3)':
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@iconify/vue': 5.0.1(vue@3.5.35(typescript@6.0.3))
@@ -10003,7 +10342,7 @@ snapshots:
       '@internationalized/number': 3.6.6
       '@nuxt/content': 3.14.0(@valibot/to-json-schema@1.7.0(valibot@1.4.1(typescript@6.0.3)))(better-sqlite3@12.10.0)(magicast@0.5.3)(valibot@1.4.1(typescript@6.0.3))
       valibot: 1.4.1(typescript@6.0.3)
-      vue-router: 5.0.7(@vue/compiler-sfc@3.5.35)(vue@3.5.35(typescript@6.0.3))
+      vue-router: 5.0.7(@vue/compiler-sfc@3.5.35)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))
       zod: 4.4.3
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -10047,7 +10386,7 @@ snapshots:
       - vue
       - yjs
 
-  '@nuxt/vite-builder@4.4.6(fa20d5f656e1d999a2efafd12cb06e2a)':
+  '@nuxt/vite-builder@4.4.6(0ed5022709d0ed9642c3bc754cc2dfdc)':
     dependencies:
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
       '@rollup/plugin-replace': 6.0.3(rollup@4.61.1)
@@ -10065,7 +10404,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0)
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0)
       nypm: 0.6.6
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -10177,15 +10516,15 @@ snapshots:
       - magicast
       - supports-color
 
-  '@nuxtjs/robots@6.0.8(@nuxt/schema@4.4.7)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3)':
+  '@nuxtjs/robots@6.0.8(@nuxt/schema@4.4.7)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3)':
     dependencies:
       '@fingerprintjs/botd': 2.0.0
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
       consola: 3.4.2
       defu: 6.1.7
       h3: 1.15.11
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.7)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3)
-      nuxtseo-shared: 5.1.3(3fdde9871f908ce56d837be444028573)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.7)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3)
+      nuxtseo-shared: 5.1.3(bbb49a4f1d55bd5d48af832ceb62aeb0)
       pathe: 2.0.3
       pkg-types: 2.3.1
       ufo: 1.6.4
@@ -10198,18 +10537,18 @@ snapshots:
       - vite
       - vue
 
-  '@nuxtjs/seo@5.1.3(812b8aaf6d84c73eda28d1c9be5df7d7)':
+  '@nuxtjs/seo@5.1.3(127cb3337c735f977f287e36311083a9)':
     dependencies:
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
-      '@nuxtjs/robots': 6.0.8(@nuxt/schema@4.4.7)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3)
-      '@nuxtjs/sitemap': 8.0.15(@nuxt/schema@4.4.7)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3)
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0)
-      nuxt-link-checker: 5.0.10(@nuxt/schema@4.4.7)(db0@0.3.4(better-sqlite3@12.10.0))(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3)
-      nuxt-og-image: 6.5.1(c43040121486367668522af37dede4e2)
-      nuxt-schema-org: 6.0.4(3aeace53c6b2775e68f9417596802cce)
-      nuxt-seo-utils: 8.1.11(@nuxt/schema@4.4.7)(crossws@0.4.5(srvx@0.11.16))(esbuild@0.28.0)(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(rolldown@1.0.3)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3)
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.7)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3)
-      nuxtseo-shared: 5.1.3(3fdde9871f908ce56d837be444028573)
+      '@nuxtjs/robots': 6.0.8(@nuxt/schema@4.4.7)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3)
+      '@nuxtjs/sitemap': 8.0.15(@nuxt/schema@4.4.7)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3)
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0)
+      nuxt-link-checker: 5.0.10(@nuxt/schema@4.4.7)(db0@0.3.4(better-sqlite3@12.10.0))(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3)
+      nuxt-og-image: 6.5.1(48397fc69582c1d8d8304cae042ecef0)
+      nuxt-schema-org: 6.0.4(6311dd38811056d070c87551bfe43ae8)
+      nuxt-seo-utils: 8.1.11(@nuxt/schema@4.4.7)(crossws@0.4.5(srvx@0.11.16))(esbuild@0.28.0)(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(rolldown@1.0.3)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.7)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3)
+      nuxtseo-shared: 5.1.3(bbb49a4f1d55bd5d48af832ceb62aeb0)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -10291,14 +10630,14 @@ snapshots:
       - yup
       - zod
 
-  '@nuxtjs/sitemap@8.0.15(@nuxt/schema@4.4.7)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3)':
+  '@nuxtjs/sitemap@8.0.15(@nuxt/schema@4.4.7)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3)':
     dependencies:
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
       consola: 3.4.2
       defu: 6.1.7
       fast-xml-parser: 5.8.0
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.7)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3)
-      nuxtseo-shared: 5.1.3(3fdde9871f908ce56d837be444028573)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.7)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3)
+      nuxtseo-shared: 5.1.3(bbb49a4f1d55bd5d48af832ceb62aeb0)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -10799,6 +11138,10 @@ snapshots:
 
   '@pkgr/core@0.3.6': {}
 
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
   '@polka/url@1.0.0-next.29': {}
 
   '@poppinss/colors@4.1.6':
@@ -10816,6 +11159,36 @@ snapshots:
   '@quansync/fs@1.0.0':
     dependencies:
       quansync: 1.0.0
+
+  '@regle/core@1.26.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@vue/devtools-api': 7.7.9
+      type-fest: 5.6.0
+      vue: 3.5.35(typescript@6.0.3)
+    optionalDependencies:
+      pinia: 3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3))
+
+  '@regle/rules@1.26.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))':
+    dependencies:
+      '@regle/core': 1.26.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))
+      type-fest: 5.6.0
+    transitivePeerDependencies:
+      - pinia
+      - vue
+
+  '@regle/schemas@1.26.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(valibot@1.4.1(typescript@6.0.3))(vue@3.5.35(typescript@6.0.3))(zod@3.25.76)':
+    dependencies:
+      '@regle/core': 1.26.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))
+      '@regle/rules': 1.26.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))
+      '@standard-schema/spec': 1.1.0
+      type-fest: 5.6.0
+    optionalDependencies:
+      valibot: 1.4.1(typescript@6.0.3)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - pinia
+      - vue
 
   '@resvg/resvg-js-android-arm-eabi@2.6.2':
     optional: true
@@ -11259,9 +11632,35 @@ snapshots:
       tailwindcss: 4.3.0
       vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
 
+  '@tanstack/devtools-event-client@0.4.3': {}
+
+  '@tanstack/form-core@1.33.0':
+    dependencies:
+      '@tanstack/devtools-event-client': 0.4.3
+      '@tanstack/pacer-lite': 0.1.1
+      '@tanstack/store': 0.11.0
+
+  '@tanstack/pacer-lite@0.1.1': {}
+
+  '@tanstack/store@0.11.0': {}
+
   '@tanstack/table-core@8.21.3': {}
 
   '@tanstack/virtual-core@3.15.0': {}
+
+  '@tanstack/vue-form@1.33.0(vue@3.5.35(typescript@6.0.3))':
+    dependencies:
+      '@tanstack/form-core': 1.33.0
+      '@tanstack/vue-store': 0.11.0(vue@3.5.35(typescript@6.0.3))
+      vue: 3.5.35(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+
+  '@tanstack/vue-store@0.11.0(vue@3.5.35(typescript@6.0.3))':
+    dependencies:
+      '@tanstack/store': 0.11.0
+      vue: 3.5.35(typescript@6.0.3)
+      vue-demi: 0.14.10(vue@3.5.35(typescript@6.0.3))
 
   '@tanstack/vue-table@8.21.3(vue@3.5.35(typescript@6.0.3))':
     dependencies:
@@ -11704,6 +12103,14 @@ snapshots:
     dependencies:
       valibot: 1.4.1(typescript@6.0.3)
 
+  '@vee-validate/zod@4.15.1(vue@3.5.35(typescript@6.0.3))(zod@3.25.76)':
+    dependencies:
+      type-fest: 4.41.0
+      vee-validate: 4.15.1(vue@3.5.35(typescript@6.0.3))
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - vue
+
   '@vercel/nft@1.5.0(rollup@4.61.1)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3
@@ -11929,6 +12336,10 @@ snapshots:
       '@vue/compiler-dom': 3.5.35
       '@vue/shared': 3.5.35
 
+  '@vue/devtools-api@7.7.9':
+    dependencies:
+      '@vue/devtools-kit': 7.7.9
+
   '@vue/devtools-api@8.1.2':
     dependencies:
       '@vue/devtools-kit': 8.1.2
@@ -11939,12 +12350,26 @@ snapshots:
       '@vue/devtools-shared': 8.1.2
       vue: 3.5.35(typescript@6.0.3)
 
+  '@vue/devtools-kit@7.7.9':
+    dependencies:
+      '@vue/devtools-shared': 7.7.9
+      birpc: 2.9.0
+      hookable: 5.5.3
+      mitt: 3.0.1
+      perfect-debounce: 1.0.0
+      speakingurl: 14.0.1
+      superjson: 2.2.6
+
   '@vue/devtools-kit@8.1.2':
     dependencies:
       '@vue/devtools-shared': 8.1.2
       birpc: 2.9.0
       hookable: 5.5.3
       perfect-debounce: 2.1.0
+
+  '@vue/devtools-shared@7.7.9':
+    dependencies:
+      rfdc: 1.4.1
 
   '@vue/devtools-shared@8.1.2': {}
 
@@ -12029,6 +12454,16 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
+  '@vuelidate/core@2.0.3(vue@3.5.35(typescript@6.0.3))':
+    dependencies:
+      vue: 3.5.35(typescript@6.0.3)
+      vue-demi: 0.13.11(vue@3.5.35(typescript@6.0.3))
+
+  '@vuelidate/validators@2.0.4(vue@3.5.35(typescript@6.0.3))':
+    dependencies:
+      vue: 3.5.35(typescript@6.0.3)
+      vue-demi: 0.13.11(vue@3.5.35(typescript@6.0.3))
+
   '@vueuse/core@10.11.1(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
@@ -12058,13 +12493,13 @@ snapshots:
 
   '@vueuse/metadata@14.3.0': {}
 
-  '@vueuse/nuxt@14.3.0(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))':
+  '@vueuse/nuxt@14.3.0(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
       '@vueuse/core': 14.3.0(vue@3.5.35(typescript@6.0.3))
       '@vueuse/metadata': 14.3.0
       local-pkg: 1.2.1
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0)
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0)
       vue: 3.5.35(typescript@6.0.3)
     transitivePeerDependencies:
       - magicast
@@ -12557,6 +12992,10 @@ snapshots:
   cookie-es@2.0.1: {}
 
   cookie-es@3.1.1: {}
+
+  copy-anything@4.0.5:
+    dependencies:
+      is-what: 5.5.0
 
   core-util-is@1.0.3: {}
 
@@ -13384,6 +13823,9 @@ snapshots:
 
   fs-constants@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -13876,6 +14318,8 @@ snapshots:
   is-typed-array@1.1.15:
     dependencies:
       which-typed-array: 1.1.20
+
+  is-what@5.5.0: {}
 
   is-wsl@2.2.0:
     dependencies:
@@ -14594,6 +15038,8 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
+  mitt@3.0.1: {}
+
   mkdirp-classic@0.5.3: {}
 
   mkdist@2.4.1(typescript@6.0.3)(vue-tsc@3.3.3(typescript@6.0.3))(vue@3.5.35(typescript@6.0.3)):
@@ -14934,7 +15380,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  nuxt-link-checker@5.0.10(@nuxt/schema@4.4.7)(db0@0.3.4(better-sqlite3@12.10.0))(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3):
+  nuxt-link-checker@5.0.10(@nuxt/schema@4.4.7)(db0@0.3.4(better-sqlite3@12.10.0))(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3):
     dependencies:
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
       '@vueuse/core': 14.3.0(vue@3.5.35(typescript@6.0.3))
@@ -14942,9 +15388,9 @@ snapshots:
       diff: 9.0.0
       fuse.js: 7.3.0
       magic-string: 0.30.21
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0)
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.7)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3)
-      nuxtseo-shared: 5.1.3(3fdde9871f908ce56d837be444028573)
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.7)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3)
+      nuxtseo-shared: 5.1.3(bbb49a4f1d55bd5d48af832ceb62aeb0)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -14978,7 +15424,7 @@ snapshots:
       - vue
       - zod
 
-  nuxt-og-image@6.5.1(c43040121486367668522af37dede4e2):
+  nuxt-og-image@6.5.1(48397fc69582c1d8d8304cae042ecef0):
     dependencies:
       '@clack/prompts': 1.4.0
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
@@ -14996,8 +15442,8 @@ snapshots:
       magic-string: 0.30.21
       magicast: 0.5.3
       mocked-exports: 0.1.1
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.7)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3)
-      nuxtseo-shared: 5.1.3(3fdde9871f908ce56d837be444028573)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.7)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3)
+      nuxtseo-shared: 5.1.3(bbb49a4f1d55bd5d48af832ceb62aeb0)
       nypm: 0.6.6
       ofetch: 1.5.1
       ohash: 2.0.11
@@ -15019,6 +15465,7 @@ snapshots:
       '@resvg/resvg-js': 2.6.2
       fontless: 0.2.1(db0@0.3.4(better-sqlite3@12.10.0))(ioredis@5.10.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
       nitropack: 2.13.4(better-sqlite3@12.10.0)(oxc-parser@0.127.0)(rolldown@1.0.3)(srvx@0.11.16)
+      playwright-core: 1.60.0
       satori: 0.26.0
       sharp: 0.34.5
       tailwindcss: 4.3.0
@@ -15031,14 +15478,14 @@ snapshots:
       - vite
       - vue
 
-  nuxt-schema-org@6.0.4(3aeace53c6b2775e68f9417596802cce):
+  nuxt-schema-org@6.0.4(6311dd38811056d070c87551bfe43ae8):
     dependencies:
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
       '@unhead/schema-org': 2.1.15(@unhead/vue@2.1.15(vue@3.5.35(typescript@6.0.3)))
       defu: 6.1.7
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.7)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3)
-      nuxtseo-layer-devtools: 0.5.1(23966b22b446c4780c091ad143df0cc6)
-      nuxtseo-shared: 0.9.0(3fdde9871f908ce56d837be444028573)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.7)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3)
+      nuxtseo-layer-devtools: 0.5.1(9c79c35a78f21b0446aa8652f2db8581)
+      nuxtseo-shared: 0.9.0(bbb49a4f1d55bd5d48af832ceb62aeb0)
       pkg-types: 2.3.1
     optionalDependencies:
       '@unhead/vue': 2.1.15(vue@3.5.35(typescript@6.0.3))
@@ -15101,7 +15548,7 @@ snapshots:
       - yjs
       - yup
 
-  nuxt-seo-utils@8.1.11(@nuxt/schema@4.4.7)(crossws@0.4.5(srvx@0.11.16))(esbuild@0.28.0)(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(rolldown@1.0.3)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3):
+  nuxt-seo-utils@8.1.11(@nuxt/schema@4.4.7)(crossws@0.4.5(srvx@0.11.16))(esbuild@0.28.0)(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(rolldown@1.0.3)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3):
     dependencies:
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
       '@unhead/bundler': 3.1.0(crossws@0.4.5(srvx@0.11.16))(esbuild@0.28.0)(lightningcss@1.32.0)(rolldown@1.0.3)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
@@ -15110,9 +15557,9 @@ snapshots:
       escape-string-regexp: 5.0.0
       exsolve: 1.0.8
       image-size: 2.0.2
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0)
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.7)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3)
-      nuxtseo-shared: 5.1.3(3fdde9871f908ce56d837be444028573)
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.7)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3)
+      nuxtseo-shared: 5.1.3(bbb49a4f1d55bd5d48af832ceb62aeb0)
       pathe: 2.0.3
       pkg-types: 2.3.1
       scule: 1.3.0
@@ -15148,12 +15595,12 @@ snapshots:
       - magicast
       - vue
 
-  nuxt-site-config@4.0.8(@nuxt/schema@4.4.7)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3):
+  nuxt-site-config@4.0.8(@nuxt/schema@4.4.7)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3):
     dependencies:
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
       h3: 1.15.11
       nuxt-site-config-kit: 4.0.8(magicast@0.5.3)(vue@3.5.35(typescript@6.0.3))
-      nuxtseo-shared: 5.1.3(3fdde9871f908ce56d837be444028573)
+      nuxtseo-shared: 5.1.3(bbb49a4f1d55bd5d48af832ceb62aeb0)
       pathe: 2.0.3
       pkg-types: 2.3.1
       site-config-stack: 4.0.8(vue@3.5.35(typescript@6.0.3))
@@ -15166,16 +15613,16 @@ snapshots:
       - vue
       - zod
 
-  nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0):
+  nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.3)(typescript@6.0.3)
       '@nuxt/cli': 3.35.2(@nuxt/schema@4.4.6)(cac@6.7.14)(magicast@0.5.3)
       '@nuxt/devtools': 3.2.4(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
-      '@nuxt/nitro-server': 4.4.6(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(better-sqlite3@12.10.0)(db0@0.3.4(better-sqlite3@12.10.0))(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(oxc-parser@0.131.0)(rolldown@1.0.3)(srvx@0.11.16)(typescript@6.0.3)
+      '@nuxt/nitro-server': 4.4.6(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(better-sqlite3@12.10.0)(db0@0.3.4(better-sqlite3@12.10.0))(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(oxc-parser@0.131.0)(rolldown@1.0.3)(srvx@0.11.16)(typescript@6.0.3)
       '@nuxt/schema': 4.4.6
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.6(magicast@0.5.3))
-      '@nuxt/vite-builder': 4.4.6(fa20d5f656e1d999a2efafd12cb06e2a)
+      '@nuxt/vite-builder': 4.4.6(0ed5022709d0ed9642c3bc754cc2dfdc)
       '@unhead/vue': 2.1.15(vue@3.5.35(typescript@6.0.3))
       '@vue/shared': 3.5.34
       chokidar: 5.0.0
@@ -15222,7 +15669,7 @@ snapshots:
       unrouting: 0.1.7
       untyped: 2.0.0
       vue: 3.5.35(typescript@6.0.3)
-      vue-router: 5.0.7(@vue/compiler-sfc@3.5.35)(vue@3.5.35(typescript@6.0.3))
+      vue-router: 5.0.7(@vue/compiler-sfc@3.5.35)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))
     optionalDependencies:
       '@parcel/watcher': 2.5.6
       '@types/node': 25.9.1
@@ -15296,15 +15743,15 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxtseo-layer-devtools@0.5.1(23966b22b446c4780c091ad143df0cc6):
+  nuxtseo-layer-devtools@0.5.1(9c79c35a78f21b0446aa8652f2db8581):
     dependencies:
       '@nuxt/devtools-kit': 4.0.0-alpha.3(magicast@0.5.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
-      '@nuxt/ui': 4.8.0(@internationalized/date@3.12.1)(@internationalized/number@3.6.6)(@nuxt/content@3.14.0(@valibot/to-json-schema@1.7.0(valibot@1.4.1(typescript@6.0.3)))(better-sqlite3@12.10.0)(magicast@0.5.3)(valibot@1.4.1(typescript@6.0.3)))(@tiptap/extensions@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(db0@0.3.4(better-sqlite3@12.10.0))(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.3)(tailwindcss@4.3.0)(typescript@6.0.3)(valibot@1.4.1(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-router@5.0.7(@vue/compiler-sfc@3.5.35)(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))(yjs@13.6.30)(zod@4.4.3)
+      '@nuxt/ui': 4.8.0(@internationalized/date@3.12.1)(@internationalized/number@3.6.6)(@nuxt/content@3.14.0(@valibot/to-json-schema@1.7.0(valibot@1.4.1(typescript@6.0.3)))(better-sqlite3@12.10.0)(magicast@0.5.3)(valibot@1.4.1(typescript@6.0.3)))(@tiptap/extensions@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(db0@0.3.4(better-sqlite3@12.10.0))(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.3)(tailwindcss@4.3.0)(typescript@6.0.3)(valibot@1.4.1(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-router@5.0.7(@vue/compiler-sfc@3.5.35)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))(yjs@13.6.30)(zod@4.4.3)
       '@shikijs/langs': 4.1.0
       '@shikijs/themes': 4.1.0
-      '@vueuse/nuxt': 14.3.0(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
-      nuxtseo-shared: 0.9.0(3fdde9871f908ce56d837be444028573)
+      '@vueuse/nuxt': 14.3.0(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
+      nuxtseo-shared: 0.9.0(bbb49a4f1d55bd5d48af832ceb62aeb0)
       ofetch: 1.5.1
       shiki: 4.1.0
       ufo: 1.6.4
@@ -15365,7 +15812,7 @@ snapshots:
       - yup
       - zod
 
-  nuxtseo-shared@0.9.0(3fdde9871f908ce56d837be444028573):
+  nuxtseo-shared@0.9.0(bbb49a4f1d55bd5d48af832ceb62aeb0):
     dependencies:
       '@clack/prompts': 1.4.0
       '@nuxt/devtools-kit': 4.0.0-alpha.3(magicast@0.5.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
@@ -15374,7 +15821,7 @@ snapshots:
       birpc: 4.0.0
       consola: 3.4.2
       defu: 6.1.7
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0)
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -15384,13 +15831,13 @@ snapshots:
       ufo: 1.6.4
       vue: 3.5.35(typescript@6.0.3)
     optionalDependencies:
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.7)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.7)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3)
       zod: 4.4.3
     transitivePeerDependencies:
       - magicast
       - vite
 
-  nuxtseo-shared@5.1.3(3fdde9871f908ce56d837be444028573):
+  nuxtseo-shared@5.1.3(bbb49a4f1d55bd5d48af832ceb62aeb0):
     dependencies:
       '@clack/prompts': 1.4.0
       '@nuxt/devtools-kit': 4.0.0-alpha.3(magicast@0.5.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
@@ -15399,7 +15846,7 @@ snapshots:
       birpc: 4.0.0
       consola: 3.4.2
       defu: 6.1.7
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0)
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -15409,7 +15856,7 @@ snapshots:
       ufo: 1.6.4
       vue: 3.5.35(typescript@6.0.3)
     optionalDependencies:
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.7)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.7)(magicast@0.5.3)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))(zod@4.4.3)
       zod: 4.4.3
     transitivePeerDependencies:
       - magicast
@@ -15771,6 +16218,8 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  perfect-debounce@1.0.0: {}
+
   perfect-debounce@2.1.0: {}
 
   picocolors@1.1.1: {}
@@ -15780,6 +16229,13 @@ snapshots:
   picomatch@4.0.4: {}
 
   pify@4.0.1: {}
+
+  pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)):
+    dependencies:
+      '@vue/devtools-api': 7.7.9
+      vue: 3.5.35(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
 
   pkg-types@1.3.1:
     dependencies:
@@ -15792,6 +16248,14 @@ snapshots:
       confbox: 0.2.4
       exsolve: 1.0.8
       pathe: 2.0.3
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 
@@ -16798,6 +17262,8 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  speakingurl@14.0.1: {}
+
   srvx@0.11.16: {}
 
   stackback@0.0.2: {}
@@ -16898,6 +17364,10 @@ snapshots:
       browserslist: 4.28.2
       postcss: 8.5.15
       postcss-selector-parser: 7.1.1
+
+  superjson@2.2.6:
+    dependencies:
+      copy-anything: 4.0.5
 
   supports-color@10.2.2: {}
 
@@ -17076,6 +17546,8 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-fest@4.41.0: {}
 
   type-fest@5.6.0:
     dependencies:
@@ -17412,6 +17884,12 @@ snapshots:
     transitivePeerDependencies:
       - '@vue/composition-api'
 
+  vee-validate@4.15.1(vue@3.5.35(typescript@6.0.3)):
+    dependencies:
+      '@vue/devtools-api': 7.7.9
+      type-fest: 4.41.0
+      vue: 3.5.35(typescript@6.0.3)
+
   vfile-location@5.0.3:
     dependencies:
       '@types/unist': 3.0.3
@@ -17534,9 +18012,9 @@ snapshots:
       terser: 5.48.0
       yaml: 2.9.0
 
-  vitest-environment-nuxt@2.0.0(crossws@0.4.5(srvx@0.11.16))(jsdom@29.1.1)(magicast@0.5.3)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.8):
+  vitest-environment-nuxt@2.0.0(@playwright/test@1.60.0)(crossws@0.4.5(srvx@0.11.16))(jsdom@29.1.1)(magicast@0.5.3)(playwright-core@1.60.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.8):
     dependencies:
-      '@nuxt/test-utils': 4.0.3(crossws@0.4.5(srvx@0.11.16))(jsdom@29.1.1)(magicast@0.5.3)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.8)
+      '@nuxt/test-utils': 4.0.3(@playwright/test@1.60.0)(crossws@0.4.5(srvx@0.11.16))(jsdom@29.1.1)(magicast@0.5.3)(playwright-core@1.60.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.8)
     transitivePeerDependencies:
       - '@cucumber/cucumber'
       - '@jest/globals'
@@ -17711,6 +18189,10 @@ snapshots:
 
   vue-component-type-helpers@3.3.1: {}
 
+  vue-demi@0.13.11(vue@3.5.35(typescript@6.0.3)):
+    dependencies:
+      vue: 3.5.35(typescript@6.0.3)
+
   vue-demi@0.14.10(vue@3.5.35(typescript@6.0.3)):
     dependencies:
       vue: 3.5.35(typescript@6.0.3)
@@ -17729,7 +18211,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-router@5.0.7(@vue/compiler-sfc@3.5.35)(vue@3.5.35(typescript@6.0.3)):
+  vue-router@5.0.7(@vue/compiler-sfc@3.5.35)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3)):
     dependencies:
       '@babel/generator': 8.0.0-rc.5
       '@vue-macros/common': 3.1.2(vue@3.5.35(typescript@6.0.3))
@@ -17751,12 +18233,13 @@ snapshots:
       yaml: 2.9.0
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.35
+      pinia: 3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3))
 
-  vue-sonner@2.0.9(@nuxt/kit@4.4.6(magicast@0.5.3))(@nuxt/schema@4.4.7)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0)):
+  vue-sonner@2.0.9(@nuxt/kit@4.4.6(magicast@0.5.3))(@nuxt/schema@4.4.7)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0)):
     optionalDependencies:
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
       '@nuxt/schema': 4.4.7
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0)
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(meow@13.2.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0)
 
   vue-tsc@3.3.3(typescript@6.0.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,6 +244,9 @@ importers:
       attaform:
         specifier: workspace:*
         version: link:../..
+      attaform-bench-arena:
+        specifier: workspace:*
+        version: link:../bench-arena
       better-sqlite3:
         specifier: ^12.9.0
         version: 12.10.0

--- a/test/composables/errors-call-form-and-remount-probe.test.ts
+++ b/test/composables/errors-call-form-and-remount-probe.test.ts
@@ -141,8 +141,16 @@ describe('errors call-form: empty-string vs no-arg divergence', () => {
 
 describe('remount-with-same-key: async-factory lifecycle on consumer churn', () => {
   const apps: App[] = []
-  afterEach(() => {
+  afterEach(async () => {
     while (apps.length > 0) apps.pop()?.unmount()
+    // A remount triggers the adapter's async fingerprint mismatch check,
+    // which dynamically imports the adapter module. If that import is
+    // still in flight when vitest tears the environment down it rejects
+    // with EnvironmentTeardownError noise (the library catches it and
+    // skips the check, but it clutters CI logs). Drain it here while the
+    // environment is alive; the module is already cached from the
+    // initial mount, so one macrotask is enough.
+    await new Promise((resolve) => setTimeout(resolve, 0))
   })
 
   /**

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,8 +5,12 @@ import { defineConfig } from 'vitest/config'
 const rootDir = fileURLToPath(new URL('.', import.meta.url))
 
 /**
- * Vitest config — kept intentionally minimal. The default test picker
- * (test/**) is fine; we only need to override coverage settings.
+ * Vitest config — kept intentionally minimal. The unit suite lives
+ * entirely under `test/`, so `include` is anchored there: vitest's
+ * default glob otherwise also swept `apps/bench-arena/tests/arena.spec.ts`,
+ * a Playwright spec that throws when vitest imports it. The bench arena
+ * runs under its own Playwright config; the root suite stays in `test/`.
+ * Coverage settings are overridden below.
  *
  * Coverage scope is the "new-code" surface: core primitives, the abstract
  * composable, and the v4 adapter. The v3 adapter is the pre-rewrite
@@ -56,6 +60,10 @@ export default defineConfig({
     ],
   },
   test: {
+    // Anchor the picker to the unit suite. Without this, vitest's default
+    // glob collects `apps/bench-arena/tests/*.spec.ts` (Playwright specs)
+    // and fails to import them.
+    include: ['test/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     // Global setup file: stubs `window.isSecureContext = true` so the
     // secure-context gate doesn't disable multi-tab sync and built-in
     // persistence in jsdom-backed tests, and resets the


### PR DESCRIPTION
## What this lands

`apps/bench-arena` is a fair, reproducible, public cross-library Vue form benchmark. It
stress-tests Attaform against the current Vue form-library field across a suite of practical,
increasingly demanding form shapes in a real browser (Playwright), emits a provenance-stamped
`results.json`, and renders it on a new **Comparison > Benchmarks** docs page where every number
links back to the exact CI run that produced it.

The benchmark's credibility is the deliverable. The harness is built so any developer can replicate
it by hand, every competitor runs in its most performant idiomatic configuration, and the results
include the dimension where Attaform is heavier (bundle size). The numbers carry the verdict; the
page never editorializes about other libraries.

## The cohort

Attaform (real `dist`, zod v3) measured against vee-validate, @tanstack/vue-form, @formisch/vue
(valibot), Regle in both schema and rules modes, FormKit, and Vuelidate. Each library is implemented
behind a single adapter contract in its own idiomatic API, so one driver runs them all identically.
Layer differences (headless form-state, headless validation-only, batteries-included) are absorbed by
what each adapter owns, never by branching in the driver. zod v3 is pinned across the zod-capable
cohort.

## Scenarios and dimensions

Seven scenarios from a flat baseline up to deliberately demanding shapes: flat (10 to 500 fields),
deeply-nested, dynamic-arrays, grid (a line-items editor), discriminated-union, massive (thousands of
leaves), and a multi-step wizard. Each runs across keystroke latency, mount and init, re-render scope,
validation throughput, scenario-specific ops (array mutations, variant flips, step transitions),
retained-heap memory, and per-library gzipped bundle size. A capability matrix marks each library
native / hand-rolled / unsupported per shape, so a missing primitive reads as honest expressiveness
data, never a rigged timing loss.

## Fairness guardrails

- Consumes the real `prepack` build, never the `unbuild --stub` shim or an `attaform` to `src` alias
  (the only consumer in the repo that does).
- Vite minifies every library, Attaform included, in the same build.
- DOM held constant for the headless libraries (identical bare inputs, field count, schema), so the
  measurement isolates the engine, not the rendering.
- Trigger normalized and per-library debounces neutralized, so a keystroke does comparable work
  everywhere.
- FormKit is always labeled batteries-included and its render-scope figure is a clearly caveated
  DOM-mutation proxy.
- The README invites a fairer adapter via PR.

## Supply-chain transparency

Each row carries its OpenSSF Scorecard score with a three-state model: published, not-published (the
project opted out, its choice), and unavailable (our lookup did not complete on that run, a gap on our
side). The three are never conflated, and the page footnote spells out both absent meanings.

## CI: strictly non-gating

`.github/workflows/bench-arena.yml` refreshes the numbers monthly (and on dispatch), commits a signed
`results.json` via `createCommitOnBranch`, and opens a reviewable PR. It is never a required check; the
existing `check:bench` floor remains the real perf gate. Passes zizmor at the pedantic persona.

## Zero-dep purity preserved

Every competitor is a bench-only devDependency quarantined inside the isolated `attaform-bench-arena`
workspace. Attaform's own `package.json` stays at zero runtime dependencies.

## Follow-ups (separate PRs)

- A flat third slope point (F200) for a richer growth curve: a re-seed plus a prose recheck.
- zod v3/v4 version-skew hardening in the shipped zod-v3 adapter. Consuming the real `dist` under a
  duplicated zod surfaced a silent write-rejection; `main` and any single-zod consumer are unaffected.
  Tracked as its own small PR.

## Gate

typecheck, eslint, prettier, zizmor pedantic, and the docs `build-site` link-checker all green. The
workflow is absent from required checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
