### PR TITLE
chore(size): tree-shaking tripwires proving useForm drops useWizard

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -853,4 +853,90 @@ export default [
     ignore: ['@vue/compiler-core'],
     modifyEsbuildConfig: asEsmNode,
   },
+
+  // ----------------------------------------------------------------
+  // Tree-shaking tripwires (single named import, NOT the whole entry).
+  //
+  // The entries above cap each subpath's FULL inlined surface. They do
+  // NOT prove that a consumer importing only one symbol drops the rest
+  // — `import:` does. size-limit's esbuild analyzer bundles ONLY the
+  // named import and tree-shakes the entry around it, so the gzipped
+  // number here is the real cost a consumer pays for that one symbol
+  // (Vue is external as for every entry; `zod` is ignored explicitly).
+  //
+  // The load-bearing case: `useWizard` shares its physical chunk with
+  // `useAbstractForm` (the engine behind every `useForm`), so dropping
+  // it relies on the consumer bundler's intra-chunk dead-code
+  // elimination, not a whole-module drop. These caps are the standing
+  // proof that elimination still works: a regression that makes
+  // `useForm` transitively reach `use-wizard.ts` (e.g. a shared helper
+  // migrating into it) pushes `{ useForm }` up by ~5 KB gzip and trips
+  // the cap — the kind of leak no full-entry cap above can see.
+  //
+  // Caps are snug against the measured size. They track the same shared
+  // core as the full entries, so they bump in lockstep on feature
+  // branches that legitimately grow `useForm`'s closure — same cadence
+  // as `index.mjs` / `zod.mjs` above. A jump LARGER than the
+  // accompanying full-entry bump is the leak signal.
+  {
+    name: 'zod: { useForm } only (no wizard/register/injectForm)',
+    path: 'dist/zod.mjs',
+    import: '{ useForm }',
+    // Unified entry, so `{ useForm }` pulls BOTH adapters (runtime
+    // dispatch) but NOT the wizard / injectForm / useRegister / unset /
+    // lazy surface that the full 59 KB cap above includes. The ~6 KB
+    // gap below that cap is the tree-shaken optional surface. Measured
+    // at 52.15 KB; ~0.85 KB headroom.
+    limit: '53 KB',
+    gzip: true,
+    ignore: ['zod'],
+    modifyEsbuildConfig: asEsm,
+  },
+  {
+    name: 'zod-v4: { useForm } only',
+    path: 'dist/zod-v4.mjs',
+    import: '{ useForm }',
+    // Single-adapter v4 entry: one adapter, no wizard surface. Measured
+    // at 45.99 KB; ~1 KB headroom.
+    limit: '47 KB',
+    gzip: true,
+    ignore: ['zod'],
+    modifyEsbuildConfig: asEsm,
+  },
+  {
+    name: 'zod-v3: { useForm } only',
+    path: 'dist/zod-v3.mjs',
+    import: '{ useForm }',
+    // Single-adapter v3 entry. Measured at 47.48 KB; ~0.5 KB headroom.
+    limit: '48 KB',
+    gzip: true,
+    ignore: ['zod'],
+    modifyEsbuildConfig: asEsm,
+  },
+  {
+    name: 'zod: { injectForm } only',
+    path: 'dist/zod.mjs',
+    import: '{ injectForm }',
+    // Reaching an ancestor form's surface (proxy + FieldState read
+    // machinery) without the schema / validation / store-creation that
+    // `useForm` carries, and crucially without the wizard surface.
+    // Measured at 22.44 KB; ~0.56 KB headroom.
+    limit: '23 KB',
+    gzip: true,
+    ignore: ['zod'],
+    modifyEsbuildConfig: asEsm,
+  },
+  {
+    name: 'zod: { useRegister } only',
+    path: 'dist/zod.mjs',
+    import: '{ useRegister }',
+    // The leanest field-rebind helper. The tightest tripwire: anything
+    // heavy leaking into it (form store, adapters, wizard) shows up
+    // immediately against this small baseline. Measured at 9.65 KB;
+    // ~0.35 KB headroom.
+    limit: '10 KB',
+    gzip: true,
+    ignore: ['zod'],
+    modifyEsbuildConfig: asEsm,
+  },
 ]

