### PR TITLE
fix(ssr): mark slotted <option>s on a v-register component host (#394)

### DIFF
--- a/src/runtime/lib/core/transforms/component-bridge-transform.ts
+++ b/src/runtime/lib/core/transforms/component-bridge-transform.ts
@@ -211,7 +211,10 @@ function inferOptionValueFromChildren(node: TemplateChildNode | RootNode): strin
  *   - `<MyComponent v-register>` and kebab-case custom-element hosts
  *     — injects a `:registerValue` bridge prop so `useRegister` inside
  *     the child sees the parent's RegisterValue (the binding the audit
- *     called out as the transform's "fires on every component" path).
+ *     called out as the transform's "fires on every component" path),
+ *     and marks any parent-authored slotted `<option>`s with `:selected`
+ *     the same way the native path does, so a `<select>` wrapped in a
+ *     styled component keeps its SSR-selected option (#394).
  *
  * Wired automatically by `attaform/vite` and `attaform/nuxt`. Use
  * directly only when integrating with a custom bundler.
@@ -440,10 +443,23 @@ export const componentBridgeTransform: NodeTransform = (node, context) => {
       node.props.push(valueProp)
     }
 
+    // <option> children of a v-register host derive their SSR :selected from
+    // the host's single register. For a native <select> they're inline; for a
+    // component / custom-element host they're parent-authored slot content,
+    // still present in node.children at this (enter-phase) point in the parent
+    // AST -- before Vue's later buildSlots pass folds them into a slot
+    // function. Walking them here marks them identically, so wrapping a
+    // <select> in a styled component no longer drops the SSR selected option
+    // (and reintroduces a first-paint flash). traverseSelectNode is a no-op
+    // when there are no <option> descendants, so this is zero-cost for hosts
+    // that don't project options.
+    for (const child of node.children) {
+      traverseSelectNode(child, previousOptionExpressions) // start searching for options in dfs manner
+    }
+
     if (isSelect) {
-      for (const child of node.children) {
-        traverseSelectNode(child, previousOptionExpressions) // start searching for options in dfs manner
-      }
+      // Native <select> is fully handled by the option walk above plus the
+      // :value injection; component hosts fall through to the bridge prop.
       return
     }
 

--- a/test/ssr-bare-vue/component-wrapper-select-ssr.test.ts
+++ b/test/ssr-bare-vue/component-wrapper-select-ssr.test.ts
@@ -1,0 +1,142 @@
+import { baseCompile } from '@vue/compiler-core'
+import { renderToString } from '@vue/server-renderer'
+import { describe, expect, it } from 'vitest'
+import * as Vue from 'vue'
+import { createSSRApp, defineComponent, h } from 'vue'
+import { z as zV4 } from 'zod'
+import { z as zV3 } from 'zod-v3'
+import { useForm as useFormV4 } from '../../src/zod-v4'
+import { useForm as useFormV3 } from '../../src/zod-v3'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import { componentBridgeTransform } from '../../src/runtime/lib/core/transforms/component-bridge-transform'
+import { vRegisterHintTransform } from '../../src/runtime/lib/core/transforms/v-register-hint-transform'
+import { vRegisterPreambleTransform } from '../../src/runtime/lib/core/transforms/v-register-preamble-transform'
+
+/**
+ * End-to-end SSR coverage for #394. A `v-register` on a component wrapper
+ * (`<CustomSelect>` whose template is `<select><slot/></select>`) projects
+ * its `<option>`s as parent-authored slot content. The compiled-template
+ * path must SSR-mark the selected option exactly like an inline `<select>`,
+ * otherwise the server HTML omits `selected` and the browser flashes the
+ * first option until hydration corrects it.
+ *
+ * Mirrors `use-register-ssr.test.ts`: compile the parent template to a render
+ * function (`baseCompile` `mode:'function'` → `new Function`), wire it onto a
+ * parent that registers the wrapper child and seeds the model via `useForm`,
+ * then assert the serialized HTML. Both zod majors are covered for parity.
+ */
+
+function compileFn(template: string): (this: unknown, ctx: unknown) => unknown {
+  const result = baseCompile(template, {
+    nodeTransforms: [componentBridgeTransform, vRegisterPreambleTransform, vRegisterHintTransform],
+    mode: 'function',
+    prefixIdentifiers: true,
+    hoistStatic: false,
+  })
+  const fn = new Function('Vue', `${result.code}\nreturn render`)
+  return fn(Vue) as (this: unknown, ctx: unknown) => unknown
+}
+
+// The styled wrapper under test: `<select><slot/></select>`, forwarding
+// `multiple` to the inner native control. `inheritAttrs: false` keeps the
+// bridged host props (registerValue / value / data-atta-pre-mark) off the
+// <select>, matching a real component wrapper.
+const CustomSelect = defineComponent({
+  name: 'CustomSelect',
+  props: { multiple: { type: Boolean, default: false } },
+  inheritAttrs: false,
+  setup(props, { slots }) {
+    return () => h('select', { multiple: props.multiple }, [slots['default']?.()])
+  },
+})
+
+// Extract the full `<option ...>` open tag carrying value="<value>", whatever
+// the attribute order — so the `selected` assertion is order-independent.
+function optionTag(html: string, value: string): string {
+  const match = html.match(new RegExp(`<option\\b[^>]*\\bvalue="${value}"[^>]*>`))
+  return match ? match[0] : ''
+}
+
+const OPTIONS = [
+  { value: 'admin', label: 'Admin' },
+  { value: 'editor', label: 'Editor' },
+  { value: 'viewer', label: 'Viewer' },
+]
+
+type UseFormish = (config: Record<string, unknown>) => unknown
+
+function mountSingle(useForm: UseFormish, makeSchema: () => unknown, template: string) {
+  const render = compileFn(template)
+  const Parent = defineComponent({
+    name: 'Parent',
+    components: { CustomSelect },
+    setup() {
+      const form = useForm({
+        schema: makeSchema(),
+        key: `wrap-single-${Math.random()}`,
+        defaultValues: { role: 'editor' },
+      })
+      return { form, options: OPTIONS }
+    },
+    render,
+  })
+  return createSSRApp(Parent).use(createAttaform())
+}
+
+function mountMulti(useForm: UseFormish, makeSchema: () => unknown, template: string) {
+  const render = compileFn(template)
+  const Parent = defineComponent({
+    name: 'Parent',
+    components: { CustomSelect },
+    setup() {
+      const form = useForm({
+        schema: makeSchema(),
+        key: `wrap-multi-${Math.random()}`,
+        defaultValues: { roles: ['editor', 'viewer'] },
+      })
+      return { form, options: OPTIONS }
+    },
+    render,
+  })
+  return createSSRApp(Parent).use(createAttaform())
+}
+
+const SINGLE_TPL = `<CustomSelect v-register="form.register('role')"><option v-for="o in options" :key="o.value" :value="o.value">{{ o.label }}</option></CustomSelect>`
+const MULTI_TPL = `<CustomSelect v-register="form.register('roles')" multiple><option v-for="o in options" :key="o.value" :value="o.value">{{ o.label }}</option></CustomSelect>`
+
+function runSuite(
+  label: string,
+  useForm: UseFormish,
+  single: () => unknown,
+  multi: () => unknown
+): void {
+  describe(`component-wrapped <select> SSR marks slotted options (${label})`, () => {
+    it('single-select: the seeded option renders selected in the SSR HTML', async () => {
+      const html = await renderToString(mountSingle(useForm, single, SINGLE_TPL))
+      expect(optionTag(html, 'editor')).toContain('selected')
+      expect(optionTag(html, 'admin')).not.toContain('selected')
+      expect(optionTag(html, 'viewer')).not.toContain('selected')
+    })
+
+    it('multi-select: every member option renders selected, non-members do not', async () => {
+      const html = await renderToString(mountMulti(useForm, multi, MULTI_TPL))
+      expect(optionTag(html, 'editor')).toContain('selected')
+      expect(optionTag(html, 'viewer')).toContain('selected')
+      expect(optionTag(html, 'admin')).not.toContain('selected')
+    })
+  })
+}
+
+runSuite(
+  'v4',
+  useFormV4 as unknown as UseFormish,
+  () => zV4.object({ role: zV4.string() }),
+  () => zV4.object({ roles: zV4.array(zV4.string()) })
+)
+
+runSuite(
+  'v3',
+  useFormV3 as unknown as UseFormish,
+  () => zV3.object({ role: zV3.string() }),
+  () => zV3.object({ roles: zV3.array(zV3.string()) })
+)

--- a/test/transforms/component-bridge-transform.test.ts
+++ b/test/transforms/component-bridge-transform.test.ts
@@ -165,3 +165,75 @@ describe('componentBridgeTransform — E1 source-location fidelity', () => {
     expect(valueProp.loc.start.line).toBeGreaterThan(0)
   })
 })
