### PR TITLE
fix(bench-arena): reliable first monthly refresh (pegged-renderer DNF + lint generated results)

### DIFF
--- a/.github/workflows/bench-arena.yml
+++ b/.github/workflows/bench-arena.yml
@@ -262,6 +262,14 @@ jobs:
           set -euo pipefail
           pnpm --filter attaform-bench-arena exec node scripts/run-arena.mjs --assemble test-results/merged
 
+      - name: Format generated results.json
+        # The orchestrator writes results.json with JSON.stringify, which does not
+        # match Prettier's JSON formatting, so the refresh PR's own `pnpm lint`
+        # (which ends in `prettier --check`) would fail on it. A human refreshing
+        # locally runs `pnpm format`; the automated refresh has no human, so format
+        # the one generated file here, before the signed commit captures it.
+        run: pnpm exec prettier --write apps/bench-arena/results.json
+
       - name: Prepare commit metadata
         id: meta
         env:

--- a/.github/workflows/bench-arena.yml
+++ b/.github/workflows/bench-arena.yml
@@ -179,11 +179,16 @@ jobs:
         env:
           GREP: ${{ matrix.grep }}
           SHARD: ${{ matrix.shard }}
+          # The matrix size, so each partial declares the cohort it ran under and
+          # the merge can detect a shard that uploaded nothing. Tracks the matrix
+          # automatically, so changing the shard count needs no edit here.
+          SHARD_TOTAL: ${{ strategy.job-total }}
         run: |
           set -euo pipefail
           pnpm --filter attaform-bench-arena exec node scripts/run-arena.mjs \
             --grep "$GREP" \
-            --emit-cells "test-results/cells-${SHARD}.json"
+            --emit-cells "test-results/cells-${SHARD}.json" \
+            --shard-total "$SHARD_TOTAL"
 
       - name: Upload shard cells
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/apps/bench-arena/scripts/run-arena.mjs
+++ b/apps/bench-arena/scripts/run-arena.mjs
@@ -29,10 +29,12 @@
  *
  * Sharded across runners (the monthly workflow), the same orchestrator runs in
  * two extra modes so the long sweep splits over separate CPU-isolated machines:
- *   node scripts/run-arena.mjs --grep <pat> --emit-cells <path>
+ *   node scripts/run-arena.mjs --grep <pat> --emit-cells <path> --shard-total <n>
  *                                                shard mode: run one grep slice and write its
- *                                                harvested cells (no scorecards/bundles/runtime)
- *   node scripts/run-arena.mjs --assemble <dir>  merge mode: fold every shard partial in <dir>,
+ *                                                harvested cells, stamped with the cohort size n
+ *                                                (no scorecards/bundles/runtime)
+ *   node scripts/run-arena.mjs --assemble <dir>  merge mode: fold every shard partial in <dir>
+ *                                                (refusing unless all n shards reported),
  *                                                run the global tail once -> results.json
  */
 import { spawnSync } from 'node:child_process'
@@ -87,6 +89,7 @@ function parseArgs() {
     scorecardsOnly: argv.includes('--scorecards-only'),
     emitCells: flagValue('--emit-cells'),
     assemble: flagValue('--assemble'),
+    shardTotal: flagValue('--shard-total'),
   }
 }
 
@@ -330,9 +333,11 @@ async function assembleResults(cells, meta, runner, outPath) {
  * the cohort meta, when the slice included the metadata test) to a partial. The
  * merge step concatenates the partials and runs the global tail once. Aborts
  * without writing if the slice is red, the same contract as a full run, so a red
- * shard contributes nothing rather than a half-measured partial.
+ * shard contributes nothing rather than a half-measured partial. Stamps the
+ * cohort size (shardTotal) so the merge can tell a shard that uploaded nothing
+ * from one that legitimately had no cells.
  */
