### PR TITLE
perf(arrays): scope hasAtPath to the queried index, not the array length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,9 +67,14 @@
   hundred-row grid recomputes one row's state instead of all hundred, and the
   cost stays flat as the array grows. This compounds with the in-place reconcile
   above, so a row add or reorder updates only the rows that changed, from the
-  write through to every reader. Behaviour is unchanged, pinned by a
-  recompute-count regression guard and the full array and reactivity suites
-  across the Zod v3 and v4 adapters; zero new dependencies, no size change. (#XXX)
+  write through to every reader. The same holds for state addressed at a row
+  itself rather than at a field inside it: an error or field state pinned
+  directly to `rows.3` is kept or dropped by a presence check on that one index,
+  no longer by a read of the array's length, so it too is left alone when a
+  sibling row is added or removed. Behaviour is unchanged, pinned by a
+  recompute-count regression guard, a reactive-coupling test on the path walker,
+  and the full array and reactivity suites across the Zod v3 and v4 adapters;
+  zero new dependencies, no size change. (#XXX)
 
 ## v0.21.2
 ### Changed

--- a/src/runtime/core/path-walker.ts
+++ b/src/runtime/core/path-walker.ts
@@ -121,7 +121,16 @@ export function hasAtPath(root: unknown, path: Path): boolean {
   if (current === null || current === undefined) return false
   if (typeof current !== 'object') return false
   if (Array.isArray(current)) {
-    return typeof last === 'number' && last >= 0 && last < current.length
+    // Presence-test the index rather than comparing it against `current.length`,
+    // for the same reason `descendStep` does: `in` hits Vue's `has` trap and
+    // tracks only this index, whereas a `.length` read would subscribe the caller
+    // to the array length. `hasAtPath` is the active-path gate for errors and
+    // field-state (errors-proxy, the field-state orphan check); an entry pinned
+    // directly at an array-index path (`rows.3`) must not re-run that gate on
+    // every append / remove just because a sibling changed the length. `in` is
+    // also truer to this function's own contract: a never-assigned hole is
+    // "missing", which the `< length` comparison wrongly reported as present.
+    return typeof last === 'number' && last in current
   }
   const key = typeof last === 'number' ? String(last) : last
   // Own-property existence for prototype-shadowed names — `key in

--- a/test/core/path-walker.test.ts
+++ b/test/core/path-walker.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { computed, reactive } from 'vue'
 import { getAtPath, hasAtPath, setAtPath } from '../../src/runtime/core/path-walker'
 
 describe('getAtPath', () => {
@@ -87,6 +88,40 @@ describe('hasAtPath', () => {
   it('returns true for a valid array index, false for out-of-bounds', () => {
     expect(hasAtPath([10, 20], [1])).toBe(true)
     expect(hasAtPath([10, 20], [5])).toBe(false)
+  })
+
+  it('treats a never-assigned hole as missing, an explicit slot as present', () => {
+    // A sparse hole (within length but never assigned) is "missing" per this
+    // function's contract, which distinguishes a present-but-undefined slot
+    // from an absent one. An explicitly-set slot exists even when its value is
+    // undefined; only the genuine hole is absent.
+    const sparse = [10]
+    sparse[2] = 30 // index 1 is a hole; length is now 3
+    expect(hasAtPath(sparse, [1])).toBe(false)
+    expect(hasAtPath(sparse, [2])).toBe(true)
+    expect(hasAtPath([undefined], [0])).toBe(true)
+  })
+})
+
+describe('hasAtPath — reactive coupling', () => {
+  it('an array-index lookup tracks the index, never the array length', () => {
+    // The active-path gate (errors-proxy, field-state-api's orphan check) runs
+    // `hasAtPath` against the live reactive form value. An existence check at an
+    // array-index path must subscribe only to that index (Vue's `has` trap), not
+    // to `.length`: a length read would re-run the gate for every pinned entry on
+    // any append / remove, turning an array op into O(N) gate re-evaluations.
+    const root = reactive({ rows: [{ a: 1 }, { a: 2 }, { a: 3 }] })
+    let runs = 0
+    const present = computed(() => {
+      runs += 1
+      return hasAtPath(root, ['rows', 1])
+    })
+    expect(present.value).toBe(true) // prime: index 1 is present, dep tracked
+    expect(runs).toBe(1)
+
+    root.rows.push({ a: 4 }) // length 3 -> 4; index 1 is untouched
+    expect(present.value).toBe(true) // served from cache
+    expect(runs).toBe(1) // never subscribed to `.length`, so no recompute
   })
 })
 


### PR DESCRIPTION
## What

`hasAtPath` is the active-path gate that `errors-proxy` and `field-state-api`
use to decide whether an error or field-state entry is currently live. Its
array branch tested the final index with `last < current.length`, which reads
the array length. Against a reactive form value that subscribes the gate to the
array's length, so an entry pinned **directly at an array-index path** (a
container-level error on `rows.3`, or `form.fields('rows.3')`) re-ran on every
append or remove, even when only a sibling row changed the count.

This swaps the length comparison for an `in` presence test, mirroring the
`descendStep` change in #402: `in` hits Vue's `has` trap and tracks only that
one index, never the length.

## The sibling of #402

#402 decoupled a row's field-state **rollup** from the array length by fixing
the two length reads on the *traversal* path (`descendStep`'s bounds check and
`getArrayLength`). Those cover paths that descend *through* an array index
(`rows.3.name`). `hasAtPath`'s own array branch is the remaining length read,
reached when a path *terminates* at an array index. Closing it means no
array-index length read is left in the field-state / errors hot path.

## Behavior

Behavior-preserving for every value Attaform actually constructs. Present
indices, out-of-bounds indices, negatives, and a string segment against an
array all answer identically to the old comparison.

The one intentional divergence, called out for review: a never-assigned
**hole** in a sparse array (within `length` but never written) now reads as
"missing" rather than "present". That is *truer* to `hasAtPath`'s documented
contract, which distinguishes "exists and is undefined" from "missing", and a
hole is missing. It is also unreachable through Attaform's own array
construction (`setAtPath` pushes `undefined` slots, never holes). A consumer's
explicitly-set `undefined` slot still reads as present.

## Tests

Characterization-first, both red before the fix:

- A reactive-coupling unit test: an array-index lookup inside a `computed` does
  not recompute when a sibling is appended, because it never subscribed to
  `.length`.
- A hole test pinning the intentional "a hole is missing, an explicit slot is
  present" contract.

Verification (Docker):

- `path-walker` 30 pass (including the 2 new)
- Full suite 4464 pass (only the known local-build-only `packaging/exports`
  zod-v3 quirk fails locally, green in CI)
- `typecheck`, `lint` + format, and `check:size` all clean; `zod-v3.mjs` holds
  at 63.05 KB (no cap bump)

Zero new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
