### PR TITLE
perf(arrays): scope element field-state to its own subtree, not the array length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,19 @@
   reactivity-contract suite and re-render-count guards across the Zod v3 and v4
   adapters; zero new dependencies. (#XXX)
 
+- **A row's field state stays put when the list grows or shrinks.** Reading
+  `form.fields` or `form.list` over an array builds one `FieldState` per row, and
+  each row's rolled-up state had been tied to the array's length, so adding or
+  removing a single row recomputed every row's field state (an O(N x fields)
+  re-walk on each structural op). A row's field state now depends only on its own
+  subtree, so a row that did not change is left untouched: appending to a
+  hundred-row grid recomputes one row's state instead of all hundred, and the
+  cost stays flat as the array grows. This compounds with the in-place reconcile
+  above, so a row add or reorder updates only the rows that changed, from the
+  write through to every reader. Behaviour is unchanged, pinned by a
+  recompute-count regression guard and the full array and reactivity suites
+  across the Zod v3 and v4 adapters; zero new dependencies, no size change. (#XXX)
+
 ## v0.21.2
 ### Changed
 

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -1382,7 +1382,18 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
   // it can't follow; structural mutations replay their permutation onto
   // the tokens through `applyOp`.
   const arrayIdentity = createArrayIdentity((arraySegs) => {
-    const v = getAtPath(form.value, arraySegs)
+    // Read the length off the RAW form value so this lookup never registers a
+    // reactive dependency. The identity-token read (`arrayElementKey` ->
+    // `tokenAt`) runs inside every array-element's FieldState computed; tracking
+    // the array length here would couple every element's rollup to the array
+    // length, so a single append / remove (a length change) would invalidate
+    // all N element rollups and re-walk O(N x M). An element's state depends
+    // only on its own subtree: a structural op that changes which element sits
+    // at a slot also changes that slot's value reference (the field-array
+    // helpers relocate element references in place), firing the element's own
+    // value dep and re-running exactly its rollup. The length is needed only to
+    // seed / bounds-check the token list, never as a reactive input.
+    const v = getAtPath(toRaw(form.value), arraySegs)
     return Array.isArray(v) ? v.length : 0
   })
 

--- a/src/runtime/core/path-walker.ts
+++ b/src/runtime/core/path-walker.ts
@@ -55,7 +55,16 @@ function descendStep(value: unknown, segment: Segment): unknown | typeof NOT_FOU
   if (typeof value !== 'object') return NOT_FOUND
   if (Array.isArray(value)) {
     if (typeof segment !== 'number') return NOT_FOUND
-    if (segment < 0 || segment >= value.length) return NOT_FOUND
+    // Presence-test the index rather than comparing it against `value.length`.
+    // On a reactive array the `in` check tracks only this index's dependency
+    // (Vue's `has` trap), whereas reading `.length` would subscribe the caller
+    // to the array length. Descending into an element must NOT couple the
+    // reader to the sibling count: a length read here makes every element's
+    // value access (and the FieldState rollup built on it) re-run on any
+    // append / remove, turning an array op into O(N x element-leaves). An
+    // out-of-range, negative, or hole index is absent, so `in` is false and we
+    // return NOT_FOUND exactly as the bounds comparison did.
+    if (!(segment in value)) return NOT_FOUND
     return value[segment]
   }
   const record = value as Record<string, unknown>

--- a/test/composables/field-array-perf-guard.test.ts
+++ b/test/composables/field-array-perf-guard.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { computed, createApp, defineComponent, h, type App } from 'vue'
 import { useForm } from '../../src'
+import { EMPTY_RESOLVED_FIELD_META } from '../../src/runtime/core/field-meta'
 import { attachRegistryToApp, createRegistry } from '../../src/runtime/core/registry'
 import type { Path } from '../../src/runtime/core/paths'
 import type { UseFormReturnType } from '../../src/runtime/types/types-api'
@@ -91,6 +92,44 @@ function nestedHarness(sections: Section[]) {
   attachRegistryToApp(app, createRegistry())
   app.mount(document.createElement('div'))
   return { app, form }
+}
+
+/**
+ * A grid form whose schema counts every `getFieldMetaAtPath` call, bucketed by
+ * path. `buildContainerFieldStateBase` calls it exactly once per rollup
+ * evaluation (field-state-api.ts), so the per-path count is a deterministic,
+ * non-flaky proxy for "how many times did this path's FieldState recompute."
+ */
+function meteredHarness(n: number) {
+  const base = fakeSchema<Grid>({ rows: makeRows(n) })
+  const metaCalls = new Map<string, number>()
+  const schema = {
+    ...base,
+    getFieldMetaAtPath(path: Path) {
+      metaCalls.set(path.join('.'), (metaCalls.get(path.join('.')) ?? 0) + 1)
+      return EMPTY_RESOLVED_FIELD_META
+    },
+  }
+  let form!: UseFormReturnType<Grid>
+  const Probe = defineComponent({
+    setup() {
+      form = useForm<Grid>({ schema, key: `metered-${n}-${Math.random()}` })
+      return () => h('div')
+    },
+  })
+  const app = createApp(Probe)
+  attachRegistryToApp(app, createRegistry())
+  app.mount(document.createElement('div'))
+  return {
+    app,
+    form,
+    resetMeta: () => metaCalls.clear(),
+    elementRollupRecomputes: () => {
+      let total = 0
+      for (const [k, c] of metaCalls) if (/^rows\.\d+$/.test(k)) total += c
+      return total
+    },
+  }
 }
 
 describe('field arrays — per-element work does not scale with N (perf guard)', () => {
@@ -277,5 +316,37 @@ describe('field arrays — per-element work does not scale with N (perf guard)',
     // this is not a dead-form false zero.
     expect(small.touchedLen).toBeGreaterThan(0)
     expect(large.touchedLen).toBeGreaterThan(0)
+  })
+
+  /**
+   * Recomputes of per-element FieldState rollups across a tail append. Reading
+   * `form.fields('rows.i').key` subscribes element i's container rollup, which
+   * derives its identity token through the parent array (`arrayElementKey` →
+   * `tokenAt`). An element's FieldState depends only on its own subtree, so a
+   * tail append (which changes neither an existing element's value nor its
+   * token) must leave every existing row's rollup memoized: only the appended
+   * row computes, flat in N. A rollup coupled to the array length instead
+   * invalidates all N on the length change, scaling the recompute count with N.
+   */
+  function elementRollupRecomputesOnAppend(n: number): number {
+    const harness = meteredHarness(n)
+    apps.push(harness.app)
+    const { form } = harness
+    const fields = form.fields as unknown as (p: string) => Record<string, unknown>
+    // Prime: evaluate each element rollup once so its deps are tracked.
+    for (let i = 0; i < n; i++) void fields(`rows.${i}`)['key']
+    form.append('rows', newRow())
+    // Count only the recomputes the post-append re-read drives (the host's read
+    // of every row's `key` when the length-changed v-for re-renders).
+    harness.resetMeta()
+    for (let i = 0; i <= n; i++) void fields(`rows.${i}`)['key']
+    return harness.elementRollupRecomputes()
+  }
+
+  it('appending a row recomputes only the appended element rollup, flat in N', () => {
+    const small = elementRollupRecomputesOnAppend(20)
+    const large = elementRollupRecomputesOnAppend(200)
+    expect(small).toBeLessThanOrEqual(2)
+    expect(large).toBe(small) // flat in N — only the appended row recomputes
   })
 })


