### PR TITLE
fix(aria): scope aria-required for array checkboxes (#381) and component hosts (#404)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,21 @@
 
 ## Unreleased
 
-_No unreleased changes yet._
+### Fixed
+
+- **A multi-select checkbox group no longer announces every box as required.**
+  `aria-required` is now scoped to the control that owns it: a checkbox that
+  aggregates into a `z.array(...)` or `z.set(...)` model omits it, since no single
+  box is required on its own and an empty selection is valid, while a required
+  single boolean checkbox keeps it. Fixed on the client, in runtime SSR, and in
+  compiled SSR. (#381)
+
+- **autoAria attributes land on the bound control, never on a component wrapper's
+  root.** When `v-register` is placed on a custom component, `aria-required` and
+  the other managed aria attributes now follow the inner element re-bound with
+  `useRegister`, instead of stamping the component's presentational root and
+  leaving a role-less `<div>` carrying an invalid ARIA attribute. Fixed on the
+  client and the server, including compiled SSR. (#404)
 
 ## v0.24.0
 ### Added

--- a/docs/binding-inputs/v-register.md
+++ b/docs/binding-inputs/v-register.md
@@ -67,6 +67,8 @@ By default, `v-register` keeps a field's aria attributes in sync with its [displ
 
 These track the same gated `displayState` that drives `form.fields.email.showErrors`, so the announcement and the visible message reveal together, never on a half-typed value. The required and invalid states are emitted during SSR too, so a server-rendered form is accessible before hydration.
 
+`aria-required` is scoped with care. A checkbox that rolls up into an array or set group never carries it, since no single box is required on its own and an empty selection is valid; the requirement lives on the group. And every attribute lands on the real form control: when `v-register` is on a wrapper component, the attributes follow the inner element it re-binds with [`useRegister`](/docs/binding-inputs/use-register), never the presentational root.
+
 ### Wiring the error element
 
 Auto-aria sets `aria-describedby` to [`form.fields.<path>.aria.errorId`](/docs/reading-the-form/fields). Put that id on your error element so the reference resolves:

--- a/src/runtime/core/directive-aria.ts
+++ b/src/runtime/core/directive-aria.ts
@@ -1,5 +1,7 @@
 import { effectScope, watch, type VNode } from 'vue'
 import type { DisplayState, RegisterValue } from '../types/types-api'
+import { INTERACTIVE_TAG_NAMES } from './interactive-tags'
+import { isArray, isSet } from './vue-shared-shim'
 
 /**
  * The aria attributes the directive keeps in sync with the field's
@@ -62,16 +64,23 @@ function setAriaAttr(el: HTMLElement, attr: string, value: string | null): void 
  * screen-reader signal stays in lockstep with the visible error state.
  * Binding to the gated display state (not raw `errors`) keeps the
  * signal honest about whether the consumer's `getDisplayState`
- * predicate has admitted the verdict for surfacing.
+ * predicate has admitted the verdict for surfacing. `suppressRequired`
+ * withholds `aria-required` for array / set checkbox groups, where no
+ * single member is individually required (#381).
  */
-function resolveAriaValue(attr: string, rv: RegisterValue, ds: DisplayState): string | null {
+function resolveAriaValue(
+  attr: string,
+  rv: RegisterValue,
+  ds: DisplayState,
+  suppressRequired: boolean
+): string | null {
   switch (attr) {
     case 'aria-invalid':
       return ds === 'error' ? 'true' : null
     case 'aria-busy':
       return ds === 'pending' ? 'true' : null
     case 'aria-required':
-      return rv.isRequired === true ? 'true' : null
+      return rv.isRequired === true && !suppressRequired ? 'true' : null
     case 'aria-describedby':
       return ds === 'error' && rv.aria?.errorId !== undefined ? rv.aria.errorId : null
     default:
@@ -80,15 +89,52 @@ function resolveAriaValue(attr: string, rv: RegisterValue, ds: DisplayState): st
 }
 
 /**
+ * Whether `aria-required` must be withheld for this binding. A checkbox
+ * that aggregates into an array / set model is one member of a group:
+ * no single member is individually required, an empty selection is
+ * valid, and `aria-required` on a checkbox specifically announces "this
+ * box must be checked." So the required signal is suppressed for array /
+ * set checkbox members (#381), while a single boolean checkbox and a
+ * multi-select `<select>` (both valid `aria-required` carriers) keep it.
+ * The collection check reads the seeded model value, mirroring the
+ * `vRegisterCheckbox` array / set detection.
+ */
+function suppressesRequired(rv: RegisterValue, isCheckbox: boolean): boolean {
+  if (!isCheckbox) return false
+  const model = rv.innerRef.value
+  return isArray(model) || isSet(model)
+}
+
+/**
+ * A native checkbox input, identified by tag name (uppercase, matching
+ * `el.tagName`) and resolved `type`. The type is sourced from the vnode
+ * props rather than the DOM: Vue's `created` directive hook runs before
+ * props are patched, so `el.type` is not yet `'checkbox'` at the first
+ * aria paint (the same reason `resolveDynamicModel` reads
+ * `vnode.props.type`).
+ */
+function isCheckboxInput(tagName: string, type: unknown): boolean {
+  return tagName === 'INPUT' && typeof type === 'string' && type.toLowerCase() === 'checkbox'
+}
+
+/**
  * Reflect the binding's gated display state onto the unmanaged aria
  * attributes. Each managed attr is set or removed independently.
  */
-export function applyAria(el: AriaCarrier, rv: RegisterValue): void {
+export function applyAria(el: AriaCarrier, rv: RegisterValue, vnode: VNode | null): void {
   if (rv.ariaEnabled !== true || rv.ariaDisplayState === undefined) return
+  // Only real form controls carry autoAria (see setupAria). (#404)
+  if (!INTERACTIVE_TAG_NAMES.has(el.tagName)) return
   const locks = el[ariaLockKey] ?? EMPTY_ARIA_LOCKS
   const ds = rv.ariaDisplayState.value
+  const vnodeType = vnode?.props?.['type']
+  const checkbox = isCheckboxInput(
+    el.tagName,
+    typeof vnodeType === 'string' ? vnodeType : (el as HTMLInputElement).type
+  )
+  const suppressRequired = suppressesRequired(rv, checkbox)
   for (const attr of MANAGED_ARIA_ATTRS) {
-    if (!locks.has(attr)) setAriaAttr(el, attr, resolveAriaValue(attr, rv, ds))
+    if (!locks.has(attr)) setAriaAttr(el, attr, resolveAriaValue(attr, rv, ds, suppressRequired))
   }
 }
 
@@ -100,12 +146,17 @@ export function applyAria(el: AriaCarrier, rv: RegisterValue): void {
  */
 export function setupAria(el: AriaCarrier, rv: RegisterValue, vnode: VNode): void {
   if (rv.ariaEnabled !== true || rv.ariaDisplayState === undefined) return
+  // autoAria only manages real form controls. When v-register lands on a
+  // component host (a presentational wrapper such as a <div>), the attrs
+  // would be invalid ARIA on a role-less element; the inner control the
+  // component re-binds via useRegister carries them instead. (#404)
+  if (!INTERACTIVE_TAG_NAMES.has(el.tagName)) return
   mergeAriaLocks(el, vnode)
-  applyAria(el, rv)
+  applyAria(el, rv, vnode)
   const displayState = rv.ariaDisplayState
   const scope = effectScope(true)
   scope.run(() => {
-    watch(displayState, () => applyAria(el, rv), { flush: 'post' })
+    watch(displayState, () => applyAria(el, rv, vnode), { flush: 'post' })
   })
   el[ariaScopeKey] = (): void => scope.stop()
 }
@@ -128,10 +179,12 @@ export function getSSRAriaProps(
   if (rv.ariaEnabled !== true || rv.ariaDisplayState === undefined) return undefined
   const props = vnode?.props ?? null
   const ds = rv.ariaDisplayState.value
+  const tagName = typeof vnode?.type === 'string' ? vnode.type.toUpperCase() : ''
+  const suppressRequired = suppressesRequired(rv, isCheckboxInput(tagName, props?.['type']))
   const out: Record<string, string> = {}
   for (const attr of MANAGED_ARIA_ATTRS) {
     if (props !== null && attr in props) continue
-    const value = resolveAriaValue(attr, rv, ds)
+    const value = resolveAriaValue(attr, rv, ds, suppressRequired)
     if (value !== null) out[attr] = value
   }
   return out

--- a/src/runtime/core/directive.ts
+++ b/src/runtime/core/directive.ts
@@ -1187,8 +1187,11 @@ const vRegisterDynamic: RegisterModelDynamicCustomDirective = {
       INTERACTIVE_TAG_NAMES.has(realVnode.type.toUpperCase())
     // The compile-time componentBridgeTransform stamps this modifier on a
     // component-host v-register, the only signal available under compiled
-    // SSR's null vnode.
-    const isComponentHostModifier = binding.modifiers[SSR_COMPONENT_HOST_MODIFIER] === true
+    // SSR's null vnode. `modifiers` is typed as always-present, but the
+    // compiled SSR helper (and synthetic bindings) can omit it, so treat it
+    // as optional the same way the vnode above is.
+    const modifiers = binding.modifiers as Record<string, boolean> | undefined
+    const isComponentHostModifier = modifiers?.[SSR_COMPONENT_HOST_MODIFIER] === true
     const suppressHostAria =
       isComponentHostModifier || (realVnode !== null && !isInteractiveElementVnode)
     const ariaProps = suppressHostAria ? undefined : getSSRAriaProps(rv, realVnode)

--- a/src/runtime/core/directive.ts
+++ b/src/runtime/core/directive.ts
@@ -22,6 +22,7 @@ import {
   isRegisterValue,
   isTransforming,
   REGISTER_OWNER_MARKER,
+  SSR_COMPONENT_HOST_MODIFIER,
   V_REGISTER_MARKER,
 } from './register-protocol'
 import { __DEV__ } from './dev'
@@ -1184,7 +1185,12 @@ const vRegisterDynamic: RegisterModelDynamicCustomDirective = {
       realVnode !== null &&
       typeof realVnode.type === 'string' &&
       INTERACTIVE_TAG_NAMES.has(realVnode.type.toUpperCase())
-    const suppressHostAria = realVnode !== null && !isInteractiveElementVnode
+    // The compile-time componentBridgeTransform stamps this modifier on a
+    // component-host v-register, the only signal available under compiled
+    // SSR's null vnode.
+    const isComponentHostModifier = binding.modifiers[SSR_COMPONENT_HOST_MODIFIER] === true
+    const suppressHostAria =
+      isComponentHostModifier || (realVnode !== null && !isInteractiveElementVnode)
     const ariaProps = suppressHostAria ? undefined : getSSRAriaProps(rv, realVnode)
 
     // Form-state (`value` / `checked`) is the runtime path's analogue of

--- a/src/runtime/core/directive.ts
+++ b/src/runtime/core/directive.ts
@@ -1119,7 +1119,7 @@ const vRegisterDynamic: RegisterModelDynamicCustomDirective = {
         setupAria(ariaEl, value, vnode)
       } else {
         mergeAriaLocks(ariaEl, vnode)
-        applyAria(ariaEl, value)
+        applyAria(ariaEl, value, vnode)
       }
     }
   },
@@ -1170,7 +1170,22 @@ const vRegisterDynamic: RegisterModelDynamicCustomDirective = {
     // SSR path; under compiled SSR an authored aria attribute can't be
     // detected here, and the client directive reconciles it on hydration.
     const realVnode = (vnode as VNode | null) ?? null
-    const ariaProps = getSSRAriaProps(rv, realVnode)
+    // autoAria attrs belong on the bound form control, never on a
+    // component host's root element (a presentational wrapper would carry
+    // an invalid aria-* attribute). On the runtime path Vue invokes this
+    // hook for both the component vnode and the resolved root element, so
+    // emit only for an interactive form-control element vnode; a component
+    // vnode or a non-control root (e.g. a wrapper <div>) is suppressed.
+    // The inner control the component re-binds via useRegister emits its
+    // own aria. A `null` vnode is the compiled-SSR path, which cannot see
+    // the element here and is handled by the component-host signal the
+    // transform stamps. (#404)
+    const isInteractiveElementVnode =
+      realVnode !== null &&
+      typeof realVnode.type === 'string' &&
+      INTERACTIVE_TAG_NAMES.has(realVnode.type.toUpperCase())
+    const suppressHostAria = realVnode !== null && !isInteractiveElementVnode
+    const ariaProps = suppressHostAria ? undefined : getSSRAriaProps(rv, realVnode)
 
     // Form-state (`value` / `checked`) is the runtime path's analogue of
     // the compile-time transform's injected binding. Compiled SSR passes a

--- a/src/runtime/core/register-protocol.ts
+++ b/src/runtime/core/register-protocol.ts
@@ -35,6 +35,18 @@ export const V_REGISTER_MARKER: unique symbol = Symbol.for('attaform:v-register-
 export const REGISTER_OWNER_MARKER: unique symbol = Symbol.for('attaform:register-owner-marker')
 
 /**
+ * Directive modifier the `componentBridgeTransform` stamps onto a
+ * `v-register` that lands on a component host (or kebab custom element).
+ * It is the compile-time -> runtime signal the directive's `getSSRProps`
+ * reads under compiled SSR, where Vue passes a `null` vnode and the host
+ * is otherwise indistinguishable from a native control. autoAria then
+ * suppresses its attrs on the host root (the inner control the component
+ * re-binds via useRegister carries them). Namespaced to avoid collision
+ * with any author-written modifier. (#404)
+ */
+export const SSR_COMPONENT_HOST_MODIFIER = 'attaformComponentHost'
+
+/**
  * Type guard for a `RegisterValue`. Returns `true` when `val` looks
  * like the object returned from `form.register(path)`.
  *

--- a/src/runtime/lib/core/transforms/component-bridge-transform.ts
+++ b/src/runtime/lib/core/transforms/component-bridge-transform.ts
@@ -13,6 +13,7 @@ import {
   type SourceLocation,
   type TemplateChildNode,
 } from '@vue/compiler-core'
+import { SSR_COMPONENT_HOST_MODIFIER } from '../../../core/register-protocol'
 import {
   flattenExpression,
   getSummarizedProps,
@@ -470,6 +471,20 @@ export const componentBridgeTransform: NodeTransform = (node, context) => {
         p.arg.content === 'registerValue'
     )
     if (alreadyInjected) return
+
+    // Signal compiled SSR that this v-register host is a component, so the
+    // directive's getSSRProps suppresses autoAria on the host root (the
+    // inner control the component re-binds via useRegister carries it).
+    // The runtime path reads the component vnode directly; compiled SSR
+    // only has a null vnode, so this modifier is the channel. (#404)
+    if (
+      registerProp.type === NodeTypes.DIRECTIVE &&
+      !registerProp.modifiers.some(
+        (m) => m.type === NodeTypes.SIMPLE_EXPRESSION && m.content === SSR_COMPONENT_HOST_MODIFIER
+      )
+    ) {
+      registerProp.modifiers.push(createSimpleExpression(SSR_COMPONENT_HOST_MODIFIER, true))
+    }
 
     const customElementProp: DirectiveNode = {
       arg: createSimpleExpression('registerValue', true),

--- a/test/composables/aria-required-scoping.test.ts
+++ b/test/composables/aria-required-scoping.test.ts
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, withDirectives, type App } from 'vue'
+import { z } from 'zod'
+import { vRegister } from '../../src/runtime/core/directive'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import { useRegister } from '../../src/runtime/composables/use-register'
+import { useForm } from '../../src/zod'
+import { awaitSettle, waitUntil } from '../utils/form-harness'
+
+/**
+ * Regression coverage for the two autoAria `aria-required` scoping
+ * defects, #381 and #404. Both trace back to `resolveAriaValue`
+ * deciding `aria-required` purely from `rv.isRequired` (the schema's
+ * path-level required flag), applied uniformly to whatever element
+ * `v-register` resolves to:
+ *
+ *   - #381: every `<input type="checkbox">` aggregating into an array
+ *           model carries `aria-required`, though no member checkbox is
+ *           individually required and an empty selection (`[]`) is valid.
+ *   - #404: a component host's root element (a presentational wrapper
+ *           such as a `<div>`) carries `aria-required` — invalid ARIA on
+ *           a role-less element — instead of only the bound inner control.
+ *
+ * These specs assert the FIXED behaviour and are expected to fail on the
+ * unfixed tree (proving the bugs reproduce).
+ */
+
+describe('#381 — aria-required is not stamped on array-member checkboxes', () => {
+  let app: App | undefined
+  afterEach(() => {
+    app?.unmount()
+    app = undefined
+    document.body.innerHTML = ''
+  })
+
+  it('omits aria-required on every checkbox bound to a required array path', async () => {
+    const schema = z.object({ permissions: z.array(z.string()) })
+    const Parent = defineComponent({
+      setup() {
+        const form = useForm({
+          schema,
+          key: 'aria-381-array',
+          defaultValues: { permissions: ['role_create'] },
+          strict: false,
+        })
+        return () =>
+          h(
+            'fieldset',
+            ['role_create', 'role_update', 'member_invite'].map((v) =>
+              withDirectives(h('input', { type: 'checkbox', value: v, class: `cb-${v}` }), [
+                [vRegister, form.register('permissions')],
+              ])
+            )
+          )
+      },
+    })
+    app = createApp(Parent).use(createAttaform())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await waitUntil(() => (root.querySelector('input.cb-role_create') !== null ? true : null))
+    await awaitSettle()
+
+    const boxes = Array.from(root.querySelectorAll('input[type=checkbox]')) as HTMLInputElement[]
+    expect(boxes.length).toBe(3)
+    for (const box of boxes) {
+      expect(box.hasAttribute('aria-required')).toBe(false)
+    }
+  })
+
+  it('still stamps aria-required on a required single boolean checkbox (no over-correction)', async () => {
+    const schema = z.object({ agree: z.boolean() })
+    const Parent = defineComponent({
+      setup() {
+        const form = useForm({ schema, key: 'aria-381-bool', strict: false })
+        return () =>
+          withDirectives(h('input', { type: 'checkbox', class: 'agree' }), [
+            [vRegister, form.register('agree')],
+          ])
+      },
+    })
+    app = createApp(Parent).use(createAttaform())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await waitUntil(() => (root.querySelector('input.agree') !== null ? true : null))
+    await awaitSettle()
+
+    const box = root.querySelector('input.agree') as HTMLInputElement
+    expect(box.getAttribute('aria-required')).toBe('true')
+  })
+})
+
+describe('#404 — aria-required lands on the bound control, not the component host root', () => {
+  let app: App | undefined
+  afterEach(() => {
+    app?.unmount()
+    app = undefined
+    document.body.innerHTML = ''
+  })
+
+  const schema = z.object({ email: z.string() })
+
+  // A presentational wrapper whose root is a non-control <div>, with the
+  // real <input> re-bound via useRegister — the recommended styled-field
+  // pattern from the #404 report.
+  const FieldWrapper = defineComponent({
+    name: 'FieldWrapper',
+    inheritAttrs: false,
+    setup() {
+      const register = useRegister()
+      return { register }
+    },
+    render() {
+      return h('div', { class: 'field-wrapper' }, [
+        withDirectives(h('input', { type: 'text', class: 'inner' }), [[vRegister, this.register]]),
+      ])
+    },
+  })
+
+  function mountWrapper(): { root: HTMLElement } {
+    const Parent = defineComponent({
+      setup() {
+        const form = useForm({ schema, key: 'aria-404', defaultValues: { email: '' } })
+        const rv = form.register('email')
+        return () =>
+          withDirectives(h(FieldWrapper, { registerValue: rv, value: rv.innerRef.value }), [
+            [vRegister, rv],
+          ])
+      },
+    })
+    app = createApp(Parent).use(createAttaform())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    return { root }
+  }
+
+  it('does NOT stamp aria-required on the component host root (the wrapper <div>)', async () => {
+    const { root } = mountWrapper()
+    await waitUntil(() => (root.querySelector('input.inner') !== null ? true : null))
+    await awaitSettle()
+
+    const wrapper = root.querySelector('div.field-wrapper') as HTMLElement
+    // aria-required on a role-less <div> is invalid ARIA (axe
+    // aria-allowed-attr, WCAG 4.1.2). The host must stay clean.
+    expect(wrapper.hasAttribute('aria-required')).toBe(false)
+  })
+
+  it('keeps aria-required on the inner bound <input> (no over-correction)', async () => {
+    const { root } = mountWrapper()
+    await waitUntil(() => (root.querySelector('input.inner') !== null ? true : null))
+    await awaitSettle()
+
+    const inner = root.querySelector('input.inner') as HTMLInputElement
+    expect(inner.getAttribute('aria-required')).toBe('true')
+  })
+})

--- a/test/fixtures/ssr/AriaWrapper.vue
+++ b/test/fixtures/ssr/AriaWrapper.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+  import { useRegister } from '@runtime/composables/use-register'
+
+  // Recommended styled-field pattern: the parent binds v-register on this
+  // component; useRegister re-binds it onto the inner native control. The
+  // wrapper's <div> root must not carry autoAria's aria-required (#404).
+  const rv = useRegister()
+</script>
+
+<template>
+  <div id="aria-host-wrapper" class="field-wrapper">
+    <input id="aria-host-inner" v-register="rv" />
+  </div>
+</template>

--- a/test/fixtures/ssr/app.vue
+++ b/test/fixtures/ssr/app.vue
@@ -3,6 +3,7 @@
   // The SSR fixture exercises the zod v3 adapter via useForm auto-import.
   // Installed side-by-side with zod v4 via pnpm alias.
   import { z } from 'zod-v3'
+  import AriaWrapper from './AriaWrapper.vue'
 
   const schema = z.object({
     favoriteGame: z.string().default('chess'),
@@ -88,6 +89,16 @@
     key: 'hydration-check',
   })
   hydrationForm.setValue('hydratedField', 'server-written-value')
+
+  // -- autoAria component-host fixture (#404) --
+  // A required field rendered through a presentational wrapper component.
+  // The wrapper's root <div> must NOT carry aria-required (invalid ARIA on
+  // a role-less element); the inner <input> the wrapper re-binds via
+  // useRegister carries it. Exercises the compiled-SSR null-vnode path.
+  const ariaHostForm = useForm({
+    schema: z.object({ email: z.string().min(1) }),
+    key: 'aria-host',
+  })
 </script>
 
 <template>
@@ -199,6 +210,11 @@
       <div id="hydration-check">
         <span id="hydration-check-value">{{ hydrationForm.values.hydratedField }}</span>
       </div>
+    </section>
+
+    <section>
+      <h2>autoAria component host</h2>
+      <AriaWrapper v-register="ariaHostForm.register('email')" />
     </section>
   </div>
 </template>

--- a/test/ssr-bare-vue/aria-component-host-ssr.test.ts
+++ b/test/ssr-bare-vue/aria-component-host-ssr.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import { compileTemplate } from '@vue/compiler-sfc'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, type App, type DirectiveBinding } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import type { RegisterValue } from '../../src/runtime/types/types-api'
+import { vRegister } from '../../src/runtime/core/directive'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import { SSR_COMPONENT_HOST_MODIFIER } from '../../src/runtime/core/register-protocol'
+import { componentBridgeTransform } from '../../src/runtime/lib/core/transforms/component-bridge-transform'
+import { inputTextAreaNodeTransform } from '../../src/runtime/lib/core/transforms/input-text-area-transform'
+import { vRegisterHintTransform } from '../../src/runtime/lib/core/transforms/v-register-hint-transform'
+import { vRegisterPreambleTransform } from '../../src/runtime/lib/core/transforms/v-register-preamble-transform'
+import { waitUntil } from '../utils/form-harness'
+
+/**
+ * Compiled-SSR coverage for #404. Production SSR compiles SFC templates
+ * with `@vue/compiler-ssr`, which emits `ssrGetDirectiveProps(...)` and
+ * hands the directive a `null` vnode — so the runtime hook cannot tell a
+ * component host from a native control there. The fix relies on
+ * `componentBridgeTransform` stamping the `SSR_COMPONENT_HOST_MODIFIER`
+ * onto a component-host `v-register`, which the directive's `getSSRProps`
+ * reads from `binding.modifiers`.
+ *
+ * This file proves both ends of that null-vnode mechanism directly: the
+ * transform stamps the modifier (and only for component hosts), and
+ * `getSSRProps` suppresses autoAria when it sees the modifier with a null
+ * vnode (while still emitting for a bare native control). The full
+ * runtime-vnode SSR path is covered in `aria-ssr.test.ts`; the end-to-end
+ * Nuxt build is covered in `test/ssr.test.ts`.
+ */
+
+function compileSSR(template: string): string {
+  return compileTemplate({
+    source: template,
+    filename: 'aria-host.vue',
+    id: 'aria-host',
+    ssr: true,
+    compilerOptions: {
+      ssr: true,
+      nodeTransforms: [
+        componentBridgeTransform,
+        inputTextAreaNodeTransform,
+        vRegisterPreambleTransform,
+        vRegisterHintTransform,
+      ],
+    },
+  }).code
+}
+
+describe('compiled-SSR transform — component-host modifier (#404)', () => {
+  it('stamps the component-host modifier on a <Component v-register> host', () => {
+    const code = compileSSR(`<FieldWrapper v-register="form.register('email')" />`)
+    expect(code).toContain('ssrGetDirectiveProps')
+    expect(code).toContain(SSR_COMPONENT_HOST_MODIFIER)
+  })
+
+  it('does NOT stamp the modifier on a bare native <input v-register>', () => {
+    const code = compileSSR(`<input type="text" v-register="form.register('email')" />`)
+    expect(code).toContain('ssrGetDirectiveProps')
+    expect(code).not.toContain(SSR_COMPONENT_HOST_MODIFIER)
+  })
+})
+
+describe('getSSRProps — null vnode (compiled SSR) honours the host modifier (#404)', () => {
+  let app: App | undefined
+  const handle: { rv?: RegisterValue | undefined } = {}
+
+  afterEach(() => {
+    app?.unmount()
+    app = undefined
+    handle.rv = undefined
+    document.body.innerHTML = ''
+  })
+
+  async function captureRequiredRv(): Promise<RegisterValue> {
+    const schema = z.object({ email: z.string().min(1) })
+    const Comp = defineComponent({
+      setup() {
+        const form = useForm({ schema, key: `gsp-${Math.random().toString(36).slice(2)}` })
+        handle.rv = form.register('email') as unknown as RegisterValue
+        return () => h('input', { type: 'text' })
+      },
+    })
+    app = createApp(Comp).use(createAttaform())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await waitUntil(() => (handle.rv !== undefined ? true : null))
+    if (handle.rv === undefined) throw new Error('rv never captured')
+    return handle.rv
+  }
+
+  function bindingFor(rv: RegisterValue, modifiers: Record<string, boolean>): DirectiveBinding {
+    return {
+      value: rv,
+      oldValue: null,
+      modifiers,
+      dir: vRegister,
+      instance: null,
+    } as unknown as DirectiveBinding
+  }
+
+  it('suppresses aria for a host-modified binding (the compiled wrapper case)', async () => {
+    const rv = await captureRequiredRv()
+    const props = vRegister.getSSRProps?.(
+      bindingFor(rv, { [SSR_COMPONENT_HOST_MODIFIER]: true }),
+      null as never
+    )
+    expect(props?.['aria-required']).toBeUndefined()
+  })
+
+  it('still emits aria-required for an unmodified binding (the compiled native case)', async () => {
+    const rv = await captureRequiredRv()
+    const props = vRegister.getSSRProps?.(bindingFor(rv, {}), null as never)
+    expect(props?.['aria-required']).toBe('true')
+  })
+})

--- a/test/ssr-bare-vue/aria-ssr.test.ts
+++ b/test/ssr-bare-vue/aria-ssr.test.ts
@@ -93,3 +93,88 @@ describe('auto-aria SSR', () => {
     expect(html).not.toContain('aria-required')
   })
 })
+
+describe('auto-aria SSR — array-member checkboxes (#381)', () => {
+  it('omits aria-required on every checkbox bound to a required array path', async () => {
+    const schema = z.object({ permissions: z.array(z.string()) })
+    const Comp = defineComponent({
+      setup() {
+        const form = useForm({
+          schema,
+          key: `ssr-381-${Math.random().toString(36).slice(2)}`,
+          defaultValues: { permissions: ['role_create'] },
+        })
+        return () =>
+          h(
+            'fieldset',
+            ['role_create', 'role_update', 'member_invite'].map((v) =>
+              withDirectives(h('input', { type: 'checkbox', value: v }), [
+                [vRegister, form.register('permissions')],
+              ])
+            )
+          )
+      },
+    })
+    const html = await renderToString(createSSRApp(Comp).use(createAttaform()))
+    expect(html).not.toContain('aria-required')
+  })
+
+  it('still emits aria-required for a required single boolean checkbox', async () => {
+    const schema = z.object({ agree: z.boolean() })
+    const Comp = defineComponent({
+      setup() {
+        const form = useForm({ schema, key: `ssr-381-bool-${Math.random().toString(36).slice(2)}` })
+        return () =>
+          withDirectives(h('input', { type: 'checkbox' }), [[vRegister, form.register('agree')]])
+      },
+    })
+    const html = await renderToString(createSSRApp(Comp).use(createAttaform()))
+    expect(html).toContain('aria-required="true"')
+  })
+})
+
+describe('auto-aria SSR — component host (#404)', () => {
+  it('does not stamp aria-required on a component host root', async () => {
+    const schema = z.object({ email: z.string() })
+    // Presentational wrapper whose root is a non-control <div>.
+    const FieldWrapper = defineComponent({
+      name: 'FieldWrapper',
+      setup:
+        (_, { slots }) =>
+        () =>
+          h('div', { class: 'field-wrapper' }, slots['default']?.()),
+    })
+    const Comp = defineComponent({
+      setup() {
+        const form = useForm({
+          schema,
+          key: `ssr-404-${Math.random().toString(36).slice(2)}`,
+          defaultValues: { email: '' },
+        })
+        return () =>
+          withDirectives(h(FieldWrapper, null, { default: () => h('input', { type: 'text' }) }), [
+            [vRegister, form.register('email')],
+          ])
+      },
+    })
+    const html = await renderToString(createSSRApp(Comp).use(createAttaform()))
+    // The role-less wrapper <div> must not carry aria-required.
+    expect(html).not.toContain('aria-required')
+  })
+
+  it('still emits aria-required on a bare native control (positive control)', async () => {
+    const schema = z.object({ email: z.string() })
+    const Comp = defineComponent({
+      setup() {
+        const form = useForm({
+          schema,
+          key: `ssr-404-native-${Math.random().toString(36).slice(2)}`,
+        })
+        return () =>
+          withDirectives(h('input', { type: 'text' }), [[vRegister, form.register('email')]])
+      },
+    })
+    const html = await renderToString(createSSRApp(Comp).use(createAttaform()))
+    expect(html).toContain('aria-required="true"')
+  })
+})

--- a/test/ssr.test.ts
+++ b/test/ssr.test.ts
@@ -319,4 +319,32 @@ describe('SSR behavior of useForm', async () => {
       expect(typedHtml).toMatch(/__NUXT(?:_DATA)?__/)
     })
   })
+
+  /*
+    Test Suite: autoAria on a component host (#404)
+    Focus: v-register on a custom component must not stamp aria-required on
+    the component's wrapper root (invalid ARIA on a role-less <div>); the
+    inner control the wrapper re-binds via useRegister carries it. This is
+    the production compiled-SSR null-vnode path the runtime hook can't see
+    without the component-host modifier the transform stamps.
+  */
+  describe('SSR behavior of autoAria component host >>', () => {
+    it('does not stamp aria-required on the component host wrapper root', async () => {
+      const html = await $fetch('/')
+      assertHTML(html)
+      const $ = cheerio.load(html as string)
+      const wrapper = $('#aria-host-wrapper')
+      expect(wrapper.length).toBe(1)
+      expect(wrapper.attr('aria-required')).toBeUndefined()
+    })
+
+    it('keeps aria-required on the inner bound control', async () => {
+      const html = await $fetch('/')
+      assertHTML(html)
+      const $ = cheerio.load(html as string)
+      const inner = $('#aria-host-inner')
+      expect(inner.length).toBe(1)
+      expect(inner.attr('aria-required')).toBe('true')
+    })
+  })
 })


### PR DESCRIPTION
Fixes two autoAria scoping defects that share one root cause: `resolveAriaValue` emitted `aria-required` from `rv.isRequired` onto whatever element `v-register` resolved to, with no awareness of element kind.

## #381: array-member checkboxes
Every `<input type=checkbox>` aggregating into a `z.array(...)` / `z.set(...)` model carried `aria-required="true"`, though no single member is individually required and an empty selection is valid. Now suppressed for array / set checkbox members; a required single boolean checkbox keeps it, and a `<select multiple>` (a valid carrier) keeps it.

## #404: component-host wrapper root
`v-register` on a custom component fell through to the component's root element, stamping `aria-required` on a presentational wrapper (axe `aria-allowed-attr`, critical, WCAG 4.1.2). autoAria now manages only real form controls; on a wrapper the attributes follow the inner control re-bound via `useRegister`.

## Render paths
- **Client**: `applyAria` / `setupAria` gate on `INTERACTIVE_TAG_NAMES`; the checkbox type is read from `vnode.props`, since Vue patches `el.type` after the `created` hook.
- **Runtime SSR**: `getSSRProps` emits only for an interactive element vnode (Vue calls it for both the component vnode and the resolved root element).
- **Compiled SSR**: `componentBridgeTransform` stamps an internal modifier on a component-host `v-register`, the only signal under compiled SSR's null vnode, which `getSSRProps` reads from `binding.modifiers`.

## Tests
Regression coverage at every layer, written red-first:
- Client (jsdom): array checkboxes omit / single boolean keeps; host omits / inner keeps.
- Runtime SSR: the issue repros via `renderToString`.
- Compiled SSR: transform output + `getSSRProps` null-vnode behaviour, plus an end-to-end case in the Nuxt SSR fixture.

## Verification
`pnpm typecheck`, `pnpm lint`, full `pnpm test` (4203 passed), `check:bundled-types` (v3 + v4, public surface unchanged), `check:eager` (within budget), and a full docs-site `nuxi build` (link checker 0 errors across 184 pages, 424 routes prerendered).

Closes #381
Closes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)