### PR TITLE
fix(bench-arena): match the zod-isolation importer case-insensitively for CI

### DIFF
--- a/apps/bench-arena/vite.config.ts
+++ b/apps/bench-arena/vite.config.ts
@@ -24,10 +24,16 @@ function attaformZodVersionIsolation(): Plugin {
     name: 'attaform-zod-version-isolation',
     enforce: 'pre',
     async resolveId(source, importer) {
+      // Case-insensitive: the importer is the dist file's real (symlink-resolved)
+      // path, whose `attaform` segment is the checkout directory, and CI capitalizes
+      // it. GitHub checks this repo out to `.../Attaform/Attaform/dist/`, while the
+      // dev tree lives at `.../attaform/dist/`; a case-sensitive test matched only
+      // the latter, so in CI the redirect never fired and the v4 adapter resolved the
+      // v3 `zod` instead, surfacing as the discriminated-union cells failing to mount.
       if (
         source === 'zod' &&
         importer !== undefined &&
-        /[\\/]attaform[\\/]dist[\\/]/.test(importer)
+        /[\\/]attaform[\\/]dist[\\/]/i.test(importer)
       ) {
         return this.resolve('zod-v4', `${BENCH_DIR}vite.config.ts`, { skipSelf: true })
       }


### PR DESCRIPTION
## What

The dual-zod isolation that lets the arena host Attaform's zod-v4 adapter alongside the zod-v3
cohort did not fire in CI, so the zod-v4 adapter resolved the v3 `zod` and the discriminated-union
cells failed to mount. This makes the importer match case-insensitive.

## Root cause

The isolation plugin redirects the Attaform dist's bare `zod` to the `zod-v4` alias by testing
whether the importer path contains an `attaform/dist/` segment. That path is the dist file's real
(symlink-resolved) location, and its `attaform` segment is the checkout directory. GitHub checks
this repo out to `…/Attaform/Attaform/dist/` (capital), while the dev tree is `…/attaform/dist/`
(lowercase). The test was case-sensitive, so it matched only locally; in CI it silently missed, the
v4 adapter fell back to zod v3, and zod v3 parsing a v4-built `discriminatedUnion` threw on mount.

Only the discriminated-union shard went red because DU is the one construct that hard-fails on a
major-version mismatch; the other zod4 scenarios limped through measuring the wrong zod (so the
refresh would also have published wrong zod-v4 numbers had it completed).

## The fix

Make the importer test case-insensitive. One character, and the minimal change that cannot
introduce a new match (the lowercase dev path still matches).

## Verification

- Deterministic check against the real CI path: the old pattern returns `false` on
  `/home/runner/work/Attaform/Attaform/dist/…`, the new one returns `true`; both still return
  `false` for the v3 cohort's dist and the arena's own zod-v3 scenario imports, so the redirect
  stays scoped.
- All 54 discriminated-union cells (nine libraries) pass locally; bench typecheck, eslint, and
  prettier are green.

## Follow-up

After merge, re-dispatch the bench refresh so `results.json` repopulates with the corrected
zod-v4 numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
