### PR TITLE
perf(arrays): scope array-op write work to the changed element, not all N

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -683,7 +683,14 @@ export default [
     // useForm({ onChange }) surface). zod-v3.mjs, the tightest adapter
     // bundle, lands at 62.80 KB — keep an eye on it; a further core
     // addition will bind here first.
-    limit: '63 KB',
+    //
+    // Raised 63 → 64 KB on the array-write-path perf branch (#399): the
+    // array-op fast path adds freshElementIndices plus the scoped slim-gate /
+    // mergeStructural / authored-walk branches and an authoredPaths migration to
+    // the shared core. zod-v3.mjs lands at 62.96; this restores ~1 KB of headroom
+    // (the 63 cap was the predicted bind point and left ~40 bytes, within gzip
+    // measurement jitter and apt to flake the gate). Measured at 62.96 KB.
+    limit: '64 KB',
     gzip: true,
     ignore: ['zod'],
     modifyEsbuildConfig: asEsm,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,20 @@
   server-validation guide, document the split. Verified against both the Zod v3
   and v4 adapters; zero new runtime dependencies. (#XXX)
 
+### Performance
+
+- **Array mutation scales with the change, not the form.** Adding, inserting,
+  reordering, or removing a row now costs work proportional to the one element
+  that changed, not to the whole array. The write funnel had been re-validating,
+  re-completing, and re-authoring every element on every structural array op; it
+  now scopes that per-element work to the element the operation actually
+  introduces, guided by the hint each `form.append` / `insert` / `swap` / `move`
+  / `remove` already records. Large arrays and grids gain the most: a row added
+  to a hundred-row grid is several times cheaper, and the per-op cost stays flat
+  as the array grows. Behaviour is unchanged, pinned by a call-count regression
+  guard and the full array suite across the Zod v3 and v4 adapters; zero new
+  dependencies. (#XXX)
+
 ## v0.21.2
 ### Changed
 

--- a/src/runtime/core/array-bookkeeping.ts
+++ b/src/runtime/core/array-bookkeeping.ts
@@ -67,6 +67,7 @@ export type ArrayBookkeepingDeps = {
   readonly originals: Map<PathKey, OriginalsRecord>
   readonly blankPaths: Set<PathKey>
   readonly originalBlankPaths: Set<PathKey>
+  readonly authoredPaths: Set<PathKey>
   readonly fieldValidationCounts: Map<PathKey, number>
   readonly fieldValidatingSince: Map<PathKey, number>
   readonly fieldValidationState: Map<PathKey, FieldValidationEntry>
@@ -147,6 +148,7 @@ export function createArrayBookkeeping(deps: ArrayBookkeepingDeps): ArrayBookkee
     originals,
     blankPaths,
     originalBlankPaths,
+    authoredPaths,
     fieldValidationCounts,
     fieldValidatingSince,
     fieldValidationState,
@@ -172,6 +174,12 @@ export function createArrayBookkeeping(deps: ArrayBookkeepingDeps): ArrayBookkee
     }))
     migrateSetSubtree(blankPaths, arrayPath, remap)
     migrateSetSubtree(originalBlankPaths, arrayPath, remap)
+    // Authored marks are per-element facts too: a moved element keeps "the
+    // consumer wrote here" so the schema-error filter's verdict at preprocess /
+    // coerce leaves follows the element rather than the slot. The write funnel
+    // now authors only fresh elements on an array op, so this relocation is what
+    // keeps survivors' authored marks correct across a reorder / shift.
+    migrateSetSubtree(authoredPaths, arrayPath, remap)
     // The validation-streak anchor leads its count, mirroring
     // `incFieldValidation`: relocating `fieldValidatingSince` before
     // `fieldValidationCounts` keeps `validatingSince !== null` an outer bracket

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -1109,6 +1109,27 @@ function walkAuthoredFromConstraints(value: unknown, prefix: Path, out: Set<Path
 }
 
 /**
+ * The indices a structural array op introduces a brand-new element at:
+ * `insert` / `replace-at` carry one fresh slot, while `swap` / `move` /
+ * `remove` only permute or drop existing elements and carry none. The write
+ * funnel uses this to scope its per-element work (slim gate, structural
+ * completion, authoring) to just the new element(s) on an array op, since
+ * existing elements were already gated / completed / authored when first
+ * written and only change position here.
+ */
+function freshElementIndices(op: NonNullable<WriteMeta['arrayOp']>): readonly number[] {
+  switch (op.kind) {
+    case 'insert':
+    case 'replace-at':
+      return [op.index]
+    case 'remove':
+    case 'swap':
+    case 'move':
+      return []
+  }
+}
+
+/**
  * Diff the schema's with-defaults data against its blank baseline (the
  * raw `deriveDefault(false)` walk) to find every path where the schema
  * author declared a `.default(...)` chain. Paths whose value differs
@@ -1984,6 +2005,7 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     originals,
     blankPaths,
     originalBlankPaths,
+    authoredPaths,
     fieldValidationCounts,
     fieldValidatingSince,
     fieldValidationState,
@@ -2128,7 +2150,21 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     // The gate short-circuits at `z.preprocess` / `z.coerce` wrappers
     // so storage retains the consumer's raw input; the schema-side
     // normalizers fire during `safeParse`, not at the write boundary.
-    if (!isSlimPrimitiveValid(schema, form, path, value)) {
+    let slimOk = true
+    if (meta?.arrayOp !== undefined && Array.isArray(value)) {
+      // Array structural op: only the freshly-introduced element(s) carry new
+      // leaf values. Existing elements were gated when first written and only
+      // shift position here, so validate just the fresh slots, not all N.
+      for (const idx of freshElementIndices(meta.arrayOp)) {
+        if (!isSlimPrimitiveValid(schema, form, [...path, idx], value[idx])) {
+          slimOk = false
+          break
+        }
+      }
+    } else {
+      slimOk = isSlimPrimitiveValid(schema, form, path, value)
+    }
+    if (!slimOk) {
       return false
     }
     // Cross-variant write guard: walking the path, if any ancestor is
@@ -2333,7 +2369,18 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     // setValue('url', undefined) over an already-undefined leaf case;
     // the mark is cheap and consistent either way.
     const wasAuthoredBefore = authoredPaths.has(pathKey)
-    walkAuthoredFromConstraints(value, path, authoredPaths)
+    if (meta?.arrayOp !== undefined && Array.isArray(value)) {
+      // The array container itself is authored (the consumer wrote it via a
+      // field-array op), matching the whole-array walk this replaces. Existing
+      // elements keep their authored marks (relocated with the op by
+      // migrateElementState), so only the fresh element(s) need a fresh walk.
+      if (path.length > 0) authoredPaths.add(pathKey)
+      for (const idx of freshElementIndices(meta.arrayOp)) {
+        walkAuthoredFromConstraints(value[idx], [...path, idx], authoredPaths)
+      }
+    } else {
+      walkAuthoredFromConstraints(value, path, authoredPaths)
+    }
     const newlyAuthored = !wasAuthoredBefore && authoredPaths.has(pathKey)
 
     // Structural-completeness invariant: every write must leave the
@@ -2348,7 +2395,19 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     // hits no schema lookups: mergeStructural short-circuits on
     // ref-equal sub-trees, and the fill walker only queries the
     // schema at gap sites.
-    const completedValue = mergeStructural(schema, path, value)
+    let completedValue: unknown
+    if (meta?.arrayOp !== undefined && Array.isArray(value)) {
+      // Complete only the fresh element(s) against the schema element default;
+      // existing elements are already structurally complete from prior writes.
+      // Mutating the caller's fresh array copy in place is safe (the field-array
+      // helper builds and hands it off exactly once).
+      for (const idx of freshElementIndices(meta.arrayOp)) {
+        value[idx] = mergeStructural(schema, [...path, idx], value[idx])
+      }
+      completedValue = value
+    } else {
+      completedValue = mergeStructural(schema, path, value)
+    }
     // Identity short-circuit: if the path's current value already
     // matches what we'd write, skip the replacement. Without this,
     // every keystroke that produces an unchanged trimmed/cast value

--- a/src/runtime/core/field-arrays.ts
+++ b/src/runtime/core/field-arrays.ts
@@ -64,12 +64,14 @@ export function buildFieldArrayApi<F extends GenericForm>(
 
   return {
     append(path, value) {
-      // Pure length-grow at the tail — existing indices keep their
-      // identities, so no variant-memory key is invalidated. Skip the
-      // arrayOp hint; nothing to clear.
+      // Pure length-grow at the tail. Recorded as an insert at the tail slot
+      // so the write funnel scopes its per-element work (slim gate, structural
+      // completion, authoring, bookkeeping) to the one fresh element instead
+      // of re-walking all N. Existing indices keep their identities; an
+      // insert-at-tail remap shifts nothing.
       const next = readArray(path)
       next.push(value)
-      return writeArray(path, next)
+      return writeArray(path, next, { kind: 'insert', index: next.length - 1 })
     },
     prepend(path, value) {
       const next = readArray(path)

--- a/test/composables/field-array-perf-guard.test.ts
+++ b/test/composables/field-array-perf-guard.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, type App } from 'vue'
+import { useForm } from '../../src'
+import { attachRegistryToApp, createRegistry } from '../../src/runtime/core/registry'
+import type { Path } from '../../src/runtime/core/paths'
+import type { UseFormReturnType } from '../../src/runtime/types/types-api'
+import { fakeSchema } from '../utils/fake-schema'
+
+/**
+ * Performance regression guard for the array-mutation write path.
+ *
+ * A structural array op (append / swap / insert / remove / ...) must scope its
+ * per-element work to the element(s) the op actually introduces, never re-walk
+ * all N. The write funnel's slim-primitive gate visits each node of the value
+ * it validates, calling `getSlimPrimitiveTypesAtPath` once per node, so the
+ * call count is a deterministic, non-flaky proxy for "how much of the array did
+ * the funnel re-process." Scoped: O(element leaves), independent of N. A
+ * regression to whole-array validation makes the count scale with N.
+ *
+ * The scoping lives in the schema-agnostic funnel (create-form-store), not in
+ * either adapter, so a neutral `fakeSchema` is the right instrument here — it
+ * isolates the funnel's behaviour from any adapter's parsing specifics.
+ */
+
+type Row = { a: string; b: string; c: string }
+type Grid = { rows: Row[] }
+
+function makeRows(n: number): Row[] {
+  const rows: Row[] = []
+  for (let i = 0; i < n; i++) rows.push({ a: `a${i}`, b: `b${i}`, c: `c${i}` })
+  return rows
+}
+
+function newRow(): Row {
+  return { a: 'x', b: 'y', c: 'z' }
+}
+
+/** A form whose schema counts every `getSlimPrimitiveTypesAtPath` visit. */
+function countingHarness(n: number) {
+  const base = fakeSchema<Grid>({ rows: makeRows(n) })
+  let slimCalls = 0
+  const schema = {
+    ...base,
+    getSlimPrimitiveTypesAtPath(path: Path) {
+      slimCalls += 1
+      return base.getSlimPrimitiveTypesAtPath(path)
+    },
+  }
+  let form!: UseFormReturnType<Grid>
+  const Probe = defineComponent({
+    setup() {
+      form = useForm<Grid>({ schema, key: `guard-${n}-${Math.random()}` })
+      return () => h('div')
+    },
+  })
+  const app = createApp(Probe)
+  attachRegistryToApp(app, createRegistry())
+  app.mount(document.createElement('div'))
+  return {
+    app,
+    form,
+    reset: () => {
+      slimCalls = 0
+    },
+    calls: () => slimCalls,
+  }
+}
+
+describe('field arrays — per-element work does not scale with N (perf guard)', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  // One fresh 3-field element costs a fixed number of slim-gate visits (the
+  // element node plus its leaves), whatever N is. A generous cap that a
+  // whole-array regression (N * that, so 80 at N=20) blows past immediately.
+  const FRESH_ELEMENT_CAP = 8
+
+  /** Slim-gate visits an op makes against an N-element form, op timed alone. */
+  function callsFor(n: number, op: (form: UseFormReturnType<Grid>) => void): number {
+    const h = countingHarness(n)
+    apps.push(h.app)
+    h.reset()
+    op(h.form)
+    return h.calls()
+  }
+
+  it('append validates only the fresh element, identically at N=20 and N=200', () => {
+    const small = callsFor(20, (f) => f.append('rows', newRow()))
+    const large = callsFor(200, (f) => f.append('rows', newRow()))
+    expect(small).toBeLessThanOrEqual(FRESH_ELEMENT_CAP)
+    expect(large).toBe(small) // constant in N — the whole point
+  })
+
+  it('insert at the head validates only the fresh element, not the N it shifts', () => {
+    const small = callsFor(20, (f) => f.insert('rows', 0, newRow()))
+    const large = callsFor(200, (f) => f.insert('rows', 0, newRow()))
+    expect(small).toBeLessThanOrEqual(FRESH_ELEMENT_CAP)
+    expect(large).toBe(small)
+  })
+
+  it('swap validates no elements (a pure reorder introduces no new values)', () => {
+    expect(callsFor(200, (f) => f.swap('rows', 0, 199))).toBe(0)
+  })
+
+  it('remove validates no elements (it drops, never introduces)', () => {
+    expect(callsFor(200, (f) => f.remove('rows', 0))).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

Makes a structural array op (add / insert / reorder / move / remove a row) cost work proportional to the one element that changed, not to the whole array. Array and grid row mutation was Attaform's weakest cell in the cross-library benchmark; this brings the scaling back under control and flattens the per-op cost as the array grows.

## Root cause (measured)

`form.append` / `swap` / ... build a fresh whole-array copy and write it through the single funnel `setValueAtPath`. Phase instrumentation of a headless store-level bench (grid N200, K=8) showed the cost was three whole-array **pre-write** passes, not the diff I first suspected:

- slim-primitive gate (validate every leaf): ~48-57%
- `mergeStructural` (re-complete every element): ~19-23%
- authored-paths walk (re-author every element): ~13-17%
- the actual diff + reactive write: ~3%

Each op changes one or two elements, but all three passes re-walked all N. The render is O(1) (one row mounts, or two identity-keyed nodes move), so the whole observed slope was store-side.

## The fix

Scope the three pre-write passes to the fresh element(s) the op introduces, read from the `arrayOp` hint the field-array helpers already record (`insert` / `replace-at` carry one fresh slot; `swap` / `move` / `remove` carry none). Existing elements were gated, completed, and authored when first written and only shift position here, so their per-element state relocates through `migrateElementState` rather than being rebuilt.

- `append` now records an insert-at-tail op so it shares the targeted path (replacing a coarse `clearUnderPath` + `realign`).
- `authoredPaths` joins the per-element state `migrateElementState` relocates, closing a latent coupling the whole-array authored walk had been masking.
- No change to the diff / reactive write path (it measured cheap), so the array-identity, reactivity, and patch-emission contracts are untouched.

## Impact (headless store bench, median per op)

| Cell (K=8) | Before | After | Speedup |
|---|---|---|---|
| grid/append N100 | 2.70 ms | 0.47 ms | 5.7x |
| grid/append N200 | 5.23 ms | 0.85 ms | 6.2x |
| grid/swap N100 | 3.58 ms | 0.99 ms | 3.6x |
| grid/swap N200 | 6.69 ms | 1.72 ms | 3.9x |

The dominant O(N x fields) slope collapses to O(fields). The monthly `bench-arena` refresh will confirm the browser numbers in results.json.

## Tests

- New `field-array-perf-guard.test.ts`: a deterministic call-count guard asserting an array op does per-element work flat in N (append / insert constant, swap / remove zero), so a regression back to whole-array re-processing fails loudly.
- Full suite green across the Zod v3 and v4 adapters. The one unrelated failure (a local build-chunking packaging check) reproduces on a clean `main` and is not touched here.
- Behaviour unchanged: array, DU, reset, persistence, per-path-snapshot, and preprocess / coerce suites all pass.

## Follow-up (deferred)

After this, `swap` is bottlenecked on `migrateElementState`'s full-map scans, a pre-existing O(F) cost this fix merely exposed. Flattening it is a riskier change to robust bookkeeping for a secondary gain; deferred to its own branch pending the CI bench's browser confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