+
+describe('componentBridgeTransform — slotted options on a component host (#394)', () => {
+  // A `v-register` on a component wrapper (e.g. a styled `<CustomSelect>`
+  // whose template is `<select><slot/></select>`) projects its `<option>`s
+  // as parent-authored slot content. Those options are still present in the
+  // host's `node.children` at transform time, so they must be marked with
+  // `:selected` exactly like the inline-`<select>` path — otherwise the SSR
+  // HTML omits the selected option and the browser flashes the first option
+  // until hydration corrects it.
+  it('marks a slotted option under a component host (the bug: was 0)', () => {
+    const code = compileWithTransform(
+      `<CustomSelect v-register="form.register('role')"><option v-for="o in options" :key="o.value" :value="o.value">{{ o.label }}</option></CustomSelect>`
+    )
+    expect(countSelectedBindings(code)).toBe(1)
+  })
+
+  it('marks options projected through an explicit <template #default>', () => {
+    const code = compileWithTransform(
+      `<CustomSelect v-register="form.register('role')"><template #default><option value="a">A</option></template></CustomSelect>`
+    )
+    expect(countSelectedBindings(code)).toBe(1)
+  })
+
+  it('marks options inside a scoped slot', () => {
+    const code = compileWithTransform(
+      `<CustomSelect v-register="form.register('role')"><template #default="{ x }"><option value="a">{{ x }}</option></template></CustomSelect>`
+    )
+    expect(countSelectedBindings(code)).toBe(1)
+  })
+
+  it('marks a slotted option under a kebab-case custom-element host', () => {
+    const code = compileWithTransform(
+      `<my-select v-register="form.register('role')"><option value="a">A</option></my-select>`
+    )
+    expect(countSelectedBindings(code)).toBe(1)
+  })
+
+  it('descends through a wrapper element in the slot to reach the option', () => {
+    const code = compileWithTransform(
+      `<CustomSelect v-register="form.register('role')"><div><option value="a">A</option></div></CustomSelect>`
+    )
+    expect(countSelectedBindings(code)).toBe(1)
+  })
+
+  it('falls back to static text content for a value-less slotted option', () => {
+    const code = compileWithTransform(
+      `<CustomSelect v-register="form.register('role')"><option>apple</option></CustomSelect>`
+    )
+    expect(countSelectedBindings(code)).toBe(1)
+    expect(code).toContain('"apple"')
+  })
+
+  it('marks every member option on a multi-select wrapper (membership form, no host :value)', () => {
+    // `multiple` on the host routes through the same machinery as a native
+    // `<select multiple>`: per-option `:selected` carries initial state via
+    // the `findIndex` membership branch, and the host `:value` injection is
+    // suppressed (patching `select.value` on a multi-select would clobber it).
+    const code = compileWithTransform(
+      `<CustomSelect v-register="form.register('roles')" multiple><option value="a">A</option><option value="b">B</option></CustomSelect>`
+    )
+    expect(countSelectedBindings(code)).toBe(2)
+    expect(code).toContain('findIndex')
+    expect(code).not.toMatch(/\bvalue:\s*[^,}\n]*displayValue/)
+  })
+
+  it('leaves the inline <select> path at exactly one binding (no double-injection)', () => {
+    const code = compileWithTransform(
+      `<select v-register="form.register('role')"><option value="a">A</option></select>`
+    )
+    expect(countSelectedBindings(code)).toBe(1)
+  })
+})