### PR DESCRIPTION
## What

A structural array op (`append` / `remove`) recomputed every row's `FieldState`,
not just the changed row: an O(N x fields) re-walk on each op. This decouples an
array element's `FieldState` rollup from the parent array's length so a row that
did not change is left untouched.

## Root cause

Reading `form.fields` or `form.list` over an array builds one `FieldState`
computed per row. Two reads inside every array-element rollup transitively
tracked the parent array's reactive length:

- the value read (`getAtPath` -> `descendStep`) bounds-checked the index with
  `segment >= value.length`, tracking the array length;
- the identity-token read (`arrayElementKey` -> `tokenAt` -> `getArrayLength`)
  read `value.length` directly.

So any append / remove (a length change) invalidated all N element rollups, each
re-walking its leaves. Confirmed with a recompute-count guard (21 recomputes at
N=20, would be 201 at N=200) and a browser CPU profile (the rollup was ~37% of
the append's on-CPU time).

## Fix

- `descendStep` presence-tests the index (`segment in value`), which tracks only
  that index via Vue's `has` trap, never the length. Behavior is identical for
  `getAtPath`: an out-of-range, negative, or hole index reads `undefined` either
  way.
- `getArrayLength` reads the length off `toRaw(form.value)`, since the token
  list needs the length only to seed and bounds-check, never as a reactive
  input.

An element's `FieldState` now depends only on its own subtree. Correctness holds
without the length dep because a structural op that changes which element sits
at a slot also changes that slot's value reference (the field-array helpers
relocate element references in place), which fires the element's own value
dependency and re-runs exactly its rollup.

## Result

- Recompute-count guard: append recomputes one row, flat in N (was N+1).
- Local arena `grid/arrayAdd/N100M8`: 12.65ms -> 3.40ms (~3.7x); the container
  rollup leaves the append hot path (the monthly CI arena is canonical).
- Store-side append goes O(N x fields) -> O(fields); the remaining cost is the
  keyed `v-for` re-render plus the op's own per-element bookkeeping.

## Verification

- New recompute-count regression guard in `field-array-perf-guard.test.ts`.
- Full suite green across the Zod v3 and v4 adapters (the one local
  `packaging/exports.test.ts` failure is the known local-build-only quirk, green
  in CI).
- `typecheck`, `lint`, `check:size` all clean; zod-v3 63.05 / 64 KB, no bump.
- Zero new dependencies; no public API change (an internal reactivity dependency
  narrowing, output-identical).

## Noted follow-up (not in this PR)

`hasAtPath`'s last-array-segment bounds check (`path-walker.ts`) has the same
length read, but is only reached for an error pinned directly at an array-index
path. Narrow and separate; left for a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
