### PR TITLE
fix(bench-arena): guarantee one machine per dimension of introspection

### DIFF
--- a/.github/workflows/bench-arena.yml
+++ b/.github/workflows/bench-arena.yml
@@ -102,9 +102,10 @@ jobs:
     # that, continue-on-error lets the merge job fold whatever shards finished if
     # one slice flakes (a red slice simply uploads no artifact).
     continue-on-error: true
-    # The slowest single slice is shard 1: its two formkit massive cells each run
-    # out a full ~320s did-not-finish budget back to back. 20 min leaves headroom
-    # over that; retune alongside the grep map after a real CI timing pass.
+    # The slowest single slice is massive-validate: its two L5000 did-not-finish
+    # cells (formkit and tanstack) each run out a full ~320s budget back to back,
+    # ~11 min. 20 min leaves ample headroom, and the did-not-finish budgets are
+    # capped, so a slower runner cannot push this slice over the cap.
     timeout-minutes: 20
     # A shard only measures; it never touches the privileged release-PR
     # credentials (only the merge job does), so it stays read-only.
@@ -115,32 +116,49 @@ jobs:
       # whatever finished.
       fail-fast: false
       matrix:
-        # shard -> the spec grep slice it drives. The slices are disjoint and
-        # their union is every cell plus the cohort-metadata and dnf-conversion
-        # tests exactly once. Re-verify with `playwright test --grep <p> --list`
-        # after any change to the scenario matrix. Balanced by wall-clock, not
-        # cell count: the three ~320s did-not-finish cells (all massive at L5000)
-        # dominate, so the two heaviest libraries' massive cells take their own
-        # shards and the many small scenarios share the remaining two.
+        # shard -> the spec grep slice it drives. One shard per scenario, so every
+        # library in a (scenario, dim) comparison is measured on the same machine:
+        # the page only ever compares within a scenario (library-versus-baseline
+        # ratios, across-param slopes, the standing sentence), so scenario-whole
+        # slices are fair by construction. massive is the one scenario split
+        # further, by dimension, because all of it on one shard runs ~17 min against
+        # the 20 min cap; splitting by dimension keeps each comparison's libraries
+        # together, so it stays just as fair. The merge enforces this rather than
+        # trusting it: assemble refuses to publish if any (scenario, dim) was
+        # measured across more than one machine, so the slices below are free to be
+        # re-sliced as long as no dimension is split. GitHub's fleet is heterogeneous
+        # (a sweep can draw two CPU generations), which is why same-machine-per-
+        # dimension is enforced; pinning identical machines (self-hosted or large
+        # runners) would let the two validate did-not-finish cells split apart and
+        # drop the long pole to ~6 min, but that infra is not worth ~5 min on a
+        # monthly job. The slices are disjoint and their union is every cell plus the
+        # cohort-metadata and dnf-conversion tests exactly once; re-verify with
+        # `playwright test --grep <p> --list` after any change to the scenario matrix.
         include:
-          # The two formkit massive did-not-finish cells (keystroke + validate at
-          # L5000), the slowest single slice.
-          - shard: 1
-            grep: 'massive scenario.*formkit'
-          # Every other library's massive cells, including the tanstack L5000
-          # validate did-not-finish cell.
-          - shard: 2
-            grep: 'massive scenario.*(attaform|vee-validate|tanstack|formisch|regle-schema|regle-rules|vuelidate)'
-          # The small headless scenarios, plus the cohort-metadata test (it emits
-          # the capability matrix the merge needs) and the dnf-conversion guard
-          # tests. This slice has no did-not-finish cells, so it is the least
-          # likely to go red, which is where the load-bearing meta belongs.
-          - shard: 3
-            grep: '(flat|nested|discriminated-union|wizard) scenario|cohort metadata|dnf conversion'
-          # The array and grid scenarios (their own slice for the per-row
-          # mutation dimensions).
-          - shard: 4
-            grep: '(arrays|grid) scenario'
+          # massive validate carries both L5000 did-not-finish cells (formkit and
+          # tanstack), back to back at ~320s each: the ~11 min long pole. Anchored on
+          # the dim at end-of-title so it does not also catch the vee-validate
+          # adapter's other dimensions (its name contains "validate").
+          - shard: massive-validate
+            grep: 'massive scenario.* validate$'
+          # The rest of massive (keystroke, mount, memory; one did-not-finish cell,
+          # formkit keystroke L5000), plus the cohort-metadata test (it emits the
+          # capability matrix the merge needs) and the dnf-conversion guards. Those
+          # two carry no cohort cells, so they ride a slice that does.
+          - shard: massive-rest
+            grep: 'massive scenario.*(keystroke|mount|memory)|cohort metadata|dnf conversion'
+          - shard: flat
+            grep: 'flat scenario'
+          - shard: nested
+            grep: 'nested scenario'
+          - shard: discriminated-union
+            grep: 'discriminated-union scenario'
+          - shard: wizard
+            grep: 'wizard scenario'
+          - shard: arrays
+            grep: 'arrays scenario'
+          - shard: grid
+            grep: 'grid scenario'
     steps:
       - name: Checkout main
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -250,7 +268,8 @@ jobs:
 
       - name: Download shard cells
         # merge-multiple flattens every bench-cells-* artifact into one directory,
