### PR TITLE
chore(docs): fix wrong-case repo links and stale version claims; stamp version at release

### DIFF
--- a/apps/site/components/OgImage/Default.satori.vue
+++ b/apps/site/components/OgImage/Default.satori.vue
@@ -128,7 +128,7 @@
           display: flex;
         "
       >
-        Vue 3 · Nuxt 4 · Zod
+        Vue 3 · Nuxt 3 / 4 · Zod
       </span>
     </div>
   </div>

--- a/apps/site/docs-demos/transforms-async/App.vue
+++ b/apps/site/docs-demos/transforms-async/App.vue
@@ -8,7 +8,7 @@
     '# links.txt: one web address per line. Blank lines and # comments are skipped.',
     'attaform.com',
     'https://Example.com/Docs/Getting-Started',
-    'github.com/attaform/attaform',
+    'github.com/attaform/Attaform',
     '',
     'zod.dev/Guides/Migration',
     'ftp://files.example.com/not-a-web-link',

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > A type-safe, schema-driven form library for Vue 3 and Nuxt with first-class Zod support. Hand a Zod schema to `useForm` and Attaform turns it into a reactive form, typed end-to-end, with live errors, automatic accessibility, and SSR out of the box.
 
-*This index is hand-maintained and may lag the live source. These things happen. If a link 404s, an export looks missing, or a signature seems off, treat the docs at [attaform.com](https://www.attaform.com), the published `attaform` types, and the source at [github.com/attaform/attaform](https://github.com/attaform/attaform) as canonical. When in doubt, crawl from the homepage rather than giving up on the project.*
+*This index is hand-maintained and may lag the live source. These things happen. If a link 404s, an export looks missing, or a signature seems off, treat the docs at [attaform.com](https://www.attaform.com), the published `attaform` types, and the source at [github.com/attaform/Attaform](https://github.com/attaform/Attaform) as canonical. When in doubt, crawl from the homepage rather than giving up on the project.*
 
 Attaform's core idea is that the schema IS the form. One Zod schema declares the shape, the defaults, the validation, the per-field errors, and the input/output types. Attaform builds the reactive surface around it.
 
@@ -226,9 +226,9 @@ Patterns that keep Attaform code clean.
 
 ## Optional
 
-- [GitHub](https://github.com/attaform/attaform): source, issues, discussions.
+- [GitHub](https://github.com/attaform/Attaform): source, issues, discussions.
 - [npm](https://www.npmjs.com/package/attaform): published versions and install command.
-- [CHANGELOG](https://github.com/attaform/attaform/blob/main/CHANGELOG.md): release history.
+- [CHANGELOG](https://github.com/attaform/Attaform/blob/main/CHANGELOG.md): release history.
 
 ## Author
 

--- a/docs/scorecard/cii-best-practices-answers.md
+++ b/docs/scorecard/cii-best-practices-answers.md
@@ -87,7 +87,7 @@ npm package: <https://www.npmjs.com/package/attaform>
 
 **Answer:** Met.
 **URL/evidence:** [Recent commits](https://github.com/attaform/Attaform/commits/main), [Recent releases](https://github.com/attaform/Attaform/releases)
-**Notes:** Active development with multiple commits per week and weekly-to-bi-weekly releases (current: 0.19.0, May 2026). Issues responded to within days. Active maintainer signal is the strongest signal Scorecard's `Maintained` check already grades at 10/10.
+**Notes:** Active development with multiple commits per week and weekly-to-bi-weekly releases (current: 0.21.2). Issues responded to within days. Active maintainer signal is the strongest signal Scorecard's `Maintained` check already grades at 10/10.
 
 ## CHANGE_CONTROL
 

--- a/docs/server-and-ssr/performance.md
+++ b/docs/server-and-ssr/performance.md
@@ -126,7 +126,7 @@ Run with `pnpm bench`. The regression gate only fires on benches that follow the
 
 ## Peer-dep coverage
 
-Per-PR CI covers Node 18 / 20 / 22 / LTS against the devDep-pinned peer versions. A weekly workflow sweeps Vue 3.5 through 3.6, Vite 5 / 6, Nuxt 3.16 through Nuxt 4. Jobs fail independently; versions not yet released surface as failed cells without blocking the main CI.
+Per-PR CI runs the suite on the current Node LTS (22.x today; the `engines.node` floor is Node 22) against the devDep-pinned peer versions. A weekly workflow sweeps Vue 3.5 through 3.6, Vite 5 / 6, Nuxt 3.16 through Nuxt 4. Jobs fail independently; versions not yet released surface as failed cells without blocking the main CI.
 
 ## Where to next
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "check:bundled-types": "node scripts/check-bundled-types.mjs",
     "check:site": "pnpm dev:prepare && pnpm --filter attaform-site typecheck",
     "fallow": "DO_NOT_TRACK=1 FALLOW_TELEMETRY=0 npx --yes fallow@2.88.3 --score",
-    "version": "node scripts/promote-changelog.mjs && (node scripts/generate-release-notes.mjs || echo '[version] release-notes step failed; continuing') && git add CHANGELOG.md RELEASES.md",
+    "version": "node scripts/promote-changelog.mjs && (node scripts/generate-release-notes.mjs || echo '[version] release-notes step failed; continuing') && node scripts/sync-doc-versions.mjs && git add CHANGELOG.md RELEASES.md docs/scorecard/cii-best-practices-answers.md",
     "prepare": "husky"
   },
   "description": "A type-safe, schema-driven form library for Vue 3 and Nuxt with first-class Zod support.",

--- a/scripts/sync-doc-versions.mjs
+++ b/scripts/sync-doc-versions.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+/**
+ * Stamp the current package.json version into the raw docs that cite it. Runs from
+ * the `version` npm hook (after `pnpm version X` bumps package.json, before the
+ * commit), alongside promote-changelog, so the stamped docs ride the version commit
+ * instead of drifting behind the tag.
+ *
+ * The site's homepage and footer read the version from package.json at build time
+ * (nuxt.config runtimeConfig). These targets are raw markdown read on GitHub, not
+ * rendered by Nuxt Content, so they cannot do that; a release-time stamp is the same
+ * idea for a file that is never rendered.
+ *
+ * Each target names a file and the regex locating its version, whose first capture
+ * group is the prefix kept verbatim (only the version after it is overwritten). A
+ * target whose marker is absent, or any read/write error, is logged and skipped:
+ * a doc may be re-worded, and the release machinery must never block on it.
+ */
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(__dirname, '..')
+const { version } = JSON.parse(readFileSync(resolve(repoRoot, 'package.json'), 'utf8'))
+
+const targets = [
+  {
+    file: 'docs/scorecard/cii-best-practices-answers.md',
+    pattern: /(current: )\d+\.\d+\.\d+/,
+  },
+]
+
+for (const { file, pattern } of targets) {
+  try {
+    const path = resolve(repoRoot, file)
+    const content = readFileSync(path, 'utf8')
+    if (!pattern.test(content)) {
+      console.error(
+        `[sync-doc-versions] no version marker in ${file} — skipping (version=${version})`
+      )
+      continue
+    }
+    const updated = content.replace(pattern, `$1${version}`)
+    if (updated === content) continue
+    writeFileSync(path, updated)
+    console.log(`[sync-doc-versions] stamped ${file} → ${version}`)
+  } catch (error) {
+    console.error(`[sync-doc-versions] ${file} skipped: ${error?.message ?? error}`)
+  }
+}


### PR DESCRIPTION
## What

A docs-accuracy sweep: correct wrong-case repo links, fix three stale version claims, and make the
one doc that names the Attaform release stamp itself at release time instead of being hand-bumped.

## Wrong-case repo links

Two surfaces linked the repo as lowercase `attaform/attaform` instead of the canonical
`attaform/Attaform`:

- `apps/site/docs-demos/transforms-async/App.vue` (a sample link in the links-to-URLs demo)
- `apps/site/public/llms.txt` (the homepage source, GitHub, and CHANGELOG links)

GitHub redirects the lowercase form, so nothing was broken, but the canonical case is consistent now.
(The CHANGELOG's historical note about a prior fix is left as written.)

## Stale version claims

- **OG image** pinned "Nuxt 4" while the homepage tile, README, and the `nuxt >=3.0.0` peer all say
  "Nuxt 3 / 4". Matched it. (It is a generated satori image, so worth an eyeball on the rendered card.)
- **`docs/server-and-ssr/performance.md`** claimed per-PR CI covers "Node 18 / 20 / 22 / LTS". The
  test matrix runs only `lts/*` (22.x today) and `engines.node` is `>=22` (Node 20 dropped at its
  EOL). Reworded to the current LTS plus the engines floor; the Vue / Vite / Nuxt parts were already
  correct.

## Dynamic version, the right way for a raw doc

`docs/scorecard/cii-best-practices-answers.md` hardcoded the current release (`0.19.0`; actual is
`0.21.2`). The homepage and footer avoid this by reading the version from `package.json` at build
time, but this doc is a **raw GitHub-read audit trail** (no frontmatter, excluded from the rendered
content collection), so render-time injection cannot reach it.

Instead, a new `scripts/sync-doc-versions.mjs` runs from the `version` npm hook (beside
`promote-changelog`), stamps `package.json`'s version into the doc, and rides the version-bump
commit, the same release-time pattern the changelog and release notes already use. Tested: a fake
old version restamps to the current one, and it is idempotent and tolerant (a missing marker or any
error is skipped, never failing a publish).

## Notes

No other hardcoded versions remain: the homepage release pill, footer, and REPL dependency versions
all derive from `package.json`; bench library versions come from `results.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
