### PR TITLE
chore(bench-arena): label the Attaform rows by zod major (Zod 3 / Zod 4)

### DIFF
--- a/apps/bench-arena/results.json
+++ b/apps/bench-arena/results.json
@@ -30,7 +30,7 @@
   "capabilities": [
     {
       "lib": "attaform",
-      "displayName": "Attaform",
+      "displayName": "Attaform (zod@v3)",
       "layer": "headless-form-state",
       "schemaLib": "zod3",
       "ownsInputs": false,
@@ -52,7 +52,7 @@
     },
     {
       "lib": "attaform-zod4",
-      "displayName": "Attaform (Zod 4)",
+      "displayName": "Attaform (zod@v4)",
       "layer": "headless-form-state",
       "schemaLib": "zod4",
       "ownsInputs": false,

--- a/apps/bench-arena/results.json
+++ b/apps/bench-arena/results.json
@@ -30,7 +30,7 @@
   "capabilities": [
     {
       "lib": "attaform",
-      "displayName": "Attaform (zod@v3)",
+      "displayName": "Attaform (Zod 3)",
       "layer": "headless-form-state",
       "schemaLib": "zod3",
       "ownsInputs": false,
@@ -52,7 +52,7 @@
     },
     {
       "lib": "attaform-zod4",
-      "displayName": "Attaform (zod@v4)",
+      "displayName": "Attaform (Zod 4)",
       "layer": "headless-form-state",
       "schemaLib": "zod4",
       "ownsInputs": false,

--- a/apps/bench-arena/src/adapters/attaform-zod4/adapter.ts
+++ b/apps/bench-arena/src/adapters/attaform-zod4/adapter.ts
@@ -43,7 +43,7 @@ const unsupported = (op: string): never => {
 export const attaformZod4Adapter: BenchAdapter = {
   meta: {
     id: 'attaform-zod4',
-    displayName: 'Attaform (Zod 4)',
+    displayName: 'Attaform (zod@v4)',
     layer: 'headless-form-state',
     schemaLib: 'zod4',
     ownsInputs: false,

--- a/apps/bench-arena/src/adapters/attaform-zod4/adapter.ts
+++ b/apps/bench-arena/src/adapters/attaform-zod4/adapter.ts
@@ -43,7 +43,7 @@ const unsupported = (op: string): never => {
 export const attaformZod4Adapter: BenchAdapter = {
   meta: {
     id: 'attaform-zod4',
-    displayName: 'Attaform (zod@v4)',
+    displayName: 'Attaform (Zod 4)',
     layer: 'headless-form-state',
     schemaLib: 'zod4',
     ownsInputs: false,

--- a/apps/bench-arena/src/adapters/attaform/adapter.ts
+++ b/apps/bench-arena/src/adapters/attaform/adapter.ts
@@ -49,7 +49,7 @@ const unsupported = (op: string): never => {
 export const attaformAdapter: BenchAdapter = {
   meta: {
     id: 'attaform',
-    displayName: 'Attaform',
+    displayName: 'Attaform (zod@v3)',
     layer: 'headless-form-state',
     schemaLib: 'zod3',
     ownsInputs: false,

--- a/apps/bench-arena/src/adapters/attaform/adapter.ts
+++ b/apps/bench-arena/src/adapters/attaform/adapter.ts
@@ -49,7 +49,7 @@ const unsupported = (op: string): never => {
 export const attaformAdapter: BenchAdapter = {
   meta: {
     id: 'attaform',
-    displayName: 'Attaform (zod@v3)',
+    displayName: 'Attaform (Zod 3)',
     layer: 'headless-form-state',
     schemaLib: 'zod3',
     ownsInputs: false,


### PR DESCRIPTION
## What

The benchmark comparison table labeled Attaform's two rows as **Attaform** and **Attaform (Zod 4)**.
The bare "Attaform" leaves a reader to infer it is the zod-v3 adapter, which is not obvious at a
glance. This makes the zod major explicit on both rows, in the "Zod 3" / "Zod 4" style the capability
table's schema column already uses:

- `Attaform` becomes **Attaform (Zod 3)**
- `Attaform (Zod 4)` is unchanged

## Where

The label is each adapter's `meta.displayName`, which the bench bakes into `results.json` and the
docs render (`BenchArena.vue` reads `capabilities[].displayName`). So this updates:

- the adapter meta (`apps/bench-arena/src/adapters/attaform/adapter.ts`), the source of truth
- the matching `displayName` field in the committed `results.json`, so the docs show the new label
  immediately

Net effect: only the v3 row gains the explicit "(Zod 3)"; the v4 row keeps "Attaform (Zod 4)". The
next bench refresh regenerates `results.json` from the adapter metas, producing the same labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
