### PR TITLE
fix: setErrors-and-return is a failed submit, not a success (#438)

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -437,7 +437,15 @@ export default [
     // (chore/rip-onchange): the unified entry's shared core chunk drops the
     // onChange seam (on-change.ts + dispatch + the silent thread). Measured at
     // 57.64 KB.
-    limit: '58 KB',
+    //
+    // Raised 58 → 59 KB on the submit-success-semantics branch (#438): the
+    // post-callback failure routing lands in the shared core chunk. process-
+    // form's handleSubmit gains a userErrors-non-empty check after onSubmit
+    // (focus + onError + early return so a setErrors-and-return callback no
+    // longer flips submitted), mirrored in use-wizard (collectCallbackErrors +
+    // focusFirstWizardError, gating done / step-advance on a clean callback).
+    // Measured at 58.08 KB.
+    limit: '59 KB',
     gzip: true,
     ignore: ['zod'],
     modifyEsbuildConfig: asEsm,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@
   leaving a role-less `<div>` carrying an invalid ARIA attribute. Fixed on the
   client and the server, including compiled SSR. (#404)
 
+- **A submit callback that hands a server rejection to `setErrors` and returns
+  no longer reads as a success.** `form.meta.submitted` flips `true` only when
+  the callback resolves without throwing and leaves no errors set, so the
+  documented `setErrors(response.errors); return` pattern marks a failed submit
+  instead of rendering a success banner. The first error now auto-focuses on
+  submit, exactly as a schema failure does, and `onError` fires with what the
+  callback set. `wizard.handleSubmit` gains the same safeguard: a server
+  rejection keeps `wizard.done` at `false` on the final step and holds the
+  wizard on the current step instead of advancing past a rejected one. (#438)
+
 ## v0.24.0
 ### Added
 

--- a/docs/multistep/handle-submit.md
+++ b/docs/multistep/handle-submit.md
@@ -74,8 +74,8 @@ type WizardSubmitContext = {
 ```ts
 const onSubmit = wizard.handleSubmit(async (ctx) => {
   if (!ctx.isFinal) {
-    // Intermediate steps: wizard has already advanced; track a step-complete
-    // event and let the user keep going.
+    // Intermediate steps: validation passed. Track a step-complete event;
+    // the wizard advances once this callback returns without setting errors.
     analytics.track('wizard_step_complete', { step: ctx.currentKey })
     return
   }
@@ -92,8 +92,8 @@ const onSubmit = wizard.handleSubmit(async (ctx) => {
 
 The two calls do different work:
 
-- **Intermediate call** (`ctx.isFinal === false`). Validates the active form only. On success, the wizard advances to the next compiled step _before_ `onSubmit` runs, so any side effect in the callback fires from the new step. On failure, the wizard stays put and `onError` fires.
-- **Final call** (`ctx.isFinal === true`). Validates every form in parallel. On success, `onSubmit` runs once and `wizard.done` flips to `true` (monotonic, only `reset()` flips it back). On failure, the wizard stays on the terminal step and `onError` fires.
+- **Intermediate call** (`ctx.isFinal === false`). Validates the active form only. On a clean pass, `onSubmit` runs from the current step and the wizard then advances to the next compiled step. The advance is gated on the result: if validation fails, or if the callback hands a server rejection to `setErrors` and returns, the wizard stays put and `onError` fires.
+- **Final call** (`ctx.isFinal === true`). Validates every form in parallel. On success, `onSubmit` runs once and `wizard.done` flips to `true` (monotonic, only `reset()` flips it back). `done` flips only when the callback also leaves no errors set, so a `setErrors`-and-return server rejection keeps it `false`. On a validation failure, the wizard stays on the terminal step and `onError` fires.
 
 The two paths share one handler and one context shape, so the consumer never has to choose between "fire the mutation now" and "fire it later" until the `if (!ctx.isFinal) return` guard at the top of the callback.
 
@@ -115,7 +115,7 @@ const onSubmit = wizard.handleSubmit(
 )
 ```
 
-Each error carries `formKey`, `path`, `message`, and an optional `code`. The list combines validation errors from every form processed on this call with any activation failures (e.g., a form whose async `defaultValues` rejected). For wizard-wide error summaries that persist between submissions, drive them off [`wizard.allErrors`](/docs/multistep/aggregates#allerrors-for-wizard-wide-summaries) instead.
+Each error carries `formKey`, `path`, `message`, and an optional `code`. The list combines validation errors from every form processed on this call, any errors the callback set with `setErrors`, and any activation failures (e.g., a form whose async `defaultValues` rejected). For wizard-wide error summaries that persist between submissions, drive them off [`wizard.allErrors`](/docs/multistep/aggregates#allerrors-for-wizard-wide-summaries) instead.
 
 ## `focusFirstError`
 
@@ -154,5 +154,5 @@ Disabling the button is belt-and-braces; the wizard refuses re-entry on its own.
 
 - [`useWizard`](/docs/multistep/use-wizard) for the construction signature and the full wizard handle.
 - [Aggregates](/docs/multistep/aggregates) for `wizard.allValues` and `wizard.allErrors`, which mirror the data `ctx.values` carries.
-- [Statuses](/docs/multistep/statuses) for the per-step `FormStatus` rollup that flips `submitted: true` when the callback resolves.
+- [Statuses](/docs/multistep/statuses) for the per-step `FormStatus` rollup that flips `submitted: true` when the callback succeeds.
 - [Patterns](/docs/multistep/patterns) for branching flows that lean on `wizard.handleSubmit` for the final-step validation sweep.

--- a/docs/reading-the-form/meta.md
+++ b/docs/reading-the-form/meta.md
@@ -20,7 +20,7 @@ metaRows:
 ::docs-meta-table
 ::
 
-Submit the demo without changing the simulate-failure toggle to watch `submitting` flip true mid-await, `submissionAttempts` increment, and `submitted` flip true once the callback resolves. Flip the toggle and submit again: `submissionAttempts` still increments and `submitError` populates with the rejected callback's message, but `submitted` stays false because the callback never resolved. The [Form-only properties](#form-only-properties) section below names every bit; the inherited FieldState aggregations [link forward to the fields page](/docs/reading-the-form/fields).
+Submit the demo without changing the simulate-failure toggle to watch `submitting` flip true mid-await, `submissionAttempts` increment, and `submitted` flip true once the callback succeeds. Flip the toggle and submit again: `submissionAttempts` still increments and `submitError` populates with the rejected callback's message, but `submitted` stays false because the callback never resolved. The [Form-only properties](#form-only-properties) section below names every bit; the inherited FieldState aggregations [link forward to the fields page](/docs/reading-the-form/fields).
 
 ::docs-demo{slug="meta" label="Meta Demo"}
 ::
@@ -45,15 +45,15 @@ form.meta.value // the full form values object
 
 These seven reads exist only on `meta`, not on individual FieldStates.
 
-| Property             | Type      | Meaning                                                                                                                                               |
-| -------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `submitting`         | `boolean` | `true` while a `handleSubmit`-produced handler is running. Covers both the validation phase and the async callback.                                   |
-| `submissionAttempts` | `number`  | How many times the handler has been invoked (pass or fail). Useful for "show errors after first submit" UX.                                           |
-| `departAttempts`     | `number`  | How many times wizard navigation has actually departed this form. Bumps on real departures only (no-op back / same-key goTo / blocked next stay put). |
-| `submitError`        | `unknown` | The error from the most recent callback rejection. `null` on success and at the start of each new attempt.                                            |
-| `errorCount`         | `number`  | Scalar mirror of `errors.length`. Read it from templates and `watch()` without indexing the array.                                                    |
-| `submitted`          | `boolean` | `true` once a `handleSubmit` callback has resolved without throwing. Failed submits leave it `false`. Zeroed by `form.reset()`.                       |
-| `instanceId`         | `string`  | Per-`useForm()`-call identity, stable for the lifetime of one call. New on every fresh mount.                                                         |
+| Property             | Type      | Meaning                                                                                                                                                                                           |
+| -------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `submitting`         | `boolean` | `true` while a `handleSubmit`-produced handler is running. Covers both the validation phase and the async callback.                                                                               |
+| `submissionAttempts` | `number`  | How many times the handler has been invoked (pass or fail). Useful for "show errors after first submit" UX.                                                                                       |
+| `departAttempts`     | `number`  | How many times wizard navigation has actually departed this form. Bumps on real departures only (no-op back / same-key goTo / blocked next stay put).                                             |
+| `submitError`        | `unknown` | The error from the most recent callback rejection. `null` on success and at the start of each new attempt.                                                                                        |
+| `errorCount`         | `number`  | Scalar mirror of `errors.length`. Read it from templates and `watch()` without indexing the array.                                                                                                |
+| `submitted`          | `boolean` | `true` once a `handleSubmit` callback resolves without throwing and without leaving errors set. Failed submits, including a `setErrors(...); return`, leave it `false`. Zeroed by `form.reset()`. |
+| `instanceId`         | `string`  | Per-`useForm()`-call identity, stable for the lifetime of one call. New on every fresh mount.                                                                                                     |
 
 ## Templates
 
@@ -73,7 +73,7 @@ The "show errors after first submit attempt" pattern reads the counter so failed
 </p>
 ```
 
-The "post-success confirmation" pattern reads `submitted` instead, so the banner only renders after the callback actually succeeded:
+The "post-success confirmation" pattern reads `submitted` instead, so the banner only renders after the callback actually succeeded. A callback that hands a server rejection to `setErrors` and returns counts as a failed submit, so the banner stays hidden:
 
 ```vue
 <p v-if="form.meta.submitted && !form.meta.dirty">All saved.</p>

--- a/docs/submitting/handle-submit.md
+++ b/docs/submitting/handle-submit.md
@@ -47,7 +47,8 @@ When the returned handler fires:
 2. Sync validation runs across every active path.
 3. Async refinements are awaited.
 4. If every refinement passes, `onSubmit(values)` is called with the **parsed** Zod output: `.transform`-aware, fully typed.
-5. If anything fails, focus pulls to the first invalid field and `onError(errors)` fires (when supplied).
+5. The submit counts as a success, flipping `form.meta.submitted` to `true`, only when `onSubmit` resolves without throwing and leaves no errors set. A callback that hands a server rejection to `setErrors` and returns is a failed submit (see [server-side errors](/docs/submitting/server-side-errors)).
+6. On any failure, whether a validation error, a thrown callback, or errors the callback set with `setErrors`, focus pulls to the first invalid field and `onError(errors)` fires (when supplied).
 
 While step 4 is awaiting your `onSubmit` callback, `form.meta.submitting` is `true`. It flips back when the callback resolves or rejects (`handleSubmit` catches and surfaces errors through `onError`).
 

--- a/docs/submitting/server-side-errors.md
+++ b/docs/submitting/server-side-errors.md
@@ -46,6 +46,8 @@ const onSubmit = form.handleSubmit(async (values) => {
 
 `response.errors` is a `ValidationError[]`: each entry carries a `message`, an optional `path`, an optional `code`, and an optional `data` payload. An entry with a `path` lands at that field; an entry with no path lands at the form level, in the global `[]` bucket. `form.setErrors` stamps the form key on every entry as it lands, so errors stay isolated to this form.
 
+Returning after `setErrors` is a failed submit, treated exactly like a schema failure: `form.meta.submitted` stays `false`, focus pulls to the first error, and your `onError` callback fires with the errors you set. You do not need to throw to signal the rejection, and you do not need to call `form.focusFirstError()` by hand. Reserve a thrown error for the unexpected (a network drop, a 500), which lands on `form.meta.submitError` instead.
+
 ## `setErrors` and `clearErrors`
 
 `form.setErrors` owns the manual error layer, the errors you set by hand. Schema errors live in their own layer and merge in on read, so setting manual errors never disturbs validation. Its call forms mirror [`form.setValue`](/docs/writing-and-mutating/set-value):

--- a/src/runtime/composables/use-wizard.ts
+++ b/src/runtime/composables/use-wizard.ts
@@ -1097,6 +1097,43 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
     return out
   }
 
+  // Lift the user-error layer of each PROCESSED form into the wizard's
+  // aggregate shape. The post-callback mirror of `collectErrors` (#438):
+  // after a clean validation pass, a callback that called `setErrors` on
+  // a step left those errors here. Scoped to the keys the submit actually
+  // processed (final = every step, intermediate = the active one),
+  // matching the entry-clear scope, so a stale error on an unprocessed
+  // step never fails the submit.
+  function collectCallbackErrors(keys: Iterable<FormKey>): WizardAggregateError[] {
+    const out: WizardAggregateError[] = []
+    for (const key of keys) {
+      const store = registry.forms.get(key)
+      if (store === undefined) continue
+      for (const errs of store.userErrors.values()) {
+        for (const err of errs) out.push(toWizardAggregateError(err, key))
+      }
+    }
+    return out
+  }
+
+  // Move to the first failed step and run its invalid-submit focus
+  // policy. Shared by the validation-failure path and the post-callback
+  // error path (#438) so both honor `options.focusFirstError` the same
+  // way, and runs BEFORE onError so the consumer can override the focus.
+  async function focusFirstWizardError(errors: readonly WizardAggregateError[]): Promise<void> {
+    if (options.focusFirstError === false) return
+    const firstFailedKey = errors[0]?.formKey
+    if (firstFailedKey === undefined || !isCompiledKey(firstFailedKey)) return
+    moveTo(firstFailedKey)
+    await nextTick()
+    const failedForm = formsRecord.value[firstFailedKey]
+    if (failedForm === undefined) return
+    const failedSource = asSubmissionSource(failedForm)
+    if (typeof failedSource.applyInvalidSubmitPolicy === 'function') {
+      failedSource.applyInvalidSubmitPolicy()
+    }
+  }
+
   function handleSubmit(
     onSubmit: WizardOnSubmit,
     onError?: WizardOnError
@@ -1186,6 +1223,25 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
           }
           const ctx = buildSubmitContext(valuesMap, currentKey, final)
           await onSubmit(ctx)
+          // #438 parity with form.handleSubmit: a callback that left errors
+          // on a processed step (the documented `setErrors(...); return`
+          // server-rejection path) has NOT succeeded. The entry-clear above
+          // means any user error present now was set by this callback. Route
+          // it through the same failure path as a validation failure: focus
+          // the first error, fire onError, and return WITHOUT completing
+          // (final) or advancing past the rejected step (intermediate).
+          const callbackErrors = collectCallbackErrors(results.keys())
+          if (callbackErrors.length > 0) {
+            await focusFirstWizardError(callbackErrors)
+            if (onError !== undefined) {
+              try {
+                await onError(callbackErrors)
+              } catch (cause) {
+                throw new SubmitErrorHandlerError('User-provided onError threw', { cause })
+              }
+            }
+            return
+          }
           if (final) {
             done.value = true
           } else {
@@ -1202,20 +1258,7 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
           // form.handleSubmit: the consumer's onError can override the
           // focus, and a throwing onError still leaves the first error
           // focused rather than stranding the user.
-          if (options.focusFirstError !== false) {
-            const firstFailedKey = errors[0]?.formKey
-            if (firstFailedKey !== undefined && isCompiledKey(firstFailedKey)) {
-              moveTo(firstFailedKey)
-              await nextTick()
-              const failedForm = formsRecord.value[firstFailedKey]
-              if (failedForm !== undefined) {
-                const failedSource = asSubmissionSource(failedForm)
-                if (typeof failedSource.applyInvalidSubmitPolicy === 'function') {
-                  failedSource.applyInvalidSubmitPolicy()
-                }
-              }
-            }
-          }
+          await focusFirstWizardError(errors)
           if (onError !== undefined) {
             try {
               await onError(errors)

--- a/src/runtime/core/process-form.ts
+++ b/src/runtime/core/process-form.ts
@@ -511,10 +511,33 @@ export function buildProcessForm<F extends GenericForm, Out extends GenericForm 
           state.clearSchemaErrors()
         }
         await onSubmit(merged.data)
-        // Flip `submitted` true once the user callback resolved
-        // without throwing — independent of `submissionAttempts`.
-        // Generation guard: a `reset()` that fired during the await
-        // already zeroed the submission surface; honor the consumer's
+        // #438: a callback that left errors in the user-error layer did not
+        // succeed. The entry-clear above means any user error present now was
+        // set by this callback (the documented setErrors-and-return
+        // server-rejection path). Route it through the same failure path as a
+        // client validation failure rather than flipping `submitted`: focus
+        // the first error (generation-gated, like the validation-failure
+        // branch) and run `onError` with what the callback left behind. On the
+        // success-then-setErrors path schema errors were just cleared and
+        // validation passed, so `userErrors` is the complete current error set
+        // and doubles as the `onError` payload.
+        if (state.userErrors.size > 0) {
+          if (state.submissionGeneration.value === genAtEntry) {
+            applyInvalidSubmitPolicy(state, formInstanceId, invalidPolicy)
+          }
+          if (onError !== undefined) {
+            try {
+              await onError(Array.from(state.userErrors.values()).flat())
+            } catch (cause) {
+              throw new SubmitErrorHandlerError('User-provided onError threw', { cause })
+            }
+          }
+          return
+        }
+        // Flip `submitted` true once the user callback resolved without
+        // throwing AND left no errors behind — independent of
+        // `submissionAttempts`. Generation guard: a `reset()` that fired during
+        // the await already zeroed the submission surface; honor the consumer's
         // intent by leaving `submitted` at the post-reset `false`.
         if (state.submissionGeneration.value === genAtEntry) {
           state.submitted.value = true

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -1436,9 +1436,11 @@ export type FormStore<TData extends GenericForm> = Map<FormKey, TData>
 export type OnSubmit<Form extends GenericForm> = (form: Form) => void | Promise<void>
 
 /**
- * Callback invoked by `handleSubmit` when validation fails. Receives
- * the full list of errors. Bind this when you want to react to
- * submit failures explicitly (alongside or instead of the
+ * Callback invoked by `handleSubmit` on a failed submit. Fires when
+ * client validation fails AND when the submit callback leaves errors in
+ * the user-error layer (the `setErrors(...); return` server-rejection
+ * pattern). Receives the full list of errors. Bind this when you want to
+ * react to submit failures explicitly (alongside or instead of the
  * automatic `onInvalidSubmit` UI nudge).
  */
 export type OnError = (error: ValidationError[]) => void | Promise<void>
@@ -3300,10 +3302,14 @@ export type FormMeta<F = unknown> = FieldState<F> & {
    *
    * The submit handler does NOT re-throw — its returned promise always
    * resolves, so binding it to `@submit.prevent` never manufactures a
-   * `window` unhandledrejection. This is the single channel for "the
-   * submit failed", read the same way in templates and after an
-   * imperative `await submit()`. Like `hydrateError`, it stays distinct
-   * from the curated user-error store: render it where you choose:
+   * `window` unhandledrejection. This is the channel for an UNEXPECTED
+   * submit failure (a thrown exception or rejected promise), read the
+   * same way in templates and after an imperative `await submit()`. An
+   * EXPECTED rejection handled the documented way (`setErrors(...)` then
+   * `return`, no throw) surfaces through the error store and `onError`
+   * instead, leaving `submitError` `null`. Like `hydrateError`, it stays
+   * distinct from the curated user-error store: render it where you
+   * choose:
    *
    * ```vue
    * <p v-if="form.meta.submitError">{{ form.meta.submitError.message }}</p>
@@ -3322,11 +3328,18 @@ export type FormMeta<F = unknown> = FieldState<F> & {
   readonly errorCount: number
 
   /**
-   * `true` once a `handleSubmit` callback has resolved without
-   * throwing. Independent of `submissionAttempts` — a failed submit
-   * (validation failure or callback rejection) increments attempts but
-   * leaves `submitted` at `false`. Templates read it as "the form has
-   * been submitted successfully at least once."
+   * `true` once a `handleSubmit` callback has resolved without throwing
+   * AND left no errors behind. Independent of `submissionAttempts` — a
+   * failed submit (validation failure, callback rejection, or a callback
+   * that calls `setErrors` and returns) increments attempts but leaves
+   * `submitted` at `false`. Templates read it as "the form has been
+   * submitted successfully at least once."
+   *
+   * The error check is scoped to the user-error layer (`setErrors` /
+   * `clearErrors`): the documented server-rejection pattern
+   * (`setErrors(response.errors); return`) is a failed submit, so it does
+   * not flip `submitted`. A background async refinement that writes a
+   * schema error mid-submit does not retroactively fail it.
    *
    * Cleared by `form.reset()` alongside `submissionAttempts` and
    * `submitError`. For "the user has attempted a submit," read

--- a/src/runtime/types/types-wizard.ts
+++ b/src/runtime/types/types-wizard.ts
@@ -228,9 +228,11 @@ export type WizardOnSubmit = (ctx: WizardSubmitContext) => void | Promise<void>
 
 /**
  * Optional `onError` callback registered via `wizard.handleSubmit`.
- * Receives the aggregate error list — entries originate from per-form
- * validation and activation failures (`atta:activation-failed`). Sync
- * or async; the returned promise gates `wizard.submitting`.
+ * Receives the aggregate error list. Entries originate from per-form
+ * validation, activation failures (`atta:activation-failed`), and a
+ * submit callback that left errors on a processed step (the
+ * `setErrors(...); return` server-rejection path). Sync or async; the
+ * returned promise gates `wizard.submitting`.
  */
 export type WizardOnError = (errors: readonly WizardAggregateError[]) => void | Promise<void>
 
@@ -438,25 +440,32 @@ export type WizardForms<S> = FormsRecordOf<S> & Readonly<Record<FormKey, AnyForm
  *                    Forward-looking; reactive to current form
  *                    validity. Gates "Finish button enable" style UI.
  *  - `done`        — monotonic latch: flips `true` the first time a
- *                    final-step `handleSubmit` resolves without
- *                    throwing, and stays `true` through subsequent
- *                    edits or invalidations. Only `reset()` flips it
- *                    back. Gates "show success card" style UI that
- *                    should reflect submission history rather than
- *                    current validity.
+ *                    final-step `handleSubmit` resolves without throwing
+ *                    AND leaves no errors set on any step, and stays
+ *                    `true` through subsequent edits or invalidations. A
+ *                    callback that calls `setErrors` and returns (the
+ *                    documented server-rejection path) is a failed submit,
+ *                    so it does not flip `done`. Only `reset()` flips it
+ *                    back. Gates "show success card" style UI that should
+ *                    reflect submission history rather than current
+ *                    validity.
  *  - `submitting`  — `true` while a `wizard.handleSubmit` call is in
  *                    flight. Global re-entrance guard: every
  *                    navigation method also refuses while this is on.
  *  - `submissionAttempts` — count of `wizard.handleSubmit` invocations
  *                    (success or failure). Always bumps, including on
  *                    noop-form steps.
- *  - `submitError` — the error thrown by the most recent
+ *  - `submitError` — the error THROWN by the most recent
  *                    `wizard.handleSubmit` callback (or its `onError`),
  *                    coerced to a real `Error`. Mirrors
- *                    `form.meta.submitError`: cleared at submit entry and
- *                    by `reset()`, parked here rather than re-thrown, so
- *                    the handler resolves and never manufactures a
- *                    `window` unhandledrejection. `null` on success.
+ *                    `form.meta.submitError`: this is the unexpected-throw
+ *                    channel, so an expected rejection handled via
+ *                    `setErrors` (no throw) surfaces through the error
+ *                    surface and `onError` instead, leaving this `null`.
+ *                    Cleared at submit entry and by `reset()`, parked here
+ *                    rather than re-thrown, so the handler resolves and
+ *                    never manufactures a `window` unhandledrejection.
+ *                    `null` on success.
  *  - `visited`     — append-only breadcrumb of navigated step keys.
  *                    `back()` does not pop; the trail is the audit
  *                    log, not the back-stack.

--- a/test/composables/submit-success-semantics.test.ts
+++ b/test/composables/submit-success-semantics.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, type App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import type { UseFormConfigV4 } from '../../src/zod'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import type { UseFormReturnType } from '../../src/runtime/types/types-api'
+import { waitUntil } from '../utils/form-harness'
+
+/**
+ * Success semantics of `handleSubmit` (#438). The documented
+ * server-rejection pattern is `setErrors(...) + return`
+ * (server-side-errors.md), so a callback that resolves AFTER leaving
+ * errors in the user-error layer has NOT submitted successfully:
+ *
+ *   - `meta.submitted` must stay `false`.
+ *   - `onError` must fire with the errors that were set.
+ *
+ * A clean return that leaves no errors behind is the only success
+ * (the positive control guards against over-correction). Validation
+ * passes before the callback runs in every case here, so the only
+ * thing distinguishing success from failure is what the callback
+ * leaves in `form.errors()`.
+ */
+
+type ApiFor<Schema extends z.ZodObject> = UseFormReturnType<z.output<Schema>>
+
+function mountForm<Schema extends z.ZodObject>(
+  schema: Schema,
+  defaultValues: NonNullable<UseFormConfigV4<Schema>['defaultValues']>
+): { app: App; api: ApiFor<Schema> } {
+  const handle: { api?: ApiFor<Schema> } = {}
+  const App = defineComponent({
+    setup() {
+      handle.api = useForm({
+        schema,
+        key: `submit-semantics-${Math.random().toString(36).slice(2)}`,
+        defaultValues,
+      }) as unknown as ApiFor<Schema>
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  app.config.warnHandler = () => {}
+  app.config.errorHandler = () => {}
+  app.mount(document.createElement('div'))
+  return { app, api: handle.api as ApiFor<Schema> }
+}
+
+describe('handleSubmit success semantics (#438)', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  const schema = z.object({ email: z.email() })
+
+  it('setErrors + return inside onSubmit leaves submitted false', async () => {
+    const { app, api } = mountForm(schema, { email: 'user@example.com' })
+    apps.push(app)
+    const handler = api.handleSubmit(async () => {
+      // The documented server-rejection pattern: hand the server's
+      // verdict to setErrors and bail. Validation already passed, so
+      // this is the only signal that the submission did not succeed.
+      api.setErrors([{ message: 'Incorrect email or password.' }])
+    })
+    await handler(new Event('submit'))
+    await waitUntil(() => api.meta.submissionAttempts === 1)
+    expect(api.meta.submitted).toBe(false)
+  })
+
+  it('scoped setErrors(path, …) inside onSubmit leaves submitted false', async () => {
+    const { app, api } = mountForm(schema, { email: 'user@example.com' })
+    apps.push(app)
+    const handler = api.handleSubmit(async () => {
+      api.setErrors('email', [{ message: 'Already registered.' }])
+    })
+    await handler(new Event('submit'))
+    await waitUntil(() => api.meta.submissionAttempts === 1)
+    expect(api.meta.submitted).toBe(false)
+  })
+
+  it('fires onError with the errors the callback left behind', async () => {
+    const { app, api } = mountForm(schema, { email: 'user@example.com' })
+    apps.push(app)
+    const onError = vi.fn()
+    const handler = api.handleSubmit(async () => {
+      api.setErrors([{ message: 'Service unavailable, try again shortly.' }])
+    }, onError)
+    await handler(new Event('submit'))
+    await waitUntil(() => api.meta.submissionAttempts === 1)
+    expect(onError).toHaveBeenCalledTimes(1)
+    const errors = onError.mock.calls[0]?.[0] ?? []
+    expect(
+      errors.some(
+        (e: { message: string }) => e.message === 'Service unavailable, try again shortly.'
+      )
+    ).toBe(true)
+  })
+
+  it('positive control: a clean return that leaves no errors submits successfully', async () => {
+    const { app, api } = mountForm(schema, { email: 'user@example.com' })
+    apps.push(app)
+    const onError = vi.fn()
+    const handler = api.handleSubmit(async () => {
+      // No setErrors: the destination accepted the payload.
+    }, onError)
+    await handler(new Event('submit'))
+    await waitUntil(() => api.meta.submitted)
+    expect(api.meta.submitted).toBe(true)
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it('does not park a submitError when the failure came from setErrors, not a throw', async () => {
+    const { app, api } = mountForm(schema, { email: 'user@example.com' })
+    apps.push(app)
+    const handler = api.handleSubmit(async () => {
+      api.setErrors([{ message: 'Incorrect email or password.' }])
+    })
+    await handler(new Event('submit'))
+    await waitUntil(() => api.meta.submissionAttempts === 1)
+    // setErrors is the expected-rejection channel; submitError stays the
+    // thrown-exception channel and remains null here.
+    expect(api.meta.submitError).toBe(null)
+  })
+})

--- a/test/composables/wizard-submit-success-semantics.test.ts
+++ b/test/composables/wizard-submit-success-semantics.test.ts
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, type App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { useWizard } from '../../src/runtime/composables/use-wizard'
+import { createAttaform } from '../../src/runtime/core/plugin'
+
+/**
+ * Parity with `form.handleSubmit` success semantics (#438), applied to
+ * `wizard.handleSubmit`. A wizard callback that leaves errors on a
+ * processed step form has NOT submitted that step successfully:
+ *
+ *   - Final step: `wizard.done` must stay `false` (a server rejection
+ *     is not completion).
+ *   - Intermediate step: the wizard must NOT advance past a step the
+ *     server just rejected.
+ *   - `onError` must fire in both cases.
+ *
+ * The clean-return positive controls guard against over-correction:
+ * a final submit that leaves no errors completes, and an intermediate
+ * one advances.
+ */
+
+const accountSchema = z.object({
+  email: z.string().min(1),
+  password: z.string().min(8),
+})
+const reviewSchema = z.object({ tos: z.literal(true) })
+
+const validAccount = { email: 'a@b.c', password: 'passw0rd' }
+
+function mountHarness<R>(setup: () => R): { app: App; result: R } {
+  const handle: { result?: R } = {}
+  const App = defineComponent({
+    setup() {
+      handle.result = setup()
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  app.config.warnHandler = () => {}
+  app.config.errorHandler = () => {}
+  app.mount(document.createElement('div'))
+  return { app, result: handle.result as R }
+}
+
+describe('wizard.handleSubmit success semantics (#438)', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('final-step setErrors inside onSubmit leaves wizard.done false', async () => {
+    const { app, result } = mountHarness(() => {
+      const account = useForm({
+        schema: accountSchema,
+        key: 'ws-final-account',
+        defaultValues: validAccount,
+      })
+      const review = useForm({
+        schema: reviewSchema,
+        key: 'ws-final-review',
+        defaultValues: { tos: true as const },
+      })
+      const wizard = useWizard({ steps: [account, review], restore: false, persist: false })
+      return { wizard, account, review }
+    })
+    apps.push(app)
+    result.wizard.goTo('ws-final-review')
+
+    const onError = vi.fn()
+    await result.wizard.handleSubmit(() => {
+      result.review.setErrors([{ message: 'Payment declined.' }])
+    }, onError)(new Event('submit'))
+
+    expect(result.wizard.done).toBe(false)
+    expect(onError).toHaveBeenCalledTimes(1)
+  })
+
+  it('intermediate setErrors inside onSubmit does not advance past the rejected step', async () => {
+    const { app, result } = mountHarness(() => {
+      const account = useForm({
+        schema: accountSchema,
+        key: 'ws-mid-account',
+        defaultValues: validAccount,
+      })
+      const review = useForm({
+        schema: reviewSchema,
+        key: 'ws-mid-review',
+        defaultValues: { tos: true as const },
+      })
+      const wizard = useWizard({ steps: [account, review], restore: false, persist: false })
+      return { wizard, account, review }
+    })
+    apps.push(app)
+    expect(result.wizard.currentStep).toBe('ws-mid-account')
+
+    const onError = vi.fn()
+    await result.wizard.handleSubmit(() => {
+      result.account.setErrors([{ message: 'This email is already taken.' }])
+    }, onError)(new Event('submit'))
+
+    expect(result.wizard.currentStep).toBe('ws-mid-account')
+    expect(onError).toHaveBeenCalledTimes(1)
+  })
+
+  it('positive control: a clean final submit completes the wizard', async () => {
+    const { app, result } = mountHarness(() => {
+      const account = useForm({
+        schema: accountSchema,
+        key: 'ws-ok-account',
+        defaultValues: validAccount,
+      })
+      const review = useForm({
+        schema: reviewSchema,
+        key: 'ws-ok-review',
+        defaultValues: { tos: true as const },
+      })
+      const wizard = useWizard({ steps: [account, review], restore: false, persist: false })
+      return { wizard, account, review }
+    })
+    apps.push(app)
+    result.wizard.goTo('ws-ok-review')
+
+    const onError = vi.fn()
+    await result.wizard.handleSubmit(() => {}, onError)(new Event('submit'))
+
+    expect(result.wizard.done).toBe(true)
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it('positive control: a clean intermediate submit advances to the next step', async () => {
+    const { app, result } = mountHarness(() => {
+      const account = useForm({
+        schema: accountSchema,
+        key: 'ws-adv-account',
+        defaultValues: validAccount,
+      })
+      const review = useForm({
+        schema: reviewSchema,
+        key: 'ws-adv-review',
+        defaultValues: { tos: true as const },
+      })
+      const wizard = useWizard({ steps: [account, review], restore: false, persist: false })
+      return { wizard, account, review }
+    })
+    apps.push(app)
+    expect(result.wizard.currentStep).toBe('ws-adv-account')
+
+    await result.wizard.handleSubmit(() => {})(new Event('submit'))
+
+    expect(result.wizard.currentStep).toBe('ws-adv-review')
+  })
+})


### PR DESCRIPTION
## What

`form.meta.submitted` is documented as a success signal ("submitted successfully at least once", drives "All saved." banners), but it flipped `true` whenever the `onSubmit` callback returned without throwing, including on the exact server-rejection path Attaform's own docs teach:

```ts
if (!response.ok) {
  form.setErrors(response.errors)
  return
}
```

The callback returns, so a success banner rendered on a failed sign-in. Because the documented happy path triggers it, this is a contract bug, not misuse. Reported in #438.

## The fix

Tighten the contract: **a submit succeeds only when the callback resolves without throwing AND leaves the user-error layer empty.** The check is scoped to the `setErrors` / `clearErrors` layer (not all of `form.errors()`), so a background async refinement that writes a _schema_ error mid-await does not retroactively fail the submit. This is sound because `handleSubmit` clears the user-error layer at entry, so any user error present after the callback was set by that callback.

- **Form** (`process-form.ts`): after `await onSubmit`, if the user-error layer is non-empty, route through the same failure path as a client validation failure (focus the first error, fire `onError`) and return without flipping `submitted`.
- **Wizard** (`use-wizard.ts`): the same safeguard. On the final step a server rejection keeps `wizard.done` at `false`; on an intermediate step the wizard no longer advances past the step the server just rejected. Scoped to the processed forms (final = every step, intermediate = the active one), matching the entry-clear scope.

## Latent gaps closed along the way

- **Server errors now auto-focus on submit.** Previously `applyInvalidSubmitPolicy` ran only on the client-validation branch, so a `setErrors`-in-`onSubmit` rejection never pulled focus to the first error on submit. It now does, matching what schema failures already do.
- **Stale wizard docs corrected.** `docs/multistep/handle-submit.md` claimed an intermediate step advances _before_ `onSubmit` runs. The v2 wizard has advanced _after_ the callback resolves, which is exactly what lets a server rejection hold the user on the rejected step. Corrected the prose and the inline demo comment to match shipped behavior.

## Scope notes

- No demo changes: the documented `setErrors + return` pattern simply becomes correct.
- No new public API field (e.g. `succeeded`): this tightens the existing `submitted` to honor its own documented contract.
- `submitError` stays the thrown / rejected channel; an expected `setErrors` rejection surfaces via the error store + `onError`, not `submitError`.

## Tests

- `test/composables/submit-success-semantics.test.ts` (5) and `test/composables/wizard-submit-success-semantics.test.ts` (4), each with positive controls so the change cannot over-correct (a clean return still completes / advances).
- Adapter-agnostic (reads `state.userErrors`); the suites route through `src/zod`, so v3 and v4 both get coverage.

## Verification

- `pnpm typecheck`, `pnpm lint`: clean
- `pnpm test`: 4233 passed, 2 skipped
- `pnpm check:bundled-types`: ok (v3 + v4 consumers)
- `pnpm check:eager`: 42.81 kB gz, within budget

Closes #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)
