### PR TITLE
feat(errors): add optional ValidationError.data payload slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
   alongside the message: a captcha challenge, a lockout `unlocks_at` timestamp, an
   MFA step-up descriptor. Attaform never inspects it; it flows untouched through
   `form.errors`, `form.meta.errors`, the SSR serialise / hydrate round-trip, and
-  undo / redo. Read it where you render the error and act on it.
+  undo / redo. Read it where you render the error and act on it. (#426)
 
 ## v0.23.0
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@
   inside `handleSubmit` narrows to the active variant. zod v3 and zod v4 both get
   it, both tested, and object-rooted forms behave exactly as before. (#424)
 
+- **A server can now attach a structured payload to an error, and Attaform
+  carries it straight to your UI.** Every `ValidationError` gained an optional
+  `data` slot, typed as the newly exported `Json` value shape, for whatever rides
+  alongside the message: a captcha challenge, a lockout `unlocks_at` timestamp, an
+  MFA step-up descriptor. Attaform never inspects it; it flows untouched through
+  `form.errors`, `form.meta.errors`, the SSR serialise / hydrate round-trip, and
+  undo / redo. Read it where you render the error and act on it.
+
 ## v0.23.0
 ### Removed
 

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -127,6 +127,7 @@ type ValidationError = {
   readonly message: string
   readonly code: string
   readonly formKey: string
+  readonly data?: Json | null
 }
 ```
 
@@ -134,6 +135,7 @@ type ValidationError = {
 - `message`: the human-readable error text.
 - `code`: stable identifier (`atta:no-value-supplied`, `zod:invalid_type`, `api:duplicate-email`, etc.).
 - `formKey`: which form emitted the error. Useful for cross-form aggregation in wizards.
+- `data`: optional, opaque JSON payload a server attached to the error (a captcha challenge, a lockout `unlocks_at` timestamp, an MFA step-up descriptor). Attaform carries it untouched; your UI reads it. Typed as `Json` (the JSON-serialisable value shape).
 
 The `code` is what consumers branch on; the `message` is what templates render. Avoid matching `message` strings; they're localized and may change over time without breaking the public contract.
 

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -49,7 +49,8 @@ This page is reference material, alphabetical-ish by purpose. Most consumers nev
 
 | Type                                                  | Source                  | Purpose                                                              |
 | ----------------------------------------------------- | ----------------------- | -------------------------------------------------------------------- |
-| `ValidationError`                                     | runtime/types/types-api | The error shape (`{ path, message, code, formKey }`).                |
+| `ValidationError`                                     | runtime/types/types-api | The error shape (`{ path, message, code, formKey, data? }`).         |
+| `Json`                                                | runtime/types/types-api | JSON-serialisable value; the type of the optional `data` payload.    |
 | `ValidationResponse<Form>`                            | runtime/types/types-api | Discriminated success-or-failure validation result with parsed data. |
 | `ValidationResponseWithoutValue<Form>`                | runtime/types/types-api | Same shape minus the `data` payload (used by `validateAsync`).       |
 | `ReactiveValidationStatus<Form>`                      | runtime/types/types-api | Discriminated pending-vs-settled reactive validation status.         |

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,7 @@ export type {
   GetDisplayState,
   HandleSubmit,
   HistoryConfig,
+  Json,
   MetaTrackerValue,
   OnError,
   OnInvalidSubmitPolicy,

--- a/src/runtime/core/build-form-api.ts
+++ b/src/runtime/core/build-form-api.ts
@@ -611,12 +611,16 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
     }
     state.userErrors.set(
       FORM_ERRORS_PATH_KEY,
-      errors.map((e) => ({
-        path: [...FORM_ERRORS_PATH],
-        message: e.message,
-        formKey: state.formKey,
-        code: e.code ?? 'atta:form-error',
-      }))
+      errors.map((e) => {
+        const entry: ValidationError = {
+          path: [...FORM_ERRORS_PATH],
+          message: e.message,
+          formKey: state.formKey,
+          code: e.code ?? 'atta:form-error',
+        }
+        if (e.data !== undefined) entry.data = e.data
+        return entry
+      })
     )
   }
 

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -129,6 +129,9 @@ function isHydratedValidationErrorArray(value: unknown): value is ValidationErro
     if (!Array.isArray(e.path)) return false
     if (typeof e.formKey !== 'string') return false
     if (typeof e.code !== 'string') return false
+    // `data` is an opaque JSON passthrough: it arrived via JSON.parse,
+    // so it is structurally JSON by construction. Don't hard-validate
+    // it here — it rides along on the entry untouched.
   }
   return true
 }

--- a/src/runtime/core/history.ts
+++ b/src/runtime/core/history.ts
@@ -1,5 +1,5 @@
 import { computed, shallowRef, type ComputedRef } from 'vue'
-import type { HistoryConfig, ValidationError, WriteMeta } from '../types/types-api'
+import type { HistoryConfig, Json, ValidationError, WriteMeta } from '../types/types-api'
 import type { GenericForm } from '../types/types-core'
 import type { FormStore } from './create-form-store'
 import { DEFAULT_HISTORY_MAX_SNAPSHOTS, normalizeNumericOption } from './defaults'
@@ -102,18 +102,51 @@ function captureErrorEntries(map: Map<PathKey, ValidationError[]>): ErrorEntries
 }
 
 /**
+ * Structural equality for two `ValidationError.data` payloads (opaque
+ * JSON). Most errors carry no `data`, so the `a === b` fast path (both
+ * `undefined`, or the same reference) settles the common case; the
+ * recursive walk only runs when two distinct payloads are present.
+ */
+function dataEqual(a: Json | null | undefined, b: Json | null | undefined): boolean {
+  if (a === b) return true
+  if (a === null || b === null || a === undefined || b === undefined) return false
+  if (typeof a !== typeof b) return false
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b) || a.length !== b.length) return false
+    for (let i = 0; i < a.length; i++) {
+      if (!dataEqual(a[i], b[i])) return false
+    }
+    return true
+  }
+  if (Array.isArray(b)) return false
+  if (typeof a === 'object') {
+    const ao = a as { [k: string]: Json }
+    const bo = b as { [k: string]: Json }
+    const keys = Object.keys(ao)
+    if (keys.length !== Object.keys(bo).length) return false
+    for (const k of keys) {
+      if (!Object.prototype.hasOwnProperty.call(bo, k)) return false
+      if (!dataEqual(ao[k], bo[k])) return false
+    }
+    return true
+  }
+  return false
+}
+
+/**
  * Field-by-field equality for two ValidationErrors. Identity-equal first:
  * ValidationError objects pass by reference through the snapshot chain
  * (not cloned), so most comparisons short-circuit here. On an identity
- * miss, compare message / code / formKey and the path (reference-equal or
- * structurally equal).
+ * miss, compare message / code / formKey, the path (reference-equal or
+ * structurally equal), and the opaque `data` payload (structurally).
  */
 function errorFieldsEqual(av: ValidationError, bvi: ValidationError): boolean {
   if (av === bvi) return true
   if (av.message !== bvi.message) return false
   if (av.code !== bvi.code) return false
   if (av.formKey !== bvi.formKey) return false
-  return av.path === bvi.path || pathsEqual(av.path, bvi.path)
+  if (av.path !== bvi.path && !pathsEqual(av.path, bvi.path)) return false
+  return dataEqual(av.data, bvi.data)
 }
 
 export function errorsEqual(a: ErrorEntries, b: ErrorEntries): boolean {

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -46,12 +46,31 @@ export interface SchemaFactoryOptions {
 }
 
 /**
+ * A JSON-serialisable value: the recursive shape of anything that
+ * survives a `JSON.stringify` / `JSON.parse` round-trip unchanged.
+ * The type of `ValidationError.data`.
+ *
+ * The object arm is a named interface rather than an inline index
+ * signature: TypeScript expands an anonymous recursive alias eagerly
+ * and tips into a depth-limit error (TS2589) when `Json` is checked
+ * inside a large structural type (e.g. the form store). A named
+ * reference defers that expansion.
+ */
+export type Json = string | number | boolean | null | JsonArray | JsonObject
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- a named array arm (not inline `Json[]`) is what defers the recursion and avoids TS2589
+interface JsonArray extends Array<Json> {}
+interface JsonObject {
+  [key: string]: Json
+}
+
+/**
  * One validation failure. `path` points at the offending field as a
  * structured array — `['user', 'address', 0, 'line1']` for a nested
  * field, `['']` (the empty-string path) for a form-level error
  * (root `.refine()` messages, `setFormErrors()` entries, server-
  * emitted form banners). `formKey` identifies which form produced
  * the error so a single error list can be routed to multiple forms.
+ * The optional `data` slot carries an arbitrary server payload.
  *
  * Returned by `validate()` / `validateAsync()` / `handleSubmit`'s
  * `onError` callback, and by `parseApiErrors` for server responses.
@@ -80,6 +99,14 @@ export type ValidationError = {
    *   exact-message string matching.
    */
   code: string
+  /**
+   * Optional structured payload attached to the error. Attaform never
+   * sets or reads this; it is a passthrough slot for whatever a server
+   * sends alongside the message (a captcha challenge, a lockout
+   * `unlocks_at` timestamp, an MFA step-up descriptor) so the UI can
+   * act on it. Survives serialise / hydrate and undo / redo unchanged.
+   */
+  data?: Json | null
 }
 
 /** Settled validation result when the form (or subtree) parsed successfully. */

--- a/test/composables/error-data.test.ts
+++ b/test/composables/error-data.test.ts
@@ -1,0 +1,240 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, type App } from 'vue'
+import { z as zV4 } from 'zod'
+import { z as zV3 } from 'zod-v3'
+import { useForm as useFormV4 } from '../../src/zod-v4'
+import { useForm as useFormV3 } from '../../src/zod-v3'
+import { createFormStore } from '../../src/runtime/core/create-form-store'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import { getRegistryFromApp } from '../../src/runtime/core/registry'
+import { hydrateAttaformState, renderAttaformState } from '../../src/runtime/core/serialize'
+import { errorsEqual } from '../../src/runtime/core/history'
+import { canonicalizePath, type PathKey } from '../../src/runtime/core/paths'
+import { fakeSchema } from '../utils/fake-schema'
+import type { Json, ValidationError } from '../../src/runtime/types/types-api'
+
+/**
+ * `ValidationError.data` is an opaque JSON passthrough: the consumer
+ * attaches a structured server payload (a captcha challenge, a lockout
+ * `unlocks_at` timestamp, an MFA step-up descriptor) and Attaform
+ * carries it untouched across every surface — the manual setters, the
+ * aggregate reads, the SSR serialise / hydrate round-trip, and the
+ * undo / redo equality check.
+ */
+
+// A nested payload that touches every arm of the `Json` shape (string,
+// number, boolean, null, array, object) so the round-trips below prove
+// structural preservation, not just shallow copying.
+const challenge: Json = {
+  kind: 'captcha',
+  siteKey: 'abc123',
+  attemptsRemaining: 2,
+  locked: false,
+  unlocksAt: null,
+  hints: ['retry', 'slow-down'],
+  meta: { provider: 'turnstile', tiers: [1, 2, 3] },
+}
+
+type Signup = { email: string; password: string }
+
+describe('ValidationError.data — serialise / hydrate round-trip', () => {
+  it('preserves data on user and schema errors across the SSR round-trip', () => {
+    const serverApp = createApp({ render: () => null })
+    serverApp.use(createAttaform({ ssr: true }))
+    const registry = getRegistryFromApp(serverApp)
+    const state = createFormStore<Signup>({
+      formKey: 'data-rt',
+      schema: fakeSchema<Signup>({ email: 'a@a', password: '' }),
+    })
+    registry.forms.set('data-rt', state)
+
+    state.setAllUserErrors([
+      {
+        message: 'verify',
+        path: ['email'],
+        formKey: 'data-rt',
+        code: 'api:captcha',
+        data: challenge,
+      },
+    ])
+    state.setSchemaErrorsForPath(
+      ['password'],
+      [
+        {
+          message: 'weak',
+          path: ['password'],
+          formKey: 'data-rt',
+          code: 'atta:test',
+          data: { score: 1 },
+        },
+      ]
+    )
+
+    // Round-trip through JSON the way the SSR payload reaches the client.
+    const payload = renderAttaformState(serverApp)
+    const reparsed = JSON.parse(JSON.stringify(payload)) as typeof payload
+
+    const clientApp = createApp({ render: () => null })
+    clientApp.use(createAttaform())
+    hydrateAttaformState(clientApp, reparsed)
+    const pending = getRegistryFromApp(clientApp).pendingHydration.get('data-rt')
+    expect(pending).toBeDefined()
+    if (pending === undefined) return
+
+    const client = createFormStore<Signup>({
+      formKey: 'data-rt',
+      schema: fakeSchema<Signup>({ email: '', password: '' }),
+      hydration: pending,
+    })
+
+    expect(client.getErrorsForPath(['email'])[0]?.data).toEqual(challenge)
+    expect(client.getErrorsForPath(['password'])[0]?.data).toEqual({ score: 1 })
+  })
+
+  it('round-trips a null data slot distinctly from an absent one', () => {
+    const serverApp = createApp({ render: () => null })
+    serverApp.use(createAttaform({ ssr: true }))
+    const registry = getRegistryFromApp(serverApp)
+    const state = createFormStore<Signup>({
+      formKey: 'data-null',
+      schema: fakeSchema<Signup>({ email: 'a@a', password: '' }),
+    })
+    registry.forms.set('data-null', state)
+
+    state.setAllUserErrors([
+      { message: 'with', path: ['email'], formKey: 'data-null', code: 'c', data: null },
+      { message: 'without', path: ['password'], formKey: 'data-null', code: 'c' },
+    ])
+
+    const payload = JSON.parse(JSON.stringify(renderAttaformState(serverApp)))
+    const clientApp = createApp({ render: () => null })
+    clientApp.use(createAttaform())
+    hydrateAttaformState(clientApp, payload)
+    const pending = getRegistryFromApp(clientApp).pendingHydration.get('data-null')
+    if (pending === undefined) throw new Error('hydration missing')
+
+    const client = createFormStore<Signup>({
+      formKey: 'data-null',
+      schema: fakeSchema<Signup>({ email: '', password: '' }),
+      hydration: pending,
+    })
+
+    expect(client.getErrorsForPath(['email'])[0]?.data).toBeNull()
+    expect(client.getErrorsForPath(['password'])[0]).not.toHaveProperty('data')
+  })
+})
+
+describe('ValidationError.data — history equality', () => {
+  const emailKey = canonicalizePath(['email']).key
+  const mk = (data?: Json | null): ValidationError[] => {
+    const e: ValidationError = { message: 'x', path: ['email'], formKey: 'k', code: 'c' }
+    if (data !== undefined) e.data = data
+    return [e]
+  }
+  const at = (errs: ValidationError[]): ReadonlyArray<readonly [PathKey, ValidationError[]]> => [
+    [emailKey, errs],
+  ]
+
+  it('treats errors that differ only in data as not equal', () => {
+    expect(errorsEqual(at(mk({ a: 1 })), at(mk({ a: 2 })))).toBe(false)
+  })
+
+  it('treats errors with deep-equal data as equal', () => {
+    const a = at(mk({ a: [1, 2], b: { c: 3 } }))
+    const b = at(mk({ a: [1, 2], b: { c: 3 } }))
+    expect(errorsEqual(a, b)).toBe(true)
+  })
+
+  it('treats two no-data errors as equal', () => {
+    expect(errorsEqual(at(mk()), at(mk()))).toBe(true)
+  })
+
+  it('treats present-data and absent-data as not equal', () => {
+    expect(errorsEqual(at(mk({ a: 1 })), at(mk()))).toBe(false)
+  })
+
+  it('distinguishes null data from a populated payload', () => {
+    expect(errorsEqual(at(mk(null)), at(mk(null)))).toBe(true)
+    expect(errorsEqual(at(mk(null)), at(mk({ a: 1 })))).toBe(false)
+  })
+})
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyUseForm = (opts: any) => any
+
+const adapters = [
+  { name: 'zod v3', useForm: useFormV3 as AnyUseForm, z: zV3 as unknown as typeof zV4 },
+  { name: 'zod v4', useForm: useFormV4 as AnyUseForm, z: zV4 },
+] as const
+
+let keySeq = 0
+
+describe.each(adapters)('ValidationError.data through the form API — $name', ({ useForm, z }) => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+    document.body.innerHTML = ''
+  })
+
+  const schema = z.object({
+    email: z.string(),
+    password: z.string(),
+  })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function mountForm(): any {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const handle: { api?: any } = {}
+    const Host = defineComponent({
+      setup() {
+        handle.api = useForm({ schema, key: `error-data-${keySeq++}`, strict: false })
+        return () => h('div')
+      },
+    })
+    const app = createApp(Host).use(createAttaform())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    apps.push(app)
+    if (handle.api === undefined) throw new Error('mountForm: api never set')
+    return handle.api
+  }
+
+  it('carries data on a field error through the drill and aggregate reads', () => {
+    const api = mountForm()
+    api.setFieldErrors([
+      {
+        path: ['email'],
+        message: 'verify',
+        formKey: api.key,
+        code: 'api:captcha',
+        data: challenge,
+      },
+    ])
+
+    expect(api.errors.email?.[0]?.data).toEqual(challenge)
+    const fromMeta = api.meta.errors.find((e: ValidationError) => e.path[0] === 'email')
+    expect(fromMeta?.data).toEqual(challenge)
+  })
+
+  it('carries data on a form-level error set via setFormErrors', () => {
+    const api = mountForm()
+    api.setFormErrors([
+      { message: 'too many attempts', data: { unlocksAt: '2026-01-01T00:00:00Z' } },
+    ])
+
+    const formLevel = api.meta.errors.find(
+      (e: ValidationError) => e.path.length === 1 && e.path[0] === ''
+    )
+    expect(formLevel?.message).toBe('too many attempts')
+    expect(formLevel?.data).toEqual({ unlocksAt: '2026-01-01T00:00:00Z' })
+  })
+
+  it('omits data when none is supplied', () => {
+    const api = mountForm()
+    api.setFieldErrors([{ path: ['email'], message: 'taken', formKey: api.key, code: 'api:dupe' }])
+
+    expect(api.errors.email?.[0]).not.toHaveProperty('data')
+  })
+})

--- a/tests/fixtures/bundled-types/error-data.ts
+++ b/tests/fixtures/bundled-types/error-data.ts
@@ -1,0 +1,42 @@
+/**
+ * Bundled-types guard for `ValidationError.data` and the exported
+ * `Json` type through the published artifact, the way a real consumer
+ * sees them: `useForm` from `attaform/zod`, the error types from the
+ * `attaform` core entry.
+ *
+ * Pins three things against the bundled `.d.ts`:
+ *   - `Json` is exported and admits every JSON arm recursively (a
+ *     bundler that collapsed it to `any` / `unknown` or dropped the
+ *     recursion fails the structural assignment below).
+ *   - `ValidationError.data` types as `Json | null | undefined` — the
+ *     opaque, optional payload slot.
+ *   - `data` is reachable on the real read surface (`form.meta.errors`),
+ *     not just on the standalone type — so an emit that drops the field
+ *     from the surfaced error shape fails here.
+ */
+import { useForm } from '../../../dist/zod'
+import type { Json, ValidationError } from '../../../dist/index'
+import { z } from 'zod'
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false
+type Expect<T extends true> = T
+
+// `Json` is exported and recursive: a value touching string, number,
+// boolean, null, array, and nested-object arms must assign cleanly.
+const sample: Json = { a: [1, 'two', true, null, { nested: [0, { deep: true }] }] }
+void sample
+
+// The standalone type carries an optional, opaque `data` slot.
+declare const err: ValidationError
+type _DataSlot = Expect<Equal<typeof err.data, Json | null | undefined>>
+
+// And it is reachable on the real read surface.
+const form = useForm({ schema: z.object({ email: z.string() }), key: 'error-data-fixture' })
+const first = form.meta.errors[0]
+if (first) {
+  const payload: Json | null | undefined = first.data
+  void payload
+}
+
+export { form }


### PR DESCRIPTION
Part of #423 (the "sharpen the error model" issue), delivered as the first of three
independently-reviewable slices. This slice adds the **structured-payload** part; the
`[]`-vs-`['']` global-errors migration and the `setErrors` / `clearErrors` collapse follow in
their own PRs.

## What changed

- **`ValidationError` gains an optional `data?: Json | null` slot** for the structured payload a
  server may attach to an error (a captcha challenge, a lockout `unlocks_at` timestamp, an MFA
  step-up descriptor). Attaform never sets or reads it; it is an opaque passthrough the UI acts on.
- **`Json` is a new type-only export** from the `attaform` core entry (no runtime dependency). Its
  array and object arms are named interfaces so the recursive alias does not expand eagerly and trip
  TS2589 inside the large form-store structural type.
- **`data` survives every surface it must:** the path-restamp spreads (unchanged), the SSR
  serialise / hydrate round-trip (opaque, not hard-validated by the hydration guard), and undo /
  redo (history `errorFieldsEqual` now compares `data` structurally, so a snapshot differing only in
  `data` is no longer treated as identical).
- `setFormErrors` forwards `data` through its reconstruction so the slice is internally consistent
  (this setter is replaced in slice 3).

## Verification

- `pnpm typecheck`, `pnpm lint` clean.
- New `test/composables/error-data.test.ts` (13 tests): serialise / hydrate round-trip (incl. a
  `null` slot distinct from absent), history-equality discrimination, and read-back through the
  public form API on **both** zod v3 and v4.
- Full suite green (4213 passed, 2 skipped).
- `pnpm check:bundled-types` against a fresh `dist` — new fixture pins `Json` + `data` on the
  published `.d.ts` and the real `form.meta.errors` read surface.
- `pnpm check:eager` within budget (0.34 kB gz headroom).

Object-, record-, and discriminated-union-rooted forms are all unaffected (purely additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)