### PR TITLE
fix(dirty): detect removal of seeded array elements and container subtrees (#420)

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -562,7 +562,17 @@ export default [
     // Lowered 54 → 52 KB on the form.onChange removal branch
     // (chore/rip-onchange): same shared core chunk drops the onChange seam
     // (on-change.ts + dispatch + the silent thread). Measured at 51.56 KB.
-    limit: '52 KB',
+    //
+    // Raised 52 → 53 KB on the meta.dirty removal-detection branch (#420):
+    // the shared core chunk gains the removal-dirty machinery in
+    // create-form-store.ts — the pre-write identity-baseline realign for a
+    // wholesale array shrink, plus the removedSubtrees set + isContainer /
+    // subtreeHadRealBaseline / hasRemovedSubtreeUnder helpers and the reset()
+    // clear for a container -> non-container drop — and field-state-api.ts
+    // consults hasRemovedSubtreeUnder in the container dirty rollup. zod-v4.mjs,
+    // the tightest full entry (zod-v3 still has ~0.5 KB headroom), had spent its
+    // and crossed 52. Measured at 52.12 KB.
+    limit: '53 KB',
     gzip: true,
     ignore: ['zod'],
     modifyEsbuildConfig: asEsm,

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -64,6 +64,13 @@ import { walkUnspecified } from './unset-walker'
 import { mergeSparseHydration } from './merge-hydration'
 
 /**
+ * A value that holds descendant leaves — an array or a plain object. The dirty
+ * machinery treats anything else (primitive, `undefined`, `null`) as a leaf, so
+ * replacing a container with one of those drops a whole subtree at once.
+ */
+const isContainer = (value: unknown): boolean => Array.isArray(value) || isPlainRecord(value)
+
+/**
  * Per-form closure state — the single store owned by each `useForm` call.
  * Bundles the form value, the summary record, element references, field
  * state, the meta tracker, and the error stores under one keyed-by-
@@ -642,6 +649,15 @@ export type FormStore<F extends GenericForm, G extends GenericForm = F> = {
    * no longer see the shape change.
    */
   hasStructuralChangeUnder(path: Path): boolean
+  /**
+   * Whether a baseline-present container under `path` was replaced wholesale by
+   * a non-container (e.g. `setValue('profile', undefined)`) and is still absent.
+   * The other half of removal-driven `dirty`: such a subtree's leaves vanish
+   * from the live value, so neither the present-leaf walk nor the array tracker
+   * can see the loss. Self-filters by current liveness, so a refilled path stops
+   * counting.
+   */
+  hasRemovedSubtreeUnder(path: Path): boolean
   getFieldRecord(path: Path): FieldRecord | undefined
   getOriginalAtPath(path: Path): unknown
   /**
@@ -1334,6 +1350,18 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
   // picking up exactly the change that prompted the originals
   // mutation.
   const originals = reactive(new Map<PathKey, OriginalsRecord>()) as Map<PathKey, OriginalsRecord>
+
+  // Paths where a baseline-present container (object or array) was replaced
+  // wholesale by a non-container — `setValue('profile', undefined)` and the
+  // like. Every leaf under such a path vanishes from the live value at once, so
+  // the present-leaf dirty walk can't see the loss and the array identity
+  // tracker (which only follows array -> array writes) doesn't apply; this set
+  // is how a container removal still dirties the form (#420, the non-array
+  // sibling of an array shrink). Reactivity rides on the form-value mutation
+  // that always accompanies a write here, so a plain Set is enough — and the
+  // membership read self-filters by current liveness, so it needs no reactive
+  // collection deps of its own. Cleared on `reset()`.
+  const removedSubtrees = new Set<PathKey>()
 
   // Blank bookkeeping. The reactive Set tracks paths whose
   // displayed state should be EMPTY even though storage holds a real
@@ -2353,6 +2381,20 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     // `currentValue` here, while it still reflects the array the operation
     // acted on. Only the `arrayOp` branch reads it.
     const oldArrayLength = Array.isArray(currentValue) ? currentValue.length : 0
+    // For a wholesale array replacement (no `arrayOp` to follow), anchor the
+    // identity baseline at the PRE-write order before `applyTargetedWrite`
+    // resizes the array in place. On an array's first track this is the only
+    // chance to capture its baseline length: realigning only afterwards (below)
+    // would anchor the already-resized order, so a shrink — an element removal —
+    // on a never-rendered array would read structurally pristine and fail to
+    // dirty the form (#420). The post-write realign then advances the current
+    // order while the baseline stays put, so the length delta surfaces through
+    // `hasStructuralChangeUnder`. Idempotent once the array is tracked, and it
+    // mirrors what the `arrayOp` branch already gets for free by reconstructing
+    // the pre-op length before replaying its permutation.
+    if (meta?.arrayOp === undefined && Array.isArray(value) && Array.isArray(currentValue)) {
+      arrayIdentity.realign(path)
+    }
     applyTargetedWrite(path, completedValue, meta)
     // Variant-memory bookkeeping for array structural mutations. The
     // field-array helpers tag each op with an `arrayOp` describing
@@ -2377,6 +2419,15 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     } else if (Array.isArray(value) && Array.isArray(currentValue)) {
       variantMemory.clearUnderPath(path)
       arrayIdentity.realign(path)
+    } else if (isContainer(currentValue) && !isContainer(value)) {
+      // A baseline-present container dropped to a non-container: record the path
+      // so the container dirty check still fires for the vanished subtree (see
+      // `removedSubtrees`). Gated on real baseline presence so removing an
+      // optional section that was empty at construction — added, then cleared
+      // again — lands back at pristine rather than reading dirty.
+      if (subtreeHadRealBaseline(path, currentValue)) {
+        removedSubtrees.add(canonicalizePath(path).key)
+      }
     }
     const effectiveModeAfterWrite = meta?.instance?.validateOn ?? fieldValidationMode
     if (effectiveModeAfterWrite === 'change') {
@@ -3481,6 +3532,9 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     // reorder or removal made before this reset no longer reads as a
     // structural change once the form is back at its baseline.
     arrayIdentity.rebaselineAll()
+    // The post-reset value is the new baseline, so any subtree dropped before
+    // this reset is no longer a removal to flag.
+    removedSubtrees.clear()
     // Rebuild originals from the new baseline. The set becomes the
     // post-reset pristine reference — a subsequent dirty comparison
     // returns false until the consumer mutates again.
@@ -3788,6 +3842,39 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     return arrayIdentity.hasStructuralChangeUnder(path)
   }
 
+  // Did the subtree at `prefix` (its pre-write value in `removedValue`) hold any
+  // leaf that was part of the construction / reset baseline — a real recorded
+  // value, not an absence baseline seeded for a runtime-added path? Bounds the
+  // check to the subtree being dropped by enumerating that subtree's own leaves,
+  // so it only walks what `setValue` is removing, on the rare container ->
+  // non-container write.
+  function subtreeHadRealBaseline(prefix: Path, removedValue: unknown): boolean {
+    let had = false
+    diffAndApply(removedValue, undefined, prefix, (patch) => {
+      if (had || patch.kind !== 'removed') return
+      const record = originals.get(canonicalizePath(patch.path).key)
+      if (record?.value !== undefined) had = true
+    })
+    return had
+  }
+
+  function hasRemovedSubtreeUnder(prefix: Path): boolean {
+    if (removedSubtrees.size === 0) return false
+    for (const key of removedSubtrees) {
+      const segments = segmentsForPathKey(key)
+      if (segments === null) continue
+      if (!isPathPrefix(prefix, segments)) continue
+      // Skip a recorded path that a later write refilled with a container: the
+      // present-leaf walk then judges it (an identical refill reads pristine, a
+      // changed one dirties), so only a still-absent subtree counts as removed
+      // here. Read raw — the accompanying write already fired the dirty walk's
+      // own dep on this path, so no reactive tracking is needed to re-run.
+      if (isContainer(getAtPath(toRaw(form.value), segments))) continue
+      return true
+    }
+    return false
+  }
+
   function getFieldRecord(path: Path): FieldRecord | undefined {
     const { key } = canonicalizePath(path)
     return fields.get(key)
@@ -3914,6 +4001,7 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     isPristineAtPath,
     isPristineAtPathByKey,
     hasStructuralChangeUnder,
+    hasRemovedSubtreeUnder,
     getFieldRecord,
     getOriginalAtPath,
     getFirstErrorElement,

--- a/src/runtime/core/field-state-api.ts
+++ b/src/runtime/core/field-state-api.ts
@@ -497,6 +497,15 @@ export function buildContainerFieldStateBase<F extends GenericForm>(
     pristine = false
     dirty = true
   }
+  // A baseline-present object or array replaced wholesale by a non-container
+  // (e.g. `setValue('profile', undefined)`) drops every leaf under it from the
+  // live value at once, so the positional walk above never visits the vanished
+  // leaves and the array tracker (array -> array only) can't see it either. Ask
+  // the store whether such a subtree under this container is still absent.
+  if (!dirty && state.hasRemovedSubtreeUnder(segments)) {
+    pristine = false
+    dirty = true
+  }
   // Aggregate errors at this prefix. Drives `form.fields(p).errors`,
   // `form.errors(p)`, and `form.meta.errors` through one helper so
   // the three surfaces read identically. Active-variant filter

--- a/test/composables/dirty-array-element-removal.test.ts
+++ b/test/composables/dirty-array-element-removal.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, type App } from 'vue'
+import { z as zV4 } from 'zod'
+import { z as zV3 } from 'zod-v3'
+import { useForm as useFormV4 } from '../../src/zod-v4'
+import { useForm as useFormV3 } from '../../src/zod-v3'
+import { createAttaform } from '../../src/runtime/core/plugin'
+
+/**
+ * #420: removing a seeded array element must dirty the form, symmetrically
+ * with adding one. The field VALUE always updated correctly both ways; only
+ * the structural dirty verdict was asymmetric. A wholesale `setValue` that
+ * shrank a never-rendered array anchored the identity baseline at the
+ * already-shortened length (the realign ran after the in-place write), so the
+ * removal read structurally pristine. The field-array `remove()` helper was
+ * unaffected, because its op replay reconstructs the pre-op length and anchors
+ * the baseline before splicing.
+ *
+ * Motivated by a checkbox group bound to one array path: un-checking a
+ * pre-checked box (a removal) left a `:disabled="!form.meta.dirty"` Save button
+ * disabled, so a record value already granted could not be revoked. Asserted
+ * through the authoritative `setValue` (the checkbox assigner forwards to it),
+ * with the `remove()` helper and the symmetric add as parity / regression
+ * guards. Both adapters — same runtime contract.
+ */
+
+type DirtyForm = {
+  meta: { dirty: boolean }
+  setValue: (path: string, value: unknown) => void
+  remove: (path: string, index: number) => void
+  values: Record<string, unknown>
+}
+
+const apps: App[] = []
+afterEach(() => {
+  while (apps.length > 0) apps.pop()?.unmount()
+  document.body.innerHTML = ''
+})
+
+function mountWithApp(setup: () => DirtyForm): DirtyForm {
+  const handle: { captured?: DirtyForm } = {}
+  const App = defineComponent({
+    setup() {
+      handle.captured = setup()
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  const root = document.createElement('div')
+  document.body.appendChild(root)
+  app.mount(root)
+  apps.push(app)
+  if (handle.captured === undefined) throw new Error('mountWithApp: setup never returned')
+  return handle.captured
+}
+
+function runSuite(label: string, build: () => DirtyForm): void {
+  describe(`array element removal dirties the form (${label})`, () => {
+    it('dirties when a seeded element is removed via wholesale setValue', () => {
+      const form = build()
+      expect(form.meta.dirty).toBe(false)
+      form.setValue('tags', ['a', 'b']) // drop the seeded 'c'
+      expect(form.values['tags']).toEqual(['a', 'b'])
+      expect(form.meta.dirty).toBe(true)
+    })
+
+    it('stays dirty after removing then re-shrinking via setValue', () => {
+      const form = build()
+      form.setValue('tags', ['a', 'b'])
+      form.setValue('tags', ['a'])
+      expect(form.values['tags']).toEqual(['a'])
+      expect(form.meta.dirty).toBe(true)
+    })
+
+    it('dirties when a seeded element is added (symmetric regression guard)', () => {
+      const form = build()
+      form.setValue('tags', ['a', 'b', 'c', 'd'])
+      expect(form.meta.dirty).toBe(true)
+    })
+
+    it('dirties when a seeded element is removed via the remove() helper', () => {
+      const form = build()
+      form.remove('tags', 2)
+      expect(form.values['tags']).toEqual(['a', 'b'])
+      expect(form.meta.dirty).toBe(true)
+    })
+
+    it('stays pristine when setValue rewrites the array to its seeded value', () => {
+      const form = build()
+      form.setValue('tags', ['a', 'b', 'c'])
+      expect(form.meta.dirty).toBe(false)
+    })
+  })
+}
+
+runSuite('v4', () =>
+  mountWithApp(
+    () =>
+      useFormV4({
+        schema: zV4.object({ tags: zV4.array(zV4.string()) }),
+        key: `dirty-rm-v4-${Math.random()}`,
+        defaultValues: { tags: ['a', 'b', 'c'] },
+      }) as unknown as DirtyForm
+  )
+)
+
+runSuite('v3', () =>
+  mountWithApp(
+    () =>
+      useFormV3({
+        schema: zV3.object({ tags: zV3.array(zV3.string()) }),
+        key: `dirty-rm-v3-${Math.random()}`,
+        defaultValues: { tags: ['a', 'b', 'c'] },
+      }) as unknown as DirtyForm
+  )
+)

--- a/test/composables/dirty-subtree-removal.test.ts
+++ b/test/composables/dirty-subtree-removal.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, type App } from 'vue'
+import { z as zV4 } from 'zod'
+import { z as zV3 } from 'zod-v3'
+import { useForm as useFormV4 } from '../../src/zod-v4'
+import { useForm as useFormV3 } from '../../src/zod-v3'
+import { createAttaform } from '../../src/runtime/core/plugin'
+
+/**
+ * #420, folded-in sibling: removing a whole baseline-present subtree by writing
+ * a non-container over it must dirty the form. `setValue('profile', undefined)`
+ * (object) and `setValue('tags', undefined)` (array) both drop every leaf under
+ * the path from the live value at once, so the present-leaf dirty walk never
+ * visits the vanished leaves and the array identity tracker (array -> array
+ * only) can't see it. A `removedSubtrees` record closes that gap.
+ *
+ * The mechanism is baseline-aware and self-clearing, so the guards below pin all
+ * three edges: an optional section absent at construction stays pristine across
+ * an add-then-remove; refilling the path with the seeded value lands pristine
+ * (the leaf walk judges the refill), a different value dirties; and `reset()`
+ * re-baselines so a prior removal stops counting. Both adapters.
+ */
+
+type DirtyForm = {
+  meta: { dirty: boolean }
+  setValue: (path: string, value: unknown) => void
+  reset: () => void
+  values: Record<string, unknown>
+}
+
+const apps: App[] = []
+afterEach(() => {
+  while (apps.length > 0) apps.pop()?.unmount()
+  document.body.innerHTML = ''
+})
+
+function mountWithApp(setup: () => DirtyForm): DirtyForm {
+  const handle: { captured?: DirtyForm } = {}
+  const App = defineComponent({
+    setup() {
+      handle.captured = setup()
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  const root = document.createElement('div')
+  document.body.appendChild(root)
+  app.mount(root)
+  apps.push(app)
+  if (handle.captured === undefined) throw new Error('mountWithApp: setup never returned')
+  return handle.captured
+}
+
+function runSuite(label: string, build: () => DirtyForm): void {
+  describe(`subtree removal dirties the form (${label})`, () => {
+    it('dirties when a seeded object subtree is set to undefined (B1)', () => {
+      const form = build()
+      expect(form.meta.dirty).toBe(false)
+      form.setValue('profile', undefined)
+      expect(form.values['profile']).toBeUndefined()
+      expect(form.meta.dirty).toBe(true)
+    })
+
+    it('dirties when a seeded array subtree is set to undefined (B2)', () => {
+      const form = build()
+      expect(form.meta.dirty).toBe(false)
+      form.setValue('tags', undefined)
+      expect(form.values['tags']).toBeUndefined()
+      expect(form.meta.dirty).toBe(true)
+    })
+
+    it('stays pristine removing an optional section absent at construction', () => {
+      // `opt` is explicitly `undefined` in the defaults, so it has no baseline
+      // (schema optionals named in the defaults are otherwise pre-filled with
+      // slim values). Adding then removing it is a round-trip back to baseline,
+      // so the baseline-presence gate must keep it out of `removedSubtrees`.
+      const form = build()
+      form.setValue('opt', { note: 'hi' })
+      expect(form.meta.dirty).toBe(true)
+      form.setValue('opt', undefined)
+      expect(form.meta.dirty).toBe(false)
+    })
+
+    it('returns to pristine when the subtree is refilled with its seeded value', () => {
+      const form = build()
+      form.setValue('profile', undefined)
+      expect(form.meta.dirty).toBe(true)
+      form.setValue('profile', { name: 'Sam' })
+      expect(form.meta.dirty).toBe(false)
+    })
+
+    it('stays dirty when the subtree is refilled with a different value', () => {
+      const form = build()
+      form.setValue('profile', undefined)
+      form.setValue('profile', { name: 'Pat' })
+      expect(form.meta.dirty).toBe(true)
+    })
+
+    it('rebaselines on reset after a subtree removal', () => {
+      const form = build()
+      form.setValue('profile', undefined)
+      expect(form.meta.dirty).toBe(true)
+      form.reset()
+      expect(form.meta.dirty).toBe(false)
+    })
+  })
+}
+
+runSuite('v4', () =>
+  mountWithApp(
+    () =>
+      useFormV4({
+        schema: zV4.object({
+          profile: zV4.object({ name: zV4.string() }).optional(),
+          tags: zV4.array(zV4.string()).optional(),
+          opt: zV4.object({ note: zV4.string() }).optional(),
+        }),
+        key: `dirty-subtree-v4-${Math.random()}`,
+        defaultValues: { profile: { name: 'Sam' }, tags: ['x', 'y'], opt: undefined },
+      }) as unknown as DirtyForm
+  )
+)
+
+runSuite('v3', () =>
+  mountWithApp(
+    () =>
+      useFormV3({
+        schema: zV3.object({
+          profile: zV3.object({ name: zV3.string() }).optional(),
+          tags: zV3.array(zV3.string()).optional(),
+          opt: zV3.object({ note: zV3.string() }).optional(),
+        }),
+        key: `dirty-subtree-v3-${Math.random()}`,
+        defaultValues: { profile: { name: 'Sam' }, tags: ['x', 'y'], opt: undefined },
+      }) as unknown as DirtyForm
+  )
+)


### PR DESCRIPTION
## What

`form.meta.dirty` flagged **additions** to a seeded array but not **removals**. The field *value* updated correctly both ways; only the structural dirty verdict was asymmetric, so a `:disabled="!form.meta.dirty"` Save button stayed disabled after un-checking a pre-checked box in an array-bound checkbox group (you could grant but not revoke).

Fixes #420, with the adjacent non-array trap folded in.

## Root cause

Both halves are the same blind spot: a baseline leaf vanishes from the live value, and the present-leaf dirty walk only visits leaves that are still there.

- **Array element removal** via a wholesale `setValue` realigned the identity tracker *after* `applyTargetedWrite` resized the array in place, so a never-rendered array's first track anchored its baseline at the already-shortened length and read structurally pristine. (The field-array `remove()` helper was unaffected: its op replay reconstructs the pre-op length before splicing. Additions were caught by a different path that seeds the new index into `originals`.)
- **Container subtree removal** (`setValue('profile', undefined)`, object *or* array) drops every leaf under the path at once, and the array tracker only follows `array -> array` writes, so nothing caught it.

## Fix

- Anchor the identity baseline at the **pre-write** order before the in-place resize, so a shrink surfaces through `hasStructuralChangeUnder` (mirrors what the op path already gets for free).
- Record container -> non-container removals in a baseline-gated, self-clearing `removedSubtrees` set the container dirty check consults. The gate keeps an optional section that was empty at construction pristine across an add-then-remove; the liveness filter makes an identical refill land pristine (a different one dirties through the normal leaf walk); `reset()` rebaselines.

No public API change. `dirty` just stops missing a removal.

## Testing

- Full suite green: 338 files, 4261 passed, 2 skipped. Lint + typecheck clean.
- 22 new tests across two files, **both zod v3 and v4**: removal via `setValue`, the `remove()` helper, the symmetric add, re-shrink, rewrite-to-seeded (pristine), object -> `undefined`, array -> `undefined`, refill-identical (pristine), refill-different (dirty), the absent-at-construction gate, and `reset()` rebaseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)