--- a/test/transforms/v-register-component.test.ts
+++ b/test/transforms/v-register-component.test.ts
@@ -149,14 +149,14 @@ describe('v-register on Vue components — AST behaviour', () => {
       expect(code).toContain('registerValue:')
     })
 
-    it('does NOT recurse into slot children — option-tagged slot content gets no :selected', () => {
-      // ⚠ Asymmetry: native <select v-register>'s <option> children get
-      // a `:selected` binding injected at compile time (D3 fallback, etc).
-      // For <MyCustomSelect v-register>'s slot-content <option>s, the
-      // recursion is gated on `if (isSelect)`, so the same options pass
-      // through unmodified. A "transparent custom select" wrapper has to
-      // implement option-selection itself by reading `props.value`
-      // (auto-injected above) inside its template.
+    it('recurses into slot children — option-tagged slot content gets :selected (#394)', () => {
+      // #394: a `v-register` on a component wrapper projects its <option>s as
+      // parent-authored slot content, which is still present in the host's
+      // node.children at transform time. Those options now receive the same
+      // `:selected` binding a native <select v-register>'s inline options do,
+      // so wrapping a <select> in a styled component keeps the SSR-selected
+      // option instead of dropping it (and flashing the first option until
+      // hydration). The host still receives the value + registerValue pair.
       const code = compileWith(
         `<MyCustomSelect v-register="form.register('role')">
            <option value="admin">Admin</option>
@@ -167,11 +167,11 @@ describe('v-register on Vue components — AST behaviour', () => {
       // The component itself gets the value + registerValue prop pair.
       expect(code).toContain('displayValue')
       expect(code).toContain('registerValue:')
-      // But the slot-content options stay raw — no `:selected` was
-      // injected. Vue codegen still uses the keyword "selected" in
-      // patch flag comments if any prop named "selected" exists; we
-      // search for the BINDING form `selected:` to be precise.
-      expect(code).not.toMatch(/selected:\s*\(.*\)\?\.innerRef\?\.value/)
+      // And the slot-content options are now marked, same as the native
+      // path. Vue codegen also uses the keyword "selected" in patch-flag
+      // comments, so we search for the BINDING form `selected:` to be precise.
+      expect(code).toContain('innerRef')
+      expect(code).toMatch(/selected:\s*\(/)
     })
 
     it('still injects :selected on direct <option> children of a native <select v-register>', () => {


### PR DESCRIPTION
## What

Closes #394. A `v-register` on a **component wrapper** (a styled `<CustomSelect>` whose template is `<select><slot/></select>`) dropped the SSR selected-option, reintroducing a first-paint flash (wrong option → correct option) on every cold load / refresh / deep-link. An inline `<select v-register>` SSR-marks the chosen option; the wrapper did not.

```vue
<CustomSelect v-register="form.register('role')">
  <option v-for="o in options" :key="o.value" :value="o.value">{{ o.label }}</option>
</CustomSelect>
<!-- CustomSelect = <template><select><slot/></select></template> -->
```

## Root cause

`componentBridgeTransform` walked `<option>` children to inject `:selected` **only** on the native `<select>` path (gated by `if (isSelect)`). For a component host it injected the `:registerValue` bridge prop but never walked the children, so the parent-authored slotted options got only `key`/`value`, never `:selected`. The runtime `getSSRProps` path can't cover this either: it explicitly delegates select-option `selected` to this compile-time transform (`directive.ts` — "option-level, not expressible from the `<select>` element's props").

The key fact: the slotted options are still present in the host's `node.children` at transform (enter-phase) time, **before** Vue's `buildSlots` pass folds them into a slot function. So the parent transform can see and mark them.

## Fix

Hoist the existing `traverseSelectNode` walk above the `if (isSelect)` gate so component / kebab-element hosts run it too. `traverseSelectNode` is a no-op when there are no `<option>` descendants, so it's zero-cost for hosts that don't project options, and idempotent (it snapshots props + strips any prior `selected` before injecting).

- **General by construction:** any component / custom-element host with slotted `<option>`s gets them marked, at any nesting depth and slot shape (default, `<template #default>`, scoped, wrapper-wrapped, kebab host).
- **Multi-select wrappers** reuse the same machinery: `multiple` is read off the host identically, so the per-option `:selected` uses the `findIndex` membership form and the host `:value` injection is correctly suppressed (the documented multi-select clobber guard).
- **Audit:** select→option is the only host→child SSR derivation in Attaform. `inputTextAreaNodeTransform` requires `v-register` on the element itself (self-registering), so it has no analogous slot blind spot.

## Out of scope (documented limitation)

Options authored **inside the child's own template**, bound to an inner `<select>` the child never `v-register`s, can't be marked by any compile-time path (the parent can't see the child template) and have no directive at runtime. The two idiomatic paths already work: author options as slot content (this fix), or re-register the inner `<select v-register="useRegister()">`. Consistent with the existing runtime render-function `<select>` limitation.

## Tests (red-green)

- `component-bridge-transform.test.ts` — compile-output: a component host marks its slotted option (was 0, now 1) across slot shapes; multi-select wrapper asserts the membership form + no host `:value`; inline path stays at exactly one binding.
- `component-wrapper-select-ssr.test.ts` (new) — end-to-end `renderToString` proving `<option ... selected>` serializes for single- and multi-select wrappers, **both zod v3 and v4**.
- `v-register-component.test.ts` — flipped the test that asserted the old asymmetry to the fixed behavior.

## Verification

- New tests: 25 pass (red before, green after — including both multi-select cases)
- Full suite: 4273 pass, 0 fail · `typecheck` clean · `lint` + format clean · `check:size` under all caps

🤖 Generated with [Claude Code](https://claude.com/claude-code)