-function emitCells(grep, outPath) {
+function emitCells(grep, outPath, shardTotal) {
   const { status, reportPath } = runSpec(grep)
   if (status !== 0) {
     console.error(`\n[run-arena] the shard slice failed (exit ${status}); not writing cells.`)
@@ -345,6 +350,7 @@ function emitCells(grep, outPath) {
   }
   const partial = {
     schemaVersion: SCHEMA_VERSION,
+    shardTotal,
     cells,
     meta: meta ?? null,
     runner: runnerIdentity(),
@@ -360,17 +366,37 @@ function emitCells(grep, outPath) {
  * Merge mode: read every cells-*.json partial the shards uploaded, concatenate
  * their cells, take the cohort meta from the first partial that carried it (the
  * shard whose slice ran the metadata test), fold the runner identities, and run
- * the global tail once. Mirrors the full-run guards: no partials, no cells, or no
- * meta each abort without writing, so an incomplete sweep publishes nothing
- * rather than a thin results.json.
+ * the global tail once. Mirrors the full-run guards: no partials, a shard missing
+ * from the cohort, no cells, or no meta each abort without writing, so an
+ * incomplete sweep publishes nothing rather than a thin results.json.
  */
 async function assemble(dir) {
-  const partials = readdirSync(dir)
+  const files = readdirSync(dir)
     .filter((f) => /^cells-.*\.json$/.test(f))
     .sort()
-    .map((f) => JSON.parse(readFileSync(join(dir, f), 'utf8')))
-  if (partials.length === 0) {
+  if (files.length === 0) {
     console.error(`[run-arena] no cells-*.json shard partials found in ${dir}.`)
+    exit(1)
+  }
+  const partials = files.map((f) => JSON.parse(readFileSync(join(dir, f), 'utf8')))
+  // Completeness gate. Every shard stamps the matrix size it ran under
+  // (strategy.job-total) into its partial, so a shard that hard-failed and
+  // uploaded nothing leaves a detectable gap here: the shards report success
+  // even when their slice fails (continue-on-error keeps the rest of the matrix
+  // running), so a missing partial is the only signal the merge gets. Publishing
+  // a cohort short a shard would silently drop whole libraries or scenarios from
+  // the page, so refuse rather than fold a partial sweep into a thin refresh PR.
+  const totals = [...new Set(partials.map((p) => p.shardTotal).filter((n) => Number.isInteger(n)))]
+  if (totals.length !== 1) {
+    console.error(
+      `[run-arena] shard partials carry no single cohort size (shardTotal: ${totals.join(', ') || 'none'}); refusing to assemble.`
+    )
+    exit(1)
+  }
+  if (files.length !== totals[0]) {
+    console.error(
+      `[run-arena] expected ${totals[0]} shard partials but found ${files.length} (${files.join(', ')}); a shard failed to upload, refusing to publish an incomplete cohort.`
+    )
     exit(1)
   }
   const cells = partials.flatMap((p) => p.cells ?? [])
@@ -388,7 +414,13 @@ async function assemble(dir) {
 }
 
 async function main() {
-  const { grep, scorecardsOnly, emitCells: emitCellsPath, assemble: assembleDir } = parseArgs()
+  const {
+    grep,
+    scorecardsOnly,
+    emitCells: emitCellsPath,
+    assemble: assembleDir,
+    shardTotal: shardTotalArg,
+  } = parseArgs()
   if (scorecardsOnly) {
     await refreshScorecards()
     return
@@ -398,7 +430,12 @@ async function main() {
     return
   }
   if (emitCellsPath !== null) {
-    emitCells(grep, resolve(PKG_ROOT, emitCellsPath))
+    const shardTotal = Number(shardTotalArg)
+    if (!Number.isInteger(shardTotal) || shardTotal < 1) {
+      console.error('[run-arena] --emit-cells requires --shard-total <n> (a positive integer).')
+      exit(1)
+    }
+    emitCells(grep, resolve(PKG_ROOT, emitCellsPath), shardTotal)
     return
   }
   const smoke = grep !== null

--- a/apps/bench-arena/tests/arena.spec.ts
+++ b/apps/bench-arena/tests/arena.spec.ts
@@ -1,4 +1,4 @@
-import { type Page, errors, expect, test } from '@playwright/test'
+import { type Page, expect, test } from '@playwright/test'
 
 /**
  * The cohort driver: loop every adapter across the scenario suite and every
@@ -128,7 +128,32 @@ interface RecordOptions {
   readonly allowDnf: boolean
 }
 
-const isTimeout = (e: unknown): boolean => e instanceof errors.TimeoutError
+/** Wait for the page to signal benchDone, bounded by a driver-side timer rather
+ *  than waitForFunction's own timeout. A cell that pegs the renderer's main
+ *  thread synchronously (a 5000-field FormKit keystroke or full-form validate)
+ *  never yields, so Playwright cannot service the abort behind waitForFunction's
+ *  timeout: the test-level deadline fires instead and hard-fails the cell,
+ *  defeating the did-not-finish path. A setTimeout on the driver fires whatever
+ *  the renderer is doing, so the wait always settles within budget.
+ *  waitForFunction carries no timeout of its own; the driver timer is the sole
+ *  gate. Resolves true if benchDone was observed within budget, false if the
+ *  budget elapsed first. A genuine page error (a crash, a destroyed context)
+ *  still rejects, so it stays a hard failure rather than a silent did-not-finish. */
+async function waitForBenchDone(page: Page, waitMs: number): Promise<boolean> {
+  const settled = page
+    .waitForFunction(() => document.body.dataset['benchDone'] === '1', undefined, { timeout: 0 })
+    .then(() => true as const)
+  // Once the budget wins, this wait outlives the cell; its eventual teardown
+  // rejection ('target closed') must not surface as an unhandled rejection.
+  settled.catch(() => {})
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const budget = new Promise<false>((resolve) => {
+    timer = setTimeout(() => resolve(false), waitMs)
+  })
+  const finished = await Promise.race([settled, budget])
+  clearTimeout(timer)
+  return finished
+}
 
 async function recordCell(
   page: Page,
@@ -142,13 +167,9 @@ async function recordCell(
     `/?adapter=${adapter}&scenario=${scenario}&params=${params}&trigger=input&dim=${dim}`,
     { waitUntil }
   )
-  try {
-    await page.waitForFunction(() => document.body.dataset['benchDone'] === '1', undefined, {
-      timeout: waitMs,
-    })
-  } catch (err) {
-    if (allowDnf && isTimeout(err)) return { kind: 'dnf', budgetMs: waitMs }
-    throw err
+  if (!(await waitForBenchDone(page, waitMs))) {
+    if (allowDnf) return { kind: 'dnf', budgetMs: waitMs }
+    throw new Error(`${adapter}/${scenario}/${params}/${dim} exceeded its ${waitMs}ms budget`)
   }
   const payload = await page.evaluate(
     () => (window as unknown as { __BENCH_RESULTS__: Payload }).__BENCH_RESULTS__
@@ -481,5 +502,29 @@ test.describe('dnf conversion', () => {
         allowDnf: false,
       })
     ).rejects.toThrow()
+  })
+
+  test('the driver budget preempts a synchronously pegged renderer', async ({ page }) => {
+    test.setTimeout(20_000)
+    await page.goto('about:blank')
+    // Peg the main thread for 2s with no yield and never set benchDone: the exact
+    // shape of the FormKit L5000 cell that hard-failed on CI. Kicked off without
+    // awaiting, so the wait runs against a live peg. waitForFunction cannot even
+    // install its poll on a pegged renderer, let alone fire a timeout; only the
+    // driver-side timer can settle the wait, which is the property under test.
+    const peg = page.evaluate(() => {
+      const end = Date.now() + 2000
+      while (Date.now() < end) {
+        /* spin, never yielding to the event loop */
+      }
+    })
+    peg.catch(() => {})
+    const started = Date.now()
+    const finished = await waitForBenchDone(page, 100)
+    expect(finished).toBe(false)
+    // Settled at ~100ms despite the 2s peg. A regression to waitForFunction's own
+    // timeout would hang here until the test deadline, the CI failure in minature.
+    expect(Date.now() - started).toBeLessThan(1500)
+    await peg.catch(() => {})
   })
 })


### PR DESCRIPTION
## Why

The first live dispatch of the sharded monthly refresh ([run 27329351493](https://github.com/attaform/Attaform/actions/runs/27329351493)) surfaced two issues that blocked a clean first publish:

1. **Shard 1 hard-failed**, so the merge published with no FormKit massive rows.
2. The bot-generated `results.json` **failed the refresh PR's own lint** ([run 27330276574](https://github.com/attaform/Attaform/actions/runs/27330276574)).

## 1. Pegged-renderer did-not-finish (`arena.spec.ts`)

The did-not-finish path relied on `waitForFunction`'s own timeout firing and being caught. But FormKit's L5000 keystroke and full-form validate are single synchronous main-thread operations that peg the renderer with no yield. Playwright can't service the abort behind `waitForFunction`'s timeout against a pegged renderer, so the 320s budget never fired; the 440s test-level deadline fired instead, which is an uncatchable hard failure. Both cells failed, the shard exited non-zero, its cells never uploaded, and the merge folded only 3 of 4 shards.

Proof it was specific to synchronous pegs: on shard 2, TanStack's over-budget L5000 validate *yields*, so it converted to a clean did-not-finish and passed.

**Fix:** budget the wait from a driver-side `setTimeout` raced against a no-timeout `waitForFunction`, so it settles within budget whatever the renderer is doing. A genuine page error still rejects and stays a hard failure (non-massive scenarios keep their hard-fail-on-timeout semantics). A new standing test pegs the main thread for 2s and asserts the 100ms budget still fires, so a regression to the old mechanism fails loudly.

## 2. Lint the generated results.json (`bench-arena.yml`)

The orchestrator writes `results.json` with `JSON.stringify`, whose formatting differs from Prettier's, so the refresh PR's own `pnpm lint` (which ends in `prettier --check`) failed on it. The committed file passes only because a human runs `pnpm format` before committing; the automated refresh has no human. The merge job now runs `prettier --write` on the one generated file before the signed commit captures it.

## Verification

- 3/3 `dnf conversion` Playwright tests pass, including the new pegged-renderer guard (5/5 under `--repeat-each`, not flaky); the two existing tests didn't regress.
- 10/10 gating `runtime-shape` vitest (DNF math contract unchanged).
- `vue-tsc`, ESLint, and Prettier clean.
- Proved locally that a `JSON.stringify`'d `results.json` fails `prettier --check` and `--write` fixes it.

Once merged, a fresh `gh workflow run bench-arena.yml --ref main` should take all 4 shards green and open a refresh PR that passes its own lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