-        # so assemble reads cells-1.json, cells-2.json, ... side by side.
+        # so assemble reads cells-flat.json, cells-massive-validate.json, ... side
+        # by side.
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           pattern: bench-cells-*

--- a/apps/bench-arena/scripts/run-arena.mjs
+++ b/apps/bench-arena/scripts/run-arena.mjs
@@ -34,7 +34,8 @@
  *                                                harvested cells, stamped with the cohort size n
  *                                                (no scorecards/bundles/runtime)
  *   node scripts/run-arena.mjs --assemble <dir>  merge mode: fold every shard partial in <dir>
- *                                                (refusing unless all n shards reported),
+ *                                                (refusing unless all n shards reported and no
+ *                                                dimension was measured across machines),
  *                                                run the global tail once -> results.json
  */
 import { spawnSync } from 'node:child_process'
@@ -45,7 +46,7 @@ import { argv, env, exit, version as nodeVersion } from 'node:process'
 import { fileURLToPath } from 'node:url'
 import { readInstalledRepoSlug, readInstalledVersions } from './installed-version.mjs'
 import { measureBundles } from './measure-bundles.mjs'
-import { BASELINE, buildRuntime, isDnf, SCENARIO_ORDER } from './runtime-shape.mjs'
+import { BASELINE, buildRuntime, crossMachineColumns, isDnf, SCENARIO_ORDER } from './runtime-shape.mjs'
 import { fetchScorecards, scorecardViewerUrl } from './scorecards.mjs'
 
 const PKG_ROOT = dirname(dirname(fileURLToPath(import.meta.url)))