--- a/src/runtime/_shared-exports.ts
+++ b/src/runtime/_shared-exports.ts
@@ -12,8 +12,13 @@
  * Rollup builds keep the barrel from defeating per-entry pruning. A
  * consumer importing only `useForm` from `attaform/zod-v4` still gets
  * a bundle that includes nothing else from this barrel — the unused
- * names are eliminated at build time. `pnpm check:size` is the
- * standing gate.
+ * names are eliminated at build time. `useWizard` shares a chunk with
+ * `useAbstractForm`, so that elimination is intra-chunk; the standing
+ * gate is the set of `import:` tripwires in `.size-limit.js` (the
+ * `{ useForm } only`, `{ injectForm } only`, and `{ useRegister }
+ * only` caps), which bundle a single named import and tree-shake the
+ * rest. The whole-entry caps there cannot see a single-import
+ * regression; these can.
  *
  * Names that stay per-entry (do NOT add them here):
  * - `useForm` — different source per entry (abstract / unified


### PR DESCRIPTION
## Why

Came out of verifying a question: does a `useForm`-only consumer actually drop `useWizard`? It does (proven below), but **nothing in CI guarded it**. The `_shared-exports.ts` barrel docblock claimed `pnpm check:size` was the "standing gate" for tree-shaking, yet every entry in `.size-limit.js` measures a subpath's **full inlined surface**. None of them simulate a single-named-import consumer, so a future refactor that made `useForm` transitively reach `use-wizard.ts` (e.g. a shared helper migrating into it) would regress tree-shaking with zero CI signal.

This is sharper than a normal size cap because `useWizard` physically shares one chunk (`attaform.NWrEGrNo.mjs`) with `useAbstractForm` (the engine behind every `useForm`). So dropping the wizard relies on the consumer bundler's **intra-chunk** dead-code elimination, not a whole-module drop. That works today, but it's exactly the kind of thing that silently breaks.

## What

Five `size-limit` `import:` tripwires that bundle a single named import and tree-shake the entry around it (zero new deps — `@size-limit/esbuild` already ships in the preset):

| Tripwire | Measured | Cap |
|---|---|---|
| `zod` `{ useForm }` (no wizard/register/injectForm) | 52.15 kB | 53 kB |
| `zod-v4` `{ useForm }` | 45.99 kB | 47 kB |
| `zod-v3` `{ useForm }` | 47.48 kB | 48 kB |
| `zod` `{ injectForm }` | 22.44 kB | 23 kB |
| `zod` `{ useRegister }` | 9.65 kB | 10 kB |

Caps are snug. They track the same shared core as the full-entry caps, so they bump in lockstep on feature branches that legitimately grow `useForm`'s closure. A jump *larger* than the accompanying full-entry bump is the leak signal: a `useWizard` leak adds ~5 kB gzip to `{ useForm }` and trips the cap.

Also fixes the `_shared-exports.ts` docblock to point at these tripwires instead of the whole-entry caps.

## Evidence it holds today

Real Vite production builds, `useForm`-only vs `useForm`+`useWizard`, across both the unified `attaform/zod` and single-adapter `attaform/zod-v4`:

- `useForm`-only bundle: **zero** wizard injection keys (`attaform:ancestor-wizard`, `attaform:wizard-active-step-resolver`, `attaform:wizard-noop` all absent).
- `useForm`+`useWizard` bundle: those three keys present; **+20 KB raw / +4.8 KB gzip**.

So `useWizard` is billed only when imported.

## Verification

- `pnpm check:size` green (16 entries, all within limits, exit 0).
- `pnpm lint` + `pnpm typecheck` clean.
- No runtime code touched (size config + one docblock comment); no CHANGELOG entry (internal CI hardening, zero consumer impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
