### PR TITLE
fix(zod-v3): reconstruct slim/stripped nodes version-faithfully to survive zod skew

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -381,7 +381,17 @@ export default [
     // (#361): same shared core chunk (transform primitive + handleSubmit
     // drain + settleTransforms surface + transforming rollup + vRegisterFile
     // unification). Measured at 65.09 KB.
-    limit: '66 KB',
+    //
+    // Raised 66 → 67 KB on the zod-version-skew hardening branch (#383):
+    // the v3 adapter's new rebuild-schema.ts reconstructs slim / stripped
+    // nodes from the consumer's own node (prototype-preserving, zero
+    // ambient `z.*` construction) so a hoisted second zod major cannot
+    // poison the rebuild. The unified entry bundles the v3 adapter, so it
+    // absorbs the module (rebuildWithDef + the per-kind wrappers + the DU
+    // optionsMap remap, which reuses zod's own discriminator extraction
+    // rather than re-deriving it). zod-v3.mjs holds at 62 KB (61.53).
+    // Measured at 66.23 KB.
+    limit: '67 KB',
     gzip: true,
     ignore: ['zod'],
     modifyEsbuildConfig: asEsm,

--- a/src/runtime/adapters/zod-v3/index.ts
+++ b/src/runtime/adapters/zod-v3/index.ts
@@ -907,7 +907,7 @@ function stripRefinements<T extends z.ZodTypeAny>(schema: T) {
       const stripped = options.map(
         (o) => _stripRefinements(o, depth + 1) as z.ZodObject<z.ZodRawShape>
       )
-      return rebuildDiscriminatedUnion(_schema, discKey, stripped)
+      return rebuildDiscriminatedUnion(_schema, stripped)
     }
 
     if (isZodSchemaType(_schema, 'ZodIntersection')) {
@@ -1040,7 +1040,6 @@ function getSlimSchema<RS extends z.ZodRawShape, Schema extends z.ZodSchema>(
 
       return rebuildDiscriminatedUnion(
         _schema,
-        discKey,
         slimmedSchemas as unknown as readonly z.AnyZodObject[]
       )
     }

--- a/src/runtime/adapters/zod-v3/index.ts
+++ b/src/runtime/adapters/zod-v3/index.ts
@@ -1,8 +1,11 @@
-// Imports zod v3 via the pnpm alias defined in devDependencies; the
-// published bundle rewrites this specifier back to 'zod' via the build
-// step (see build.config.ts). Consumers of `attaform/zod-v3`
-// install zod@3 themselves and the resolved import works.
-import { z } from 'zod-v3'
+// Type-only import of zod v3. The adapter constructs zero schema nodes
+// through the ambient `z`; every slim / strip rebuild goes through
+// `rebuild-schema.ts`, which reconstructs from the consumer's own
+// (correct-version) node. That keeps the adapter immune to a second,
+// mismatched zod hoisted alongside the one a schema was authored with.
+// `attaform/zod-v3` consumers install zod@3 themselves; only its types
+// are referenced here.
+import type { z } from 'zod-v3'
 import type {
   AbstractSchema,
   DefaultValuesResponse,
@@ -29,6 +32,19 @@ import { canonicalizePath, type Path } from '../../core/paths'
 import { slimKindOf } from '../../core/slim-primitive-gate'
 import { getFieldMeta, getFieldMetaList } from './field-meta'
 import { cloneSchemaDeep } from './clone-schema'
+import {
+  rebuildArray,
+  rebuildDiscriminatedUnion,
+  rebuildIntersection,
+  rebuildLazy,
+  rebuildObject,
+  rebuildRecord,
+  rebuildSet,
+  rebuildTuple,
+  rebuildUnion,
+  rebuildWrapperInner,
+  stripLeafChecks,
+} from './rebuild-schema'
 import type { GenericForm } from '../../types/types-core'
 
 // The adapter exchanges dotted-string paths with core at the
@@ -774,20 +790,20 @@ function stripRefinements<T extends z.ZodTypeAny>(schema: T) {
   function _stripRefinements(_schema: z.ZodTypeAny, depth: number): z.ZodTypeAny {
     if (depth >= MAX_UNWRAP_STEPS) return _schema as T
     if (isZodSchemaType(_schema, 'ZodString') && hasChecks(_schema)) {
-      // Rebuild a ZodString without checks
-      return z.string()
+      // Clear the ZodString's checks, keeping its prototype and coerce
+      return stripLeafChecks(_schema)
     }
 
     if (isZodSchemaType(_schema, 'ZodNumber') && hasChecks(_schema)) {
-      // Rebuild a ZodNumber without checks
-      return z.number()
+      // Clear the ZodNumber's checks, keeping its prototype and coerce
+      return stripLeafChecks(_schema)
     }
 
     if (isZodSchemaType(_schema, 'ZodArray')) {
       // Recursively process the array's inner type
       const inner = getArrayElement(_schema)
       if (!inner) return _schema
-      return z.array(_stripRefinements(inner, depth + 1))
+      return rebuildArray(_schema, _stripRefinements(inner, depth + 1))
     }
 
     if (isZodSchemaType(_schema, 'ZodObject')) {
@@ -798,7 +814,7 @@ function stripRefinements<T extends z.ZodTypeAny>(schema: T) {
           _stripRefinements(value, depth + 1),
         ])
       )
-      return z.object(strippedShape)
+      return rebuildObject(_schema, strippedShape)
     }
 
     if (isZodSchemaType(_schema, 'ZodEffects')) {
@@ -812,14 +828,14 @@ function stripRefinements<T extends z.ZodTypeAny>(schema: T) {
       // Recursively strip optional's inner type
       const inner = unwrapInner(_schema)
       if (!inner) return _schema
-      return z.optional(_stripRefinements(inner, depth + 1))
+      return rebuildWrapperInner(_schema, _stripRefinements(inner, depth + 1))
     }
 
     if (isZodSchemaType(_schema, 'ZodNullable')) {
       // Recursively strip nullable's inner type
       const inner = unwrapInner(_schema)
       if (!inner) return _schema
-      return z.nullable(_stripRefinements(inner, depth + 1))
+      return rebuildWrapperInner(_schema, _stripRefinements(inner, depth + 1))
     }
 
     // Newer transparent wrappers — descend into their inner schema and
@@ -853,14 +869,14 @@ function stripRefinements<T extends z.ZodTypeAny>(schema: T) {
     if (isZodSchemaType(_schema, 'ZodSet')) {
       const valueType = getSetValueType(_schema)
       if (!valueType) return _schema
-      return z.set(_stripRefinements(valueType, depth + 1))
+      return rebuildSet(_schema, _stripRefinements(valueType, depth + 1))
     }
 
     if (isZodSchemaType(_schema, 'ZodTuple')) {
       const items = getTupleItems(_schema)
       if (items.length === 0) return _schema
       const stripped = items.map((it) => _stripRefinements(it, depth + 1))
-      return z.tuple(stripped as [z.ZodTypeAny, ...z.ZodTypeAny[]])
+      return rebuildTuple(_schema, stripped)
     }
 
     if (isZodSchemaType(_schema, 'ZodRecord')) {
@@ -872,16 +888,16 @@ function stripRefinements<T extends z.ZodTypeAny>(schema: T) {
       // on record keys aren't load-bearing for slim-schema concerns.
       const keyType = getRecordKeyType(_schema)
       if (keyType) {
-        return z.record(keyType as z.ZodString, value)
+        return rebuildRecord(_schema, value, keyType)
       }
-      return z.record(value)
+      return rebuildRecord(_schema, value)
     }
 
     if (isZodSchemaType(_schema, 'ZodUnion')) {
       const options = getUnionOptions(_schema)
       if (options.length === 0) return _schema
       const stripped = options.map((o) => _stripRefinements(o, depth + 1))
-      return z.union(stripped as [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]])
+      return rebuildUnion(_schema, stripped)
     }
 
     if (isZodSchemaType(_schema, 'ZodDiscriminatedUnion')) {
@@ -891,17 +907,18 @@ function stripRefinements<T extends z.ZodTypeAny>(schema: T) {
       const stripped = options.map(
         (o) => _stripRefinements(o, depth + 1) as z.ZodObject<z.ZodRawShape>
       )
-      return z.discriminatedUnion(
-        discKey,
-        stripped as [z.ZodObject<z.ZodRawShape>, ...z.ZodObject<z.ZodRawShape>[]]
-      )
+      return rebuildDiscriminatedUnion(_schema, discKey, stripped)
     }
 
     if (isZodSchemaType(_schema, 'ZodIntersection')) {
       const left = getIntersectionLeft(_schema)
       const right = getIntersectionRight(_schema)
       if (!left || !right) return _schema
-      return z.intersection(_stripRefinements(left, depth + 1), _stripRefinements(right, depth + 1))
+      return rebuildIntersection(
+        _schema,
+        _stripRefinements(left, depth + 1),
+        _stripRefinements(right, depth + 1)
+      )
     }
 
     if (isZodSchemaType(_schema, 'ZodLazy')) {
@@ -911,7 +928,7 @@ function stripRefinements<T extends z.ZodTypeAny>(schema: T) {
       // returned lazy resolves to a stable schema. assertSupportedKinds
       // has already rejected self-referencing lazies, so this is finite.
       const stripped = _stripRefinements(inner, depth + 1)
-      return z.lazy(() => stripped)
+      return rebuildLazy(_schema, stripped)
     }
 
     // Return other schema types as-is
@@ -990,13 +1007,13 @@ function getSlimSchema<RS extends z.ZodRawShape, Schema extends z.ZodSchema>(
       for (const [key, value] of Object.entries(getObjectShape(_schema))) {
         newShape[key] = _getSlimSchema(value as z.ZodSchema)
       }
-      return z.object(newShape)
+      return rebuildObject(_schema, newShape)
     }
 
     if (isZodSchemaType(_schema, 'ZodArray')) {
       const inner = getArrayElement(_schema)
       if (!inner) return _schema
-      return z.array(_getSlimSchema(inner as z.ZodSchema))
+      return rebuildArray(_schema, _getSlimSchema(inner as z.ZodSchema))
     }
 
     if (isZodSchemaType(_schema, 'ZodRecord')) {
@@ -1005,7 +1022,7 @@ function getSlimSchema<RS extends z.ZodRawShape, Schema extends z.ZodSchema>(
       if (!keyType || !valueType) return _schema
       const key = _getSlimSchema(keyType as z.ZodSchema)
       const value = _getSlimSchema(valueType as z.ZodSchema)
-      return z.record(key as z.ZodString, value)
+      return rebuildRecord(_schema, value, key)
     }
 
     // same way we go into records, objects, and arrays, go into discriminated unions
@@ -1021,12 +1038,10 @@ function getSlimSchema<RS extends z.ZodRawShape, Schema extends z.ZodSchema>(
         slimmedSchemas.push(deepCloneSlimmedSchema)
       }
 
-      return z.discriminatedUnion(
+      return rebuildDiscriminatedUnion(
+        _schema,
         discKey,
-        slimmedSchemas as unknown as readonly [
-          z.ZodDiscriminatedUnionOption<string>,
-          ...z.ZodDiscriminatedUnionOption<string>[],
-        ]
+        slimmedSchemas as unknown as readonly z.AnyZodObject[]
       )
     }
 

--- a/src/runtime/adapters/zod-v3/introspect.ts
+++ b/src/runtime/adapters/zod-v3/introspect.ts
@@ -649,6 +649,20 @@ export function getNativeEnumValues(schema: z.ZodTypeAny): Record<string, unknow
 }
 
 /**
+ * Members of a `z.enum([...])` as an array. v3 stores them on
+ * `_def.values` (an array for `ZodEnum`, distinct from
+ * `ZodNativeEnum`'s object), and the instance `.options` getter
+ * resolves to the same array. Returns an empty array for non-enum
+ * inputs. Used when extracting the discriminator values an enum-keyed
+ * discriminated-union option admits.
+ */
+export function getEnumOptions(schema: z.ZodTypeAny): readonly unknown[] {
+  const def = readDef(schema)
+  const values: unknown = def?.values
+  return Array.isArray(values) ? values : []
+}
+
+/**
  * Resolve a `z.default(...)` wrapper's value by invoking the v3
  * `_def.defaultValue` thunk. v3 stores the default as a function
  * (lazy evaluation, useful for `new Date()` defaults); v4 stores the

--- a/src/runtime/adapters/zod-v3/introspect.ts
+++ b/src/runtime/adapters/zod-v3/introspect.ts
@@ -86,6 +86,7 @@ interface ZodV3InternalShape {
     keyType?: unknown // ZodRecord key
     items?: readonly unknown[] // ZodTuple
     options?: readonly unknown[] // ZodUnion / ZodDiscriminatedUnion / ZodEnum
+    optionsMap?: Map<unknown, unknown> // ZodDiscriminatedUnion parse routing
     discriminator?: string // ZodDiscriminatedUnion
     left?: unknown // ZodIntersection
     right?: unknown // ZodIntersection
@@ -291,6 +292,19 @@ export function getDiscriminatedOptions(schema: z.ZodTypeAny): readonly z.AnyZod
 export function getDiscriminator(schema: z.ZodTypeAny): string | undefined {
   const def = readDef(schema)
   return def?.discriminator
+}
+
+/**
+ * ZodDiscriminatedUnion: the `discriminatorValue -> option` map zod
+ * builds at construction and reads in `_parse` to route a value to its
+ * branch. Reused when rebuilding a slimmed DU so the new map keys off
+ * zod's own discriminator extraction rather than re-deriving it.
+ */
+export function getDiscriminatedOptionsMap(
+  schema: z.ZodTypeAny
+): Map<unknown, z.AnyZodObject> | undefined {
+  const map = readDef(schema)?.optionsMap
+  return map instanceof Map ? (map as Map<unknown, z.AnyZodObject>) : undefined
 }
 
 export function getIntersectionLeft(schema: z.ZodTypeAny): z.ZodTypeAny | undefined {
@@ -646,20 +660,6 @@ export function getLiteralValues(schema: z.ZodTypeAny): readonly unknown[] {
 export function getNativeEnumValues(schema: z.ZodTypeAny): Record<string, unknown> | undefined {
   const def = readDef(schema)
   return def?.values
-}
-
-/**
- * Members of a `z.enum([...])` as an array. v3 stores them on
- * `_def.values` (an array for `ZodEnum`, distinct from
- * `ZodNativeEnum`'s object), and the instance `.options` getter
- * resolves to the same array. Returns an empty array for non-enum
- * inputs. Used when extracting the discriminator values an enum-keyed
- * discriminated-union option admits.
- */
-export function getEnumOptions(schema: z.ZodTypeAny): readonly unknown[] {
-  const def = readDef(schema)
-  const values: unknown = def?.values
-  return Array.isArray(values) ? values : []
 }
 
 /**

--- a/src/runtime/adapters/zod-v3/rebuild-schema.ts
+++ b/src/runtime/adapters/zod-v3/rebuild-schema.ts
@@ -27,17 +27,7 @@
  * field names written below are the same ones `introspect.ts` reads.
  */
 import type { z } from 'zod-v3'
-import {
-  getEnumOptions,
-  getLiteralValues,
-  getNativeEnumValues,
-  getObjectShape,
-  unwrapBranded,
-  unwrapEffectsSource,
-  unwrapInner,
-  unwrapLazy,
-} from './introspect'
-import { isZodSchemaType } from './helpers'
+import { getDiscriminatedOptions, getDiscriminatedOptionsMap } from './introspect'
 
 // The internal `_def` carrier. Reads go through `introspect.ts`; the
 // writes below are the one sanctioned place outside it that mirrors
@@ -195,78 +185,35 @@ export function stripLeafChecks<T extends z.ZodTypeAny>(original: T): T {
 }
 
 /**
- * Discriminator values a Zod v3 schema node admits at a discriminated
- * union's key. Mirrors Zod's own internal `getDiscriminator` (the
- * routine `z.discriminatedUnion` runs at construction time to key its
- * `optionsMap`), reconstructed from version-faithful introspection so
- * the rebuild never reaches for the ambient constructor.
- */
-function discriminatorValuesOf(schema: z.ZodTypeAny): unknown[] {
-  if (isZodSchemaType(schema, 'ZodLazy')) {
-    const inner = unwrapLazy(schema)
-    return inner === undefined ? [] : discriminatorValuesOf(inner)
-  }
-  if (isZodSchemaType(schema, 'ZodEffects')) {
-    const inner = unwrapEffectsSource(schema)
-    return inner === undefined ? [] : discriminatorValuesOf(inner)
-  }
-  if (isZodSchemaType(schema, 'ZodLiteral')) {
-    return [...getLiteralValues(schema)]
-  }
-  if (isZodSchemaType(schema, 'ZodEnum')) {
-    return [...getEnumOptions(schema)]
-  }
-  if (isZodSchemaType(schema, 'ZodNativeEnum')) {
-    const values = getNativeEnumValues(schema)
-    return values === undefined ? [] : Object.values(values)
-  }
-  if (isZodSchemaType(schema, 'ZodDefault') || isZodSchemaType(schema, 'ZodCatch')) {
-    const inner = unwrapInner(schema)
-    return inner === undefined ? [] : discriminatorValuesOf(inner)
-  }
-  if (isZodSchemaType(schema, 'ZodUndefined')) return [undefined]
-  if (isZodSchemaType(schema, 'ZodNull')) return [null]
-  if (isZodSchemaType(schema, 'ZodOptional')) {
-    const inner = unwrapInner(schema)
-    return [undefined, ...(inner === undefined ? [] : discriminatorValuesOf(inner))]
-  }
-  if (isZodSchemaType(schema, 'ZodNullable')) {
-    const inner = unwrapInner(schema)
-    return [null, ...(inner === undefined ? [] : discriminatorValuesOf(inner))]
-  }
-  if (isZodSchemaType(schema, 'ZodBranded')) {
-    const inner = unwrapBranded(schema)
-    return inner === undefined ? [] : discriminatorValuesOf(inner)
-  }
-  if (isZodSchemaType(schema, 'ZodReadonly')) {
-    const inner = unwrapInner(schema)
-    return inner === undefined ? [] : discriminatorValuesOf(inner)
-  }
-  return []
-}
-
-/**
  * Rebuild a `ZodDiscriminatedUnion` around new options. Both
- * `_def.options` (introspected, and what `getDiscriminator` reads) and
- * `_def.optionsMap` (what the DU's `_parse` reads to route a value to
- * its branch) are swapped. Rebuilding the map is load-bearing: a
- * swap-options-only rebuild would leave the original map pointing at
- * the unslimmed options, and every empty-default write would route to
- * a branch that still carries its refinements and be rejected. The
- * map is keyed by each new option's discriminator value(s), exactly
- * as Zod keys it at construction.
+ * `_def.options` and `_def.optionsMap` (what the DU's `_parse` reads to
+ * route a value to its branch) are swapped. Rebuilding the map is
+ * load-bearing: a swap-options-only rebuild would leave the original
+ * map pointing at the unslimmed options, and every empty-default write
+ * would route to a branch that still carries its refinements and be
+ * rejected.
+ *
+ * The new map reuses the original's: zod already built it at
+ * construction (with its full discriminator extraction over literal /
+ * enum / native-enum / optional / nullable / default / catch / ...),
+ * so we walk it and remap each value to the matching NEW option. The
+ * new options are produced in the original options' order at every call
+ * site, so an original option's index selects its replacement. This
+ * keeps zod's discriminator logic as the single source of truth rather
+ * than re-deriving it here.
  */
 export function rebuildDiscriminatedUnion(
   original: z.ZodTypeAny,
-  discriminator: string,
   options: readonly z.AnyZodObject[]
 ): z.ZodTypeAny {
+  const originalOptions = getDiscriminatedOptions(original)
+  const originalMap = getDiscriminatedOptionsMap(original)
   const optionsMap = new Map<unknown, z.AnyZodObject>()
-  for (const option of options) {
-    const discField = getObjectShape(option)[discriminator]
-    if (discField === undefined) continue
-    for (const value of discriminatorValuesOf(discField)) {
-      optionsMap.set(value, option)
+  if (originalMap !== undefined) {
+    for (const [value, originalOption] of originalMap) {
+      const index = originalOptions.indexOf(originalOption)
+      const replacement = index >= 0 ? options[index] : undefined
+      if (replacement !== undefined) optionsMap.set(value, replacement)
     }
   }
   return rebuildWithDef(original, { options, optionsMap })

--- a/src/runtime/adapters/zod-v3/rebuild-schema.ts
+++ b/src/runtime/adapters/zod-v3/rebuild-schema.ts
@@ -1,0 +1,273 @@
+/**
+ * Version-faithful, prototype-preserving reconstruction of Zod v3
+ * schema nodes.
+ *
+ * The adapter slims and strips schemas by rebuilding container and
+ * wrapper nodes around already-processed children. Building those
+ * replacements through the ambient `z.object()` / `z.array()` / ...
+ * constructors is a latent version-skew hazard: the published bundle
+ * rewrites `import 'zod-v3'` back to `import 'zod'` (see
+ * `build.config.ts`), so the resolved `z` is whichever Zod the
+ * consumer's dependency tree hoists. When that is a mismatched second
+ * major (a hoisted Zod v4 beside the Zod v3 a schema was authored
+ * with), the freshly built nodes carry the wrong internal shape, the
+ * v3 slim walk reads an empty accept-set, and every write is silently
+ * rejected.
+ *
+ * These helpers sidestep the resolved version entirely. Each derives
+ * the replacement from the ORIGINAL node the consumer handed in:
+ * `Object.create(Object.getPrototypeOf(original))` keeps the node on
+ * its authoring Zod's prototype (so `instanceof`, `_parse`, and every
+ * getter stay that version's), and only the changed `_def` children
+ * are patched. No ambient constructor is ever called, so a second Zod
+ * in the tree cannot poison the rebuild.
+ *
+ * Shallow by design: the children passed in are already processed, so
+ * unlike `cloneSchemaDeep` there is no recursive descent here. The
+ * field names written below are the same ones `introspect.ts` reads.
+ */
+import type { z } from 'zod-v3'
+import {
+  getEnumOptions,
+  getLiteralValues,
+  getNativeEnumValues,
+  getObjectShape,
+  unwrapBranded,
+  unwrapEffectsSource,
+  unwrapInner,
+  unwrapLazy,
+} from './introspect'
+import { isZodSchemaType } from './helpers'
+
+// The internal `_def` carrier. Reads go through `introspect.ts`; the
+// writes below are the one sanctioned place outside it that mirrors
+// the same field names back onto a node.
+interface DefCarrier {
+  _def: Record<string, unknown>
+}
+
+/**
+ * Shallow, prototype-preserving rebuild. Returns a new node on
+ * `original`'s prototype whose `_def` is `original._def` with
+ * `defPatch` merged over it. `original._def` is never mutated — the
+ * spread allocates a fresh object.
+ *
+ * No own properties are copied. The Zod constructor binds `parse` /
+ * `safeParse` / `default` / `catch` / ... as own properties bound to
+ * the instance that built them, so copying them would bind the
+ * rebuilt node's methods to `original`. Leaving them off lets every
+ * method resolve through the prototype with a dynamic `this`, which
+ * is exactly what reads the patched `_def`.
+ */
+function rebuildWithDef<T extends z.ZodTypeAny>(original: T, defPatch: Record<string, unknown>): T {
+  const node = Object.create(Object.getPrototypeOf(original)) as T & DefCarrier
+  node._def = { ...(original as unknown as DefCarrier)._def, ...defPatch }
+  return node
+}
+
+/**
+ * Rebuild a `ZodObject` around a new shape. The shape is stored as the
+ * `_def.shape` thunk Zod expects (lazy, for self-referential schemas).
+ *
+ * `ZodObject` memoises `{ shape, keys }` on an own `_cached` slot its
+ * constructor seeds to `null`. `Object.create` skips the constructor,
+ * so seed it here; without it `_getCached` returns the `undefined`
+ * sentinel and the first parse throws on `cached.shape`.
+ */
+export function rebuildObject(
+  original: z.ZodTypeAny,
+  shape: z.ZodRawShape
+): z.ZodObject<z.ZodRawShape> {
+  // `unknownKeys` resets to the fresh-constructor default ('strip') so
+  // the slim rebuild matches the old `z.object(shape)` exactly: a
+  // `.strict()` root must not start rejecting unknown keys on the
+  // lenient slim parse. The strip-async pass re-applies the real
+  // unknown-keys / catchall policy via `carryObjectChecks`, which reads
+  // them from the ORIGINAL, so that path is unchanged.
+  const node = rebuildWithDef(original, { shape: () => shape, unknownKeys: 'strip' })
+  ;(node as unknown as { _cached: unknown })._cached = null
+  return node as unknown as z.ZodObject<z.ZodRawShape>
+}
+
+/**
+ * Rebuild a `ZodArray` around a new element schema (`_def.type`). The
+ * standalone `.min` / `.max` / `.length` slots reset to null (the
+ * fresh-constructor default): the slim path lenient-parses empty seed
+ * arrays and must not keep a length floor. `carryArrayChecks` restores
+ * the real bounds from the original on the strip-async path.
+ */
+export function rebuildArray(
+  original: z.ZodTypeAny,
+  element: z.ZodTypeAny
+): z.ZodArray<z.ZodTypeAny> {
+  return rebuildWithDef(original, {
+    type: element,
+    minLength: null,
+    maxLength: null,
+    exactLength: null,
+  }) as unknown as z.ZodArray<z.ZodTypeAny>
+}
+
+/** Rebuild a `ZodSet` around a new value schema (`_def.valueType`); reset the size bounds like a fresh `z.set`. */
+export function rebuildSet(
+  original: z.ZodTypeAny,
+  valueType: z.ZodTypeAny
+): z.ZodSet<z.ZodTypeAny> {
+  return rebuildWithDef(original, {
+    valueType,
+    minSize: null,
+    maxSize: null,
+  }) as unknown as z.ZodSet<z.ZodTypeAny>
+}
+
+/**
+ * Rebuild a `ZodRecord` around a new value schema, optionally a new
+ * key schema. When `keyType` is omitted the original's key carries
+ * through the spread (Zod's one-arg `z.record` defaults it to a
+ * string key, which the original already encodes).
+ */
+export function rebuildRecord(
+  original: z.ZodTypeAny,
+  valueType: z.ZodTypeAny,
+  keyType?: z.ZodTypeAny
+): z.ZodRecord<z.ZodTypeAny, z.ZodTypeAny> {
+  const patch: Record<string, unknown> = { valueType }
+  if (keyType !== undefined) patch['keyType'] = keyType
+  return rebuildWithDef(original, patch) as unknown as z.ZodRecord<z.ZodTypeAny, z.ZodTypeAny>
+}
+
+/** Rebuild a `ZodTuple` around new items (`_def.items`); reset the variadic `_def.rest` like a fresh `z.tuple`. */
+export function rebuildTuple(
+  original: z.ZodTypeAny,
+  items: readonly z.ZodTypeAny[]
+): z.ZodTuple<[z.ZodTypeAny, ...z.ZodTypeAny[]]> {
+  return rebuildWithDef(original, { items, rest: null }) as unknown as z.ZodTuple<
+    [z.ZodTypeAny, ...z.ZodTypeAny[]]
+  >
+}
+
+/** Rebuild a `ZodUnion` around new options (`_def.options`). */
+export function rebuildUnion(
+  original: z.ZodTypeAny,
+  options: readonly z.ZodTypeAny[]
+): z.ZodUnion<[z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]> {
+  return rebuildWithDef(original, { options }) as unknown as z.ZodUnion<
+    [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]
+  >
+}
+
+/** Rebuild a `ZodIntersection` around new sides (`_def.left` / `_def.right`). */
+export function rebuildIntersection(
+  original: z.ZodTypeAny,
+  left: z.ZodTypeAny,
+  right: z.ZodTypeAny
+): z.ZodIntersection<z.ZodTypeAny, z.ZodTypeAny> {
+  return rebuildWithDef(original, { left, right }) as unknown as z.ZodIntersection<
+    z.ZodTypeAny,
+    z.ZodTypeAny
+  >
+}
+
+/**
+ * Rebuild a transparent wrapper (`ZodOptional` / `ZodNullable`) around
+ * a new inner schema (`_def.innerType`). The wrapper kind is taken
+ * from `original`'s prototype, so one helper serves both.
+ */
+export function rebuildWrapperInner<T extends z.ZodTypeAny>(original: T, inner: z.ZodTypeAny): T {
+  return rebuildWithDef(original, { innerType: inner })
+}
+
+/** Rebuild a `ZodLazy` whose getter resolves to an already-processed target (`_def.getter`). */
+export function rebuildLazy(original: z.ZodTypeAny, target: z.ZodTypeAny): z.ZodLazy<z.ZodTypeAny> {
+  return rebuildWithDef(original, { getter: () => target }) as unknown as z.ZodLazy<z.ZodTypeAny>
+}
+
+/**
+ * Clear a primitive leaf's refinement checks (`_def.checks`) while
+ * preserving everything else on the def. Notably `_def.coerce` carries
+ * through: a coercing slim leaf is strictly more permissive on the
+ * lenient slim pass, and the write gate short-circuits coerce leaves
+ * before they reach this shape, so keeping the flag is both safe and
+ * more faithful than dropping it (which a fresh `z.string()` would).
+ */
+export function stripLeafChecks<T extends z.ZodTypeAny>(original: T): T {
+  return rebuildWithDef(original, { checks: [] })
+}
+
+/**
+ * Discriminator values a Zod v3 schema node admits at a discriminated
+ * union's key. Mirrors Zod's own internal `getDiscriminator` (the
+ * routine `z.discriminatedUnion` runs at construction time to key its
+ * `optionsMap`), reconstructed from version-faithful introspection so
+ * the rebuild never reaches for the ambient constructor.
+ */
+function discriminatorValuesOf(schema: z.ZodTypeAny): unknown[] {
+  if (isZodSchemaType(schema, 'ZodLazy')) {
+    const inner = unwrapLazy(schema)
+    return inner === undefined ? [] : discriminatorValuesOf(inner)
+  }
+  if (isZodSchemaType(schema, 'ZodEffects')) {
+    const inner = unwrapEffectsSource(schema)
+    return inner === undefined ? [] : discriminatorValuesOf(inner)
+  }
+  if (isZodSchemaType(schema, 'ZodLiteral')) {
+    return [...getLiteralValues(schema)]
+  }
+  if (isZodSchemaType(schema, 'ZodEnum')) {
+    return [...getEnumOptions(schema)]
+  }
+  if (isZodSchemaType(schema, 'ZodNativeEnum')) {
+    const values = getNativeEnumValues(schema)
+    return values === undefined ? [] : Object.values(values)
+  }
+  if (isZodSchemaType(schema, 'ZodDefault') || isZodSchemaType(schema, 'ZodCatch')) {
+    const inner = unwrapInner(schema)
+    return inner === undefined ? [] : discriminatorValuesOf(inner)
+  }
+  if (isZodSchemaType(schema, 'ZodUndefined')) return [undefined]
+  if (isZodSchemaType(schema, 'ZodNull')) return [null]
+  if (isZodSchemaType(schema, 'ZodOptional')) {
+    const inner = unwrapInner(schema)
+    return [undefined, ...(inner === undefined ? [] : discriminatorValuesOf(inner))]
+  }
+  if (isZodSchemaType(schema, 'ZodNullable')) {
+    const inner = unwrapInner(schema)
+    return [null, ...(inner === undefined ? [] : discriminatorValuesOf(inner))]
+  }
+  if (isZodSchemaType(schema, 'ZodBranded')) {
+    const inner = unwrapBranded(schema)
+    return inner === undefined ? [] : discriminatorValuesOf(inner)
+  }
+  if (isZodSchemaType(schema, 'ZodReadonly')) {
+    const inner = unwrapInner(schema)
+    return inner === undefined ? [] : discriminatorValuesOf(inner)
+  }
+  return []
+}
+
+/**
+ * Rebuild a `ZodDiscriminatedUnion` around new options. Both
+ * `_def.options` (introspected, and what `getDiscriminator` reads) and
+ * `_def.optionsMap` (what the DU's `_parse` reads to route a value to
+ * its branch) are swapped. Rebuilding the map is load-bearing: a
+ * swap-options-only rebuild would leave the original map pointing at
+ * the unslimmed options, and every empty-default write would route to
+ * a branch that still carries its refinements and be rejected. The
+ * map is keyed by each new option's discriminator value(s), exactly
+ * as Zod keys it at construction.
+ */
+export function rebuildDiscriminatedUnion(
+  original: z.ZodTypeAny,
+  discriminator: string,
+  options: readonly z.AnyZodObject[]
+): z.ZodTypeAny {
+  const optionsMap = new Map<unknown, z.AnyZodObject>()
+  for (const option of options) {
+    const discField = getObjectShape(option)[discriminator]
+    if (discField === undefined) continue
+    for (const value of discriminatorValuesOf(discField)) {
+      optionsMap.set(value, option)
+    }
+  }
+  return rebuildWithDef(original, { options, optionsMap })
+}

--- a/src/runtime/adapters/zod-v3/strip-async.ts
+++ b/src/runtime/adapters/zod-v3/strip-async.ts
@@ -181,7 +181,7 @@ export function stripAsyncChecks(schema: z.ZodTypeAny): z.ZodTypeAny {
         (o) => recurse(o) as z.ZodObject<z.ZodRawShape>
       )
       if (discKey === undefined || options.length === 0) return s
-      return rebuildDiscriminatedUnion(s, discKey, options)
+      return rebuildDiscriminatedUnion(s, options)
     }
     if (isZodSchemaType(s, 'ZodIntersection')) {
       const left = getIntersectionLeft(s)

--- a/src/runtime/adapters/zod-v3/strip-async.ts
+++ b/src/runtime/adapters/zod-v3/strip-async.ts
@@ -1,4 +1,8 @@
-import { z } from 'zod-v3'
+// Type-only: this pass constructs zero nodes through the ambient `z`.
+// Every container / wrapper rebuild goes through `rebuild-schema.ts`,
+// which reconstructs from the consumer's own (correct-version) node,
+// keeping the pass immune to a second, mismatched zod in the tree.
+import type { z } from 'zod-v3'
 
 import {
   getArrayElement,
@@ -21,6 +25,18 @@ import {
   unwrapPipeIn,
 } from './introspect'
 import { isZodSchemaType } from './helpers'
+import {
+  rebuildArray,
+  rebuildDiscriminatedUnion,
+  rebuildIntersection,
+  rebuildLazy,
+  rebuildObject,
+  rebuildRecord,
+  rebuildSet,
+  rebuildTuple,
+  rebuildUnion,
+  rebuildWrapperInner,
+} from './rebuild-schema'
 
 /**
  * v3 analogue of v4's `strip.ts stripAsyncChecks` (`zod-v4/strip.ts:212`).
@@ -81,11 +97,11 @@ export function stripAsyncChecks(schema: z.ZodTypeAny): z.ZodTypeAny {
     // Transparent wrappers: recurse the inner and rewrap.
     if (isZodSchemaType(s, 'ZodOptional')) {
       const inner = unwrapInner(s)
-      return inner === undefined ? s : z.optional(recurse(inner))
+      return inner === undefined ? s : rebuildWrapperInner(s, recurse(inner))
     }
     if (isZodSchemaType(s, 'ZodNullable')) {
       const inner = unwrapInner(s)
-      return inner === undefined ? s : z.nullable(recurse(inner))
+      return inner === undefined ? s : rebuildWrapperInner(s, recurse(inner))
     }
     if (isZodSchemaType(s, 'ZodDefault')) {
       const inner = unwrapInner(s)
@@ -111,7 +127,7 @@ export function stripAsyncChecks(schema: z.ZodTypeAny): z.ZodTypeAny {
       const inner = unwrapLazy(s)
       if (inner === undefined) return s
       const stripped = recurse(inner)
-      return z.lazy(() => stripped)
+      return rebuildLazy(s, stripped)
     }
     if (isZodSchemaType(s, 'ZodPipeline')) {
       // Pipelines carry transforms whose output shape is load-bearing
@@ -132,36 +148,32 @@ export function stripAsyncChecks(schema: z.ZodTypeAny): z.ZodTypeAny {
       for (const [k, v] of Object.entries(shape)) {
         next[k] = recurse(v)
       }
-      return carryObjectChecks(z.object(next), s)
+      return carryObjectChecks(rebuildObject(s, next), s)
     }
     if (isZodSchemaType(s, 'ZodArray')) {
       const element = getArrayElement(s)
       if (element === undefined) return s
-      return carryArrayChecks(z.array(recurse(element)), s)
+      return carryArrayChecks(rebuildArray(s, recurse(element)), s)
     }
     if (isZodSchemaType(s, 'ZodSet')) {
       const valueType = getSetValueType(s)
       if (valueType === undefined) return s
-      return carrySetChecks(z.set(recurse(valueType)), s)
+      return carrySetChecks(rebuildSet(s, recurse(valueType)), s)
     }
     if (isZodSchemaType(s, 'ZodTuple')) {
       const items = getTupleItems(s).map(recurse)
-      // z.tuple requires [T, ...T[]] but the runtime accepts an array.
-      const rebuilt = z.tuple(items as [z.ZodTypeAny, ...z.ZodTypeAny[]])
-      return rebuilt
+      return rebuildTuple(s, items)
     }
     if (isZodSchemaType(s, 'ZodRecord')) {
       const keyType = getRecordKeyType(s)
       const valueType = getRecordValueType(s)
       if (valueType === undefined) return s
       const next = recurse(valueType)
-      return keyType === undefined
-        ? z.record(next as z.ZodTypeAny)
-        : z.record(keyType as z.ZodString, next as z.ZodTypeAny)
+      return keyType === undefined ? rebuildRecord(s, next) : rebuildRecord(s, next, keyType)
     }
     if (isZodSchemaType(s, 'ZodUnion')) {
       const options = getUnionOptions(s).map(recurse)
-      return z.union(options as [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]])
+      return rebuildUnion(s, options)
     }
     if (isZodSchemaType(s, 'ZodDiscriminatedUnion')) {
       const discKey = getDiscriminator(s)
@@ -169,16 +181,13 @@ export function stripAsyncChecks(schema: z.ZodTypeAny): z.ZodTypeAny {
         (o) => recurse(o) as z.ZodObject<z.ZodRawShape>
       )
       if (discKey === undefined || options.length === 0) return s
-      return z.discriminatedUnion(
-        discKey,
-        options as [z.ZodObject<z.ZodRawShape>, ...z.ZodObject<z.ZodRawShape>[]]
-      )
+      return rebuildDiscriminatedUnion(s, discKey, options)
     }
     if (isZodSchemaType(s, 'ZodIntersection')) {
       const left = getIntersectionLeft(s)
       const right = getIntersectionRight(s)
       if (left === undefined || right === undefined) return s
-      return z.intersection(recurse(left), recurse(right))
+      return rebuildIntersection(s, recurse(left), recurse(right))
     }
 
     // Leaves: pass through unchanged. ZodEffects is the only carrier

--- a/test/adapters/zod-v3/rebuild-schema.test.ts
+++ b/test/adapters/zod-v3/rebuild-schema.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod-v3'
+import * as z4 from 'zod/v4'
+import {
+  rebuildArray,
+  rebuildDiscriminatedUnion,
+  rebuildIntersection,
+  rebuildLazy,
+  rebuildObject,
+  rebuildRecord,
+  rebuildSet,
+  rebuildTuple,
+  rebuildUnion,
+  rebuildWrapperInner,
+  stripLeafChecks,
+} from '../../../src/runtime/adapters/zod-v3/rebuild-schema'
+
+/**
+ * Unit suite for the version-faithful schema rebuild that replaced the
+ * adapter's ambient `z.object()` / `z.array()` / ... construction. The
+ * invariants pinned here are what make a hoisted second zod harmless:
+ * each rebuild stays on the input node's prototype, never mutates the
+ * original, and the discriminated-union recipe reconstructs the parse
+ * `optionsMap`, not just the options array.
+ */
+
+// `_def.optionsMap` is internal; read it through a local cast rather
+// than widening the public types.
+function optionsMapOf(schema: z.ZodTypeAny): Map<unknown, z.AnyZodObject> {
+  return (schema as unknown as { _def: { optionsMap: Map<unknown, z.AnyZodObject> } })._def
+    .optionsMap
+}
+
+describe('rebuildObject', () => {
+  it('preserves the prototype and typeName, swapping only the shape', () => {
+    const original = z.object({ a: z.string().min(5) })
+    const rebuilt = rebuildObject(original, { a: z.string() })
+
+    expect(Object.getPrototypeOf(rebuilt)).toBe(Object.getPrototypeOf(original))
+    expect(rebuilt).toBeInstanceOf(z.ZodObject)
+    expect(rebuilt._def.typeName).toBe('ZodObject')
+  })
+
+  it('seeds the _cached slot so the first parse does not throw', () => {
+    const rebuilt = rebuildObject(z.object({ a: z.string().min(5) }), { a: z.string() })
+    // `Object.create` skips the constructor that seeds `_cached` to
+    // null; without the explicit seed `_getCached` returns undefined
+    // and this parse throws on `cached.shape`.
+    expect((rebuilt as unknown as { _cached: unknown })._cached).toBe(null)
+    expect(rebuilt.parse({ a: '' })).toEqual({ a: '' })
+  })
+
+  it('parses against the new shape, not the original checks', () => {
+    const original = z.object({ a: z.string().min(5) })
+    const rebuilt = rebuildObject(original, { a: z.string() })
+    // min(5) is gone on the rebuild.
+    expect(rebuilt.safeParse({ a: '' }).success).toBe(true)
+  })
+
+  it('never mutates the original node', () => {
+    const original = z.object({ a: z.string().min(5) })
+    rebuildObject(original, { a: z.string() })
+    // The original still rejects the short string.
+    expect(original.safeParse({ a: '' }).success).toBe(false)
+    expect(original._def).not.toBeUndefined()
+  })
+})
+
+describe('rebuild* container helpers', () => {
+  it('rebuildArray swaps the element and drops length checks', () => {
+    const original = z.array(z.string()).min(2)
+    const rebuilt = rebuildArray(original, z.string())
+    expect(rebuilt).toBeInstanceOf(z.ZodArray)
+    expect(rebuilt._def.type).toBeInstanceOf(z.ZodString)
+    expect(rebuilt.parse(['only-one'])).toEqual(['only-one'])
+  })
+
+  it('rebuildSet swaps the value type', () => {
+    const rebuilt = rebuildSet(z.set(z.number()), z.string())
+    expect(rebuilt).toBeInstanceOf(z.ZodSet)
+    expect(rebuilt.parse(new Set(['x']))).toEqual(new Set(['x']))
+  })
+
+  it('rebuildRecord swaps value (and key when given)', () => {
+    const oneArg = rebuildRecord(z.record(z.number()), z.string())
+    expect(oneArg).toBeInstanceOf(z.ZodRecord)
+    expect(oneArg.parse({ a: 'x' })).toEqual({ a: 'x' })
+
+    const twoArg = rebuildRecord(z.record(z.string(), z.number()), z.string(), z.string())
+    expect(twoArg.parse({ a: 'x' })).toEqual({ a: 'x' })
+  })
+
+  it('rebuildTuple swaps the items', () => {
+    const rebuilt = rebuildTuple(z.tuple([z.number()]), [z.string(), z.number()])
+    expect(rebuilt).toBeInstanceOf(z.ZodTuple)
+    expect(rebuilt.parse(['x', 1])).toEqual(['x', 1])
+  })
+
+  it('rebuildUnion swaps the options', () => {
+    const rebuilt = rebuildUnion(z.union([z.string(), z.number()]), [z.boolean(), z.number()])
+    expect(rebuilt).toBeInstanceOf(z.ZodUnion)
+    expect(rebuilt.parse(true)).toBe(true)
+    expect(rebuilt.safeParse('nope').success).toBe(false)
+  })
+
+  it('rebuildIntersection swaps both sides', () => {
+    const rebuilt = rebuildIntersection(
+      z.intersection(z.string(), z.string()),
+      z.object({ a: z.string() }),
+      z.object({ b: z.number() })
+    )
+    expect(rebuilt).toBeInstanceOf(z.ZodIntersection)
+    expect(rebuilt.parse({ a: 'x', b: 1 })).toEqual({ a: 'x', b: 1 })
+  })
+
+  it('rebuildWrapperInner swaps a transparent wrapper inner', () => {
+    const rebuilt = rebuildWrapperInner(z.string().optional(), z.number())
+    expect(rebuilt).toBeInstanceOf(z.ZodOptional)
+    expect(rebuilt.parse(undefined)).toBeUndefined()
+    expect(rebuilt.parse(5)).toBe(5)
+    expect(rebuilt.safeParse('x').success).toBe(false)
+  })
+
+  it('resets container constraint slots to fresh-constructor defaults', () => {
+    // This is the byte-faithfulness guarantee for the slim path: the
+    // rebuild must match the old `z.array()` / `z.object()` (which drop
+    // these), so the lenient slim parse of an empty seed never fails.
+    expect(rebuildArray(z.array(z.string()).min(3), z.string()).safeParse([]).success).toBe(true)
+    expect(rebuildSet(z.set(z.number()).min(2), z.number()).safeParse(new Set()).success).toBe(true)
+    const strict = rebuildObject(z.object({ a: z.string() }).strict(), { a: z.string() })
+    expect(strict.safeParse({ a: 'x', extra: 1 }).success).toBe(true)
+  })
+
+  it('rebuildLazy resolves the getter to the new target', () => {
+    const rebuilt = rebuildLazy(
+      z.lazy(() => z.string()),
+      z.number()
+    )
+    expect(rebuilt).toBeInstanceOf(z.ZodLazy)
+    expect(rebuilt._def.getter()).toBeInstanceOf(z.ZodNumber)
+    expect(rebuilt.parse(7)).toBe(7)
+  })
+})
+
+describe('stripLeafChecks', () => {
+  it('clears checks while keeping description', () => {
+    const original = z.string().min(5).describe('a label')
+    const rebuilt = stripLeafChecks(original)
+    expect(rebuilt._def.checks).toEqual([])
+    expect(rebuilt._def.description).toBe('a label')
+    expect(rebuilt.safeParse('').success).toBe(true)
+  })
+
+  it('keeps the coerce flag (unlike a fresh z.string())', () => {
+    const coerced = z.coerce.number().min(3)
+    expect(coerced._def.coerce).toBe(true)
+    const rebuilt = stripLeafChecks(coerced)
+    expect(rebuilt._def.coerce).toBe(true)
+    expect(rebuilt._def.checks).toEqual([])
+  })
+
+  it('never mutates the original leaf', () => {
+    const original = z.string().min(5)
+    stripLeafChecks(original)
+    expect(original.safeParse('').success).toBe(false)
+  })
+})
+
+describe('rebuildDiscriminatedUnion', () => {
+  it('reconstructs the optionsMap keyed by literal discriminators', () => {
+    const card = z.object({ kind: z.literal('card'), number: z.string() })
+    const cash = z.object({ kind: z.literal('cash'), amount: z.number() })
+    const original = z.discriminatedUnion('kind', [card, cash])
+    const rebuilt = rebuildDiscriminatedUnion(original, 'kind', [card, cash])
+
+    const map = optionsMapOf(rebuilt)
+    expect(map.get('card')).toBe(card)
+    expect(map.get('cash')).toBe(cash)
+    expect(rebuilt.parse({ kind: 'card', number: '4242' })).toEqual({
+      kind: 'card',
+      number: '4242',
+    })
+  })
+
+  it('rejects an unmapped discriminator with invalid_union_discriminator', () => {
+    const card = z.object({ kind: z.literal('card'), number: z.string() })
+    const cash = z.object({ kind: z.literal('cash'), amount: z.number() })
+    const rebuilt = rebuildDiscriminatedUnion(z.discriminatedUnion('kind', [card, cash]), 'kind', [
+      card,
+      cash,
+    ])
+    const result = rebuilt.safeParse({ kind: 'wire' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0]?.code).toBe('invalid_union_discriminator')
+    }
+  })
+
+  it('maps every value of a multi-value (enum) discriminator to its option', () => {
+    const ab = z.object({ kind: z.enum(['a', 'b']), v: z.string() })
+    const c = z.object({ kind: z.literal('c'), w: z.number() })
+    const rebuilt = rebuildDiscriminatedUnion(z.discriminatedUnion('kind', [ab, c]), 'kind', [
+      ab,
+      c,
+    ])
+
+    const map = optionsMapOf(rebuilt)
+    expect(map.get('a')).toBe(ab)
+    expect(map.get('b')).toBe(ab)
+    expect(map.get('c')).toBe(c)
+  })
+})
+
+describe('realm faithfulness (the anti-skew invariant)', () => {
+  it('rebuilds onto the INPUT node prototype, never an ambient one', () => {
+    // A v3-built node rebuilds to v3's prototype.
+    const v3obj = z.object({ a: z.string() })
+    expect(Object.getPrototypeOf(rebuildObject(v3obj, { a: z.string() }))).toBe(
+      Object.getPrototypeOf(v3obj)
+    )
+
+    // The SAME helper handed a foreign-realm node (zod v4, standing in
+    // for a mismatched hoisted major) keeps that node's prototype. The
+    // rebuild never substitutes a constructor of its own, so a second
+    // zod in the tree cannot leak into the result.
+    const v4obj = z4.object({ a: z4.string() }) as unknown as z.ZodTypeAny
+    expect(Object.getPrototypeOf(rebuildObject(v4obj, {}))).toBe(Object.getPrototypeOf(v4obj))
+    expect(Object.getPrototypeOf(rebuildObject(v4obj, {}))).not.toBe(Object.getPrototypeOf(v3obj))
+  })
+})

--- a/test/adapters/zod-v3/rebuild-schema.test.ts
+++ b/test/adapters/zod-v3/rebuild-schema.test.ts
@@ -167,25 +167,27 @@ describe('stripLeafChecks', () => {
 })
 
 describe('rebuildDiscriminatedUnion', () => {
-  it('reconstructs the optionsMap keyed by literal discriminators', () => {
-    const card = z.object({ kind: z.literal('card'), number: z.string() })
+  it('remaps the optionsMap to the NEW (slim) options in order', () => {
+    const card = z.object({ kind: z.literal('card'), number: z.string().min(4) })
     const cash = z.object({ kind: z.literal('cash'), amount: z.number() })
     const original = z.discriminatedUnion('kind', [card, cash])
-    const rebuilt = rebuildDiscriminatedUnion(original, 'kind', [card, cash])
+    // Distinct slim options in the original order (number's min dropped).
+    const slimCard = rebuildObject(card, { kind: z.literal('card'), number: z.string() })
+    const slimCash = rebuildObject(cash, { kind: z.literal('cash'), amount: z.number() })
+    const rebuilt = rebuildDiscriminatedUnion(original, [slimCard, slimCash])
 
     const map = optionsMapOf(rebuilt)
-    expect(map.get('card')).toBe(card)
-    expect(map.get('cash')).toBe(cash)
-    expect(rebuilt.parse({ kind: 'card', number: '4242' })).toEqual({
-      kind: 'card',
-      number: '4242',
-    })
+    // The map points at the SLIM options, not the originals.
+    expect(map.get('card')).toBe(slimCard)
+    expect(map.get('cash')).toBe(slimCash)
+    // Routing reaches the slim branch: min(4) is gone, so 'ab' parses.
+    expect(rebuilt.parse({ kind: 'card', number: 'ab' })).toEqual({ kind: 'card', number: 'ab' })
   })
 
   it('rejects an unmapped discriminator with invalid_union_discriminator', () => {
     const card = z.object({ kind: z.literal('card'), number: z.string() })
     const cash = z.object({ kind: z.literal('cash'), amount: z.number() })
-    const rebuilt = rebuildDiscriminatedUnion(z.discriminatedUnion('kind', [card, cash]), 'kind', [
+    const rebuilt = rebuildDiscriminatedUnion(z.discriminatedUnion('kind', [card, cash]), [
       card,
       cash,
     ])
@@ -196,18 +198,20 @@ describe('rebuildDiscriminatedUnion', () => {
     }
   })
 
-  it('maps every value of a multi-value (enum) discriminator to its option', () => {
+  it('carries every value of a multi-value (enum) discriminator to its slim option', () => {
     const ab = z.object({ kind: z.enum(['a', 'b']), v: z.string() })
     const c = z.object({ kind: z.literal('c'), w: z.number() })
-    const rebuilt = rebuildDiscriminatedUnion(z.discriminatedUnion('kind', [ab, c]), 'kind', [
-      ab,
-      c,
-    ])
+    const original = z.discriminatedUnion('kind', [ab, c])
+    const slimAb = rebuildObject(ab, { kind: z.enum(['a', 'b']), v: z.string() })
+    const slimC = rebuildObject(c, { kind: z.literal('c'), w: z.number() })
+    const rebuilt = rebuildDiscriminatedUnion(original, [slimAb, slimC])
 
+    // Reused from zod's own optionsMap, both enum values route to the
+    // same slim option.
     const map = optionsMapOf(rebuilt)
-    expect(map.get('a')).toBe(ab)
-    expect(map.get('b')).toBe(ab)
-    expect(map.get('c')).toBe(c)
+    expect(map.get('a')).toBe(slimAb)
+    expect(map.get('b')).toBe(slimAb)
+    expect(map.get('c')).toBe(slimC)
   })
 })
 

--- a/test/adapters/zod-v3/zod-skew.test.ts
+++ b/test/adapters/zod-v3/zod-skew.test.ts
@@ -1,0 +1,102 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import * as ZodV3 from 'zod-v3'
+import { zodAdapter } from '../../../src/runtime/adapters/zod-v3'
+import { stripAsyncChecks } from '../../../src/runtime/adapters/zod-v3/strip-async'
+
+// This static import IS subject to the `vi.mock` below, so the `ZodV3`
+// VALUE resolves to v4 at runtime (used in the live-skew check). Its
+// TYPE, which TypeScript resolves against the real zod-v3 types
+// regardless of the runtime mock, gives `z` the correct v3 module shape
+// while the v3 runtime value comes from `vi.importActual`.
+type ZodV3Module = typeof ZodV3
+
+/**
+ * Version-skew guard for the zod-v3 adapter.
+ *
+ * The published bundle rewrites the adapter's `zod-v3` specifier to
+ * `zod` (see `build.config.ts`), so at runtime it resolves to whichever
+ * zod the consumer's dependency tree hoists. This mock forces that to a
+ * MISMATCHED major (v4) while the schema under test is authored with
+ * real v3 (pulled through `vi.importActual`). That is the exact shape of
+ * the failure first seen in `apps/bench-arena`: a hoisted v4 beside the
+ * v3 a schema was built with.
+ *
+ * Post-fix the adapter imports `zod-v3` for TYPES only and rebuilds
+ * every slim / stripped node from the consumer's own node, so this mock
+ * is inert and the assertions below hold. Reintroduce a value
+ * `import { z } from 'zod-v3'` plus ambient `z.object()` construction and
+ * the mock would poison every rebuild: the v3 slim walk would read an
+ * empty accept set and reject every write, failing these same
+ * assertions. That is the regression this guard exists to catch.
+ */
+vi.mock('zod-v3', async () => await vi.importActual('zod/v4'))
+
+let z: ZodV3Module
+
+beforeAll(async () => {
+  z = (await vi.importActual('zod-v3')) as ZodV3Module
+})
+
+describe('zod-v3 adapter under version skew (hoisted zod v4 alongside v3)', () => {
+  it('confirms the skew is live: a value import of zod-v3 resolves to v4', () => {
+    // `ZodV3` is the static (mocked) import, so this is the v4 builder.
+    const probe = ZodV3.object({ a: ZodV3.string() })
+    const def = (probe as unknown as { _def: { type?: string; typeName?: string } })._def
+    // v4 carries `_def.type`; v3 carries `_def.typeName`. Seeing v4's
+    // shape here proves the adapter's correctness below is genuinely
+    // skew-resistant, not an artifact of an inert mock.
+    expect(def.typeName).toBeUndefined()
+    expect(def.type).toBe('object')
+  })
+
+  it('accepts writes: the slim accept-set is non-empty and typed', () => {
+    const schema = z.object({ name: z.string().min(2), age: z.number().int() })
+    const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+
+    expect([...adapter.getSlimPrimitiveTypesAtPath(['name'])]).toEqual(['string'])
+    expect([...adapter.getSlimPrimitiveTypesAtPath(['age'])]).toEqual(['number'])
+  })
+
+  it('seeds defaults from the slim shape', () => {
+    const schema = z.object({ name: z.string(), agree: z.boolean(), count: z.number() })
+    const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+
+    expect(adapter.getDefaultAtPath(['name'])).toBe('')
+    expect(adapter.getDefaultAtPath(['agree'])).toBe(false)
+    expect(adapter.getDefaultAtPath(['count'])).toBe(0)
+  })
+
+  it('still rejects a path absent from the schema', () => {
+    const schema = z.object({ name: z.string() })
+    const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+
+    expect(adapter.getSlimPrimitiveTypesAtPath(['nope']).size).toBe(0)
+  })
+
+  it('builds a discriminated union through the slim path', () => {
+    const schema = z.object({
+      payment: z.discriminatedUnion('kind', [
+        z.object({ kind: z.literal('card'), number: z.string() }),
+        z.object({ kind: z.literal('cash'), amount: z.number() }),
+      ]),
+    })
+    const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+
+    // Exercises rebuildDiscriminatedUnion (the optionsMap reconstruction)
+    // without an empty accept-set swallowing the branch leaf.
+    expect(adapter.getSlimPrimitiveTypesAtPath(['payment', 'number']).size).toBeGreaterThan(0)
+    expect(() =>
+      adapter.getDefaultValues({ useDefaultSchemaValues: true, constraints: {}, strict: false })
+    ).not.toThrow()
+  })
+
+  it('strips effects into a working v3 schema', () => {
+    const schema = z.object({ name: z.string().refine((v) => v.length > 2, 'too short') })
+    const stripped = stripAsyncChecks(schema)
+
+    expect(stripped).toBeInstanceOf(z.ZodObject)
+    // The strip drops the ZodEffects refinement (rebuilt via rebuildObject
+    // under the skew); the rebuilt node parses the empty seed.
+    expect(stripped.safeParse({ name: '' }).success).toBe(true)
+  })
+})

--- a/test/composables/library-hardening-probes.test.ts
+++ b/test/composables/library-hardening-probes.test.ts
@@ -5634,11 +5634,12 @@ describe('chaos — multi-tab persistence via the storage event', () => {
       })
     )
     await nextTick()
-    await new Promise((r) => setTimeout(r, 30))
 
-    // If attaform supports cross-tab sync, this updates. If not, the
-    // form holds 'tab-A' and the assertion fails — documenting that
-    // multi-tab is not currently a feature.
+    // The cross-tab storage sync is async (handler + debounced persist
+    // re-read), so poll for it to settle rather than racing a fixed
+    // timeout: a single 30ms sleep flaked ~50% of the time under load.
+    // Mirrors the waitUntil settle pattern used elsewhere in this file.
+    await waitUntil(() => (api.values.name === 'tab-B' ? true : null))
     expect(api.values.name).toBe('tab-B')
   })
 


### PR DESCRIPTION
## Problem

Attaform's `zod-v3` adapter silently rejected **every** `form.setValue` write when a consumer's dependency tree carried a second, mismatched zod major (a hoisted zod v4 alongside the zod v3 a schema was built with). No throw, no accurate warning: the write became a no-op, and the dev-facing message misattributed it to a schema typo. It surfaced while building `apps/bench-arena`, the first thing in the repo that consumes the real published `dist` (every test and the docs site alias `attaform` to `src`).

### Root cause

The adapter rebuilt slim / stripped schema nodes through the ambient `z.object()` / `z.array()` / ... constructors. The published build rewrites `import 'zod-v3'` to `import 'zod'` (`build.config.ts`), so that ambient `z` resolves to whichever zod the consumer's tree hoists. Under skew it is v4, so the rebuilt nodes are v4-shaped, the v3 slim walk reads an empty accept-set, and the write gate rejects everything.

## Fix

Remove the adapter's dependency on the resolved zod version entirely. A new module `rebuild-schema.ts` reconstructs each node from the consumer's **own** node: `Object.create(Object.getPrototypeOf(original))` keeps it on the authoring zod's prototype, and only the changed `_def` children are patched. Every ambient construction site across `index.ts` and `strip-async.ts` now routes through these helpers, and both `z` imports become type-only. The adapter constructs zero nodes from ambient zod, so a second zod in the tree cannot poison it. The skew becomes structurally impossible, not merely diagnosed.

Correctness details, worked against the real zod 3.25.76 internals:

- `ZodObject._cached` is seeded to `null` (the constructor does it; `Object.create` skips it) so the first parse does not throw on `cached.shape`.
- No own properties are copied. Zod binds `parse` / `safeParse` / `default` / ... to the building instance, so copying them would bind the rebuilt node's methods to the original; leaving them off lets each method resolve through the prototype with a dynamic `this`, which reads the patched `_def`.
- The discriminated-union rebuild reconstructs `_def.optionsMap` (what `_parse` reads to route a value to its branch), not just `_def.options`.
- Container helpers reset the constraint slots a fresh constructor nulls (array / set length, object `unknownKeys`, tuple `rest`) so the lenient slim parse stays byte-faithful to the old construction, while `strip-async`'s `carry*` helpers still re-apply the real bounds from the original.

## Tests

- `test/adapters/zod-v3/rebuild-schema.test.ts`: prototype preservation, no-mutation of the original, the `optionsMap` recipe, and realm faithfulness (the same helper handed a v4 node keeps that node's prototype).
- `test/adapters/zod-v3/zod-skew.test.ts`: mocks `zod-v3` to v4 and proves the adapter still accepts writes, seeds defaults, and routes unions. Confirmed as a real guard: it fails the moment ambient construction returns (verified by temporarily reverting one site).
- Full `test/**` green; zero regressions across the existing zod-v3 parity suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
