### PR TITLE
feat(form): z.discriminatedUnion schema roots (variant forms)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@
   and zod v4 both get it, both tested, and object-rooted forms behave exactly as
   before. (#421)
 
+- **A `z.discriminatedUnion` schema can now be the whole form, not just a field
+  inside one.** `useForm({ schema: z.discriminatedUnion('method', […]) })` is a
+  variant form: `form.values` reads the active variant at the top level,
+  `form.register('cardNumber')` binds a variant field by its own key, and writing
+  the discriminator reshapes the whole form to the chosen variant, old keys
+  purged and new keys seeded, with variant memory on by default. The parsed value
+  inside `handleSubmit` narrows to the active variant. zod v3 and zod v4 both get
+  it, both tested, and object-rooted forms behave exactly as before. (#423)
+
 ## v0.23.0
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
   the discriminator reshapes the whole form to the chosen variant, old keys
   purged and new keys seeded, with variant memory on by default. The parsed value
   inside `handleSubmit` narrows to the active variant. zod v3 and zod v4 both get
-  it, both tested, and object-rooted forms behave exactly as before. (#423)
+  it, both tested, and object-rooted forms behave exactly as before. (#424)
 
 ## v0.23.0
 ### Removed

--- a/apps/site/composables/useDocsNavigation.ts
+++ b/apps/site/composables/useDocsNavigation.ts
@@ -59,6 +59,7 @@ export const docsNavigation: DocsSection[] = [
       { title: 'How values are stored', to: '/docs/schemas/storage-shape' },
       { title: 'Optional, nullable, defaulted', to: '/docs/schemas/optional-nullable' },
       { title: 'Discriminated unions', to: '/docs/schemas/discriminated-unions' },
+      { title: 'Variant forms', to: '/docs/schemas/variant-forms' },
       { title: 'Arrays & tuples', to: '/docs/schemas/arrays-and-tuples' },
       { title: 'Records & maps', to: '/docs/schemas/records' },
       { title: 'Dictionary forms', to: '/docs/schemas/dictionary-forms' },

--- a/apps/site/docs-demos/variant-forms/App.vue
+++ b/apps/site/docs-demos/variant-forms/App.vue
@@ -1,0 +1,107 @@
+<script setup lang="ts">
+  import { useForm } from 'attaform/zod'
+  import { z } from 'zod'
+  import './styles.css'
+
+  const schema = z.discriminatedUnion('method', [
+    z.object({
+      method: z.literal('card'),
+      cardNumber: z.string().min(12, 'Enter a valid card number'),
+      cvc: z.string().min(3, '3 or 4 digits'),
+    }),
+    z.object({
+      method: z.literal('bank'),
+      iban: z.string().min(15, 'Enter a valid IBAN'),
+    }),
+    z.object({
+      method: z.literal('invoice'),
+      poNumber: z.string().min(1, 'Purchase order required'),
+      netDays: z.number().min(1, 'At least 1 day').max(90, 'At most 90 days'),
+    }),
+  ])
+
+  const form = useForm({
+    schema,
+    defaultValues: { method: 'card', cardNumber: '', cvc: '' },
+    key: 'docs-demo-variant-forms',
+  })
+
+  const onSubmit = form.handleSubmit(async (payment) => {
+    toast.success(`Paying by ${payment.method}`, { description: payment })
+  })
+</script>
+
+<template>
+  <form class="demo" @submit.prevent="onSubmit">
+    <label>
+      Payment method
+      <select v-register="form.register('method')">
+        <option value="card">Card</option>
+        <option value="bank">Bank transfer</option>
+        <option value="invoice">Invoice</option>
+      </select>
+    </label>
+
+    <template v-if="form.values.method === 'card'">
+      <label>
+        Card number
+        <input
+          v-register="form.register('cardNumber')"
+          inputmode="numeric"
+          placeholder="4242 4242 4242 4242"
+        />
+        <em v-if="form.fields.cardNumber?.showErrors">{{
+          form.fields.cardNumber?.firstError?.message
+        }}</em>
+      </label>
+      <label>
+        CVC
+        <input v-register="form.register('cvc')" inputmode="numeric" placeholder="123" />
+        <em v-if="form.fields.cvc?.showErrors">{{ form.fields.cvc?.firstError?.message }}</em>
+      </label>
+    </template>
+
+    <template v-else-if="form.values.method === 'bank'">
+      <label>
+        IBAN
+        <input v-register="form.register('iban')" placeholder="GB29 NWBK 6016 1331 9268 19" />
+        <em v-if="form.fields.iban?.showErrors">{{ form.fields.iban?.firstError?.message }}</em>
+      </label>
+    </template>
+
+    <template v-else-if="form.values.method === 'invoice'">
+      <label>
+        Purchase order
+        <input v-register="form.register('poNumber')" placeholder="PO-12345" />
+        <em v-if="form.fields.poNumber?.showErrors">{{
+          form.fields.poNumber?.firstError?.message
+        }}</em>
+      </label>
+      <label>
+        Net payment days
+        <input v-register="form.register('netDays')" type="number" min="1" max="90" />
+        <em v-if="form.fields.netDays?.showErrors">{{
+          form.fields.netDays?.firstError?.message
+        }}</em>
+      </label>
+    </template>
+
+    <button type="submit">Pay</button>
+
+    <pre>{{ JSON.stringify(form.values(), null, 2) }}</pre>
+
+    <p class="hint">
+      The whole form is one <code>z.discriminatedUnion</code>. Switching the method reshapes storage
+      to the chosen variant: the previous variant's keys are purged and the new variant's keys are
+      seeded. Refill a variant you visited before and the values come back, that is
+      <a href="/docs/writing-and-mutating/variant-memory">variant memory</a>.
+    </p>
+  </form>
+</template>
+
+<style scoped>
+  a {
+    color: var(--color-accent);
+    text-decoration: underline;
+  }
+</style>

--- a/apps/site/docs-demos/variant-forms/styles.json
+++ b/apps/site/docs-demos/variant-forms/styles.json
@@ -1,0 +1,1 @@
+{ "with": ["label", "input", "select", "button", "error", "hint", "code", "pre"] }

--- a/docs/schemas/discriminated-unions.md
+++ b/docs/schemas/discriminated-unions.md
@@ -117,8 +117,11 @@ The form-level `form.meta.errors` aggregate is **NOT** variant-filtered; errors 
 
 If the user types a discriminator value that doesn't match any variant (`channel: 'fax'` against `'email' | 'sms' | 'push'`), the reshape is skipped; the variant fields stay as they were, and the schema surfaces a refinement error on the discriminator itself. Template variant-conditional rendering can branch on the schema's kind rather than relying on the runtime to "guess" a variant.
 
+When the whole form is one of several shapes rather than a field nested inside one, reach for a [variant form](/docs/schemas/variant-forms): the `z.discriminatedUnion` becomes the schema root, `form.values` reads the active variant at the top level, and variant fields bind by their own key.
+
 ## Where to next
 
+- [Variant forms](/docs/schemas/variant-forms): a `z.discriminatedUnion` schema as the form root, not just a field inside an object.
 - [Variant memory](/docs/writing-and-mutating/variant-memory): when to keep the prior typed subtree, when to drop it.
 - [`setValue` patterns](/docs/writing-and-mutating/set-value): programmatic writes that drive the same reshape.
 - [`errors`](/docs/reading-the-form/errors): the variant-filtered per-leaf view vs. the un-filtered aggregate.

--- a/docs/schemas/variant-forms.md
+++ b/docs/schemas/variant-forms.md
@@ -1,0 +1,136 @@
+---
+title: Variant forms
+description: A z.discriminatedUnion schema can be the form root, not just a field. form.values reads the active variant at the top level, register binds variant fields by their own key, and a bare root defaults to the first variant.
+metaRows:
+  - label: Category
+    value: Schema feature
+  - label: Form root
+    value: z.discriminatedUnion('key', [variantA, variantB, …])
+    kind: code
+  - label: Reshape trigger
+    value: writing the discriminator
+  - label: Default
+    value: first variant
+---
+
+# Variant forms
+
+> When the form _is_ one of several shapes, make the union the root. A `z.discriminatedUnion` schema at the top level gives you a variant form: `form.values` reads the active variant, and writing the discriminator reshapes the whole form.
+
+::docs-meta-table
+::
+
+The demo is a checkout payment method. A payment is exactly one of card, bank transfer, or invoice, each with its own fields, so the schema root is a `z.discriminatedUnion('method', …)`. Switch the method and the form reshapes to that variant; the readout below tracks the change.
+
+::docs-demo{slug="variant-forms" label="Variant Form Demo"}
+::
+
+## The schema
+
+A variant form declares a `z.discriminatedUnion` schema as the root, not nested under a key. One discriminator (`method`) picks the variant; each variant is a regular Zod schema:
+
+```ts
+import { useForm } from 'attaform/zod'
+import { z } from 'zod'
+
+const schema = z.discriminatedUnion('method', [
+  z.object({ method: z.literal('card'), cardNumber: z.string(), cvc: z.string() }),
+  z.object({ method: z.literal('bank'), iban: z.string() }),
+  z.object({ method: z.literal('invoice'), poNumber: z.string(), netDays: z.number() }),
+])
+
+const form = useForm({ schema })
+```
+
+There is no wrapper key. The discriminator and every variant's fields sit at the top level of the form.
+
+## Reading the active variant
+
+Because the union is the root, `form.values` reads the variant directly. Every variant's keys are reachable at the top level, so a field read works without narrowing first:
+
+```ts
+form.values.method // the discriminator: string while editing
+form.values.cardNumber // string | undefined (present on the card variant)
+form.values.iban // string | undefined (present on the bank variant)
+```
+
+A per-variant field reads as `T | undefined` because it is present only while its variant is active, matching the runtime, where reading a key from another variant returns `undefined`. The discriminator reads as `string` while editing, since the user may be mid-switch. Inside [`handleSubmit`](/docs/submitting/handle-submit) the parsed value is the true narrowed union, so you branch on it with full type narrowing:
+
+```ts
+const onSubmit = form.handleSubmit((payment) => {
+  if (payment.method === 'card') {
+    payment.cardNumber // string, narrowed to the card variant
+  }
+})
+```
+
+## Binding the discriminator and variant fields
+
+The discriminator is an ordinary field: bind it to a `<select>` or a set of radios, and each variant's fields bind by their own key, no wrapper prefix. Branch the template on `form.values.method`:
+
+```vue
+<template>
+  <label>
+    Payment method
+    <select v-register="form.register('method')">
+      <option value="card">Card</option>
+      <option value="bank">Bank transfer</option>
+      <option value="invoice">Invoice</option>
+    </select>
+  </label>
+
+  <template v-if="form.values.method === 'card'">
+    <input v-register="form.register('cardNumber')" />
+    <em v-if="form.fields.cardNumber?.showErrors">{{
+      form.fields.cardNumber?.firstError?.message
+    }}</em>
+  </template>
+
+  <template v-else-if="form.values.method === 'bank'">
+    <input v-register="form.register('iban')" />
+  </template>
+</template>
+```
+
+A variant field's node is absent while its variant is inactive, so reach it through `?.`: `form.fields.cardNumber?.showErrors`. The same chaining applies to [`form.errors`](/docs/reading-the-form/errors), which is variant-filtered, so an inactive variant's errors stay silent.
+
+## Switching variants reshapes the form
+
+Writing the discriminator reshapes storage to the new variant: the outgoing variant's keys are purged, and the new variant's keys seed from the schema's slim defaults. At the root, the reshape is the whole form:
+
+```ts
+form.setValue('method', 'bank')
+// form.values() : { method: 'bank', iban: '' }
+//   (card's cardNumber / cvc purged; bank's iban seeded)
+```
+
+This is the same engine that drives a nested discriminated union, run at the root path. Variant memory (restoring a variant's values when you switch back to it) is on by default. The full reshape and memory semantics live on [Discriminated unions](/docs/schemas/discriminated-unions), which covers the same feature as a field inside an object form.
+
+## Defaults
+
+A bare variant root defaults to the first variant, with its fields at their slim defaults:
+
+```ts
+const form = useForm({ schema })
+form.values() // { method: 'card', cardNumber: '', cvc: '' }
+```
+
+Start on a different variant, or seed its fields, with `defaultValues`. Pass one complete variant:
+
+```ts
+const form = useForm({
+  schema,
+  defaultValues: { method: 'invoice', poNumber: 'PO-1', netDays: 30 },
+})
+```
+
+## When the shape is fixed, reach for an object
+
+Variant forms are for a value that is genuinely one of several shapes. When every field is always present, a `z.object` root is the better fit. The two compose freely: an object form can hold a discriminated-union field (see [Discriminated unions](/docs/schemas/discriminated-unions)), and a variant's schema can be any Zod schema, including nested objects, arrays, and records.
+
+## Where to next
+
+- [Discriminated unions](/docs/schemas/discriminated-unions): the same feature as a field inside an object form, with the full reshape and error-filtering detail.
+- [Variant memory](/docs/writing-and-mutating/variant-memory): when to keep a variant's values on switch-back, when to drop them.
+- [Dictionary forms](/docs/schemas/dictionary-forms): the other non-object root, a `z.record` map.
+- [`handleSubmit`](/docs/submitting/handle-submit): where the parsed value narrows to the active variant.

--- a/src/runtime/adapters/unified/types-unified.ts
+++ b/src/runtime/adapters/unified/types-unified.ts
@@ -27,6 +27,8 @@ import type {
   ValidateOnConfig,
 } from '../../types/types-api'
 import type { DefaultValuesInput } from '../../types/types-core'
+import type { SupportedRootSchema as SupportedRootSchemaV4 } from '../zod-v4/types-root'
+import type { SupportedRootSchema as SupportedRootSchemaV3 } from '../zod-v3/types-root'
 import type { V3FormOf, V3OutOf, V3ReadOf, V4FormOf, V4OutOf, V4ReadOf } from './types-projections'
 
 /**
@@ -84,7 +86,10 @@ export type UseFormConfigV3<
 /**
  * The return shape of `useForm` for a given Zod schema. Dispatches
  * once on the schema's major version and projects to the matching
- * adapter's `Form` / `Out` / `Read` slots.
+ * adapter's `Form` / `Out` / `Read` slots. The dispatch matches the
+ * full `SupportedRootSchema` per major, so an object, record, or
+ * discriminated-union root all resolve here exactly as the runtime
+ * `useForm` overloads accept them.
  *
  * Replaces `ReturnType<typeof useForm<Schema, K>>` in test code with
  * concrete schemas. For generic helpers (`<S extends z.ZodObject>`),
@@ -96,9 +101,9 @@ export type UseFormConfigV3<
 export type UseFormReturn<
   Schema,
   K extends FormKey = FormKey,
-> = Schema extends z.ZodObject<z.ZodRawShape> & ZodV4Internals
+> = Schema extends SupportedRootSchemaV4 & ZodV4Internals
   ? UseFormReturnType<V4FormOf<Schema>, V4OutOf<Schema>, V4ReadOf<Schema>, K>
-  : Schema extends zV3.ZodObject<zV3.ZodRawShape>
+  : Schema extends SupportedRootSchemaV3
     ? UseFormReturnType<V3FormOf<Schema>, V3OutOf<Schema>, V3ReadOf<Schema>, K>
     : never
 
@@ -110,7 +115,7 @@ export type UseFormReturn<
 export type UseFormConfig<
   Schema,
   K extends FormKey = FormKey,
-> = Schema extends z.ZodObject<z.ZodRawShape> & ZodV4Internals
+> = Schema extends SupportedRootSchemaV4 & ZodV4Internals
   ? Omit<
       UseFormConfiguration<
         V4FormOf<Schema>,
@@ -121,7 +126,7 @@ export type UseFormConfig<
       >,
       'schema' | 'validateOn' | 'debounceMs'
     > & { schema: Schema } & ValidateOnConfig
-  : Schema extends zV3.ZodObject<zV3.ZodRawShape>
+  : Schema extends SupportedRootSchemaV3
     ? Omit<
         UseFormConfiguration<
           V3FormOf<Schema>,

--- a/src/runtime/adapters/zod-v3/index.ts
+++ b/src/runtime/adapters/zod-v3/index.ts
@@ -157,12 +157,13 @@ export function zodAdapter<
   })
   if (
     !isZodSchemaType(_strippedRoot, 'ZodObject') &&
-    !isZodSchemaType(_strippedRoot, 'ZodRecord')
+    !isZodSchemaType(_strippedRoot, 'ZodRecord') &&
+    !isZodSchemaType(_strippedRoot, 'ZodDiscriminatedUnion')
   ) {
     const name = getTypeName(_strippedRoot)
     throw new Error(
-      `Attaform: useForm schema root must be a ZodObject or ZodRecord (got ${name}). ` +
-        `Wrap other shapes under a key.`
+      `Attaform: useForm schema root must be a ZodObject, ZodRecord, or ` +
+        `ZodDiscriminatedUnion (got ${name}). Wrap other shapes under a key.`
     )
   }
 

--- a/src/runtime/adapters/zod-v3/types-root.ts
+++ b/src/runtime/adapters/zod-v3/types-root.ts
@@ -3,15 +3,19 @@ import type { z } from 'zod-v3'
 /**
  * The Zod v3 schema roots `useForm` accepts. Mirror of the v4
  * `SupportedRootSchema`, expressed in v3's type vocabulary: a
- * fixed-shape `z.object({ … })` or a `z.record(K, V)` dictionary form.
+ * fixed-shape `z.object({ … })`, a `z.record(K, V)` dictionary form, or
+ * a `z.discriminatedUnion(disc, [...])` variant form.
  *
  * Other roots (a bare `z.union`, a root `z.array`, primitives,
  * `z.map` / `z.set`) are not form roots; wrap them under a key. The
  * adapter's runtime construction rejects them with a legible error.
  *
- * Widened per feature: the discriminated-union arm lands alongside its
- * runtime support.
+ * The discriminated-union arm is written with v3's parameter order
+ * (`<Discriminator, Options>`), the reverse of v4's; both classes
+ * require their arguments, so the arm stays fully applied to avoid the
+ * single-major `any`-collapse the v4 alias documents.
  */
 export type SupportedRootSchema =
   | z.ZodObject<z.ZodRawShape>
   | z.ZodRecord<z.ZodTypeAny, z.ZodTypeAny>
+  | z.ZodDiscriminatedUnion<string, readonly z.ZodDiscriminatedUnionOption<string>[]>

--- a/src/runtime/adapters/zod-v3/types-zod-adapter.ts
+++ b/src/runtime/adapters/zod-v3/types-zod-adapter.ts
@@ -3,10 +3,11 @@ import type { z } from 'zod-v3'
 /**
  * Peel `.optional()` / `.nullable()` / `.default()` / `.refine()` /
  * `.transform()` wrappers off a Zod v3 schema to reach the form root,
- * then return it: a `ZodObject` (fixed-shape form) or a `ZodRecord`
- * (dictionary form). Returns `never` for any other root, which makes
- * the `useForm` projections collapse to `never` so the call fails to
- * typecheck rather than producing a misshapen form type.
+ * then return it: a `ZodObject` (fixed-shape form), a `ZodRecord`
+ * (dictionary form), or a `ZodDiscriminatedUnion` (variant form).
+ * Returns `never` for any other root, which makes the `useForm`
+ * projections collapse to `never` so the call fails to typecheck
+ * rather than producing a misshapen form type.
  *
  * Used internally by the v3 `useForm` overload to project an arbitrary
  * supported root to its input / output / storage-read shapes.
@@ -24,4 +25,6 @@ export type UnwrapZodRoot<T> =
             ? z.ZodObject<Shape>
             : T extends z.ZodRecord<infer Key, infer Value>
               ? z.ZodRecord<Key, Value>
-              : never
+              : T extends z.ZodDiscriminatedUnion<infer Disc, infer Options>
+                ? z.ZodDiscriminatedUnion<Disc, Options>
+                : never

--- a/src/runtime/adapters/zod-v4/types-root.ts
+++ b/src/runtime/adapters/zod-v4/types-root.ts
@@ -3,28 +3,34 @@ import type { z } from 'zod'
 /**
  * The Zod v4 schema roots `useForm` accepts. A fixed-shape
  * `z.object({ … })` is the common case; `z.record(K, V)` admits a
- * dictionary form (a homogeneous map with runtime-known keys). Both
- * project to a `GenericForm`-shaped value the form engine drives — an
- * object root descends into its fixed keys, a record root treats its
- * entries as an open, live-keyed container.
+ * dictionary form (a homogeneous map with runtime-known keys);
+ * `z.discriminatedUnion(disc, [...])` admits a variant form (one of
+ * several object shapes, picked by a discriminator). Each projects to
+ * a `GenericForm`-shaped value the form engine drives: an object root
+ * descends into its fixed keys, a record root treats its entries as an
+ * open live-keyed container, a variant root lifts the active variant's
+ * keys into one addressable surface.
  *
  * Other roots (a bare `z.union`, a root `z.array`, primitives,
  * `z.map` / `z.set`) are not form roots; wrap them under a key. The
  * adapter's runtime construction rejects them with a legible error.
  *
- * Widened per feature: the discriminated-union arm
- * (`z.discriminatedUnion`, variant forms) lands alongside its runtime
- * support.
- *
- * `z.ZodObject` MUST keep its `z.ZodRawShape` argument. The unified
- * entry's v4 overload constrains on `SupportedRootSchema & ZodV4Internals`
- * to keep v3 schemas out (see `../unified/types-zod-major.ts`). In a
+ * `z.ZodObject` MUST keep its `z.ZodRawShape` argument, and the
+ * discriminated-union arm MUST stay fully applied. The unified entry's
+ * v4 overload constrains on `SupportedRootSchema & ZodV4Internals` to
+ * keep v3 schemas out (see `../unified/types-zod-major.ts`). In a
  * single-major (v3-only) consumer install, the published `.d.mts`
- * resolves this `z` to v3, where bare `z.ZodObject` is missing its
- * required shape argument and degrades to an `any`-like error type;
- * `any` then absorbs the union and `any & ZodV4Internals` collapses back
- * to `any`, so the marker stops excluding v3 schemas and the read slot
- * poisons to `never`. `z.ZodRecord` carries defaults for both arguments,
- * so it stays a concrete type in either major.
+ * resolves this `z` to v3, where a bare or under-applied Zod class is
+ * missing its required arguments and degrades to an `any`-like error
+ * type; `any` then absorbs the union and `any & ZodV4Internals`
+ * collapses back to `any`, so the marker stops excluding v3 schemas and
+ * the read slot poisons to `never`. `z.ZodRecord` carries defaults for
+ * both arguments, so it stays concrete in either major.
+ * `z.ZodDiscriminatedUnion` does NOT (v3 requires both arguments, and
+ * its parameter order is the reverse of v4's), so the arm is written
+ * fully applied; the v3-only bundled-types fixture guards it.
  */
-export type SupportedRootSchema = z.ZodObject<z.ZodRawShape> | z.ZodRecord
+export type SupportedRootSchema =
+  | z.ZodObject<z.ZodRawShape>
+  | z.ZodRecord
+  | z.ZodDiscriminatedUnion<readonly z.ZodObject<z.ZodRawShape>[], string>

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -1599,11 +1599,14 @@ export type MetaTrackerValue = {
 // recursion in `types-core.ts`; the `'register'` mode skips container
 // paths because `v-register` only binds onto leaf-backing native
 // elements (`<input>` / `<select>` / `<textarea>`).
-export type RegisterFlatPath<Form, Key extends keyof Form = keyof Form> = FlatPathBuilder<
-  Form,
-  'register',
-  Key
->
+//
+// The `Form extends unknown` wrapper distributes over a top-level union
+// (a `z.discriminatedUnion` root) so each variant's keys register, not
+// just the shared discriminator; for a single-shape `Form` it is a
+// one-member no-op. Mirrors `PartialFlatPath` in `types-core.ts`.
+export type RegisterFlatPath<Form> = Form extends unknown
+  ? FlatPathBuilder<Form, 'register'>
+  : never
 
 /**
  * A transformation applied to a field's value as user input flows
@@ -3720,13 +3723,12 @@ export type UseFormReturnType<
    * user-typed values before they reach form state.
    */
   register: {
-    <Path extends RegisterFlatPath<Form, keyof Form>>(
+    <Path extends RegisterFlatPath<Form>>(
       path: Path,
       options?: RegisterOptions
     ): RegisterValue<NestedReadType<WriteShape<ReadForm>, Path>>
     <const S extends ReadonlyArray<string | number>>(
-      segments: S &
-        ([JoinSegments<S>] extends [RegisterFlatPath<Form, keyof Form>] ? unknown : never),
+      segments: S & ([JoinSegments<S>] extends [RegisterFlatPath<Form>] ? unknown : never),
       options?: RegisterOptions
     ): RegisterValue<NestedReadType<WriteShape<ReadForm>, JoinSegments<S>>>
   }

--- a/src/runtime/types/types-core.ts
+++ b/src/runtime/types/types-core.ts
@@ -82,12 +82,17 @@ export type FlatPathBuilder<
  * Inlining at consumer call sites compounds into TS2589 territory
  * when multiple complex forms share a scope. Consumers should reach
  * for `FlatPath` instead; this alias is not part of the stable surface.
+ *
+ * The `Form extends unknown` wrapper distributes over a top-level
+ * union so each member contributes its OWN `keyof` — a discriminated-
+ * union root (`z.discriminatedUnion`) thus exposes every variant's
+ * keys as addressable paths, not just the discriminator that naked
+ * `keyof (A | B)` would intersect to. For a single object / array /
+ * record `Form` it is a one-member no-op and stays byte-identical to
+ * the prior walk. Interior unions already distribute inside
+ * `FlatPathBuilder` via its `infer Value` step.
  */
-export type PartialFlatPath<Form, Key extends keyof Form = keyof Form> = FlatPathBuilder<
-  Form,
-  'partial',
-  Key
->
+export type PartialFlatPath<Form> = Form extends unknown ? FlatPathBuilder<Form, 'partial'> : never
 
 // FlatPath Generic Gotchas:
 //
@@ -112,7 +117,7 @@ export type PartialFlatPath<Form, Key extends keyof Form = keyof Form> = FlatPat
  * `register(path)`, `toRef(path)`, etc.) so paths autocomplete in
  * the IDE and typos compile-error.
  */
-export type FlatPath<Form, Key extends keyof Form = keyof Form> = PartialFlatPath<Form, Key>
+export type FlatPath<Form> = PartialFlatPath<Form>
 
 /**
  * Convert a tuple of path segments to its dotted-string equivalent.

--- a/test/adapters/zod-v3/required-discriminator-parity.test.ts
+++ b/test/adapters/zod-v3/required-discriminator-parity.test.ts
@@ -198,4 +198,20 @@ describe('zod v3: required + discriminator parity (D9 / D10 / D11 / D12)', () =>
       expect(adapter.getUnionDiscriminatorAtPath(['p'])?.discriminatorKey).toBe('kind')
     })
   })
+
+  describe('discriminated union at the ROOT (variant form)', () => {
+    it('resolves the root discriminator + variants via getUnionDiscriminatorAtPath([])', () => {
+      const schema = z.discriminatedUnion('method', [
+        z.object({ method: z.literal('card'), cardNumber: z.string() }),
+        z.object({ method: z.literal('bank'), iban: z.string() }),
+      ])
+      const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+      const ctx = adapter.getUnionDiscriminatorAtPath([])
+      expect(ctx).toBeDefined()
+      expect(ctx?.discriminatorKey).toBe('method')
+      expect(ctx?.isVariantSelected('card')).toBe(true)
+      expect(ctx?.isVariantSelected('bank')).toBe(true)
+      expect(ctx?.isVariantSelected('paypal')).toBe(false)
+    })
+  })
 })

--- a/test/adapters/zod-v4/required-discriminator-parity.test.ts
+++ b/test/adapters/zod-v4/required-discriminator-parity.test.ts
@@ -157,4 +157,20 @@ describe('zod v4: required + discriminator parity', () => {
       expect(adapter.getUnionDiscriminatorAtPath(['p'])?.discriminatorKey).toBe('kind')
     })
   })
+
+  describe('discriminated union at the ROOT (variant form)', () => {
+    it('resolves the root discriminator + variants via getUnionDiscriminatorAtPath([])', () => {
+      const schema = z.discriminatedUnion('method', [
+        z.object({ method: z.literal('card'), cardNumber: z.string() }),
+        z.object({ method: z.literal('bank'), iban: z.string() }),
+      ])
+      const adapter = zodAdapter(schema)('f', { maxRecursionDepth: 64 })
+      const ctx = adapter.getUnionDiscriminatorAtPath([])
+      expect(ctx).toBeDefined()
+      expect(ctx?.discriminatorKey).toBe('method')
+      expect(ctx?.isVariantSelected('card')).toBe(true)
+      expect(ctx?.isVariantSelected('bank')).toBe(true)
+      expect(ctx?.isVariantSelected('paypal')).toBe(false)
+    })
+  })
 })

--- a/test/composables/discriminated-union-root.test.ts
+++ b/test/composables/discriminated-union-root.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, watchEffect, type App } from 'vue'
+import { z as zV4 } from 'zod'
+import { z as zV3 } from 'zod-v3'
+import { useForm as useFormV4 } from '../../src/zod-v4'
+import { useForm as useFormV3 } from '../../src/zod-v3'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import { waitUntil } from '../utils/form-harness'
+
+/**
+ * Discriminated-union ROOT (variant form): the whole schema is a
+ * `z.discriminatedUnion`, not a DU nested under a key. The engine's
+ * variant machinery must fire at the root path `[]` exactly as it does
+ * for an interior DU:
+ *
+ *   - default derivation seeds the FIRST variant,
+ *   - writing the root discriminator reshapes storage (old variant keys
+ *     purged, new variant keys seeded),
+ *   - the active-path error filter hides the inactive variant's errors,
+ *   - the reshape does not flash an empty `{}` frame between two
+ *     meaningful error states (the du-variant-error-flicker contract).
+ *
+ * Pinned on both adapters per the v3/v4 parity contract.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyUseForm = (opts: any) => any
+
+const adapters = [
+  { name: 'zod v3', useForm: useFormV3 as AnyUseForm, z: zV3 as unknown as typeof zV4 },
+  { name: 'zod v4', useForm: useFormV4 as AnyUseForm, z: zV4 },
+] as const
+
+let keySeq = 0
+
+describe.each(adapters)('discriminated-union root — $name', ({ useForm, z }) => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+    document.body.innerHTML = ''
+  })
+
+  const schema = z.discriminatedUnion('method', [
+    z.object({ method: z.literal('card'), cardNumber: z.string().min(1, 'Card number required') }),
+    z.object({ method: z.literal('bank'), iban: z.string().min(7, 'IBAN too short') }),
+  ])
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function mount(defaultValues?: any): { api: any; snapshots: string[] } {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const handle: { api?: any } = {}
+    const snapshots: string[] = []
+    const Host = defineComponent({
+      setup() {
+        handle.api = useForm({
+          schema,
+          key: `du-root-${keySeq++}`,
+          ...(defaultValues ? { defaultValues } : {}),
+          validateOn: 'change',
+          debounceMs: 0,
+        })
+        watchEffect(() => {
+          snapshots.push(JSON.stringify(handle.api?.errors))
+        })
+        return () => h('div')
+      },
+    })
+    const app = createApp(Host).use(createAttaform())
+    app.config.warnHandler = () => {}
+    app.config.errorHandler = () => {}
+    app.mount(document.createElement('div'))
+    apps.push(app)
+    return { api: handle.api, snapshots }
+  }
+
+  it('defaults to the first variant', () => {
+    const { api } = mount()
+    expect(api.values.method).toBe('card')
+    expect(api.values.cardNumber).toBe('')
+    // The bank-only key is absent while the card variant is active.
+    expect(api.values.iban).toBeUndefined()
+  })
+
+  it('writing the root discriminator reshapes storage to the new variant', async () => {
+    const { api } = mount({ method: 'card', cardNumber: '4242' })
+    expect(api.values.cardNumber).toBe('4242')
+
+    api.setValue('method', 'bank')
+    await waitUntil(() => (api.values.method === 'bank' ? true : null))
+
+    // New variant seeded, old variant key purged.
+    expect(api.values.iban).toBe('')
+    expect(api.values.cardNumber).toBeUndefined()
+  })
+
+  it('filters the inactive variant errors after a root switch, with no {} flicker', async () => {
+    const { api, snapshots } = mount({ method: 'card', cardNumber: '' })
+
+    // Card variant: cardNumber '' fails min(1).
+    await waitUntil(() => (snapshots.some((s) => /cardNumber/.test(s)) ? true : null))
+    const initialIdx = snapshots.findIndex((s) => /cardNumber/.test(s))
+    expect(initialIdx).toBeGreaterThanOrEqual(0)
+
+    // Switch to bank: iban '' fails min(7); the cardNumber error must clear.
+    api.setValue('method', 'bank')
+    await waitUntil(() => (/iban/.test(snapshots[snapshots.length - 1] ?? '') ? true : null))
+
+    const finalSnapshot = snapshots[snapshots.length - 1] ?? ''
+    expect(finalSnapshot).toMatch(/iban/)
+    expect(finalSnapshot).not.toMatch(/cardNumber/)
+
+    // No empty frame between the last card-error snapshot and the bank one.
+    const transition = snapshots.slice(initialIdx)
+    let lastNonEmpty = -1
+    for (let i = transition.length - 1; i >= 0; i--) {
+      if (transition[i] !== '{}') {
+        lastNonEmpty = i
+        break
+      }
+    }
+    const blanks = transition.slice(0, lastNonEmpty).filter((s) => s === '{}')
+    expect(blanks).toEqual([])
+  })
+})

--- a/test/docs-demos/docs-demos-smoke.test.ts
+++ b/test/docs-demos/docs-demos-smoke.test.ts
@@ -679,6 +679,21 @@ const entries: SmokeEntry[] = [
       expect(tokens).toContain('mae')
     },
   },
+  {
+    // Variant-root form: the whole schema is a `z.discriminatedUnion`.
+    // Switch the method <select> to bank; the variant swap reshapes
+    // storage and renders the bank-only IBAN field.
+    slug: 'variant-forms',
+    gesture: async (root) => {
+      const select = root.querySelector<HTMLSelectElement>('select')
+      if (!select) throw new Error('method select not found')
+      select.value = 'bank'
+      await dispatchChange(select)
+    },
+    assert: async (root) => {
+      expect(root.textContent ?? '').toContain('IBAN')
+    },
+  },
 
   // ─── PHASE 2: READING STATE ───────────────────────────────────
   {

--- a/test/types/discriminated-union-root.test.ts
+++ b/test/types/discriminated-union-root.test.ts
@@ -1,0 +1,85 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import { z } from 'zod'
+import type { ValidationError } from '../../src/runtime/types/types-api'
+import type { UseFormReturn } from '../../src/zod'
+
+/**
+ * Type surface for a discriminated-union ROOT (variant form): the whole
+ * schema is a `z.discriminatedUnion`. The read views (`form.values`,
+ * `form.fields`, `form.errors`) lift the top-level union exactly as they
+ * do for an interior DU (see `discriminated-union-lift.test.ts`), variant
+ * fields are addressable as root string paths (`form.register('cardNumber')`),
+ * and `handleSubmit` receives the true, narrowable parsed union.
+ */
+
+const _paymentSchema = z.discriminatedUnion('method', [
+  z.object({ method: z.literal('card'), cardNumber: z.string(), cvc: z.string() }),
+  z.object({ method: z.literal('bank'), iban: z.string() }),
+  z.object({ method: z.literal('invoice'), poNumber: z.string(), netDays: z.number() }),
+])
+
+type PaymentForm = UseFormReturn<typeof _paymentSchema>
+
+// Recursive Proxy stand-in (same pattern as discriminated-union-lift):
+// the file never invokes useForm because there's no Vue app context;
+// only the static types the checker sees matter.
+const form: PaymentForm = (() => {
+  const handler: ProxyHandler<() => unknown> = {
+    get: () => proxy,
+    apply: () => proxy,
+  }
+  const proxy: unknown = new Proxy(() => undefined, handler)
+  return proxy as PaymentForm
+})()
+
+describe('DU root — form.values lift', () => {
+  it('discriminator reads as in-flight string; per-variant keys lift to `T | undefined`', () => {
+    expectTypeOf(form.values.method).toEqualTypeOf<string>()
+    expectTypeOf(form.values.cardNumber).toEqualTypeOf<string | undefined>()
+    expectTypeOf(form.values.cvc).toEqualTypeOf<string | undefined>()
+    expectTypeOf(form.values.iban).toEqualTypeOf<string | undefined>()
+    expectTypeOf(form.values.poNumber).toEqualTypeOf<string | undefined>()
+    expectTypeOf(form.values.netDays).toEqualTypeOf<number | undefined>()
+  })
+})
+
+describe('DU root — form.fields / form.errors lift', () => {
+  it('per-variant field nodes are node-optional, reachable via `?.`', () => {
+    expectTypeOf(form.fields.cardNumber?.value).toEqualTypeOf<string | undefined>()
+    expectTypeOf(form.fields.netDays?.value).toEqualTypeOf<number | undefined>()
+  })
+
+  it('per-variant errors are reachable; leaf is ValidationError[] | undefined', () => {
+    expectTypeOf(form.errors.cardNumber).toEqualTypeOf<readonly ValidationError[] | undefined>()
+    expectTypeOf(form.errors.iban).toEqualTypeOf<readonly ValidationError[] | undefined>()
+  })
+})
+
+describe('DU root — register accepts variant + discriminator string paths', () => {
+  it('register(discriminator) and register(variant key) typecheck', () => {
+    form.register('method')
+    form.register('cardNumber')
+    form.register('iban')
+    form.register('netDays')
+  })
+
+  it('register rejects an unknown path', () => {
+    // @ts-expect-error 'nope' is not a registrable path on any variant
+    form.register('nope')
+  })
+})
+
+describe('DU root — handleSubmit narrows the parsed union', () => {
+  it('values is the true discriminated union, narrowable on the discriminator', () => {
+    form.handleSubmit((values) => {
+      expectTypeOf(values.method).toEqualTypeOf<'card' | 'bank' | 'invoice'>()
+      if (values.method === 'card') {
+        expectTypeOf(values.cardNumber).toEqualTypeOf<string>()
+        expectTypeOf(values.cvc).toEqualTypeOf<string>()
+      }
+      if (values.method === 'invoice') {
+        expectTypeOf(values.netDays).toEqualTypeOf<number>()
+      }
+    })
+  })
+})

--- a/test/types/flat-path-walker.test.ts
+++ b/test/types/flat-path-walker.test.ts
@@ -54,6 +54,24 @@ describe('PartialFlatPath — container + array-root + leaf enumeration', () => 
     expectTypeOf<Extract<Paths, 'a.b.c'>>().toEqualTypeOf<'a.b.c'>()
     expectTypeOf<Extract<Paths, 'a.b.c.d'>>().toEqualTypeOf<'a.b.c.d'>()
   })
+
+  it('distributes over a top-level discriminated-union root (every variant key)', () => {
+    // A `z.discriminatedUnion` root value shape. The `Form extends
+    // unknown` wrapper distributes over the union so each variant
+    // contributes its OWN keys, not just the shared discriminator that
+    // naked `keyof (A | B | C)` would intersect to.
+    type Form =
+      | { method: 'card'; cardNumber: string; cvc: string }
+      | { method: 'bank'; iban: string }
+      | { method: 'invoice'; poNumber: string; netDays: number }
+    type Paths = PartialFlatPath<Form>
+    expectTypeOf<Extract<Paths, 'method'>>().toEqualTypeOf<'method'>()
+    expectTypeOf<Extract<Paths, 'cardNumber'>>().toEqualTypeOf<'cardNumber'>()
+    expectTypeOf<Extract<Paths, 'cvc'>>().toEqualTypeOf<'cvc'>()
+    expectTypeOf<Extract<Paths, 'iban'>>().toEqualTypeOf<'iban'>()
+    expectTypeOf<Extract<Paths, 'poNumber'>>().toEqualTypeOf<'poNumber'>()
+    expectTypeOf<Extract<Paths, 'netDays'>>().toEqualTypeOf<'netDays'>()
+  })
 })
 
 describe('RegisterFlatPath — leaf-only enumeration (no containers)', () => {
@@ -98,5 +116,21 @@ describe('RegisterFlatPath — leaf-only enumeration (no containers)', () => {
     expectTypeOf<Extract<Paths, 'a.b'>>().toEqualTypeOf<never>()
     expectTypeOf<Extract<Paths, 'a.b.c'>>().toEqualTypeOf<never>()
     expectTypeOf<Extract<Paths, 'a.b.c.d'>>().toEqualTypeOf<'a.b.c.d'>()
+  })
+
+  it('distributes over a top-level discriminated-union root (every variant leaf registrable)', () => {
+    // Each variant key backs a native element, so all are registrable
+    // leaves; the discriminator drives the variant `<select>` / radios.
+    type Form =
+      | { method: 'card'; cardNumber: string; cvc: string }
+      | { method: 'bank'; iban: string }
+      | { method: 'invoice'; poNumber: string; netDays: number }
+    type Paths = RegisterFlatPath<Form>
+    expectTypeOf<Extract<Paths, 'method'>>().toEqualTypeOf<'method'>()
+    expectTypeOf<Extract<Paths, 'cardNumber'>>().toEqualTypeOf<'cardNumber'>()
+    expectTypeOf<Extract<Paths, 'cvc'>>().toEqualTypeOf<'cvc'>()
+    expectTypeOf<Extract<Paths, 'iban'>>().toEqualTypeOf<'iban'>()
+    expectTypeOf<Extract<Paths, 'poNumber'>>().toEqualTypeOf<'poNumber'>()
+    expectTypeOf<Extract<Paths, 'netDays'>>().toEqualTypeOf<'netDays'>()
   })
 })

--- a/tests/fixtures/bundled-types-v3/consumer.ts
+++ b/tests/fixtures/bundled-types-v3/consumer.ts
@@ -64,4 +64,25 @@ const roster = useForm({ schema: rosterSchema, key: 'roster-v3' })
 // Read slot must resolve to the record map (not `never`, not `any`).
 type _RosterEntry = Expect<Equal<ReturnType<typeof roster.values>['member-1'], { tier: number }>>
 
-export { form, roster }
+// Variant-root form — a `z.discriminatedUnion` schema as the root
+// (variant form), the other new non-object root. Same single-major
+// hazard: the v4 overload must not greedily match this v3 DU, or the
+// read slot collapses to `never`. The v4 SupportedRootSchema's DU arm
+// is written fully applied (v3 requires both arguments, in the reverse
+// order of v4), so it stays concrete and keeps discriminating here.
+const paymentSchema = z.discriminatedUnion('method', [
+  z.object({ method: z.literal('card'), cardNumber: z.string() }),
+  z.object({ method: z.literal('bank'), iban: z.string() }),
+])
+const payment = useForm({ schema: paymentSchema, key: 'payment-v3' })
+
+// Read slot must lift the union (not collapse to `never`/`any`): the
+// discriminator widens to `string`, per-variant keys read `T | undefined`.
+type _PayMethod = Expect<Equal<typeof payment.values.method, string>>
+type _PayCard = Expect<Equal<typeof payment.values.cardNumber, string | undefined>>
+type _PayIban = Expect<Equal<typeof payment.values.iban, string | undefined>>
+
+// A per-variant key must be addressable as a root register path.
+payment.register('cardNumber')
+
+export { form, roster, payment }

--- a/tests/fixtures/bundled-types/du-root.ts
+++ b/tests/fixtures/bundled-types/du-root.ts
@@ -1,0 +1,46 @@
+/**
+ * Bundled-types guard for a discriminated-union ROOT (variant form)
+ * through the published unified `attaform/zod` artifact, with both Zod
+ * majors installed (the normal consumer case). The v4 overload must
+ * match a `z.discriminatedUnion` root via `SupportedRootSchema &
+ * ZodV4Internals` and project the lifted read shape.
+ *
+ * This pins the v4 path deterministically against the bundled `.d.mts`,
+ * independent of the in-repo `UseFormReturn` helper: a bound regression
+ * or a depth bail that collapses the read slot to `never` fails here.
+ * The v3-only sibling fixture guards the same root through the v3 path.
+ */
+import { z } from 'zod'
+import { useForm } from '../../../dist/zod'
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false
+type Expect<T extends true> = T
+
+const paymentSchema = z.discriminatedUnion('method', [
+  z.object({ method: z.literal('card'), cardNumber: z.string(), cvc: z.string() }),
+  z.object({ method: z.literal('bank'), iban: z.string() }),
+  z.object({ method: z.literal('invoice'), poNumber: z.string(), netDays: z.number() }),
+])
+
+const payment = useForm({ schema: paymentSchema, key: 'payment-v4' })
+
+// Read slot must lift the union (not collapse to `never`/`any`): the
+// discriminator widens to `string`, per-variant keys read `T | undefined`.
+type _Method = Expect<Equal<typeof payment.values.method, string>>
+type _Card = Expect<Equal<typeof payment.values.cardNumber, string | undefined>>
+type _Net = Expect<Equal<typeof payment.values.netDays, number | undefined>>
+
+// A per-variant key is addressable as a root register path.
+payment.register('cardNumber')
+
+// handleSubmit narrows to the active variant.
+payment.handleSubmit((values) => {
+  if (values.method === 'invoice') {
+    type _PO = Expect<Equal<typeof values.poNumber, string>>
+    void values.poNumber
+  }
+  void values
+})
+
+export { payment }


### PR DESCRIPTION
## Variant forms — `z.discriminatedUnion` as a `useForm` root

PR2 of 2 for #393 (non-object form roots). PR1 (record roots / dictionary forms) landed in #421; this adds the discriminated-union root.

`useForm({ schema: z.discriminatedUnion('method', […]) })` is now a **variant form**: the whole value is one of several object shapes, picked by a discriminator. The discriminator and every variant's fields sit at the root.

### Consumer surface

- `form.values` reads the active variant: discriminator widened to `string` while editing, per-variant keys lifted to `T | undefined` (the same lift a nested DU already gets).
- `form.register('method')` drives the variant; `form.register('cardNumber')` binds a variant field by its own key.
- `form.fields` / `form.errors` lift the union; variant nodes are node-optional (`?.`), errors are variant-filtered.
- `handleSubmit((payment) => …)` receives the true, narrowable parsed union.
- Writing the discriminator reshapes the whole form (old keys purged, new seeded); variant memory on by default; a bare root defaults to the first variant.
- No new public method, no breaking change; object-rooted forms behave exactly as before.

### How it lands

The engine was already root-ready (reshape, defaults, error filtering, variant memory, and discriminator resolution all run path-generically at `[]`). The work:

- **Type bound** (`SupportedRootSchema`, v4 + v3): add the `z.ZodDiscriminatedUnion` arm, written fully applied so it stays concrete in a single-major install (v3 requires both arguments, in the reverse order of v4) and never collapses the bound to `any`.
- **`UnwrapZodRoot`** (v3): peel to a `ZodDiscriminatedUnion` root.
- **`FlatPath` / `PartialFlatPath` / `RegisterFlatPath`**: distribute over a top-level union so every variant's keys are addressable string paths (a root `keyof (A|B|C)` otherwise collapses to the shared discriminator). Drops the vestigial `Key` param (only `register` passed it, always its own default); byte-identical for object / array / record roots.
- **v3 adapter root throw** accepts `ZodDiscriminatedUnion`.

`form.values` / `form.fields` / `form.errors` lift the top-level union through the existing `ValuesSurface` / `LeafWalker` composition, so no `StorageShape` arm was needed.

### Verification

- `pnpm typecheck`, `pnpm lint`, full `pnpm test` (4200 passed; v3 + v4).
- `pnpm check:bundled-types` (v4/default + v3-only single-major DU-root guard).
- Site `vue-tsc` + full `nuxi build` (427 routes prerendered, link-checker 0 errors).

### Tests / docs

- Root-DU type surface + path-walker root-union cases; dual-adapter runtime reshape / filtering / no-flicker; root discriminator parity (v3 + v4); a DU-root case in the v3-only bundled-types fixture.
- New **Variant forms** docs page + payment-method demo, cross-linked with the nested **Discriminated unions** page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