@@ -367,8 +368,9 @@ function emitCells(grep, outPath, shardTotal) {
  * their cells, take the cohort meta from the first partial that carried it (the
  * shard whose slice ran the metadata test), fold the runner identities, and run
  * the global tail once. Mirrors the full-run guards: no partials, a shard missing
- * from the cohort, no cells, or no meta each abort without writing, so an
- * incomplete sweep publishes nothing rather than a thin results.json.
+ * from the cohort, no cells, no meta, or a dimension measured across more than one
+ * machine each abort without writing, so an incomplete or cross-hardware sweep
+ * publishes nothing rather than a thin or unfair results.json.
  */
 async function assemble(dir) {
   const files = readdirSync(dir)
@@ -407,6 +409,21 @@ async function assemble(dir) {
   const meta = partials.find((p) => p.meta)?.meta ?? null
   if (!meta) {
     console.error('[run-arena] no shard partial carried the cohort meta attachment.')
+    exit(1)
+  }
+  // Single-machine-per-dimension gate. Each shard measured on one machine, so a
+  // (scenario, dim) column split across shards was timed on more than one CPU, and
+  // its ratios and slopes would then compare across hardware. GitHub's fleet is
+  // heterogeneous (a sweep can draw two CPU generations), so this is enforced, not
+  // assumed: refuse to publish a cohort whose comparisons cross machines.
+  const crossed = crossMachineColumns(partials)
+  if (crossed.length > 0) {
+    const detail = crossed.map((c) => `${c.column} (${c.models.join(' + ')})`).join('; ')
+    console.error(
+      `[run-arena] these dimensions were measured across more than one machine: ${detail}; ` +
+        'refusing to publish a cohort whose comparisons would cross hardware. ' +
+        'Keep each (scenario, dim) on a single shard.'
+    )
     exit(1)
   }
   const runner = aggregateRunners(partials.map((p) => p.runner).filter(Boolean))

--- a/apps/bench-arena/scripts/runtime-shape.d.mts
+++ b/apps/bench-arena/scripts/runtime-shape.d.mts
@@ -80,12 +80,34 @@ export interface DimBlock {
 
 export type Runtime = Record<string, Record<string, DimBlock>>
 
+export interface ShardRunner {
+  os?: string
+  arch?: string
+  cpuModel: string
+  cpuCount?: number
+  shardCount?: number
+}
+
+/** A shard partial as the merge reads it: the runner it measured on and the cells
+ *  it produced. Other fields exist on disk; the fairness gate reads only these. */
+export interface ShardPartial {
+  runner?: ShardRunner
+  cells?: Cell[]
+}
+
+export interface CrossMachineColumn {
+  column: string
+  models: string[]
+}
+
 export const SCENARIO_ORDER: string[]
 export const DIM_ORDER: string[]
 export const BASELINE: string
 
 export function statusOf(cell: Cell): CellStatus
 export function isDnf(cell: Cell): boolean
+export function dimOf(cell: Cell): string
 export function cellValue(cell: Cell): number
 export function rowOf(cell: Cell): RuntimeRow
 export function buildRuntime(cells: Cell[], libOrder: Map<string, number>): Runtime
+export function crossMachineColumns(partials: ShardPartial[]): CrossMachineColumn[]

--- a/apps/bench-arena/scripts/runtime-shape.mjs
+++ b/apps/bench-arena/scripts/runtime-shape.mjs
@@ -72,6 +72,12 @@ export function isDnf(cell) {
   return statusOf(cell) === 'did-not-finish'
 }
 
+/** A cell's comparison dimension. Timed cells name their own; a memory cell carries
+ *  no `dim` field, so its dimension is implicitly 'memory'. */
+export function dimOf(cell) {
+  return cell.kind === 'memory' ? 'memory' : cell.dim
+}
+
 /** The value a cell's ratio and slope are computed on: keystroke/mount/etc. use
  *  the timed median; memory uses retained heap (its headline, churn is noisier).
  *  Never called on a DNF cell (which has no summary); callers gate on isDnf. */
@@ -131,7 +137,7 @@ export function buildRuntime(cells, libOrder) {
   const key = (s, d, p, lib) => `${s}|${d}|${p}|${lib}`
   const grouped = {}
   for (const cell of cells) {
-    const dim = cell.kind === 'memory' ? 'memory' : cell.dim
+    const dim = dimOf(cell)
     index.set(key(cell.scenario, dim, cell.params, cell.adapter), cell)
     ;((grouped[cell.scenario] ??= {})[dim] ??= new Set()).add(cell.params)
   }
@@ -189,4 +195,39 @@ export function buildRuntime(cells, libOrder) {
     }
   }
   return runtime
+}
+
+/**
+ * The single-machine-per-dimension fairness invariant for a sharded sweep. Each
+ * shard runs on one machine, so a (scenario, dim) column whose cells came from more
+ * than one shard was measured across more than one CPU: its library ratios (a lib
+ * versus the baseline at a param) and its slopes (a lib across params) would then
+ * compare timings taken on different hardware. Given the shard partials, each
+ * carrying the runner it measured on and the cells it produced, return every column
+ * measured across more than one CPU model, so the merge can refuse to publish a
+ * cohort whose comparisons cross machines. An empty array is a clean cohort.
+ *
+ * GitHub-hosted runners are a heterogeneous fleet: one monthly sweep can draw two
+ * CPU generations at once. So the rule is enforced here rather than assumed from
+ * the shard map, which is free to be re-sliced as long as no (scenario, dim) is
+ * split across shards.
+ */
+export function crossMachineColumns(partials) {
+  const modelsByColumn = new Map()
+  for (const partial of partials) {
+    const model = partial.runner?.cpuModel ?? 'unknown'
+    for (const cell of partial.cells ?? []) {
+      const column = `${cell.scenario} / ${dimOf(cell)}`
+      let models = modelsByColumn.get(column)
+      if (!models) {
+        models = new Set()
+        modelsByColumn.set(column, models)
+      }
+      models.add(model)
+    }
+  }
+  return [...modelsByColumn.entries()]
+    .filter(([, models]) => models.size > 1)
+    .map(([column, models]) => ({ column, models: [...models].sort() }))
+    .sort((a, b) => a.column.localeCompare(b.column))
 }

--- a/test/bench-arena/runtime-shape.test.ts
+++ b/test/bench-arena/runtime-shape.test.ts
@@ -13,6 +13,8 @@ import { describe, expect, it } from 'vitest'
 import {
   buildRuntime,
   cellValue,
+  crossMachineColumns,
+  dimOf,
   isDnf,
   rowOf,
   statusOf,
@@ -22,6 +24,7 @@ import type {
   DimBlock,
   Runtime,
   RuntimeRow,
+  ShardPartial,
 } from '../../apps/bench-arena/scripts/runtime-shape.mjs'
 
 function timed(
@@ -196,5 +199,82 @@ describe('buildRuntime ratio and slope with DNF cells', () => {
     const formkitLarge = rowFor(rowsAt(rt, 'nested', 'validate', 'D8'), 'formkit')
     expect(formkitLarge.ratio).toBe(2.5) // 50 over the baseline 20, still computable
     expect(formkitLarge.slope).toBeNull() // but the D4 base did not finish
+  })
+})
+
+describe('dimOf', () => {
+  it('reads a timed cell dimension and treats a memory cell as the memory dimension', () => {
+    expect(dimOf(timed('attaform', 'massive', 'L2000', 'validate', 1))).toBe('validate')
+    expect(dimOf(memory('attaform', 'massive', 'L2000', 4096))).toBe('memory')
+  })
+})
+
+// The single-machine-per-dimension fairness gate the sharded merge enforces: a
+// (scenario, dim) column whose libraries were measured on more than one CPU model
+// would compare timings across hardware, so the merge refuses to publish it.
+describe('crossMachineColumns', () => {
+  const partial = (cpuModel: string, cells: Cell[]): ShardPartial => ({
+    runner: { cpuModel },
+    cells,
+  })
+
+  it('passes a heterogeneous fleet where each dimension was measured on one machine', () => {
+    // Two shards on different CPUs, but each owns a whole scenario, so no single
+    // (scenario, dim) column is split. Heterogeneous fleet, still fair.
+    const crossed = crossMachineColumns([
+      partial('CPU-A', [
+        timed('attaform', 'flat', 'F10', 'keystroke', 1),
+        timed('formkit', 'flat', 'F10', 'keystroke', 9),
+      ]),
+      partial('CPU-B', [
+        timed('attaform', 'grid', 'N10', 'mount', 2),
+        timed('formkit', 'grid', 'N10', 'mount', 8),
+      ]),
+    ])
+    expect(crossed).toEqual([])
+  })
+
+  it('passes the same dimension split across two shards that drew the same CPU model', () => {
+    // Identical hardware is fair to compare, so one distinct model is never a split.
+    const crossed = crossMachineColumns([
+      partial('CPU-A', [timed('attaform', 'massive', 'L2000', 'validate', 1)]),
+      partial('CPU-A', [timed('formkit', 'massive', 'L2000', 'validate', 9)]),
+    ])
+    expect(crossed).toEqual([])
+  })
+
+  it('flags every dimension whose libraries were split across two machines', () => {
+    // The PR #388 shape: formkit massive on one CPU, the baseline on another, so
+    // every massive dimension compared formkit against hardware it never ran on.
+    const crossed = crossMachineColumns([
+      partial('AMD EPYC 7763', [
+        timed('formkit', 'massive', 'L2000', 'validate', 374),
+        timed('formkit', 'massive', 'L2000', 'keystroke', 4),
+      ]),
+      partial('AMD EPYC 9V74', [
+        timed('attaform', 'massive', 'L2000', 'validate', 2),
+        timed('attaform', 'massive', 'L2000', 'keystroke', 16),
+      ]),
+    ])
+    expect(crossed).toEqual([
+      { column: 'massive / keystroke', models: ['AMD EPYC 7763', 'AMD EPYC 9V74'] },
+      { column: 'massive / validate', models: ['AMD EPYC 7763', 'AMD EPYC 9V74'] },
+    ])
+  })
+
+  it('detects a split memory dimension (a cell that carries no dim field)', () => {
+    const crossed = crossMachineColumns([
+      partial('CPU-A', [memory('attaform', 'flat', 'F10', 4096)]),
+      partial('CPU-B', [memory('formkit', 'flat', 'F10', 8192)]),
+    ])
+    expect(crossed).toEqual([{ column: 'flat / memory', models: ['CPU-A', 'CPU-B'] }])
+  })
+
+  it('treats a partial with no runner as an unknown machine', () => {
+    const crossed = crossMachineColumns([
+      partial('CPU-A', [timed('attaform', 'flat', 'F10', 'mount', 1)]),
+      { cells: [timed('formkit', 'flat', 'F10', 'mount', 9)] },
+    ])
+    expect(crossed).toEqual([{ column: 'flat / mount', models: ['CPU-A', 'unknown'] }])
   })
 })


### PR DESCRIPTION
## Why

The first complete CI refresh (#388) exposed a fairness bug. The monthly sweep shards across separate runners, and GitHub's fleet is heterogeneous: that run drew an AMD EPYC 7763 (Zen 3) and an AMD EPYC 9V74 (Zen 4) at once. The shard map split the `massive` scenario by library (formkit on one shard, the rest on another), so formkit's `massive` cells were measured on a different CPU than the attaform baseline their ratios are computed against. Every comparison the page makes lives inside a scenario, so the fix is to keep each one on a single machine.

## The general fix: enforce it, don't assume it

`assemble` now refuses to publish if any `(scenario, dim)` column was measured across more than one CPU model. The check is `crossMachineColumns`, a pure helper in `runtime-shape.mjs` (each shard partial already stamps the runner it measured on), unit-tested in the gating suite beside the DNF math. This is the same fail-loud shape as the completeness gate: the shard map is free to be re-sliced however we like, and a slice that splits a dimension across machines fails the merge instead of silently shipping skewed numbers. GitHub will keep handing out a mixed fleet, so the rule is enforced rather than trusted.

## The concrete fix: shard by scenario

One shard per scenario, so every library in a comparison is measured on the same machine. `massive` is the one scenario split further, by dimension: `validate` alone (it carries both L5000 did-not-finish cells and is the ~11 min long pole), and `keystroke`/`mount`/`memory` together. All of `massive` on one shard runs ~17 min against the 20 min cap; splitting by dimension keeps each comparison's libraries together, so it stays just as fair. Eight slices, verified disjoint and covering every cell exactly once with `playwright --grep --list`.

We deliberately do not chase machine homogeneity (self-hosted or large runners), which would let the two `validate` did-not-finish cells split apart and drop the long pole to ~6 min: that infra is not worth ~5 min on a monthly, non-gating job. The rationale is recorded in the matrix comment.

## Verification

- 16/16 gating `runtime-shape` vitest, including 6 new cases for `dimOf` and `crossMachineColumns` (clean fleet, same-model split, the #388 shape, a split memory dimension, an unknown runner).
- `assemble` on a hand-built cross-machine cohort refuses with a precise message (the offending column and both CPUs) and writes nothing.
- The 8 grep slices are an exact partition: 564 tests, sum of slices == union == 564.
- `tsc`, ESLint, Prettier, and `vue-tsc` all clean.

This changes no numbers: `results.json` is untouched and still comes only from CI. Once merged, a fresh `gh workflow run bench-arena.yml --ref main` produces the first fair CI-sourced file; #388 (the skewed refresh) can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
