### PR TITLE
feat(form): z.record schema roots (dictionary forms)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Changelog
 
 ## Unreleased
+### Added
 
-_No unreleased changes yet._
+- **A `z.record` schema can now be the whole form, not just a field inside
+  one.** `useForm({ schema: z.record(keySchema, valueSchema) })` is a
+  dictionary form: `form.values` is the map itself, `form.register('ada.tier')`
+  binds an entry field, and the new no-arg `form.record()` hands back the root
+  entry view, one `FieldState` per key. Iterate keys you only learn at run time,
+  a members table keyed by id, a settings editor, a tag map, without keeping a
+  parallel list of your own; a bare record root defaults to an empty map. zod v3
+  and zod v4 both get it, both tested, and object-rooted forms behave exactly as
+  before. (#393)
 
 ## v0.23.0
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
   a members table keyed by id, a settings editor, a tag map, without keeping a
   parallel list of your own; a bare record root defaults to an empty map. zod v3
   and zod v4 both get it, both tested, and object-rooted forms behave exactly as
-  before. (#393)
+  before. (#421)
 
 ## v0.23.0
 ### Removed

--- a/apps/site/composables/useDocsNavigation.ts
+++ b/apps/site/composables/useDocsNavigation.ts
@@ -61,6 +61,7 @@ export const docsNavigation: DocsSection[] = [
       { title: 'Discriminated unions', to: '/docs/schemas/discriminated-unions' },
       { title: 'Arrays & tuples', to: '/docs/schemas/arrays-and-tuples' },
       { title: 'Records & maps', to: '/docs/schemas/records' },
+      { title: 'Dictionary forms', to: '/docs/schemas/dictionary-forms' },
       { title: 'Nested objects', to: '/docs/schemas/nested-objects' },
       { title: 'AbstractSchema', to: '/docs/schemas/abstract-schema' },
     ],

--- a/apps/site/docs-demos/dictionary-forms/App.vue
+++ b/apps/site/docs-demos/dictionary-forms/App.vue
@@ -1,0 +1,116 @@
+<script setup lang="ts">
+  import { ref } from 'vue'
+  import { useForm } from 'attaform/zod'
+  import { z } from 'zod'
+  import './styles.css'
+
+  const ROLES = ['admin', 'editor', 'viewer'] as const
+
+  const form = useForm({
+    schema: z.record(
+      z.string(),
+      z.object({ role: z.enum(ROLES), tier: z.number().min(1, 'min 1').max(5, 'max 5') })
+    ),
+    defaultValues: {
+      ada: { role: 'admin', tier: 3 },
+      grace: { role: 'editor', tier: 2 },
+      linus: { role: 'viewer', tier: 1 },
+    },
+    key: 'docs-demo-dictionary-forms',
+  })
+
+  const newMember = ref('')
+
+  function addMember(): void {
+    const id = newMember.value.trim()
+    if (id.length === 0) return
+    form.setValue(id, { role: 'viewer', tier: 1 })
+    newMember.value = ''
+  }
+
+  function removeMember(id: string): void {
+    const next = { ...form.values() }
+    delete next[id]
+    form.setValue(next)
+  }
+</script>
+
+<template>
+  <form class="demo" @submit.prevent>
+    <ul class="rows">
+      <li v-for="(member, id) in form.record()" :key="id" class="entry">
+        <div class="row">
+          <code class="token">{{ id }}</code>
+          <select v-register="form.register(`${id}.role`)" :aria-label="`Role for ${id}`">
+            <option v-for="role in ROLES" :key="role" :value="role">{{ role }}</option>
+          </select>
+          <input
+            v-register="form.register(`${id}.tier`)"
+            type="number"
+            :aria-label="`Tier for ${id}`"
+          />
+          <button type="button" title="Remove" @click="removeMember(id)">×</button>
+        </div>
+        <small v-if="member.showErrors" class="err">{{ member.firstError?.message }}</small>
+      </li>
+    </ul>
+
+    <div class="actions mono">
+      <input v-model="newMember" placeholder="Add a member id" @keydown.enter.prevent="addMember" />
+      <button type="button" @click="addMember">form.setValue(id, …)</button>
+    </div>
+
+    <p class="hint">
+      The schema root is a <code>z.record(…)</code>, so the whole form is the dictionary.
+      <code>form.record()</code> with no argument iterates the entries, the keys come from the form
+      itself, and <code>form.values</code> is the map you see below.
+    </p>
+
+    <pre>{{ JSON.stringify(form.values(), null, 2) }}</pre>
+  </form>
+</template>
+
+<style scoped>
+  .entry {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+  .token {
+    font-size: 0.75rem;
+    font-family: ui-monospace, monospace;
+    color: var(--color-fg);
+    background: var(--color-surface-2);
+    border-radius: 0.25rem;
+    padding: 0.15rem 0.5rem;
+    min-width: 3.5rem;
+    text-align: center;
+  }
+  .row select {
+    flex: 1;
+  }
+  input[type='number'] {
+    width: 4rem;
+  }
+  .actions input {
+    flex: 1;
+  }
+  .row button {
+    width: 1.75rem;
+    height: 1.75rem;
+    border-radius: 0.25rem;
+    border: 1px solid var(--color-border-strong);
+    background: var(--color-bg);
+    color: var(--color-fg);
+    font-size: 0.875rem;
+    cursor: pointer;
+  }
+  .row button:hover {
+    background: var(--color-surface-2);
+  }
+  .err {
+    color: var(--color-danger);
+    font-size: 0.75rem;
+    padding-left: 4rem;
+  }
+</style>

--- a/apps/site/docs-demos/dictionary-forms/styles.json
+++ b/apps/site/docs-demos/dictionary-forms/styles.json
@@ -1,0 +1,1 @@
+{ "with": ["rows", "row", "input", "select", "actions", "hint", "code", "pre"] }

--- a/docs/reading-the-form/record.md
+++ b/docs/reading-the-form/record.md
@@ -5,7 +5,7 @@ metaRows:
   - label: Category
     value: Return method
   - label: Type
-    value: (path) => Readonly<Record<string, FieldState>>
+    value: (path?) => Readonly<Record<string, FieldState>>
     kind: code
   - label: Keyed
     value: 'Yes, by record key'
@@ -68,6 +68,20 @@ The existing entries keep their field states and their component instances; only
 
 `form.fields('scoresByTeam')` remains the single aggregated container for the whole record: one rolled-up FieldState whose `errors`, `valid`, and `touched` summarize every entry at once. Reach for the aggregate when you want one verdict for the record, and for `record` when you want an entry each.
 
+## The root record, `form.record()`
+
+When the schema root is itself a `z.record` (a [dictionary form](/docs/schemas/dictionary-forms)), call `form.record()` with no argument for the root entry view. It hands back the same keyed object of field states, one per entry, for the form's top-level map:
+
+```vue
+<template>
+  <div v-for="(member, id) in form.record()" :key="id">
+    <input v-register="form.register(`${id}.tier`)" type="number" />
+  </div>
+</template>
+```
+
+The no-argument form is available only on a record root; on a fixed-shape object root it is a compile error, the same way the path form requires a record path. See [Dictionary forms](/docs/schemas/dictionary-forms) for the whole-form story.
+
 ## `list` is the array counterpart
 
 For an array, reach for [`list`](/docs/reading-the-form/list), which returns an ordered FieldState array keyed by an allocated identity token that survives reorders. `record` and `list` split cleanly by path type: a record reads through `record`, an array through `list`, and each rejects the other at compile time.
@@ -75,6 +89,7 @@ For an array, reach for [`list`](/docs/reading-the-form/list), which returns an 
 ## Where to next
 
 - [`list`](/docs/reading-the-form/list): the array counterpart, one FieldState per element with reorder-stable keys.
+- [Dictionary forms](/docs/schemas/dictionary-forms): a `z.record` schema as the form root, iterated with the no-argument `form.record()`.
 - [Records & maps](/docs/schemas/records): declaring a `z.record(...)` schema and binding its entries.
 - [`fields`](/docs/reading-the-form/fields): the per-leaf FieldState every entry carries.
 - [`setValue`](/docs/writing-and-mutating/set-value): how an entry joins or leaves the record.

--- a/docs/schemas/dictionary-forms.md
+++ b/docs/schemas/dictionary-forms.md
@@ -1,0 +1,122 @@
+---
+title: Dictionary forms
+description: A z.record schema can be the form root, not just a field. form.values is the dictionary itself, form.record() iterates the entries, and a bare record root defaults to an empty map.
+metaRows:
+  - label: Category
+    value: Schema feature
+  - label: Form root
+    value: z.record(keySchema, valueSchema)
+    kind: code
+  - label: Entry view
+    value: form.record()
+    kind: code
+  - label: Default
+    value: empty map
+---
+
+# Dictionary forms
+
+> When the form _is_ a map, make the map the root. A `z.record` schema at the top level gives you a dictionary form: `form.values` is the map itself, and `form.record()` iterates its entries.
+
+::docs-meta-table
+::
+
+The demo is a team roster keyed by member id. The ids are data you only learn at run time, so the schema root is a `z.record(z.string(), …)`, a string-keyed dictionary of members. The whole form is that map: edit a member, add one, drop one, and watch `form.values` track it below.
+
+::docs-demo{slug="dictionary-forms" label="Dictionary Form Demo"}
+::
+
+## The schema
+
+A dictionary form declares a `z.record` schema as the root, not nested under a key. The key schema constrains what counts as a valid key; the value schema validates each entry:
+
+```ts
+import { useForm } from 'attaform/zod'
+import { z } from 'zod'
+
+const schema = z.record(
+  z.string(),
+  z.object({ role: z.enum(['admin', 'editor', 'viewer']), tier: z.number() })
+)
+
+const form = useForm({ schema })
+```
+
+There is no wrapper key. `form.values` reads as `Record<string, { role: 'admin' | 'editor' | 'viewer'; tier: number }>`, the map itself.
+
+## `form.values` is the dictionary
+
+Because the record is the root, `form.values` is the whole map, and entries bind through their own key:
+
+```ts
+form.values() // the whole map: Record<string, { role; tier }>
+form.values()['ada'] // one entry, or undefined
+form.register('ada.role') // bind an entry sub-field
+form.errors['ada']?.['tier'] // ValidationError[] for that entry's tier
+```
+
+The `| undefined` on an entry read comes from `noUncheckedIndexedAccess`, the same way a record field reads anywhere else. Reach for `??` defaults at the call site when you need one.
+
+## Iterating with `form.record()`
+
+`form.record()` with no argument is the root entry view: one [`FieldState`](/docs/reading-the-form/fields) per entry, keyed by the entry's own key. It is the root counterpart of [`form.record(path)`](/docs/reading-the-form/record), which views a nested record. The keys come from the form, so you render whatever entries exist without keeping a parallel list of your own:
+
+```vue
+<template>
+  <div v-for="(member, id) in form.record()" :key="id">
+    <label>{{ id }}</label>
+    <input v-register="form.register(`${id}.tier`)" type="number" />
+    <small v-if="member.showErrors">{{ member.firstError?.message }}</small>
+  </div>
+</template>
+```
+
+Each `member` is a live `FieldState`, the same surface [`form.fields`](/docs/reading-the-form/fields) exposes, so every read stays current as the user types. Binding still flows through [`form.register`](/docs/binding-inputs/v-register) with the entry path, which the key supplies.
+
+## Adding, editing, and removing entries
+
+A dictionary form carries its own keys, so you grow and shrink it through [`setValue`](/docs/writing-and-mutating/set-value). Editing and adding are ordinary path writes:
+
+```ts
+form.setValue('ada.tier', 4) // edit one entry's field
+form.setValue('mae', { role: 'viewer', tier: 1 }) // add a key that isn't there yet
+```
+
+Removing is the one case the root changes. A nested record drops a key by rewriting its container path; a record root has no container path, so you rewrite the form itself. Passing a single argument to `setValue` is a whole-form write, and for a dictionary form the whole form is the map:
+
+```ts
+const next = { ...form.values() }
+delete next['ada']
+form.setValue(next) // write the map back without that key
+```
+
+Surviving entries keep their field states and component instances across the write; only the dropped row unmounts.
+
+## Defaults
+
+A bare record root defaults to an empty map, ready to grow:
+
+```ts
+const form = useForm({ schema })
+form.values() // {}
+```
+
+Seed initial entries with `defaultValues`, the same shape as the form value:
+
+```ts
+const form = useForm({
+  schema,
+  defaultValues: { ada: { role: 'admin', tier: 3 } },
+})
+```
+
+## When the keys are fixed, reach for an object
+
+Dictionary forms are for keys you learn at run time. When the keys are known at schema-write time, a `z.object` root is the better fit: fixed keys, a distinct type per field, and compile-time autocomplete on each one. The two compose freely. An object form can hold a `z.record` field (see [Records & maps](/docs/schemas/records)), and a dictionary form's value schema can be any Zod schema, including objects, arrays, and nested records.
+
+## Where to next
+
+- [Records & maps](/docs/schemas/records): `z.record` as a field inside an object form, plus the `z.map` primitive.
+- [`record`](/docs/reading-the-form/record): the entry view, `form.record(path)` for a nested record and `form.record()` for the root.
+- [`setValue`](/docs/writing-and-mutating/set-value): the writes that grow, edit, and shrink a dictionary.
+- [Nested objects](/docs/schemas/nested-objects): fixed-shape composition, the alternative when the keys are known.

--- a/docs/schemas/records.md
+++ b/docs/schemas/records.md
@@ -155,8 +155,11 @@ The aggregate `form.meta.errors` flattens every entry's errors into one list, in
 - **`z.map(K, V)`**: when you need `Map`'s insertion order, non-string keys, or structured-clone fidelity for IndexedDB persistence.
 - **`z.object({ … })`**: when the keys are fixed and known at schema-write time. Records are for the dynamic case.
 
+When the record is the entire form rather than a field inside one, reach for a [dictionary form](/docs/schemas/dictionary-forms): the `z.record` becomes the schema root, `form.values` is the map itself, and `form.record()` iterates it.
+
 ## Where to next
 
+- [Dictionary forms](/docs/schemas/dictionary-forms): a `z.record` schema as the form root, not just a field inside an object.
 - [Arrays & tuples](/docs/schemas/arrays-and-tuples): numeric-keyed sequences; the other half of the "many-items" picture.
 - [Nested objects](/docs/schemas/nested-objects): fixed-shape composition; the alternative when keys are known.
 - [`unset`, the blank-anywhere sentinel](/docs/writing-and-mutating/unset): how to flag a single record entry blank, or wipe the whole record back to `{}`.

--- a/src/runtime/adapters/unified/types-projections.ts
+++ b/src/runtime/adapters/unified/types-projections.ts
@@ -15,19 +15,21 @@ import type { z } from 'zod'
 import type { z as zV3 } from 'zod-v3'
 import type { StorageShape as StorageShapeV4 } from '../zod-v4/types-storage-shape'
 import type { StorageShape as StorageShapeV3 } from '../zod-v3/types-storage-shape'
-import type { UnwrapZodObject } from '../zod-v3/types-zod-adapter'
+import type { UnwrapZodRoot } from '../zod-v3/types-zod-adapter'
+import type { SupportedRootSchema as SupportedRootSchemaV4 } from '../zod-v4/types-root'
+import type { SupportedRootSchema as SupportedRootSchemaV3 } from '../zod-v3/types-root'
 import type { GenericForm } from '../../types/types-core'
 
-export type V4FormOf<S extends z.ZodObject> = z.input<S> extends GenericForm ? z.input<S> : never
-export type V4OutOf<S extends z.ZodObject> = z.output<S> extends GenericForm ? z.output<S> : never
-export type V4ReadOf<S extends z.ZodObject> =
+export type V4FormOf<S extends SupportedRootSchemaV4> =
+  z.input<S> extends GenericForm ? z.input<S> : never
+export type V4OutOf<S extends SupportedRootSchemaV4> =
+  z.output<S> extends GenericForm ? z.output<S> : never
+export type V4ReadOf<S extends SupportedRootSchemaV4> =
   StorageShapeV4<S> extends GenericForm ? StorageShapeV4<S> : never
 
-export type V3FormOf<S extends zV3.ZodObject<zV3.ZodRawShape>> =
-  zV3.input<UnwrapZodObject<S>> extends GenericForm ? zV3.input<UnwrapZodObject<S>> : never
-export type V3OutOf<S extends zV3.ZodObject<zV3.ZodRawShape>> =
-  zV3.output<UnwrapZodObject<S>> extends GenericForm ? zV3.output<UnwrapZodObject<S>> : never
-export type V3ReadOf<S extends zV3.ZodObject<zV3.ZodRawShape>> =
-  StorageShapeV3<UnwrapZodObject<S>> extends GenericForm
-    ? StorageShapeV3<UnwrapZodObject<S>>
-    : never
+export type V3FormOf<S extends SupportedRootSchemaV3> =
+  zV3.input<UnwrapZodRoot<S>> extends GenericForm ? zV3.input<UnwrapZodRoot<S>> : never
+export type V3OutOf<S extends SupportedRootSchemaV3> =
+  zV3.output<UnwrapZodRoot<S>> extends GenericForm ? zV3.output<UnwrapZodRoot<S>> : never
+export type V3ReadOf<S extends SupportedRootSchemaV3> =
+  StorageShapeV3<UnwrapZodRoot<S>> extends GenericForm ? StorageShapeV3<UnwrapZodRoot<S>> : never

--- a/src/runtime/adapters/unified/use-form.ts
+++ b/src/runtime/adapters/unified/use-form.ts
@@ -31,8 +31,6 @@
  * those subpaths are never rewritten and never load the other
  * adapter.
  */
-import type { z } from 'zod'
-import type { z as zV3 } from 'zod-v3'
 import { InvalidUseFormConfigError } from '../../core/errors'
 import { isZodV4SchemaShape } from '../../core/zod-shape'
 import type { ZodV4Internals } from './types-zod-major'
@@ -46,6 +44,8 @@ import type {
   UseFormConfiguration,
 } from '../../types/types-api'
 import type { DefaultValuesInput } from '../../types/types-core'
+import type { SupportedRootSchema as SupportedRootSchemaV4 } from '../zod-v4/types-root'
+import type { SupportedRootSchema as SupportedRootSchemaV3 } from '../zod-v3/types-root'
 import type { V3FormOf, V3OutOf, V3ReadOf, V4FormOf, V4OutOf, V4ReadOf } from './types-projections'
 
 /**
@@ -69,7 +69,7 @@ import type { V3FormOf, V3OutOf, V3ReadOf, V4FormOf, V4OutOf, V4ReadOf } from '.
  * through to the v3 overload below. See `types-zod-major.ts`.
  */
 export function useForm<
-  Schema extends z.ZodObject<z.ZodRawShape> & ZodV4Internals,
+  Schema extends SupportedRootSchemaV4 & ZodV4Internals,
   K extends FormKey = FormKey,
 >(
   configuration: Omit<
@@ -101,7 +101,7 @@ export function useForm<
  * v3 schemas match this overload; v4 schemas hit the v4 overload
  * above first and never reach here.
  */
-export function useForm<Schema extends zV3.ZodObject<zV3.ZodRawShape>, K extends FormKey = FormKey>(
+export function useForm<Schema extends SupportedRootSchemaV3, K extends FormKey = FormKey>(
   configuration: Omit<
     UseFormConfiguration<
       V3FormOf<Schema>,

--- a/src/runtime/adapters/zod-v3/index.ts
+++ b/src/runtime/adapters/zod-v3/index.ts
@@ -125,14 +125,15 @@ import { V3_INTROSPECTOR } from './walker-introspector'
 let warnedZodCodeMissing = false
 
 /**
- * Wrap a Zod v3 `ZodObject` schema in an `AbstractSchema` factory.
+ * Wrap a Zod v3 form-root schema (`ZodObject` or `ZodRecord`) in an
+ * `AbstractSchema` factory.
  *
  * Most consumers never call this directly — `useForm` from
  * `attaform/zod-v3` does the wrapping automatically. Reach
  * for it only when integrating with a custom code path that needs
  * the adapter outside of `useForm`.
  *
- * Throws if the underlying schema isn't a `ZodObject`.
+ * Throws if the underlying schema isn't a supported form root.
  */
 export function zodAdapter<
   FormSchema extends z.ZodSchema,
@@ -154,9 +155,15 @@ export function zodAdapter<
     stripZodEffects: true,
     stripZodRefinements: true,
   })
-  if (!isZodSchemaType(_strippedRoot, 'ZodObject')) {
+  if (
+    !isZodSchemaType(_strippedRoot, 'ZodObject') &&
+    !isZodSchemaType(_strippedRoot, 'ZodRecord')
+  ) {
     const name = getTypeName(_strippedRoot)
-    throw new Error(`ZodAdapter: expected ZodObject, got ${name}`)
+    throw new Error(
+      `Attaform: useForm schema root must be a ZodObject or ZodRecord (got ${name}). ` +
+        `Wrap other shapes under a key.`
+    )
   }
 
   // `options.maxRecursionDepth` caps `z.lazy(...)` descent in

--- a/src/runtime/adapters/zod-v3/types-root.ts
+++ b/src/runtime/adapters/zod-v3/types-root.ts
@@ -1,0 +1,17 @@
+import type { z } from 'zod-v3'
+
+/**
+ * The Zod v3 schema roots `useForm` accepts. Mirror of the v4
+ * `SupportedRootSchema`, expressed in v3's type vocabulary: a
+ * fixed-shape `z.object({ … })` or a `z.record(K, V)` dictionary form.
+ *
+ * Other roots (a bare `z.union`, a root `z.array`, primitives,
+ * `z.map` / `z.set`) are not form roots; wrap them under a key. The
+ * adapter's runtime construction rejects them with a legible error.
+ *
+ * Widened per feature: the discriminated-union arm lands alongside its
+ * runtime support.
+ */
+export type SupportedRootSchema =
+  | z.ZodObject<z.ZodRawShape>
+  | z.ZodRecord<z.ZodTypeAny, z.ZodTypeAny>

--- a/src/runtime/adapters/zod-v3/types-zod-adapter.ts
+++ b/src/runtime/adapters/zod-v3/types-zod-adapter.ts
@@ -2,21 +2,26 @@ import type { z } from 'zod-v3'
 
 /**
  * Peel `.optional()` / `.nullable()` / `.default()` / `.refine()` /
- * `.transform()` wrappers off a Zod v3 schema to reach the inner
- * `ZodObject`. Returns `never` if no `ZodObject` is found.
+ * `.transform()` wrappers off a Zod v3 schema to reach the form root,
+ * then return it: a `ZodObject` (fixed-shape form) or a `ZodRecord`
+ * (dictionary form). Returns `never` for any other root, which makes
+ * the `useForm` projections collapse to `never` so the call fails to
+ * typecheck rather than producing a misshapen form type.
  *
- * Used internally by the v3 `useForm` overload to verify the
- * supplied schema bottoms out at a `ZodObject`.
+ * Used internally by the v3 `useForm` overload to project an arbitrary
+ * supported root to its input / output / storage-read shapes.
  */
-export type UnwrapZodObject<T> =
+export type UnwrapZodRoot<T> =
   T extends z.ZodEffects<infer Inner>
-    ? UnwrapZodObject<Inner>
+    ? UnwrapZodRoot<Inner>
     : T extends z.ZodOptional<infer Inner>
-      ? UnwrapZodObject<Inner>
+      ? UnwrapZodRoot<Inner>
       : T extends z.ZodNullable<infer Inner>
-        ? UnwrapZodObject<Inner>
+        ? UnwrapZodRoot<Inner>
         : T extends z.ZodDefault<infer Inner>
-          ? UnwrapZodObject<Inner>
+          ? UnwrapZodRoot<Inner>
           : T extends z.ZodObject<infer Shape>
             ? z.ZodObject<Shape>
-            : never
+            : T extends z.ZodRecord<infer Key, infer Value>
+              ? z.ZodRecord<Key, Value>
+              : never

--- a/src/runtime/adapters/zod-v4/adapter.ts
+++ b/src/runtime/adapters/zod-v4/adapter.ts
@@ -19,6 +19,7 @@ import { assertSupportedKinds } from './assert-supported'
 import { unwrapToDiscriminatedUnion } from './discriminator'
 import { zodIssuesToValidationErrors } from './errors'
 import { deriveDefault, getDefaultValuesFromZodSchema } from './default-values'
+import type { SupportedRootSchema } from './types-root'
 import {
   assertZodVersion,
   containsAsyncRefine,
@@ -240,7 +241,7 @@ function isLeafRequired(schema: z.ZodType, depth = 0): boolean {
  * descent via `maxRecursionDepth`.
  */
 export function zodV4Adapter<
-  FormSchema extends z.ZodObject,
+  FormSchema extends SupportedRootSchema,
   Form extends z.input<FormSchema>,
   GetValueFormType extends z.output<FormSchema> = z.output<FormSchema>,
 >(
@@ -356,7 +357,7 @@ function runStrictGetDefaultsV4<Form>(
   maxRecursionDepth: number
 ): DefaultValuesResponse<Form> {
   const { data } = getDefaultValuesFromZodSchema<Form>({
-    schema: rootSchema as unknown as z.ZodObject,
+    schema: rootSchema,
     useDefaultSchemaValues: config.useDefaultSchemaValues,
     constraints: config.constraints,
     maxRecursionDepth,

--- a/src/runtime/adapters/zod-v4/default-values.ts
+++ b/src/runtime/adapters/zod-v4/default-values.ts
@@ -60,7 +60,10 @@ export function deriveDefault(
 // internal callers (the v4 strict-mode flow still consults it).
 
 export type GetDefaultValuesOptions = {
-  schema: z.ZodObject
+  // `z.ZodType`, not `z.ZodObject`: the derivation walk is generic over
+  // the root kind (object, record, discriminated-union), and the
+  // algorithm bottoms out at `deriveDefault` which handles each.
+  schema: z.ZodType
   useDefaultSchemaValues: boolean
   constraints: unknown
   maxRecursionDepth: number

--- a/src/runtime/adapters/zod-v4/index.ts
+++ b/src/runtime/adapters/zod-v4/index.ts
@@ -17,6 +17,7 @@ import type {
 import type { DefaultValuesInput, FlatPath, GenericForm, NestedType } from '../../types/types-core'
 import { zodV4Adapter } from './adapter'
 import type { StorageShape } from './types-storage-shape'
+import type { SupportedRootSchema } from './types-root'
 
 export { zodV4Adapter as zodAdapter } from './adapter'
 export { UnsupportedSchemaError } from './errors'
@@ -98,14 +99,14 @@ export type PathOutput<Schema extends z.ZodType, Path extends string> =
  * generics ride on the alias rather than re-evaluating the
  * conditional from scratch.
  */
-type FormOf<Schema extends z.ZodObject> =
+type FormOf<Schema extends SupportedRootSchema> =
   z.input<Schema> extends GenericForm ? z.input<Schema> : never
-type OutOf<Schema extends z.ZodObject> =
+type OutOf<Schema extends SupportedRootSchema> =
   z.output<Schema> extends GenericForm ? z.output<Schema> : never
-type ReadOf<Schema extends z.ZodObject> =
+type ReadOf<Schema extends SupportedRootSchema> =
   StorageShape<Schema> extends GenericForm ? StorageShape<Schema> : never
 
-export function useForm<Schema extends z.ZodObject, K extends FormKey = FormKey>(
+export function useForm<Schema extends SupportedRootSchema, K extends FormKey = FormKey>(
   configuration: Omit<
     UseFormConfiguration<
       FormOf<Schema>,

--- a/src/runtime/adapters/zod-v4/types-root.ts
+++ b/src/runtime/adapters/zod-v4/types-root.ts
@@ -15,5 +15,16 @@ import type { z } from 'zod'
  * Widened per feature: the discriminated-union arm
  * (`z.discriminatedUnion`, variant forms) lands alongside its runtime
  * support.
+ *
+ * `z.ZodObject` MUST keep its `z.ZodRawShape` argument. The unified
+ * entry's v4 overload constrains on `SupportedRootSchema & ZodV4Internals`
+ * to keep v3 schemas out (see `../unified/types-zod-major.ts`). In a
+ * single-major (v3-only) consumer install, the published `.d.mts`
+ * resolves this `z` to v3, where bare `z.ZodObject` is missing its
+ * required shape argument and degrades to an `any`-like error type;
+ * `any` then absorbs the union and `any & ZodV4Internals` collapses back
+ * to `any`, so the marker stops excluding v3 schemas and the read slot
+ * poisons to `never`. `z.ZodRecord` carries defaults for both arguments,
+ * so it stays a concrete type in either major.
  */
-export type SupportedRootSchema = z.ZodObject | z.ZodRecord
+export type SupportedRootSchema = z.ZodObject<z.ZodRawShape> | z.ZodRecord

--- a/src/runtime/adapters/zod-v4/types-root.ts
+++ b/src/runtime/adapters/zod-v4/types-root.ts
@@ -1,0 +1,19 @@
+import type { z } from 'zod'
+
+/**
+ * The Zod v4 schema roots `useForm` accepts. A fixed-shape
+ * `z.object({ … })` is the common case; `z.record(K, V)` admits a
+ * dictionary form (a homogeneous map with runtime-known keys). Both
+ * project to a `GenericForm`-shaped value the form engine drives — an
+ * object root descends into its fixed keys, a record root treats its
+ * entries as an open, live-keyed container.
+ *
+ * Other roots (a bare `z.union`, a root `z.array`, primitives,
+ * `z.map` / `z.set`) are not form roots; wrap them under a key. The
+ * adapter's runtime construction rejects them with a legible error.
+ *
+ * Widened per feature: the discriminated-union arm
+ * (`z.discriminatedUnion`, variant forms) lands alongside its runtime
+ * support.
+ */
+export type SupportedRootSchema = z.ZodObject | z.ZodRecord

--- a/src/runtime/composables/use-form.ts
+++ b/src/runtime/composables/use-form.ts
@@ -9,7 +9,8 @@ import type {
   ValidateOnConfig,
 } from '../types/types-api'
 import type { DefaultValuesInput, GenericForm } from '../types/types-core'
-import type { UnwrapZodObject } from '../adapters/zod-v3/types-zod-adapter'
+import type { UnwrapZodRoot } from '../adapters/zod-v3/types-zod-adapter'
+import type { SupportedRootSchema } from '../adapters/zod-v3/types-root'
 import type { StorageShape } from '../adapters/zod-v3/types-storage-shape'
 import { useAbstractForm } from './use-abstract-form'
 
@@ -24,13 +25,13 @@ import { useAbstractForm } from './use-abstract-form'
  * the v4 adapter's own `FormOf`/`OutOf`/`ReadOf` aliases verbatim so
  * v3 and v4 carry the same per-call depth cost.
  */
-type FormOf<Schema extends z.ZodObject<z.ZodRawShape>> =
-  z.input<UnwrapZodObject<Schema>> extends GenericForm ? z.input<UnwrapZodObject<Schema>> : never
-type OutOf<Schema extends z.ZodObject<z.ZodRawShape>> =
-  z.output<UnwrapZodObject<Schema>> extends GenericForm ? z.output<UnwrapZodObject<Schema>> : never
-type ReadOf<Schema extends z.ZodObject<z.ZodRawShape>> =
-  StorageShape<UnwrapZodObject<Schema>> extends GenericForm
-    ? StorageShape<UnwrapZodObject<Schema>>
+type FormOf<Schema extends SupportedRootSchema> =
+  z.input<UnwrapZodRoot<Schema>> extends GenericForm ? z.input<UnwrapZodRoot<Schema>> : never
+type OutOf<Schema extends SupportedRootSchema> =
+  z.output<UnwrapZodRoot<Schema>> extends GenericForm ? z.output<UnwrapZodRoot<Schema>> : never
+type ReadOf<Schema extends SupportedRootSchema> =
+  StorageShape<UnwrapZodRoot<Schema>> extends GenericForm
+    ? StorageShape<UnwrapZodRoot<Schema>>
     : never
 
 /**
@@ -83,7 +84,7 @@ export function useForm<
  *
  * For Zod v4, import from `attaform/zod` instead.
  */
-export function useForm<Schema extends z.ZodObject<z.ZodRawShape>, K extends FormKey = FormKey>(
+export function useForm<Schema extends SupportedRootSchema, K extends FormKey = FormKey>(
   configuration: Omit<
     UseFormConfiguration<
       FormOf<Schema>,

--- a/src/runtime/core/abstract-schema-factory.ts
+++ b/src/runtime/core/abstract-schema-factory.ts
@@ -561,8 +561,14 @@ export function createAbstractSchema<Schema, Form, GetValueFormType>(
     },
 
     isFixedObjectAtPath(path) {
-      // Root form is a fixed object — a closed top-level key set.
-      if (path.length === 0) return true
+      // At the root, consult the root schema's own kind. A fixed-shape
+      // object has a closed top-level key set, so the proxy descends
+      // into its declared keys. A record / discriminated-union / array
+      // root is an open container, so the proxy falls back to live keys
+      // (record entries, the active variant's fields) there.
+      if (path.length === 0) {
+        return intro.kindOf(services.peelAllWrappers(rootSchema)) === 'object'
+      }
       const resolved = services.getNestedSchemasAtPath(rootSchema, path, maxRecursionDepth)
       // A path the schema doesn't declare is not a fixed object; the
       // proxy falls back to live keys there.

--- a/src/runtime/core/build-form-api.ts
+++ b/src/runtime/core/build-form-api.ts
@@ -1093,9 +1093,16 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
   // and its keys tracks the key set, so the view recomputes when an entry
   // joins or leaves. The frozen result is read-only; grow or shrink the
   // record through `setValue` at an entry path.
+  //
+  // Called with no argument (`form.record()`) it views the root, for a
+  // dictionary form whose schema root is itself a record. The typed
+  // surface only offers the no-arg form when the root is an open record.
   const EMPTY_FIELD_RECORD: Readonly<Record<string, unknown>> = Object.freeze({})
-  function record(path: string): Readonly<Record<string, unknown>> {
-    const { segments } = canonicalizePath(path)
+  function record(path?: string): Readonly<Record<string, unknown>> {
+    // No argument addresses the form root (a dictionary form whose schema
+    // root is a record). A bare `''` is the literal empty-key path, not
+    // the root, so the root case keys off `undefined`, not a default `''`.
+    const segments = path === undefined ? [] : canonicalizePath(path).segments
     const value = state.getValueAtPath(segments)
     if (value === null || typeof value !== 'object' || Array.isArray(value)) {
       return EMPTY_FIELD_RECORD
@@ -1108,7 +1115,9 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
     // write — `safeAssign` lands it as an own data property here.
     const out: Record<string, unknown> = {}
     for (const key of Object.keys(value as Record<string, unknown>)) {
-      safeAssign(out, key, callTerminal(`${path}.${key}`))
+      // Root (`segments` empty) addresses entries by bare key; a nested
+      // record prefixes the entry path with its own path.
+      safeAssign(out, key, callTerminal(segments.length === 0 ? key : `${path}.${key}`))
     }
     return Object.freeze(out)
   }

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -3433,6 +3433,24 @@ export interface BlankPathsView {
   [Symbol.iterator](): IterableIterator<Path>
 }
 
+/**
+ * The no-arg `form.record()` call form, present only when the form root
+ * is itself an open record (`z.record(K, V)`). `string extends keyof
+ * Form` is the open-keyset probe: true for `Record<string, V>`, false
+ * for a fixed `z.object` shape. On a fixed object this resolves to
+ * `unknown`, which contributes nothing to the intersection in `record`
+ * below, so the no-arg call form simply does not exist there (and
+ * `form.record()` stays a compile error, as it should when the root has
+ * a closed key set). On a record root it mirrors the path-addressed
+ * `record(path)` overload: one `FieldState` per entry, keyed by the
+ * record's own runtime keys.
+ */
+export type RootRecordView<Form> = string extends keyof Form
+  ? Form extends Record<string, infer RootValue>
+    ? () => Readonly<Record<string, FieldState<RootValue>>>
+    : unknown
+  : unknown
+
 export type UseFormReturnType<
   Form extends GenericForm,
   GetValueFormType extends GenericForm = Form,
@@ -4183,10 +4201,22 @@ export type UseFormReturnType<
    * when the key leaves. `form.fields(path)` remains the single
    * aggregated container for the whole record; `record` is the
    * per-entry view.
+   *
+   * When the form root is itself a record (`useForm({ schema:
+   * z.record(K, V) })` — a dictionary form), call `form.record()` with
+   * no argument for the root entry view:
+   *
+   * ```vue
+   * <div v-for="(member, id) in form.record()" :key="id">
+   *   <input v-register="form.register(id)" />
+   *   <p v-if="member.showErrors">{{ member.firstError?.message }}</p>
+   * </div>
+   * ```
    */
-  record: <Path extends RecordPath<Form>>(
-    path: Path
-  ) => Readonly<Record<string, FieldState<RecordValue<Form, Path>>>>
+  record: RootRecordView<Form> &
+    (<Path extends RecordPath<Form>>(
+      path: Path
+    ) => Readonly<Record<string, FieldState<RecordValue<Form, Path>>>>)
   /**
    * Read-only view of the form's blank path set. Reactive — Vue 3.5
    * tracks `.has()` / `for..of` / size accesses, so consumers can drive

--- a/src/zod-v3.ts
+++ b/src/zod-v3.ts
@@ -39,6 +39,6 @@ export type {
   TypeWithNullableDynamicKeys,
   ZodTypeWithInnerType,
 } from './runtime/adapters/zod-v3/types-zod'
-export type { UnwrapZodObject } from './runtime/adapters/zod-v3/types-zod-adapter'
+export type { UnwrapZodRoot } from './runtime/adapters/zod-v3/types-zod-adapter'
 export { fieldMeta, withMeta } from './runtime/adapters/zod-v3/field-meta'
 export type { FieldMetaPayload } from './runtime/core/field-meta'

--- a/test/composables/form-record-root.test.ts
+++ b/test/composables/form-record-root.test.ts
@@ -1,0 +1,205 @@
+// @vitest-environment jsdom
+import { createApp, defineComponent, h } from 'vue'
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import { z as zV3 } from 'zod-v3'
+import { z as zV4 } from 'zod'
+import { useForm as useFormV3 } from '../../src/zod-v3'
+import { useForm as useFormV4 } from '../../src/zod'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import type { FieldState, UseFormReturnType } from '../../src/runtime/types/types-api'
+
+/**
+ * Dictionary forms: a `z.record(K, V)` schema root. The form value is a
+ * homogeneous map keyed by runtime-known keys (a members table keyed by
+ * member id, a settings editor, a tag map). `form.record()` with no
+ * argument is the root entry view, one `FieldState` per entry. zod-v3
+ * and zod-v4 are first-class peers, so the suite runs against both.
+ */
+
+function mountWith<R>(setup: () => R): { api: R; unmount: () => void } {
+  let captured: R | undefined
+  const App = defineComponent({
+    setup() {
+      captured = setup()
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  const root = document.createElement('div')
+  document.body.appendChild(root)
+  app.mount(root)
+  if (captured === undefined) throw new Error('mountWith: setup never returned')
+  return {
+    api: captured,
+    unmount: () => {
+      app.unmount()
+      document.body.removeChild(root)
+    },
+  }
+}
+
+let counter = 0
+const uniqueKey = (prefix: string): string => `frec-root-${prefix}-${(counter += 1)}`
+
+type Member = { role: string; tier: number }
+type RootRecordForm = Record<string, Member>
+
+// `useForm` overloads differ between adapters; the suite only needs the
+// shared runtime surface (`record`, `fields`, `setValue`, `register`).
+type SharedForm = UseFormReturnType<RootRecordForm>
+
+function runRootRecordSuite(
+  label: string,
+  buildForm: (key: string) => { api: SharedForm; unmount: () => void },
+  buildEmpty: (key: string) => { api: SharedForm; unmount: () => void }
+): void {
+  describe(`record root (${label})`, () => {
+    const callFields = (form: SharedForm, path: string): { readonly key: string; value: unknown } =>
+      (form.fields as unknown as (p: string) => { readonly key: string; value: unknown })(path)
+
+    it('exposes one field state per entry, keyed by the entry key', () => {
+      const { api, unmount } = buildForm(uniqueKey('shape'))
+      try {
+        const entries = api.record()
+        expect(Object.keys(entries)).toEqual(['alice', 'bob'])
+        expect(entries['alice']?.value).toEqual({ role: 'admin', tier: 1 })
+        expect(entries['bob']?.value).toEqual({ role: 'member', tier: 2 })
+      } finally {
+        unmount()
+      }
+    })
+
+    it('reads entry sub-fields through the form value surface', () => {
+      const { api, unmount } = buildForm(uniqueKey('read'))
+      try {
+        expect(api.values()['alice']?.role).toBe('admin')
+      } finally {
+        unmount()
+      }
+    })
+
+    it('root entries are the same field states the fields call form returns', () => {
+      const { api, unmount } = buildForm(uniqueKey('same'))
+      try {
+        expect(api.record()['alice']).toBe(callFields(api, 'alice'))
+      } finally {
+        unmount()
+      }
+    })
+
+    it('grows when an entry is added via setValue', () => {
+      const { api, unmount } = buildForm(uniqueKey('grow'))
+      try {
+        api.setValue('carol', { role: 'member', tier: 3 })
+        const entries = api.record()
+        expect(Object.keys(entries)).toEqual(['alice', 'bob', 'carol'])
+        expect(entries['carol']?.value).toEqual({ role: 'member', tier: 3 })
+      } finally {
+        unmount()
+      }
+    })
+
+    it('updates an entry sub-field through a dotted path', () => {
+      const { api, unmount } = buildForm(uniqueKey('subfield'))
+      try {
+        api.setValue('alice.role', 'owner')
+        expect(api.record()['alice']?.value).toEqual({ role: 'owner', tier: 1 })
+      } finally {
+        unmount()
+      }
+    })
+
+    it('defaults a bare record root to an empty map', () => {
+      const { api, unmount } = buildEmpty(uniqueKey('empty'))
+      try {
+        expect(api.values()).toEqual({})
+        expect(Object.keys(api.record())).toEqual([])
+      } finally {
+        unmount()
+      }
+    })
+
+    it('is a frozen, read-only object', () => {
+      const { api, unmount } = buildForm(uniqueKey('frozen'))
+      try {
+        expect(Object.isFrozen(api.record())).toBe(true)
+      } finally {
+        unmount()
+      }
+    })
+  })
+}
+
+runRootRecordSuite(
+  'zod-v4',
+  (key) =>
+    mountWith(() =>
+      useFormV4({
+        schema: zV4.record(zV4.string(), zV4.object({ role: zV4.string(), tier: zV4.number() })),
+        defaultValues: { alice: { role: 'admin', tier: 1 }, bob: { role: 'member', tier: 2 } },
+        key,
+      })
+    ) as { api: SharedForm; unmount: () => void },
+  (key) =>
+    mountWith(() =>
+      useFormV4({
+        schema: zV4.record(zV4.string(), zV4.object({ role: zV4.string(), tier: zV4.number() })),
+        key,
+      })
+    ) as { api: SharedForm; unmount: () => void }
+)
+
+runRootRecordSuite(
+  'zod-v3',
+  (key) =>
+    mountWith(() =>
+      useFormV3({
+        schema: zV3.record(zV3.string(), zV3.object({ role: zV3.string(), tier: zV3.number() })),
+        defaultValues: { alice: { role: 'admin', tier: 1 }, bob: { role: 'member', tier: 2 } },
+        key,
+      })
+    ) as { api: SharedForm; unmount: () => void },
+  (key) =>
+    mountWith(() =>
+      useFormV3({
+        schema: zV3.record(zV3.string(), zV3.object({ role: zV3.string(), tier: zV3.number() })),
+        key,
+      })
+    ) as { api: SharedForm; unmount: () => void }
+)
+
+describe('record root typing', () => {
+  it('offers the no-arg record() view and rejects path-addressed entries', () => {
+    const { api, unmount } = mountWith(() =>
+      useFormV4({
+        schema: zV4.record(zV4.string(), zV4.object({ role: zV4.string(), tier: zV4.number() })),
+        defaultValues: { alice: { role: 'admin', tier: 1 } },
+        key: uniqueKey('types'),
+      })
+    )
+    try {
+      expectTypeOf(api.record()).toEqualTypeOf<
+        Readonly<Record<string, FieldState<{ role: string; tier: number }>>>
+      >()
+      // @ts-expect-error a record root is viewed at the root; entries are not record paths
+      api.record('alice')
+    } finally {
+      unmount()
+    }
+  })
+
+  it('rejects the no-arg record() view on a fixed-object root', () => {
+    const { api, unmount } = mountWith(() =>
+      useFormV4({
+        schema: zV4.object({ title: zV4.string() }),
+        key: uniqueKey('fixed'),
+      })
+    )
+    try {
+      // @ts-expect-error a fixed-object root has no no-arg record() view
+      api.record()
+    } finally {
+      unmount()
+    }
+  })
+})

--- a/test/docs-demos/docs-demos-smoke.test.ts
+++ b/test/docs-demos/docs-demos-smoke.test.ts
@@ -657,6 +657,28 @@ const entries: SmokeEntry[] = [
       expect(tokens).toContain('NewAthlete')
     },
   },
+  {
+    // Record-root form: the whole schema is a `z.record`. Type a new
+    // member id and click the "form.setValue(id, …)" button; the demo's
+    // `addMember` writes a new root key and a row joins the no-arg
+    // `form.record()` view.
+    slug: 'dictionary-forms',
+    gesture: async (root) => {
+      const addInput = root.querySelector<HTMLInputElement>('.actions input')
+      if (!addInput) throw new Error('add-member input not found')
+      await dispatchInput(addInput, 'mae')
+      const addButton = root.querySelector<HTMLButtonElement>('.actions button')
+      if (!addButton) throw new Error('add-member button not found')
+      addButton.click()
+      await nextTick()
+    },
+    assert: async (root) => {
+      const tokens = Array.from(root.querySelectorAll<HTMLElement>('.token')).map(
+        (t) => t.textContent ?? ''
+      )
+      expect(tokens).toContain('mae')
+    },
+  },
 
   // ─── PHASE 2: READING STATE ───────────────────────────────────
   {

--- a/tests/fixtures/bundled-types-v3/consumer.ts
+++ b/tests/fixtures/bundled-types-v3/consumer.ts
@@ -52,4 +52,16 @@ form.handleSubmit((data) => {
   void data
 })
 
-export { form }
+// Record-root form — a `z.record` schema as the root (dictionary form),
+// the new surface this guards. Same single-major hazard as the object
+// root: the v4 overload must not greedily match this v3 record, or the
+// read slot collapses to `never`. The `z.ZodRecord` arm of the v4
+// SupportedRootSchema carries argument defaults, so it stays a concrete
+// type; this pins that it keeps discriminating in a one-major install.
+const rosterSchema = z.record(z.string(), z.object({ tier: z.number() }))
+const roster = useForm({ schema: rosterSchema, key: 'roster-v3' })
+
+// Read slot must resolve to the record map (not `never`, not `any`).
+type _RosterEntry = Expect<Equal<ReturnType<typeof roster.values>['member-1'], { tier: number }>>
+
+export { form, roster }


### PR DESCRIPTION
## What

`useForm` now accepts a `z.record(K, V)` schema at the **root**, not just nested under a key. The whole form is the dictionary: `form.values` is the map itself, `form.register('ada.role')` binds an entry field, and a new no-arg `form.record()` hands back the root entry view (one `FieldState` per key). A bare record root defaults to `{}`.

This is the **dictionary form** shape: a homogeneous map keyed at run time (a members table keyed by id, a settings editor, a tag map). Resolves the record-root half of #393; the discriminated-union root follows in a second PR.

## Why it's small

The path walker already treats records as interior nodes, so this **un-gates existing capability at the root** rather than building a subsystem. The work is widening the type bound and teaching a few runtime sites that the root is no longer always a fixed object.

## Changes

- **Type bound:** `z.ZodObject` -> a `SupportedRootSchema` alias (`z.ZodObject | z.ZodRecord`) across the unified entry overloads + projections, both direct entries, and the zod-v4 adapter factory. Internal alias files centralise it, so PR2's DU arm is a one-line add per major.
- **Public type rename:** `UnwrapZodObject` -> `UnwrapZodRoot` (exported from `attaform/zod-v3`). It now peels to a `ZodObject` *or* a `ZodRecord` root, so the old name no longer fit. :warning: the one public-surface change in this PR.
- **Runtime:** `isFixedObjectAtPath` consults the root schema kind instead of assuming a fixed object; default-derivation typing widened to `z.ZodType` (record root defaults to `{}`); the v3 adapter's root-kind throw names the supported roots and accepts records.
- **API:** no-arg `form.record()` root overload, gated on the open-keyset probe so it stays a compile error on fixed-object roots.
- **Docs:** dedicated "Dictionary forms" page + team-roster demo, the no-arg `form.record()` overload on the `record` page, cross-links from "Records & maps".

Additive: object-rooted forms behave exactly as before. zod v3 / zod v4 at parity, covered by a dual-adapter suite.

## Verification

- `pnpm typecheck` (covers `test/**`, no TS2589) and `pnpm lint` clean
- Library suite v3 + v4: 4182 passed, 2 skipped (+16 root-record tests)
- `size-limit` / `check:eager` within existing caps (0.47 kB eager headroom)
- `check:site` + full `nuxi build`: the page and the SSR demo route both prerender; nuxt-link-checker 0 errors / 0 warnings across 183 pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
