### PR TITLE
perf(arrays): a row mutation updates only the touched rows, at any nesting depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,18 +39,23 @@
   guard and the full array suite across the Zod v3 and v4 adapters; zero new
   dependencies. (#XXX)
 
-- **Reordering a row is now a two-row update, not a whole-list re-render.** The
-  typed array helpers (`append` / `insert` / `remove` / `swap` / `move` /
-  `replace`) reconcile the array in place rather than swapping in a fresh array,
-  so a swap or move fires only the two indices that actually moved. A hundred-row
-  grid that used to re-render every row now touches just the pair, and reorder
-  cost stays flat as the list grows. Keeping the array's reference stable is the
-  one behaviour to know about: a by-reference watch on the whole array stays
-  quiet across a helper op, while length, element, and deep watches fire as
-  before and every row's value stays correct. An explicit
-  `setValue('rows', wholeNewArray)` is a container-target write and still
-  replaces the reference, just like writing any other container. Pinned by a
-  reactivity-contract suite and a re-render-count guard across the Zod v3 and v4
+- **Reordering or editing a row is a touched-rows update at any nesting depth,
+  not a whole-list re-render.** The typed array helpers (`append` / `insert` /
+  `remove` / `swap` / `move` / `replace`) reconcile the array in place rather than
+  swapping in a fresh array, so a swap or move fires only the two indices that
+  actually moved, and the reconcile holds every container on the path to the
+  mutated array stable at any depth. A list nested under an object
+  (`address.contacts`) or under another row (a nested repeater,
+  `sections.0.questions`) updates only that inner list: the outer array, the
+  touched row, and the untouched sibling rows all keep their references, so a
+  hundred-row grid that used to re-render every row now touches just the pair and
+  the cost stays flat as the list grows. Keeping those references stable is the
+  one behaviour to know about: a by-reference watch on the array (or on any
+  container along its path) stays quiet across a helper op, while length, element,
+  and deep watches fire as before and every row's value stays correct. An explicit
+  `setValue('rows', wholeNewArray)` is a container-target write and still replaces
+  the reference, just like writing any other container. Pinned by a
+  reactivity-contract suite and re-render-count guards across the Zod v3 and v4
   adapters; zero new dependencies. (#XXX)
 
 ## v0.21.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,20 @@
   guard and the full array suite across the Zod v3 and v4 adapters; zero new
   dependencies. (#XXX)
 
+- **Reordering a row is now a two-row update, not a whole-list re-render.** The
+  typed array helpers (`append` / `insert` / `remove` / `swap` / `move` /
+  `replace`) reconcile the array in place rather than swapping in a fresh array,
+  so a swap or move fires only the two indices that actually moved. A hundred-row
+  grid that used to re-render every row now touches just the pair, and reorder
+  cost stays flat as the list grows. Keeping the array's reference stable is the
+  one behaviour to know about: a by-reference watch on the whole array stays
+  quiet across a helper op, while length, element, and deep watches fire as
+  before and every row's value stays correct. An explicit
+  `setValue('rows', wholeNewArray)` is a container-target write and still
+  replaces the reference, just like writing any other container. Pinned by a
+  reactivity-contract suite and a re-render-count guard across the Zod v3 and v4
+  adapters; zero new dependencies. (#XXX)
+
 ## v0.21.2
 ### Changed
 

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -2048,7 +2048,11 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     if (onChangeRegistry.active) onChangeRegistry.dispatch(patches, meta)
   }
 
-  function applyFormReplacement(next: F, meta?: WriteMeta): void {
+  function applyFormReplacementWithPath(
+    next: F,
+    meta: WriteMeta | undefined,
+    arrayOpPath: Path | null
+  ): void {
     const prev = form.value
     if (Object.is(prev, next)) return
     // Capture the diff before any mutation lands — `commitWritePatches`
@@ -2067,13 +2071,15 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     // On a top-level shape mismatch (object → array, etc.) fall back
     // to wholesale replacement — that's the only case where in-place
     // merging can't preserve existing reactive proxies anyway.
-    // The typed array helpers carry an `arrayOp` hint; on those writes a
-    // changed container-valued key reconciles in place, keeping stable references
-    // for the mutated array and every object on the path to it. So a reorder
-    // fires only the moved indices and a nested-array append re-renders only that
-    // list, never the whole-array / whole-parent re-render. A direct
-    // container-target `setValue` (no hint) replaces the reference.
-    if (!applyChangedKeys(prev, next, meta?.arrayOp !== undefined)) {
+    // The typed array helpers thread the mutated array's path (`arrayOpPath`);
+    // on those writes a changed container-valued key reconciles in place, keeping
+    // stable references for the mutated array AND every ancestor container on the
+    // path to it, at any depth. So a reorder fires only the moved indices and a
+    // nested-array append re-renders only that list, never the whole-array /
+    // whole-parent re-render. A non-helper replacement (`arrayOpPath` null:
+    // explicit setValue, reset, undo / redo, cross-tab, hydration, DU reshape)
+    // reassigns changed keys wholesale, so a container target gets a fresh ref.
+    if (!applyChangedKeys(prev, next, arrayOpPath, [])) {
       form.value = next
     } else if (
       patches.some(
@@ -2097,6 +2103,15 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     commitWritePatches(patches, meta)
   }
 
+  // Public whole-value replacement (history restore, cross-tab merge, reset,
+  // hydration, DU reshape, devtools, tests). Threads a null array path, so the
+  // reconcile reassigns changed keys wholesale and a container target gets a
+  // fresh reference. Only the targeted array-helper write path opts into the
+  // stable-reference container reconcile, via `applyFormReplacementWithPath`.
+  function applyFormReplacement(next: F, meta?: WriteMeta): void {
+    applyFormReplacementWithPath(next, meta, null)
+  }
+
   // Fast path for a single `setValue` whose target leaf already exists:
   // mutate that leaf's slot in place (O(depth)), preserving every ancestor
   // container's identity, then commit the exact per-leaf patches the
@@ -2111,9 +2126,15 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
   function applyTargetedWrite(path: Path, completedValue: unknown, meta?: WriteMeta): void {
     const result = tryInPlaceLeafWrite(form.value, path, completedValue)
     if (!result.applied) {
-      applyFormReplacement(
+      // A structural write (array growth / reorder, a new key, a container
+      // target). For a typed array-helper op (`meta.arrayOp` set), `path` IS the
+      // mutated array's canonical path — thread it so the reconcile keeps every
+      // ancestor container on the way to it stable. Any other structural write
+      // passes null and reassigns changed keys wholesale.
+      applyFormReplacementWithPath(
         setAtPathWithSchemaFill(form.value, schema, path, completedValue) as F,
-        meta
+        meta,
+        meta?.arrayOp !== undefined ? path : null
       )
       return
     }

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -2141,8 +2141,20 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     // the gate, DU reshape, or storage. Form values are string-keyed
     // by schema design and the consumer-side leak would otherwise
     // surface in `Object.getOwnPropertySymbols(values.x)` and break
-    // downstream JSON serialization (persistence) + variant memory.
-    value = stripSymbolsDeep(value)
+    // downstream JSON serialization (persistence) + variant memory. On an
+    // array structural op only the fresh element(s) carry consumer input;
+    // existing elements were stripped when first written and only shift
+    // position here, so strip just the new slot(s) instead of deep-walking
+    // all N. The field-array helper owns this fresh array copy, so the
+    // in-place element strip is safe — the same scoping the slim gate,
+    // mergeStructural, and the authored walk apply below.
+    if (meta?.arrayOp !== undefined && Array.isArray(value)) {
+      for (const idx of freshElementIndices(meta.arrayOp)) {
+        value[idx] = stripSymbolsDeep(value[idx])
+      }
+    } else {
+      value = stripSymbolsDeep(value)
+    }
     // Slim-primitive write gate: every leaf in the value must match
     // the schema's slim primitive set at its sub-path. Refinement-level
     // constraints (.email/.min/enum membership/etc.) are NOT enforced

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -2068,9 +2068,11 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     // to wholesale replacement — that's the only case where in-place
     // merging can't preserve existing reactive proxies anyway.
     // The typed array helpers carry an `arrayOp` hint; on those writes a
-    // changed array-valued key reconciles in place (stable array reference)
-    // so a reorder fires only the moved indices, not the whole-array re-render.
-    // A direct container-target `setValue` (no hint) replaces the reference.
+    // changed container-valued key reconciles in place, keeping stable references
+    // for the mutated array and every object on the path to it. So a reorder
+    // fires only the moved indices and a nested-array append re-renders only that
+    // list, never the whole-array / whole-parent re-render. A direct
+    // container-target `setValue` (no hint) replaces the reference.
     if (!applyChangedKeys(prev, next, meta?.arrayOp !== undefined)) {
       form.value = next
     } else if (

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -2067,7 +2067,11 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     // On a top-level shape mismatch (object → array, etc.) fall back
     // to wholesale replacement — that's the only case where in-place
     // merging can't preserve existing reactive proxies anyway.
-    if (!applyChangedKeys(prev, next)) {
+    // The typed array helpers carry an `arrayOp` hint; on those writes a
+    // changed array-valued key reconciles in place (stable array reference)
+    // so a reorder fires only the moved indices, not the whole-array re-render.
+    // A direct container-target `setValue` (no hint) replaces the reference.
+    if (!applyChangedKeys(prev, next, meta?.arrayOp !== undefined)) {
       form.value = next
     } else if (
       patches.some(

--- a/src/runtime/core/diff-apply.ts
+++ b/src/runtime/core/diff-apply.ts
@@ -1,4 +1,5 @@
 import { deleteAtPath, setAtPath } from './path-walker'
+import { isPathPrefix, pathsEqual } from './paths'
 import type { Path, Segment } from './paths'
 import { safeAssign, safeOwnRead } from './safe-assign'
 
@@ -252,19 +253,34 @@ function diffObjectsLockstep(
  * place, preserving ancestor container identity; this first-segment
  * reassign is retained for container and whole-form replacements.
  *
- * `reconcileContainersInPlace` scopes one extra optimization to the typed array
- * helpers (the writes that carry an `arrayOp` meta hint). When set, a changed
- * key whose old and new values are BOTH descendable containers (a plain object
- * or an array) is reconciled IN PLACE — the recursion keeps that container's own
- * reference stable and descends to repeat the decision on its changed children.
- * So an array nested under an object chain (`append('address.contacts', x)`)
- * keeps every object on the path stable too, and the array branch then truncates
- * to the new length and reassigns only the indices whose content moved. A reorder
- * (swap / move, no length change) fires only the two moved indices' deps instead
- * of the array-key dep that re-renders every `form.list` row; a nested-array
- * append re-renders only that list, not its parent object's bindings. The flag
- * is OFF for a direct `setValue(path, wholeNewValue)`, which replaces the
- * reference like any other container-target write — so the "reference changes IFF
+ * `arrayOpPath` opts the typed array helpers into one extra optimization: the
+ * writes that carry an `arrayOp` meta hint pass the mutated array's (canonical)
+ * path, every other caller passes `null`. When non-null, a changed key whose old
+ * and new values are BOTH descendable containers (a plain object or an array) is
+ * reconciled IN PLACE — the recursion keeps that container's own reference stable
+ * and descends, threading `currentPath` so each level knows where it sits. This
+ * keeps EVERY ancestor container on the path to the mutated array stable at any
+ * depth: the objects of an `address.contacts` chain AND the ancestor array
+ * elements of a nested repeater (`append('sections.0.questions', q)`) alike. So a
+ * helper op touches only the genuinely-changed leaves / length, and a `form.list`
+ * over any untouched container does not re-render.
+ *
+ * The array branch (reached only via this recursion, so `arrayOpPath` is non-null
+ * there) splits on whether `currentPath` IS the mutated array:
+ *   - the MUTATED array (`pathsEqual(currentPath, arrayOpPath)`): truncate to the
+ *     new length and reference-assign only the changed indices. Reference-assign
+ *     is what relocates a swapped / moved element to its new slot while keeping
+ *     its object identity (its subtree, focus, per-element state all ride along),
+ *     so this branch must NOT recurse into elements.
+ *   - an ANCESTOR array (not equal): a descendant write never changes this
+ *     array's length, only the one element leading to the mutated array. Recurse
+ *     that element in place (guarded by `isPathPrefix`, so untouched siblings
+ *     keep their references); reference-assign anything else defensively.
+ *
+ * When `arrayOpPath` is `null` (every non-helper write: an explicit setValue,
+ * reset, undo / redo, cross-tab merge, hydration, DU reshape) the object branch
+ * reassigns each changed key wholesale and never recurses, so a container-target
+ * write replaces the reference like any other — the "reference changes IFF
  * targeted or restructured" contract holds for explicit writes; only the helpers
  * opt into the stable-reference reconcile. Consumers reading a container then
  * subscribe to its length / keys / elements (or take a deep watch), not its bare
@@ -273,7 +289,8 @@ function diffObjectsLockstep(
 export function applyChangedKeys(
   target: unknown,
   source: unknown,
-  reconcileContainersInPlace: boolean
+  arrayOpPath: Path | null,
+  currentPath: Path
 ): boolean {
   if (!isDescendable(target) || !isDescendable(source)) return false
   const targetIsArray = Array.isArray(target)
@@ -301,16 +318,51 @@ export function applyChangedKeys(
   if (targetIsArray) {
     const t = target as unknown[]
     const s = source as readonly unknown[]
-    if (t.length > s.length) t.length = s.length
-    for (const idx of changedFirstSegments) {
-      if (typeof idx === 'symbol') continue
-      const i = typeof idx === 'number' ? idx : Number(idx)
-      // Skip slots the length cut already dropped. On a shrink, diffAndApply
-      // emits a 'removed' patch at every truncated index, so those land in
-      // `changedFirstSegments`; reassigning `s[i]` (undefined) would re-grow
-      // the array with a trailing hole. Survivors and grown slots are in range.
-      if (i >= s.length) continue
-      t[i] = s[i]
+    // `arrayOpPath === null` can't actually reach here — the array branch is
+    // only entered by recursion from the object branch, which recurses only
+    // when arrayOpPath is non-null. Folding it into the mutated-array case both
+    // documents that and narrows arrayOpPath to non-null inside the `else`.
+    if (arrayOpPath === null || pathsEqual(currentPath, arrayOpPath)) {
+      // This IS the array the op mutated. Truncate to the new length and
+      // reference-assign the changed indices: that relocates a swapped / moved
+      // element to its new slot while preserving its object identity, so its
+      // subtree / focus / per-element state ride along. Recursing here instead
+      // would content-copy and break that identity.
+      if (t.length > s.length) t.length = s.length
+      for (const idx of changedFirstSegments) {
+        if (typeof idx === 'symbol') continue
+        const i = typeof idx === 'number' ? idx : Number(idx)
+        // Skip slots the length cut already dropped. On a shrink, diffAndApply
+        // emits a 'removed' patch at every truncated index, so those land in
+        // `changedFirstSegments`; reassigning `s[i]` (undefined) would re-grow
+        // the array with a trailing hole. Survivors and grown slots are in range.
+        if (i >= s.length) continue
+        t[i] = s[i]
+      }
+    } else {
+      // An ANCESTOR array on the path to the mutated array. A descendant write
+      // never changes this array's length, only the single element leading to
+      // the mutated array — recurse THAT element in place (keeping its
+      // reference) so its siblings and their subtrees stay stable. `isPathPrefix`
+      // selects the one on-path element; anything else reference-assigns
+      // defensively (no length change, so no truncation here).
+      for (const idx of changedFirstSegments) {
+        if (typeof idx === 'symbol') continue
+        const i = typeof idx === 'number' ? idx : Number(idx)
+        if (i >= s.length) continue
+        const childPath = appendSegment(currentPath, i)
+        const curEl = t[i]
+        const nextEl = s[i]
+        if (
+          isPathPrefix(childPath, arrayOpPath) &&
+          isDescendable(curEl) &&
+          isDescendable(nextEl) &&
+          applyChangedKeys(curEl, nextEl, arrayOpPath, childPath)
+        ) {
+          continue
+        }
+        t[i] = nextEl
+      }
     }
   } else {
     const t = target as Record<string, unknown>
@@ -323,23 +375,22 @@ export function applyChangedKeys(
       if (typeof k === 'symbol') continue
       const key = String(k)
       const nextVal = safeOwnRead(s, key)
-      // On an array structural op (arrayOp present), reconcile a changed
-      // container-valued key IN PLACE: recurse so the array branch truncates and
-      // reassigns only the moved indices, and any nested object on the path keeps
-      // its own reference, instead of reassigning the whole subtree. This makes an
-      // array nested under an object chain (`append('address.contacts', x)`) keep
-      // `address`'s reference too, so `form.list('address.contacts')` is the only
-      // list that re-renders. `safeOwnRead` returns the reactive proxy for
-      // `t[key]` (tracking intact), so the in-place sets fire the right deps.
-      // Falls through to a plain reassign for a leaf value, a shape mismatch (the
-      // recurse returns false), or a direct container-target write (flag off),
-      // which replaces the reference.
-      if (reconcileContainersInPlace) {
+      // On an array helper op (arrayOpPath non-null), reconcile a changed
+      // container-valued key IN PLACE: recurse so the array branch handles the
+      // array and any nested object on the path keeps its own reference, instead
+      // of reassigning the whole subtree. This makes an array nested under an
+      // object chain (`append('address.contacts', x)`) keep `address`'s reference
+      // too, so `form.list('address.contacts')` is the only list that re-renders.
+      // `safeOwnRead` returns the reactive proxy for `t[key]` (tracking intact),
+      // so the in-place sets fire the right deps. Falls through to a plain
+      // reassign for a leaf value, a shape mismatch (the recurse returns false),
+      // or a non-helper write (arrayOpPath null), which replaces the reference.
+      if (arrayOpPath !== null) {
         const curVal = safeOwnRead(t, key)
         if (
           isDescendable(curVal) &&
           isDescendable(nextVal) &&
-          applyChangedKeys(curVal, nextVal, reconcileContainersInPlace)
+          applyChangedKeys(curVal, nextVal, arrayOpPath, appendSegment(currentPath, key))
         ) {
           continue
         }

--- a/src/runtime/core/diff-apply.ts
+++ b/src/runtime/core/diff-apply.ts
@@ -252,24 +252,28 @@ function diffObjectsLockstep(
  * place, preserving ancestor container identity; this first-segment
  * reassign is retained for container and whole-form replacements.
  *
- * `reconcileArraysInPlace` scopes one extra optimization to the typed array
+ * `reconcileContainersInPlace` scopes one extra optimization to the typed array
  * helpers (the writes that carry an `arrayOp` meta hint). When set, a changed
- * key whose old and new values are BOTH arrays is reconciled IN PLACE — the
- * array branch truncates to the new length and reassigns only the indices
- * whose content moved, keeping the array's own reference stable. A reorder
- * (swap / move, no length change) then fires only the two moved indices' deps
- * instead of the array-key dep that re-renders every `form.list` row. The flag
- * is OFF for a direct `setValue(arrayPath, wholeNewArray)`, which replaces the
- * array reference like any other container-target write — so the "reference
- * changes IFF targeted or restructured" contract holds for explicit writes;
- * only the helpers opt into the stable-reference reconcile. Consumers reading
- * an array then subscribe to its length or its elements (or take a deep watch),
- * not its bare reference.
+ * key whose old and new values are BOTH descendable containers (a plain object
+ * or an array) is reconciled IN PLACE — the recursion keeps that container's own
+ * reference stable and descends to repeat the decision on its changed children.
+ * So an array nested under an object chain (`append('address.contacts', x)`)
+ * keeps every object on the path stable too, and the array branch then truncates
+ * to the new length and reassigns only the indices whose content moved. A reorder
+ * (swap / move, no length change) fires only the two moved indices' deps instead
+ * of the array-key dep that re-renders every `form.list` row; a nested-array
+ * append re-renders only that list, not its parent object's bindings. The flag
+ * is OFF for a direct `setValue(path, wholeNewValue)`, which replaces the
+ * reference like any other container-target write — so the "reference changes IFF
+ * targeted or restructured" contract holds for explicit writes; only the helpers
+ * opt into the stable-reference reconcile. Consumers reading a container then
+ * subscribe to its length / keys / elements (or take a deep watch), not its bare
+ * reference.
  */
 export function applyChangedKeys(
   target: unknown,
   source: unknown,
-  reconcileArraysInPlace: boolean
+  reconcileContainersInPlace: boolean
 ): boolean {
   if (!isDescendable(target) || !isDescendable(source)) return false
   const targetIsArray = Array.isArray(target)
@@ -320,18 +324,22 @@ export function applyChangedKeys(
       const key = String(k)
       const nextVal = safeOwnRead(s, key)
       // On an array structural op (arrayOp present), reconcile a changed
-      // array-valued key IN PLACE: recurse so the array branch truncates and
-      // reassigns only the moved indices, keeping the array's reference stable.
-      // `safeOwnRead` returns the reactive proxy for `t[key]` (tracking intact),
-      // so the in-place index/length sets fire the right deps. Falls through to
-      // a plain reassign for non-array values, a shape mismatch, or a direct
-      // container-target write (flag off), which replaces the reference.
-      if (reconcileArraysInPlace) {
+      // container-valued key IN PLACE: recurse so the array branch truncates and
+      // reassigns only the moved indices, and any nested object on the path keeps
+      // its own reference, instead of reassigning the whole subtree. This makes an
+      // array nested under an object chain (`append('address.contacts', x)`) keep
+      // `address`'s reference too, so `form.list('address.contacts')` is the only
+      // list that re-renders. `safeOwnRead` returns the reactive proxy for
+      // `t[key]` (tracking intact), so the in-place sets fire the right deps.
+      // Falls through to a plain reassign for a leaf value, a shape mismatch (the
+      // recurse returns false), or a direct container-target write (flag off),
+      // which replaces the reference.
+      if (reconcileContainersInPlace) {
         const curVal = safeOwnRead(t, key)
         if (
-          Array.isArray(curVal) &&
-          Array.isArray(nextVal) &&
-          applyChangedKeys(curVal, nextVal, reconcileArraysInPlace)
+          isDescendable(curVal) &&
+          isDescendable(nextVal) &&
+          applyChangedKeys(curVal, nextVal, reconcileContainersInPlace)
         ) {
           continue
         }

--- a/src/runtime/core/diff-apply.ts
+++ b/src/runtime/core/diff-apply.ts
@@ -251,8 +251,26 @@ function diffObjectsLockstep(
  * fast path (`applyTargetedWrite`) deliberately mutates the leaf slot in
  * place, preserving ancestor container identity; this first-segment
  * reassign is retained for container and whole-form replacements.
+ *
+ * `reconcileArraysInPlace` scopes one extra optimization to the typed array
+ * helpers (the writes that carry an `arrayOp` meta hint). When set, a changed
+ * key whose old and new values are BOTH arrays is reconciled IN PLACE — the
+ * array branch truncates to the new length and reassigns only the indices
+ * whose content moved, keeping the array's own reference stable. A reorder
+ * (swap / move, no length change) then fires only the two moved indices' deps
+ * instead of the array-key dep that re-renders every `form.list` row. The flag
+ * is OFF for a direct `setValue(arrayPath, wholeNewArray)`, which replaces the
+ * array reference like any other container-target write — so the "reference
+ * changes IFF targeted or restructured" contract holds for explicit writes;
+ * only the helpers opt into the stable-reference reconcile. Consumers reading
+ * an array then subscribe to its length or its elements (or take a deep watch),
+ * not its bare reference.
  */
-export function applyChangedKeys(target: unknown, source: unknown): boolean {
+export function applyChangedKeys(
+  target: unknown,
+  source: unknown,
+  reconcileArraysInPlace: boolean
+): boolean {
   if (!isDescendable(target) || !isDescendable(source)) return false
   const targetIsArray = Array.isArray(target)
   const sourceIsArray = Array.isArray(source)
@@ -283,6 +301,11 @@ export function applyChangedKeys(target: unknown, source: unknown): boolean {
     for (const idx of changedFirstSegments) {
       if (typeof idx === 'symbol') continue
       const i = typeof idx === 'number' ? idx : Number(idx)
+      // Skip slots the length cut already dropped. On a shrink, diffAndApply
+      // emits a 'removed' patch at every truncated index, so those land in
+      // `changedFirstSegments`; reassigning `s[i]` (undefined) would re-grow
+      // the array with a trailing hole. Survivors and grown slots are in range.
+      if (i >= s.length) continue
       t[i] = s[i]
     }
   } else {
@@ -295,7 +318,25 @@ export function applyChangedKeys(target: unknown, source: unknown): boolean {
     for (const k of changedFirstSegments) {
       if (typeof k === 'symbol') continue
       const key = String(k)
-      safeAssign(t, key, safeOwnRead(s, key))
+      const nextVal = safeOwnRead(s, key)
+      // On an array structural op (arrayOp present), reconcile a changed
+      // array-valued key IN PLACE: recurse so the array branch truncates and
+      // reassigns only the moved indices, keeping the array's reference stable.
+      // `safeOwnRead` returns the reactive proxy for `t[key]` (tracking intact),
+      // so the in-place index/length sets fire the right deps. Falls through to
+      // a plain reassign for non-array values, a shape mismatch, or a direct
+      // container-target write (flag off), which replaces the reference.
+      if (reconcileArraysInPlace) {
+        const curVal = safeOwnRead(t, key)
+        if (
+          Array.isArray(curVal) &&
+          Array.isArray(nextVal) &&
+          applyChangedKeys(curVal, nextVal, reconcileArraysInPlace)
+        ) {
+          continue
+        }
+      }
+      safeAssign(t, key, nextVal)
     }
   }
   return true

--- a/src/runtime/core/history.ts
+++ b/src/runtime/core/history.ts
@@ -10,7 +10,7 @@ import {
   structuralSnapshot,
   type Patch,
 } from './diff-apply'
-import type { PathKey } from './paths'
+import { pathsEqual, type PathKey } from './paths'
 
 /**
  * Bounded undo/redo history for a FormStore, stored as one base
@@ -99,18 +99,6 @@ function captureErrorEntries(map: Map<PathKey, ValidationError[]>): ErrorEntries
   const out: Array<readonly [PathKey, ValidationError[]]> = []
   for (const [k, v] of map) out.push([k, [...v]] as const)
   return out
-}
-
-/**
- * Structural equality for two error paths: same length and identical
- * elements in order (numeric and string segments compared with `!==`).
- */
-function pathsEqual(a: readonly (string | number)[], b: readonly (string | number)[]): boolean {
-  if (a.length !== b.length) return false
-  for (let j = 0; j < a.length; j++) {
-    if (a[j] !== b[j]) return false
-  }
-  return true
 }
 
 /**

--- a/src/runtime/core/paths.ts
+++ b/src/runtime/core/paths.ts
@@ -334,3 +334,23 @@ export function isPathPrefix(prefix: readonly Segment[], path: readonly Segment[
   }
   return true
 }
+
+/**
+ * `true` when two paths are structurally equal: same length and identical
+ * segments in order. Numeric and string segments compare with `!==`, so `0`
+ * and `'0'` are NOT equal — pass canonicalised paths (integer-looking segments
+ * normalised to numbers, as [[canonicalizePath]] and the diff walker both do).
+ *
+ * ```ts
+ * pathsEqual(['rows', 0], ['rows', 0])   // true
+ * pathsEqual(['rows'], ['rows', 0])      // false (different length)
+ * pathsEqual(['rows', 0], ['rows', '0']) // false (segment types differ)
+ * ```
+ */
+export function pathsEqual(a: readonly Segment[], b: readonly Segment[]): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
+}

--- a/test/composables/field-array-perf-guard.test.ts
+++ b/test/composables/field-array-perf-guard.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it } from 'vitest'
-import { createApp, defineComponent, h, type App } from 'vue'
+import { computed, createApp, defineComponent, h, type App } from 'vue'
 import { useForm } from '../../src'
 import { attachRegistryToApp, createRegistry } from '../../src/runtime/core/registry'
 import type { Path } from '../../src/runtime/core/paths'
@@ -21,6 +21,13 @@ import { fakeSchema } from '../utils/fake-schema'
  * The scoping lives in the schema-agnostic funnel (create-form-store), not in
  * either adapter, so a neutral `fakeSchema` is the right instrument here — it
  * isolates the funnel's behaviour from any adapter's parsing specifics.
+ *
+ * The same N-independence is guarded on the RENDER side: an in-place reorder
+ * reconciles the array without swapping its reference, so only the moved
+ * indices' deps fire. The final case counts re-evaluations of one index-bound
+ * computed per row across a swap and asserts exactly two recompute, flat in N —
+ * a regression to whole-array reassignment fires the array-key dep every row
+ * reads, so all N would recompute.
  */
 
 type Row = { a: string; b: string; c: string }
@@ -152,5 +159,41 @@ describe('field arrays — per-element work does not scale with N (perf guard)',
     expect(rowSymbolStripsFor(200, (f) => f.swap('rows', 0, 199))).toBeLessThanOrEqual(
       FRESH_ELEMENT_CAP
     )
+  })
+
+  /**
+   * Re-evaluations of per-row, index-bound bindings across an in-place swap.
+   * One computed per row reads its own `rows[i]` — the shape of a
+   * `register(...).displayValue` cell binding. The in-place reconcile fires
+   * only the two moved indices' deps (not the array-key dep), so only those two
+   * computeds recompute; the rest stay cached. A regression to whole-array
+   * reassignment fires the array-key dep that EVERY row reads, so all N
+   * recompute — the count would scale with N instead of staying at 2.
+   */
+  function reevalsOnSwap(n: number): number {
+    const harness = countingHarness(n)
+    apps.push(harness.app)
+    const { form } = harness
+    const evals = new Array<number>(n).fill(0)
+    const cells = Array.from({ length: n }, (_, i) =>
+      computed(() => {
+        evals[i] = (evals[i] ?? 0) + 1
+        return form.values.rows[i]?.a
+      })
+    )
+    // Prime: evaluate each cell once so its index dep is tracked.
+    cells.forEach((c) => void c.value)
+    evals.fill(0)
+
+    form.swap('rows', 0, n - 1)
+    // Pull every cell; only those whose tracked index changed recompute.
+    cells.forEach((c) => void c.value)
+
+    return evals.reduce((sum, x) => sum + x, 0)
+  }
+
+  it('a swap recomputes only the two moved rows index-bound bindings, flat in N', () => {
+    expect(reevalsOnSwap(20)).toBe(2)
+    expect(reevalsOnSwap(200)).toBe(2) // flat in N — the two swapped rows only
   })
 })

--- a/test/composables/field-array-perf-guard.test.ts
+++ b/test/composables/field-array-perf-guard.test.ts
@@ -87,6 +87,36 @@ describe('field arrays — per-element work does not scale with N (perf guard)',
     return h.calls()
   }
 
+  /** A row-shaped data object — what the funnel's symbol strip would descend. */
+  function isRow(o: unknown): boolean {
+    return typeof o === 'object' && o !== null && 'a' in o && 'b' in o && 'c' in o
+  }
+
+  /**
+   * Row-object visits the funnel's `stripSymbolsDeep` pre-pass makes across one
+   * op. It calls `Object.getOwnPropertySymbols` once per plain-object node, so
+   * counting those calls (filtered to row shapes, to exclude Vue's own internal
+   * calls) is a deterministic proxy for "how much of the array did the strip
+   * re-walk." Scoped: only the fresh element. A regression to the whole-array
+   * strip re-walks every existing element, so the count scales with N.
+   */
+  function rowSymbolStripsFor(n: number, op: (form: UseFormReturnType<Grid>) => void): number {
+    const h = countingHarness(n)
+    apps.push(h.app)
+    const real = Object.getOwnPropertySymbols
+    let visits = 0
+    Reflect.set(Object, 'getOwnPropertySymbols', (o: object) => {
+      if (isRow(o)) visits += 1
+      return real(o)
+    })
+    try {
+      op(h.form)
+    } finally {
+      Reflect.set(Object, 'getOwnPropertySymbols', real)
+    }
+    return visits
+  }
+
   it('append validates only the fresh element, identically at N=20 and N=200', () => {
     const small = callsFor(20, (f) => f.append('rows', newRow()))
     const large = callsFor(200, (f) => f.append('rows', newRow()))
@@ -107,5 +137,20 @@ describe('field arrays — per-element work does not scale with N (perf guard)',
 
   it('remove validates no elements (it drops, never introduces)', () => {
     expect(callsFor(200, (f) => f.remove('rows', 0))).toBe(0)
+  })
+
+  it('append symbol-strips only the fresh element, flat in N', () => {
+    const small = rowSymbolStripsFor(20, (f) => f.append('rows', newRow()))
+    const large = rowSymbolStripsFor(200, (f) => f.append('rows', newRow()))
+    // A whole-array strip visits every existing row, so the count would climb
+    // by ~N between the two sizes. Scoped, it touches only the one fresh slot,
+    // so the two sizes agree within a fresh element's fixed visit count.
+    expect(large - small).toBeLessThanOrEqual(FRESH_ELEMENT_CAP)
+  })
+
+  it('swap symbol-strips nothing (a reorder introduces no new value)', () => {
+    expect(rowSymbolStripsFor(200, (f) => f.swap('rows', 0, 199))).toBeLessThanOrEqual(
+      FRESH_ELEMENT_CAP
+    )
   })
 })

--- a/test/composables/field-array-perf-guard.test.ts
+++ b/test/composables/field-array-perf-guard.test.ts
@@ -74,6 +74,25 @@ function countingHarness(n: number) {
   }
 }
 
+type Section = { title: string; questions: { text: string }[] }
+type Sectioned = { sections: Section[] }
+
+/** A nested-repeater form: outer `sections`, each with an inner `questions` list. */
+function nestedHarness(sections: Section[]) {
+  const schema = fakeSchema<Sectioned>({ sections })
+  let form!: UseFormReturnType<Sectioned>
+  const Probe = defineComponent({
+    setup() {
+      form = useForm<Sectioned>({ schema, key: `nested-guard-${sections.length}-${Math.random()}` })
+      return () => h('div')
+    },
+  })
+  const app = createApp(Probe)
+  attachRegistryToApp(app, createRegistry())
+  app.mount(document.createElement('div'))
+  return { app, form }
+}
+
 describe('field arrays — per-element work does not scale with N (perf guard)', () => {
   const apps: App[] = []
   afterEach(() => {
@@ -195,5 +214,68 @@ describe('field arrays — per-element work does not scale with N (perf guard)',
   it('a swap recomputes only the two moved rows index-bound bindings, flat in N', () => {
     expect(reevalsOnSwap(20)).toBe(2)
     expect(reevalsOnSwap(200)).toBe(2) // flat in N — the two swapped rows only
+  })
+
+  /**
+   * Re-evaluations of per-section inner-list IDENTITY bindings across an append
+   * to ONE inner list of a nested repeater. One computed per section reads
+   * `sections[i].questions` by reference — the array handle a
+   * `form.list('sections.i.questions')` subscription holds. The deep in-place
+   * reconcile keeps the touched inner array's reference (it mutates only the
+   * appended slot) AND every untouched section's reference, so NO identity
+   * binding recomputes — flat at zero in the number of outer sections. A
+   * reconcile that reassigned the outer array would fire every section's index
+   * dep (count climbs to the section count); one that reassigned just the
+   * touched element would fire that single binding. The length binding on the
+   * touched list is the positive control that reactivity is live.
+   */
+  function nestedAppendReevals(outerSections: number): { identity: number; touchedLen: number } {
+    const sections = Array.from({ length: outerSections }, (_, i) => ({
+      title: `s${i}`,
+      questions: [{ text: `${i}-q0` }],
+    }))
+    const harness = nestedHarness(sections)
+    apps.push(harness.app)
+    const { form } = harness
+
+    const identityEvals = new Array<number>(outerSections).fill(0)
+    const identityCells = Array.from({ length: outerSections }, (_, i) =>
+      computed(() => {
+        identityEvals[i] = (identityEvals[i] ?? 0) + 1
+        return form.values.sections[i]?.questions
+      })
+    )
+    let touchedLen = 0
+    const touchedLenCell = computed(() => {
+      touchedLen += 1
+      return form.values.sections[0]?.questions.length
+    })
+
+    // Prime so every dep is tracked, then zero the counters.
+    identityCells.forEach((c) => void c.value)
+    void touchedLenCell.value
+    identityEvals.fill(0)
+    touchedLen = 0
+
+    form.append('sections.0.questions', { text: 'appended' })
+
+    identityCells.forEach((c) => void c.value)
+    void touchedLenCell.value
+
+    return { identity: identityEvals.reduce((sum, x) => sum + x, 0), touchedLen }
+  }
+
+  it('appending to one inner list recomputes no section identity binding, flat in outer count', () => {
+    const small = nestedAppendReevals(4)
+    const large = nestedAppendReevals(40)
+    // The touched inner array keeps its reference (append mutates the new slot in
+    // place) and every untouched section keeps its reference, so no per-section
+    // identity binding recomputes — regardless of how many sections exist.
+    expect(small.identity).toBe(0)
+    expect(large.identity).toBe(0)
+    // Positive control: the touched list's length binding DID see the append, so
+    // this is not a dead-form false zero.
+    expect(small.touchedLen).toBeGreaterThan(0)
+    expect(large.touchedLen).toBeGreaterThan(0)
   })
 })

--- a/test/core/reactivity-contract.test.ts
+++ b/test/core/reactivity-contract.test.ts
@@ -26,10 +26,13 @@ import { createAttaform } from '../../src/runtime/core/plugin'
  * Array carve-out: the typed array helpers (append / insert / remove / swap /
  * move / replace) reconcile the array IN PLACE, so the array's reference stays
  * stable across the op — a reorder fires only the moved indices, not a
- * whole-array re-render. A by-reference watch on the array therefore stays
- * quiet on a helper op; length / element / deep watches fire as before. An
- * EXPLICIT setValue(arrayPath, wholeNewArray) is a container-target write and
- * still replaces the reference, preserving the object/array symmetry.
+ * whole-array re-render. The reconcile also keeps every plain-object container
+ * on the path to the array stable, so appending to an object-nested array
+ * (`address.contacts`) re-renders only that list, not its parent object's
+ * bindings. A by-reference watch on the array (or any object on its path)
+ * therefore stays quiet on a helper op; length / element / deep watches fire as
+ * before. An EXPLICIT setValue(arrayPath, wholeNewArray) is a container-target
+ * write and still replaces the reference, preserving the object/array symmetry.
  *
  * Captured against both adapters per zod-v3/v4 parity: the write path is
  * shared core, so a regression would move both identically and slip past
@@ -52,12 +55,16 @@ afterEach(() => {
 function mount(a: Adapter): any {
   const schema = a.z.object({
     a: a.z.string(),
-    address: a.z.object({ zip: a.z.string(), city: a.z.string() }),
+    address: a.z.object({
+      zip: a.z.string(),
+      city: a.z.string(),
+      contacts: a.z.array(a.z.object({ name: a.z.string() })),
+    }),
     rows: a.z.array(a.z.object({ name: a.z.string(), qty: a.z.number() })),
   })
   const defaultValues = {
     a: '',
-    address: { zip: '', city: '' },
+    address: { zip: '', city: '', contacts: [{ name: 'c0' }, { name: 'c1' }] },
     rows: [
       { name: 'r0', qty: 0 },
       { name: 'r1', qty: 1 },
@@ -157,7 +164,7 @@ describe.each(ADAPTERS)(
 
       // Container-TARGET write: address is the write target, so it (correctly)
       // gets a new reference and the by-ref watch fires.
-      form.setValue('address', { zip: '10001', city: 'NYC' })
+      form.setValue('address', { zip: '10001', city: 'NYC', contacts: [] })
       await nextTick()
       expect(addressByRef).toBeGreaterThan(0)
       expect(form.values.address).not.toBe(addressBefore)
@@ -310,6 +317,127 @@ describe.each(ADAPTERS)(
       expect(form.values.rows[0]?.name).toBe('only')
 
       stop()
+    })
+
+    it('append to an object-nested array keeps the parent object AND array refs stable; length + deep fire', async () => {
+      const form = mount(a)
+
+      let addressByRef = 0
+      let contactsByRef = 0
+      let contactsLen = 0
+      let contactsDeep = 0
+      const stops = [
+        watch(
+          () => form.values.address,
+          () => {
+            addressByRef++
+          }
+        ),
+        watch(
+          () => form.values.address.contacts,
+          () => {
+            contactsByRef++
+          }
+        ),
+        watch(
+          () => form.values.address.contacts.length,
+          () => {
+            contactsLen++
+          }
+        ),
+        watch(
+          () => form.values.address.contacts,
+          () => {
+            contactsDeep++
+          },
+          { deep: true }
+        ),
+      ]
+
+      const addressBefore = form.values.address
+      const contactsBefore = form.values.address.contacts
+
+      form.append('address.contacts', { name: 'c2' })
+      await nextTick()
+
+      // The object spine on the path to the mutated array keeps its reference:
+      // appending to a nested array re-renders only that list, not its parent.
+      expect(addressByRef).toBe(0)
+      expect(contactsByRef).toBe(0)
+      expect(form.values.address).toBe(addressBefore)
+      expect(form.values.address.contacts).toBe(contactsBefore)
+
+      // Length + deep see the new element; the value is correct.
+      expect(contactsLen).toBeGreaterThan(0)
+      expect(contactsDeep).toBeGreaterThan(0)
+      expect(form.values.address.contacts.length).toBe(3)
+      expect(form.values.address.contacts[2]?.name).toBe('c2')
+
+      stops.forEach((s) => s())
+    })
+
+    it('swap within an object-nested array keeps the parent object AND array refs stable; moved indices fire', async () => {
+      const form = mount(a)
+
+      let addressByRef = 0
+      let contactsByRef = 0
+      let contactsDeep = 0
+      let c0Leaf = 0
+      let c1Leaf = 0
+      const stops = [
+        watch(
+          () => form.values.address,
+          () => {
+            addressByRef++
+          }
+        ),
+        watch(
+          () => form.values.address.contacts,
+          () => {
+            contactsByRef++
+          }
+        ),
+        watch(
+          () => form.values.address.contacts,
+          () => {
+            contactsDeep++
+          },
+          { deep: true }
+        ),
+        watch(
+          () => form.values.address.contacts[0]?.name,
+          () => {
+            c0Leaf++
+          }
+        ),
+        watch(
+          () => form.values.address.contacts[1]?.name,
+          () => {
+            c1Leaf++
+          }
+        ),
+      ]
+
+      const addressBefore = form.values.address
+      const contactsBefore = form.values.address.contacts
+
+      form.swap('address.contacts', 0, 1)
+      await nextTick()
+
+      // Both the parent object and the array keep their references across the
+      // in-place reorder; only the two swapped elements' deps fire.
+      expect(addressByRef).toBe(0)
+      expect(contactsByRef).toBe(0)
+      expect(form.values.address).toBe(addressBefore)
+      expect(form.values.address.contacts).toBe(contactsBefore)
+
+      expect(contactsDeep).toBeGreaterThan(0)
+      expect(c0Leaf).toBeGreaterThan(0)
+      expect(c1Leaf).toBeGreaterThan(0)
+      expect(form.values.address.contacts[0]?.name).toBe('c1')
+      expect(form.values.address.contacts[1]?.name).toBe('c0')
+
+      stops.forEach((s) => s())
     })
   }
 )

--- a/test/core/reactivity-contract.test.ts
+++ b/test/core/reactivity-contract.test.ts
@@ -6,6 +6,7 @@ import { z as zV3 } from 'zod-v3'
 import { useForm as useFormV4 } from '../../src/zod-v4'
 import { useForm as useFormV3 } from '../../src/zod-v3'
 import { createAttaform } from '../../src/runtime/core/plugin'
+import { applyChangedKeys } from '../../src/runtime/core/diff-apply'
 
 /**
  * Reactivity contract for the targeted in-place write (Bust 2 / T2) and the
@@ -61,6 +62,12 @@ function mount(a: Adapter): any {
       contacts: a.z.array(a.z.object({ name: a.z.string() })),
     }),
     rows: a.z.array(a.z.object({ name: a.z.string(), qty: a.z.number() })),
+    sections: a.z.array(
+      a.z.object({
+        title: a.z.string(),
+        questions: a.z.array(a.z.object({ text: a.z.string() })),
+      })
+    ),
   })
   const defaultValues = {
     a: '',
@@ -69,6 +76,10 @@ function mount(a: Adapter): any {
       { name: 'r0', qty: 0 },
       { name: 'r1', qty: 1 },
       { name: 'r2', qty: 2 },
+    ],
+    sections: [
+      { title: 's0', questions: [{ text: 'q0' }, { text: 'q1' }] },
+      { title: 's1', questions: [{ text: 'q2' }] },
     ],
   }
   let captured: any
@@ -439,5 +450,207 @@ describe.each(ADAPTERS)(
 
       stops.forEach((s) => s())
     })
+
+    it('append to a nested-repeater inner list keeps the outer array, the element, AND the inner array stable', async () => {
+      const form = mount(a)
+
+      let sectionsByRef = 0
+      let section0ByRef = 0
+      let section1ByRef = 0
+      let inner0ByRef = 0
+      let inner0Len = 0
+      let inner0Deep = 0
+      const stops = [
+        watch(
+          () => form.values.sections,
+          () => {
+            sectionsByRef++
+          }
+        ),
+        watch(
+          () => form.values.sections[0],
+          () => {
+            section0ByRef++
+          }
+        ),
+        watch(
+          () => form.values.sections[1],
+          () => {
+            section1ByRef++
+          }
+        ),
+        watch(
+          () => form.values.sections[0]?.questions,
+          () => {
+            inner0ByRef++
+          }
+        ),
+        watch(
+          () => form.values.sections[0]?.questions.length,
+          () => {
+            inner0Len++
+          }
+        ),
+        watch(
+          () => form.values.sections[0]?.questions,
+          () => {
+            inner0Deep++
+          },
+          { deep: true }
+        ),
+      ]
+
+      const sectionsBefore = form.values.sections
+      const section0Before = form.values.sections[0]
+      const section1Before = form.values.sections[1]
+      const inner0Before = form.values.sections[0]?.questions
+
+      form.append('sections.0.questions', { text: 'q-new' })
+      await nextTick()
+
+      // Every container on the path to the mutated inner list keeps its
+      // reference: the outer array, the touched element, AND the inner array.
+      // The untouched sibling element keeps its reference too.
+      expect(sectionsByRef).toBe(0)
+      expect(section0ByRef).toBe(0)
+      expect(section1ByRef).toBe(0)
+      expect(inner0ByRef).toBe(0)
+      expect(form.values.sections).toBe(sectionsBefore)
+      expect(form.values.sections[0]).toBe(section0Before)
+      expect(form.values.sections[1]).toBe(section1Before)
+      expect(form.values.sections[0]?.questions).toBe(inner0Before)
+
+      // Only the inner list's length + deep see the new question.
+      expect(inner0Len).toBeGreaterThan(0)
+      expect(inner0Deep).toBeGreaterThan(0)
+      expect(form.values.sections[0]?.questions.length).toBe(3)
+      expect(form.values.sections[0]?.questions[2]?.text).toBe('q-new')
+
+      stops.forEach((s) => s())
+    })
+
+    it('swap on the outer repeater relocates whole element references; inner lists ride along', async () => {
+      const form = mount(a)
+
+      let sectionsByRef = 0
+      const stop = watch(
+        () => form.values.sections,
+        () => {
+          sectionsByRef++
+        }
+      )
+
+      const sectionsBefore = form.values.sections
+      const section0Before = form.values.sections[0]
+      const section1Before = form.values.sections[1]
+      const inner0Before = form.values.sections[0]?.questions
+      const inner1Before = form.values.sections[1]?.questions
+
+      form.swap('sections', 0, 1)
+      await nextTick()
+
+      // The outer array keeps its reference (in-place reconcile), and the
+      // swapped ELEMENT references relocate intact: sections[0] now IS the old
+      // sections[1] object, and its inner questions array rode along by
+      // reference rather than being content-copied. This is the load-bearing
+      // mutated-vs-ancestor distinction — treating the swapped array as an
+      // ancestor would clone the elements and break identity.
+      expect(sectionsByRef).toBe(0)
+      expect(form.values.sections).toBe(sectionsBefore)
+      expect(form.values.sections[0]).toBe(section1Before)
+      expect(form.values.sections[1]).toBe(section0Before)
+      expect(form.values.sections[0]?.questions).toBe(inner1Before)
+      expect(form.values.sections[1]?.questions).toBe(inner0Before)
+      expect(form.values.sections[0]?.title).toBe('s1')
+      expect(form.values.sections[1]?.title).toBe('s0')
+
+      stop()
+    })
+
+    it('remove on a nested-repeater inner list shrinks in place; outer + element + inner refs stable', async () => {
+      const form = mount(a)
+
+      let sectionsByRef = 0
+      let section0ByRef = 0
+      let inner0ByRef = 0
+      const stops = [
+        watch(
+          () => form.values.sections,
+          () => {
+            sectionsByRef++
+          }
+        ),
+        watch(
+          () => form.values.sections[0],
+          () => {
+            section0ByRef++
+          }
+        ),
+        watch(
+          () => form.values.sections[0]?.questions,
+          () => {
+            inner0ByRef++
+          }
+        ),
+      ]
+
+      const sectionsBefore = form.values.sections
+      const section0Before = form.values.sections[0]
+      const inner0Before = form.values.sections[0]?.questions
+
+      // sections[0].questions starts as [q0, q1]; remove index 0 leaves [q1].
+      form.remove('sections.0.questions', 0)
+      await nextTick()
+
+      expect(sectionsByRef).toBe(0)
+      expect(section0ByRef).toBe(0)
+      expect(inner0ByRef).toBe(0)
+      expect(form.values.sections).toBe(sectionsBefore)
+      expect(form.values.sections[0]).toBe(section0Before)
+      expect(form.values.sections[0]?.questions).toBe(inner0Before)
+      expect(form.values.sections[0]?.questions.length).toBe(1)
+      expect(form.values.sections[0]?.questions[0]?.text).toBe('q1')
+
+      stops.forEach((s) => s())
+    })
   }
 )
+
+/**
+ * White-box coverage of the reconcile gate's three branches as a pure function.
+ * The integration suites above prove the Vue-observable contract; these pin the
+ * decision table directly, including the shape-flip fallback the typed schema
+ * API can't reach (a real schema never flips an object to an array at a key
+ * mid-write, but the in-place recurse must still degrade safely if it ever did).
+ */
+describe('applyChangedKeys — reconcile gate (unit)', () => {
+  it('null arrayOpPath reassigns a changed nested container wholesale (no in-place recurse)', () => {
+    const target = { a: { n: 1 } }
+    const source = { a: { n: 2 } }
+    const aBefore = target.a
+    expect(applyChangedKeys(target, source, null, [])).toBe(true)
+    // No array op: the changed key is reassigned, so the container gets a fresh
+    // reference. This is the contract a DU reshape / explicit setValue rides on.
+    expect(target.a).not.toBe(aBefore)
+    expect(target.a.n).toBe(2)
+  })
+
+  it('non-null arrayOpPath reconciles an on-path container in place (reference kept)', () => {
+    const target = { a: { n: 1 } }
+    const source = { a: { n: 2 } }
+    const aBefore = target.a
+    // arrayOpPath runs through `a`, so `a` is an ancestor container on the path.
+    expect(applyChangedKeys(target, source, ['a', 'rows'], [])).toBe(true)
+    expect(target.a).toBe(aBefore) // recursed in place
+    expect(target.a.n).toBe(2)
+  })
+
+  it('falls back to a wholesale reassign when a changed key flips object <-> array under an op', () => {
+    const target: Record<string, unknown> = { a: { n: 1 } }
+    const source: Record<string, unknown> = { a: [1, 2, 3] }
+    // The in-place recurse bails on the shape mismatch (object vs array) and the
+    // key is reassigned; the value still lands correctly.
+    expect(applyChangedKeys(target, source, ['a', 'rows'], [])).toBe(true)
+    expect(target.a).toEqual([1, 2, 3])
+  })
+})

--- a/test/core/reactivity-contract.test.ts
+++ b/test/core/reactivity-contract.test.ts
@@ -8,18 +8,28 @@ import { useForm as useFormV3 } from '../../src/zod-v3'
 import { createAttaform } from '../../src/runtime/core/plugin'
 
 /**
- * Reactivity contract for the targeted in-place write (Bust 2 / T2).
+ * Reactivity contract for the targeted in-place write (Bust 2 / T2) and the
+ * in-place array reconcile (Tier 2).
  *
- * The standing lock for the ONE intended observable change: a container's
- * object reference changes IFF the write targets that container or alters
- * its structure. A write to a descendant LEAF mutates the leaf's slot in
- * place, preserving the identity of every ancestor container.
+ * The standing lock for the intended observable changes: a container's object
+ * reference changes IFF the write targets that container or alters its
+ * structure — with ONE carve-out for the typed array helpers (below). A write
+ * to a descendant LEAF mutates the leaf's slot in place, preserving the
+ * identity of every ancestor container.
  *
  * Consequence (the thing this suite pins): a by-reference (non-deep) watch
  * on a container STOPS firing when only a descendant leaf changes. Deep
  * watches and leaf watches are unchanged. Everything else (values, errors,
  * dirty, list/key identity) is locked byte-identical by the behavior-lock
  * golden — this suite owns the reactivity surface the golden can't see.
+ *
+ * Array carve-out: the typed array helpers (append / insert / remove / swap /
+ * move / replace) reconcile the array IN PLACE, so the array's reference stays
+ * stable across the op — a reorder fires only the moved indices, not a
+ * whole-array re-render. A by-reference watch on the array therefore stays
+ * quiet on a helper op; length / element / deep watches fire as before. An
+ * EXPLICIT setValue(arrayPath, wholeNewArray) is a container-target write and
+ * still replaces the reference, preserving the object/array symmetry.
  *
  * Captured against both adapters per zod-v3/v4 parity: the write path is
  * shared core, so a regression would move both identically and slip past
@@ -171,6 +181,133 @@ describe.each(ADAPTERS)(
 
       expect(form.values.a).toBe('mirror-me')
       expect(form.values.address.city).toBe('mirror-me')
+
+      stop()
+    })
+
+    it('an in-place array op (swap) preserves the array reference; by-ref quiet, deep + moved index fire', async () => {
+      const form = mount(a)
+
+      let rowsByRef = 0
+      let rowsDeep = 0
+      let row0Leaf = 0
+      let row1Leaf = 0
+      const stops = [
+        watch(
+          () => form.values.rows,
+          () => {
+            rowsByRef++
+          }
+        ),
+        watch(
+          () => form.values.rows,
+          () => {
+            rowsDeep++
+          },
+          { deep: true }
+        ),
+        watch(
+          () => form.values.rows[0]?.name,
+          () => {
+            row0Leaf++
+          }
+        ),
+        watch(
+          () => form.values.rows[1]?.name,
+          () => {
+            row1Leaf++
+          }
+        ),
+      ]
+
+      const rowsBefore = form.values.rows
+
+      form.swap('rows', 0, 2)
+      await nextTick()
+
+      // The array reference is preserved across the in-place reconcile, so the
+      // by-ref watch stays quiet — a reorder is NOT a whole-array re-render.
+      expect(rowsByRef).toBe(0)
+      expect(form.values.rows).toBe(rowsBefore)
+
+      // Deep reactivity + the two MOVED indices update; the untouched middle
+      // row's leaf watch stays quiet (the swap is surgical).
+      expect(rowsDeep).toBeGreaterThan(0)
+      expect(row0Leaf).toBeGreaterThan(0)
+      expect(row1Leaf).toBe(0)
+      expect(form.values.rows[0]?.name).toBe('r2')
+      expect(form.values.rows[2]?.name).toBe('r0')
+
+      stops.forEach((s) => s())
+    })
+
+    it('append keeps the array reference; by-ref quiet, length + deep fire', async () => {
+      const form = mount(a)
+
+      let rowsByRef = 0
+      let rowsLen = 0
+      let rowsDeep = 0
+      const stops = [
+        watch(
+          () => form.values.rows,
+          () => {
+            rowsByRef++
+          }
+        ),
+        watch(
+          () => form.values.rows.length,
+          () => {
+            rowsLen++
+          }
+        ),
+        watch(
+          () => form.values.rows,
+          () => {
+            rowsDeep++
+          },
+          { deep: true }
+        ),
+      ]
+
+      const rowsBefore = form.values.rows
+
+      form.append('rows', { name: 'r3', qty: 3 })
+      await nextTick()
+
+      // Append grows the array in place: the reference is preserved (by-ref
+      // quiet), but the length and deep watches see the new element.
+      expect(rowsByRef).toBe(0)
+      expect(form.values.rows).toBe(rowsBefore)
+      expect(rowsLen).toBeGreaterThan(0)
+      expect(rowsDeep).toBeGreaterThan(0)
+      expect(form.values.rows.length).toBe(4)
+      expect(form.values.rows[3]?.name).toBe('r3')
+
+      stops.forEach((s) => s())
+    })
+
+    it('an explicit setValue to the array path replaces the reference; by-ref fires', async () => {
+      const form = mount(a)
+
+      let rowsByRef = 0
+      const stop = watch(
+        () => form.values.rows,
+        () => {
+          rowsByRef++
+        }
+      )
+
+      const rowsBefore = form.values.rows
+
+      // A direct container-target write (no arrayOp hint) replaces the array
+      // reference like any other targeted write — the by-ref watch fires.
+      form.setValue('rows', [{ name: 'only', qty: 9 }])
+      await nextTick()
+
+      expect(rowsByRef).toBeGreaterThan(0)
+      expect(form.values.rows).not.toBe(rowsBefore)
+      expect(form.values.rows.length).toBe(1)
+      expect(form.values.rows[0]?.name).toBe('only')
 
       stop()
     })

--- a/test/core/reactivity-contract.test.ts
+++ b/test/core/reactivity-contract.test.ts
@@ -649,8 +649,9 @@ describe('applyChangedKeys — reconcile gate (unit)', () => {
     const target: Record<string, unknown> = { a: { n: 1 } }
     const source: Record<string, unknown> = { a: [1, 2, 3] }
     // The in-place recurse bails on the shape mismatch (object vs array) and the
-    // key is reassigned; the value still lands correctly.
+    // key is reassigned; the value still lands correctly. Bracket access because
+    // `target` is an index-signature bag (noPropertyAccessFromIndexSignature).
     expect(applyChangedKeys(target, source, ['a', 'rows'], [])).toBe(true)
-    expect(target.a).toEqual([1, 2, 3])
+    expect(target['a']).toEqual([1, 2, 3])
   })
 })


### PR DESCRIPTION
## What

Adding, reordering, editing, or removing a row now updates only the rows that actually changed, at any nesting depth, instead of re-rendering the whole list. This finishes the array-write-path perf arc that began with #399.

Five commits, two themes.

**Finish scoping per-element work**

- `scope the symbol strip to the fresh element on array ops`: the last whole-array pre-pass in the write funnel (the symbol strip) now touches only the fresh element(s) an op introduces, like the slim gate, structural fill, and authoring passes that #399 already scoped. Closes the last O(N x fields) gap on a structural op.

**Reconcile in place (the headline)**

- `reconcile array helpers in place so a reorder updates two rows, not N` (Tier 2): the typed helpers (append / insert / remove / swap / move / replace) reconcile the array in place instead of swapping in a fresh array, so the array reference stays stable and a swap or move fires only the two moved indices rather than the array-key dep that re-rendered every `form.list` row.
- `reconcile object containers in place so a nested-array op spares its parent`: an array nested under an object chain (`address.contacts`) keeps its parent object's reference too, so only that inner list re-renders.
- `keep every ancestor container stable so a nested-repeater op spares its tree`: a nested repeater (`sections.0.questions`) is now fully in place. The reconcile distinguishes the mutated array (reference-assign the moved indices, so a swapped element relocates with its identity and its inner arrays intact) from the ancestor arrays on the path to it (recurse only the one on-path element), using the mutated array's path as the discriminator.

## The one observable change

A typed helper op keeps the array reference, and every ancestor container reference, stable. A by-reference watch on the array (or on any container along its path) stays quiet across a helper op, while length, element, and deep watches fire as before and every row's value stays correct. An explicit `setValue('rows', wholeNewArray)` is a container-target write and still replaces the reference, just like writing any other container, so the "reference changes IFF the write targets or restructures it" contract holds for explicit writes.

## Why it matters

Downstream nested-repeater forms (a household of members, each with their own income sources) get the same touched-rows-only updates the top-level case already had, instead of re-rendering a whole inner list on every structural op.

## Verification

- Full suite green across the Zod v3 and v4 adapters; `tsc` and eslint clean; zero new dependencies.
- `check:size` holds: zod-v3 63.05 / 64 KB, no bump.
- Pinned by a reactivity-contract suite (reference stability plus watch-firing for top-level, object-nested, and nested-repeater shapes, both adapters), a unit branch-table for the reconcile gate, and re-render-count guards (a swap recomputes exactly two rows; a nested append recomputes no sibling binding, flat in the section count).

The Tier 2 reorder win shows up in a local bench-arena run (directional; the monthly CI run is canonical): grid reorder at 100 rows by 8 columns moved from last place to second. The deep-reconcile commits add no bench movement by design (the arena exercises top-level arrays only), so their proof is the characterization suites rather than a benchmark. Append stays bound by the host `v-for` re-render on a length change, which an in-place reconcile cannot help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
