### PR TITLE
test(ssr): cross-render-path parity matrix for v-register (#378)

### DIFF
--- a/test/ssr-bare-vue/cross-path-parity.test.ts
+++ b/test/ssr-bare-vue/cross-path-parity.test.ts
@@ -1,0 +1,378 @@
+// @vitest-environment jsdom
+//
+// Cross-render-path SSR parity matrix (#378).
+//
+// Attaform emits SSR form-state through two disjoint code paths: the COMPILED
+// node transforms and the RUNTIME getSSRProps. They must produce equivalent
+// output for the same form state, but the suite otherwise tests each path
+// independently against the spec -- the exact blind spot that produced #370 /
+// #374 (one symptom, two unrelated fixes in two paths) and #394. This matrix
+// renders one shared fixture set through BOTH paths and locks them in step:
+// add a new input variant and it becomes one fixture row, automatically
+// checked on both paths, so the next divergence is a red test here rather
+// than a downstream bug report.
+//
+// Three layers per row (see test/utils/ssr-cross-path.ts):
+//   1+2. ground-truth + no-flash -- each path's emitted signal equals a single
+//        declared expectation, read from the parsed pre-hydration DOM.
+//   3.   clean hydration -- mounts over the SSR markup with no mismatch and no
+//        false `v-register` no-op / no-parent-RV warn (folds #370 in).
+//
+// WHAT THIS GUARD DOES NOT CATCH: a cross-path equality check catches the two
+// paths DIVERGING. It is blind to a shared-core semantic bug where both paths
+// read the same helper and agree on the same WRONG answer -- e.g. the autoAria
+// aria-required class (#381 / #404) through shared resolveAriaValue, which
+// reproduces identically on both paths. Those need per-feature correctness
+// tests. This matrix guards path divergence and first-paint correctness only.
+import { renderToString } from '@vue/server-renderer'
+import { describe, expect, it } from 'vitest'
+import { Suspense, createSSRApp, defineComponent, h, ref, withDirectives } from 'vue'
+import { useRegister } from '../../src'
+import { vRegister } from '../../src/runtime/core/directive'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import {
+  ADAPTERS,
+  assertCrossPathParity,
+  compileToRender,
+  settle,
+  withWarnCapture,
+  type Fixture,
+} from '../utils/ssr-cross-path'
+
+// The curated fixture set: meaningful combinations of variant x value-shape x
+// type-binding, not a blind cartesian product. Schemas are built per adapter
+// so v3 and v4 both run. `typeBinding: 'dynamic'` only changes how the
+// COMPILED template authors the type (`:type="t"`, the #374 wrapper shape) --
+// the runtime path always sees the resolved `resolvedType`.
+const FIXTURES: Fixture[] = [
+  // --- Text family (value attribute) ---
+  {
+    label: 'text/seeded/static',
+    variant: 'text',
+    resolvedType: 'text',
+    typeBinding: 'static',
+    makeSchema: (z) => z.object({ orgName: z.string() }),
+    path: 'orgName',
+    defaultValues: { orgName: 'Acme PHA' },
+    expected: 'Acme PHA',
+  },
+  {
+    label: 'text/seeded/dynamic-type', // the #374 Fix A shape
+    variant: 'text',
+    resolvedType: 'text',
+    typeBinding: 'dynamic',
+    makeSchema: (z) => z.object({ orgName: z.string() }),
+    path: 'orgName',
+    defaultValues: { orgName: 'Acme PHA' },
+    expected: 'Acme PHA',
+  },
+  {
+    label: 'text/empty', // no stale value to flash; both paths show empty
+    variant: 'text',
+    resolvedType: 'text',
+    typeBinding: 'static',
+    makeSchema: (z) => z.object({ orgName: z.string() }),
+    path: 'orgName',
+    defaultValues: { orgName: '' },
+    expected: '',
+  },
+  {
+    label: 'email/seeded',
+    variant: 'email',
+    resolvedType: 'email',
+    typeBinding: 'static',
+    makeSchema: (z) => z.object({ contact: z.string() }),
+    path: 'contact',
+    defaultValues: { contact: 'ada@example.com' },
+    expected: 'ada@example.com',
+  },
+  {
+    label: 'number/seeded',
+    variant: 'number',
+    resolvedType: 'number',
+    typeBinding: 'static',
+    makeSchema: (z) => z.object({ age: z.number() }),
+    path: 'age',
+    defaultValues: { age: 42 },
+    expected: '42',
+  },
+
+  // --- Textarea (value rides as text content) ---
+  {
+    label: 'textarea/seeded',
+    variant: 'textarea',
+    makeSchema: (z) => z.object({ bio: z.string() }),
+    path: 'bio',
+    defaultValues: { bio: 'hello world' },
+    expected: 'hello world',
+  },
+  {
+    label: 'textarea/empty',
+    variant: 'textarea',
+    makeSchema: (z) => z.object({ bio: z.string() }),
+    path: 'bio',
+    defaultValues: { bio: '' },
+    expected: '',
+  },
+
+  // --- Checkbox / radio (checked) ---
+  {
+    label: 'checkbox-bool/true',
+    variant: 'checkbox',
+    resolvedType: 'checkbox',
+    typeBinding: 'static',
+    makeSchema: (z) => z.object({ agree: z.boolean() }),
+    path: 'agree',
+    defaultValues: { agree: true },
+    expected: true,
+  },
+  {
+    label: 'checkbox-bool/false',
+    variant: 'checkbox',
+    resolvedType: 'checkbox',
+    typeBinding: 'static',
+    makeSchema: (z) => z.object({ agree: z.boolean() }),
+    path: 'agree',
+    defaultValues: { agree: false },
+    expected: false,
+  },
+  {
+    label: 'checkbox-array/member',
+    variant: 'checkbox',
+    resolvedType: 'checkbox',
+    typeBinding: 'static',
+    matchValue: 'apple',
+    makeSchema: (z) => z.object({ picks: z.array(z.string()) }),
+    path: 'picks',
+    defaultValues: { picks: ['apple'] },
+    expected: true,
+  },
+  {
+    label: 'checkbox-array/dynamic-type', // Fix A coverage for a non-text variant
+    variant: 'checkbox',
+    resolvedType: 'checkbox',
+    typeBinding: 'dynamic',
+    matchValue: 'apple',
+    makeSchema: (z) => z.object({ picks: z.array(z.string()) }),
+    path: 'picks',
+    defaultValues: { picks: ['apple'] },
+    expected: true,
+  },
+  {
+    label: 'radio/match',
+    variant: 'radio',
+    resolvedType: 'radio',
+    typeBinding: 'static',
+    matchValue: 'b',
+    makeSchema: (z) => z.object({ size: z.string() }),
+    path: 'size',
+    defaultValues: { size: 'b' },
+    expected: true,
+  },
+  {
+    label: 'radio/non-match',
+    variant: 'radio',
+    resolvedType: 'radio',
+    typeBinding: 'static',
+    matchValue: 'b',
+    makeSchema: (z) => z.object({ size: z.string() }),
+    path: 'size',
+    defaultValues: { size: 'a' },
+    expected: false,
+  },
+
+  // --- Select: the one DELIBERATE asymmetry. The compiled transform emits
+  // per-option `selected`; the runtime getSSRProps cannot express option-level
+  // state from the <select> element and returns undefined (a documented
+  // first-paint flash). Encoded as an explicit per-path override so the matrix
+  // asserts the gap rather than false-failing on it. (The component-wrapper
+  // slotted-options case is owned by component-wrapper-select-ssr.test.ts.)
+  {
+    label: 'select/seeded',
+    variant: 'select',
+    optionValues: ['us', 'uk'],
+    matchValue: 'uk',
+    makeSchema: (z) => z.object({ country: z.string() }),
+    path: 'country',
+    defaultValues: { country: 'uk' },
+    expected: { us: false, uk: true },
+    asymmetry: { runtime: { us: false, uk: false } },
+  },
+
+  // --- File: symmetric non-emitter. Browsers reject a value on file inputs,
+  // so both paths emit none -- and the model string must never leak.
+  {
+    label: 'file/static',
+    variant: 'file',
+    resolvedType: 'file',
+    typeBinding: 'static',
+    makeSchema: (z) => z.object({ doc: z.string() }),
+    path: 'doc',
+    defaultValues: { doc: 'should-not-leak' },
+    expected: null,
+    leakString: 'should-not-leak',
+  },
+  {
+    label: 'file/dynamic-type',
+    variant: 'file',
+    resolvedType: 'file',
+    typeBinding: 'dynamic',
+    makeSchema: (z) => z.object({ doc: z.string() }),
+    path: 'doc',
+    defaultValues: { doc: 'should-not-leak' },
+    expected: null,
+    leakString: 'should-not-leak',
+  },
+]
+
+// Intentionally NOT in the table: dynamic `:type` for textarea/select (those
+// tags have no `type`), and the async-restored value shape -- async
+// defaultValues resolve to byte-identical markup to sync seeding once awaited,
+// so the distinct async risk is the hydration-timing race, covered as a
+// dedicated row below rather than multiplying the whole table.
+
+describe.each(ADAPTERS)('SSR cross-path parity ($name)', (adapter) => {
+  it.each(FIXTURES)('$label emits equivalent SSR state on both paths', async (fixture) => {
+    await assertCrossPathParity(fixture, adapter)
+  })
+
+  // Integration row: the realistic consumer wrapper (useRegister() + an inner
+  // `<input v-register :type>`, the UiTextField shape). Anchors the matrix to
+  // how apps actually consume the directive, and proves the wrapper emits the
+  // value identically through both render paths.
+  it('integration: a useRegister() wrapper emits the value on both paths', async () => {
+    const { z, useForm } = adapter
+
+    const UiTextFieldCompiled = defineComponent({
+      name: 'UiTextField',
+      inheritAttrs: false,
+      setup() {
+        const register = useRegister()
+        const type = ref('text')
+        return { register, type }
+      },
+      render: compileToRender(`<input v-register="register" :type="type" />`),
+    })
+    const ParentCompiled = defineComponent({
+      name: 'WrapperParentCompiled',
+      components: { UiTextField: UiTextFieldCompiled },
+      setup() {
+        const form = useForm({
+          schema: z.object({ orgName: z.string() }),
+          defaultValues: { orgName: 'Acme PHA' },
+          key: `xpath-wrapper-compiled-${adapter.name}`,
+        })
+        return { form }
+      },
+      render: compileToRender(`<div><UiTextField v-register="form.register('orgName')" /></div>`),
+    })
+
+    const UiTextFieldRuntime = defineComponent({
+      name: 'UiTextField',
+      inheritAttrs: false,
+      setup() {
+        const register = useRegister()
+        return () => withDirectives(h('input', { type: 'text' }), [[vRegister, register?.value]])
+      },
+    })
+    const ParentRuntime = defineComponent({
+      name: 'WrapperParentRuntime',
+      setup() {
+        const form = useForm({
+          schema: z.object({ orgName: z.string() }),
+          defaultValues: { orgName: 'Acme PHA' },
+          key: `xpath-wrapper-runtime-${adapter.name}`,
+        })
+        return () => {
+          const rv = form.register('orgName')
+          // Pass the registerValue bridge prop the compiled transform would
+          // inject, plus the directive marker, so the child's useRegister()
+          // binds for real. A variable (not an inline literal) sidesteps the
+          // excess-property check on the propless child.
+          const childProps = { registerValue: rv }
+          return h('div', null, [
+            withDirectives(h(UiTextFieldRuntime, childProps), [[vRegister, rv]]),
+          ])
+        }
+      },
+    })
+
+    function inputValue(html: string): string | null {
+      const root = document.createElement('div')
+      root.innerHTML = html
+      const el = root.querySelector('input')
+      return el === null ? null : (el as HTMLInputElement).value
+    }
+
+    const compiledHtml = await renderToString(createSSRApp(ParentCompiled).use(createAttaform()))
+    const runtimeHtml = await renderToString(createSSRApp(ParentRuntime).use(createAttaform()))
+
+    expect(inputValue(compiledHtml), 'compiled wrapper value').toBe('Acme PHA')
+    expect(inputValue(runtimeHtml), 'runtime wrapper value').toBe('Acme PHA')
+    // The two paths agree -- the lockstep the matrix exists to enforce.
+    expect(inputValue(compiledHtml)).toBe(inputValue(runtimeHtml))
+  })
+
+  // Async-hydration row (#370): under Nuxt-style lazy hydration (an async
+  // setup ancestor under <Suspense>), the prescribed useRegister wrapper must
+  // hydrate without the false `v-register no-op` warn that the marker-timing
+  // race used to emit. This is the genuine distinct risk of the "restored
+  // (async)" value shape -- timing, not attribute emission.
+  it('async hydration of a useRegister wrapper emits no false no-op warn (#370)', async () => {
+    const { z, useForm } = adapter
+
+    const Field = defineComponent({
+      name: 'Field',
+      inheritAttrs: false,
+      setup() {
+        const rv = useRegister()
+        return () =>
+          h('div', { class: 'field' }, [
+            withDirectives(h('input', { type: 'text' }), [[vRegister, rv]]),
+          ])
+      },
+    })
+    const Parent = defineComponent({
+      name: 'AsyncWrapperParent',
+      setup() {
+        const form = useForm({
+          schema: z.object({ email: z.string() }),
+          defaultValues: { email: '' },
+          key: `xpath-async-hydration-${adapter.name}`,
+        })
+        return () => {
+          const rv = form.register('email')
+          const childProps = { registerValue: rv }
+          return withDirectives(h(Field, childProps), [[vRegister, rv]])
+        }
+      },
+    })
+    const AsyncBoundary = defineComponent({
+      name: 'AsyncBoundary',
+      async setup() {
+        await Promise.resolve()
+        return () => h(Parent)
+      },
+    })
+    const App = defineComponent({
+      name: 'AsyncApp',
+      setup() {
+        return () => h(Suspense, null, { default: () => h(AsyncBoundary) })
+      },
+    })
+
+    const warnings = await withWarnCapture(async () => {
+      const html = await renderToString(createSSRApp(App).use(createAttaform()))
+      const container = document.createElement('div')
+      container.innerHTML = html
+      document.body.appendChild(container)
+      const app = createSSRApp(App).use(createAttaform())
+      app.mount(container)
+      await settle()
+      app.unmount()
+      container.remove()
+    })
+
+    expect(warnings.filter((w) => w.includes('is a no-op'))).toEqual([])
+  })
+})

--- a/test/utils/ssr-cross-path.ts
+++ b/test/utils/ssr-cross-path.ts
@@ -1,0 +1,346 @@
+// Shared harness for the cross-render-path SSR parity matrix (#378).
+//
+// Attaform emits SSR form-state through two disjoint code paths that must
+// agree for the same field + form state:
+//
+//   - COMPILED path: the node transforms (inputTextAreaNodeTransform,
+//     componentBridgeTransform) bake value / checked / selected into the
+//     generated render code.
+//   - RUNTIME path: the directive's getSSRFormStateProps returns the same
+//     attributes as a prop object for h() + withDirectives usage.
+//
+// The suite tests each path independently against the spec, but nothing
+// asserts the two paths emit EQUIVALENT output for the same state -- the
+// exact blind spot behind #370 / #374 (one symptom, two unrelated fixes in
+// two paths) and #394. This module renders one shared fixture through both
+// paths and locks them in step.
+//
+// IMPORTANT (scope of the guard): a cross-path equality check catches the
+// two paths DIVERGING. It cannot catch a shared-core semantic bug where both
+// paths read the same helper and agree on the same WRONG answer -- e.g. the
+// autoAria #381 / #404 class through shared resolveAriaValue. Those need
+// per-feature correctness tests, not this matrix.
+//
+// Consumers must run under `@vitest-environment jsdom` (extractSignal and the
+// hydration assertions parse and mount real DOM).
+import { baseCompile } from '@vue/compiler-core'
+import { renderToString } from '@vue/server-renderer'
+import { expect, vi } from 'vitest'
+import * as Vue from 'vue'
+import {
+  createSSRApp,
+  defineComponent,
+  h,
+  nextTick,
+  withDirectives,
+  type Component,
+  type DirectiveArguments,
+  type VNode,
+} from 'vue'
+import { z as zV4 } from 'zod'
+import { z as zV3 } from 'zod-v3'
+import { useForm as useFormV4 } from '../../src/zod-v4'
+import { useForm as useFormV3 } from '../../src/zod-v3'
+import { vRegister } from '../../src/runtime/core/directive'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import { componentBridgeTransform } from '../../src/runtime/lib/core/transforms/component-bridge-transform'
+import { inputTextAreaNodeTransform } from '../../src/runtime/lib/core/transforms/input-text-area-transform'
+import { vRegisterHintTransform } from '../../src/runtime/lib/core/transforms/v-register-hint-transform'
+import { vRegisterPreambleTransform } from '../../src/runtime/lib/core/transforms/v-register-preamble-transform'
+
+// zV3 / useFormV3 are cast to their v4 static types so a shared loop
+// type-checks (the two adapters' static types don't unify, but their runtime
+// surface used here is identical). The real v3 instances run at runtime; the
+// cast only satisfies the compiler -- same pattern as the per-path SSR tests.
+export const ADAPTERS = [
+  { name: 'zod-v4', z: zV4, useForm: useFormV4 },
+  {
+    name: 'zod-v3',
+    z: zV3 as unknown as typeof zV4,
+    useForm: useFormV3 as unknown as typeof useFormV4,
+  },
+] as const
+
+export type Adapter = (typeof ADAPTERS)[number]
+
+// The full transform stack a real SFC compile runs through, so the compiled
+// path under test matches production codegen exactly.
+const TRANSFORMS = [
+  componentBridgeTransform,
+  inputTextAreaNodeTransform,
+  vRegisterPreambleTransform,
+  vRegisterHintTransform,
+]
+
+/** Compile a parent template to a render function (mirrors the per-path tests). */
+export function compileToRender(template: string): (this: unknown, ctx: unknown) => unknown {
+  const result = baseCompile(template, {
+    nodeTransforms: TRANSFORMS,
+    mode: 'function',
+    prefixIdentifiers: true,
+    hoistStatic: false,
+  })
+  const fn = new Function('Vue', `${result.code}\nreturn render`)
+  return fn(Vue) as (this: unknown, ctx: unknown) => unknown
+}
+
+export type Variant =
+  | 'text'
+  | 'email'
+  | 'number'
+  | 'textarea'
+  | 'checkbox'
+  | 'radio'
+  | 'select'
+  | 'file'
+
+// The canonical form-state signal, normalised across both paths:
+//   - text / email / number / textarea -> the element's effective value
+//   - checkbox / radio                 -> whether `checked` is present
+//   - select                           -> per-option `selected` map
+//   - file                             -> the `value` ATTRIBUTE (expected null)
+export type Signal = string | boolean | null | Record<string, boolean>
+
+export interface Fixture {
+  /** Unique, human-readable label -- also seeds the per-row form key. */
+  label: string
+  variant: Variant
+  /** Built per adapter so v3 and v4 both run. */
+  makeSchema: (z: typeof zV4) => unknown
+  path: string
+  defaultValues: Record<string, unknown>
+  /**
+   * Concrete resolved input type (text / email / number / checkbox / radio /
+   * file). The RUNTIME path always sees this concrete value -- there is no
+   * static-vs-dynamic distinction at the SSR layer there.
+   */
+  resolvedType?: string
+  /**
+   * How the COMPILED template authors the type. 'dynamic' emits `:type="t"`
+   * (the #374 wrapper shape that the transform must still resolve); 'static'
+   * emits `type="..."`. Ignored by the runtime path.
+   */
+  typeBinding?: 'static' | 'dynamic'
+  /** Option values for select. */
+  optionValues?: string[]
+  /** The value discriminator on a checkbox/radio input (also the chosen select option). */
+  matchValue?: string
+  /** The canonical signal both paths emit, unless overridden per path below. */
+  expected: Signal
+  /**
+   * Per-path expected override for a DELIBERATE asymmetry. Only `select`
+   * needs this: the runtime path emits no option-level `selected`
+   * (getSSRFormStateProps returns undefined for select -- it is not
+   * element-expressible), while the compiled path emits it via
+   * componentBridgeTransform. Encoding it here means a future variant with an
+   * inherent split MUST declare it or the parity assertion fails.
+   */
+  asymmetry?: { compiled?: Signal; runtime?: Signal }
+  /** File only: this substring (the model value) must never appear in the SSR HTML. */
+  leakString?: string
+}
+
+type RenderPath = 'compiled' | 'runtime'
+
+/** Author the COMPILED parent template for a fixture. */
+function buildTemplate(f: Fixture): string {
+  const reg = `v-register="form.register('${f.path}')"`
+  if (f.variant === 'textarea') return `<textarea ${reg}></textarea>`
+  if (f.variant === 'select') {
+    const opts = (f.optionValues ?? []).map((v) => `<option value="${v}">${v}</option>`).join('')
+    return `<select ${reg}>${opts}</select>`
+  }
+  const typeAttr = f.typeBinding === 'dynamic' ? `:type="t"` : `type="${f.resolvedType ?? 'text'}"`
+  const valueAttr = f.matchValue !== undefined ? ` value="${f.matchValue}"` : ''
+  return `<input ${typeAttr} ${reg}${valueAttr} />`
+}
+
+/** Build the equivalent RUNTIME vnode for a fixture. */
+function buildRuntimeVNode(f: Fixture, rv: unknown): VNode {
+  const dirs: DirectiveArguments = [[vRegister, rv]]
+  if (f.variant === 'textarea') return withDirectives(h('textarea'), dirs)
+  if (f.variant === 'select') {
+    const opts = (f.optionValues ?? []).map((v) => h('option', { value: v }, v))
+    return withDirectives(h('select', null, opts), dirs)
+  }
+  const props: Record<string, unknown> = { type: f.resolvedType ?? 'text' }
+  if (f.matchValue !== undefined) props['value'] = f.matchValue
+  return withDirectives(h('input', props), dirs)
+}
+
+function makeComponent(
+  renderPath: RenderPath,
+  f: Fixture,
+  adapter: Adapter,
+  key: string
+): Component {
+  const { z, useForm } = adapter
+  if (renderPath === 'compiled') {
+    return defineComponent({
+      setup() {
+        // The schema is statically `unknown` (the harness is generic over
+        // every fixture's shape); useForm needs a concrete type, so the one
+        // cast lives here -- same as the per-path SSR tests.
+        const form = useForm({
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          schema: f.makeSchema(z) as any,
+          defaultValues: f.defaultValues,
+          key,
+        })
+        return { form, t: f.resolvedType ?? 'text' }
+      },
+      render: compileToRender(buildTemplate(f)),
+    })
+  }
+  return defineComponent({
+    setup() {
+      const form = useForm({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        schema: f.makeSchema(z) as any,
+        defaultValues: f.defaultValues,
+        key,
+      })
+      // The `any` schema collapses register's path parameter to `never`; cast
+      // the fixture path to satisfy the typed call.
+      const rv = form.register(f.path as never)
+      return () => buildRuntimeVNode(f, rv)
+    },
+  })
+}
+
+/** Read the canonical signal out of a parsed SSR container. */
+export function signalFrom(container: HTMLElement, f: Fixture): Signal {
+  switch (f.variant) {
+    case 'text':
+    case 'email':
+    case 'number': {
+      const el = container.querySelector('input')
+      return el === null ? null : (el as HTMLInputElement).value
+    }
+    case 'file': {
+      // file inputs reject a programmatic value; assert the ATTRIBUTE absence
+      // (the property is always '' in jsdom and would mask a leak).
+      return container.querySelector('input')?.getAttribute('value') ?? null
+    }
+    case 'textarea': {
+      const el = container.querySelector('textarea')
+      // `.value` reflects the spec-correct effective value: Vue routes a
+      // seeded textarea value to its text content, and the property reads it
+      // back. If a path wrongly emitted a value= ATTRIBUTE, the property would
+      // be '' -- and the parity check would catch that divergence.
+      return el === null ? null : (el as HTMLTextAreaElement).value
+    }
+    case 'checkbox':
+    case 'radio': {
+      const sel = f.matchValue !== undefined ? `input[value="${f.matchValue}"]` : 'input'
+      return container.querySelector(sel)?.hasAttribute('checked') ?? false
+    }
+    case 'select': {
+      const map: Record<string, boolean> = {}
+      for (const v of f.optionValues ?? []) {
+        map[v] = container.querySelector(`option[value="${v}"]`)?.hasAttribute('selected') ?? false
+      }
+      return map
+    }
+  }
+}
+
+function parse(html: string): HTMLElement {
+  const root = document.createElement('div')
+  root.innerHTML = html
+  return root
+}
+
+// Async hydration completes over several microtasks and the directive's warn
+// deferral is itself a post-flush nextTick, so drain both queues to make the
+// no-mismatch / no-false-warn assertions conclusive (mirrors the warn-race
+// test's settle()).
+async function settle(): Promise<void> {
+  await nextTick()
+  await new Promise((resolve) => setTimeout(resolve, 10))
+  await nextTick()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+/**
+ * Run the full guard for one fixture on one render path:
+ *   1+2. Parse the SSR HTML and assert the signal equals the per-path
+ *        expectation -- this is both ground-truth correctness AND no-flash
+ *        (the parsed markup IS the pre-hydration DOM the browser paints).
+ *   3.   Mount over that markup and assert a clean hydration: no
+ *        hydration-mismatch warning and no false `v-register` no-op /
+ *        no-parent-RV warn (folds #370 in).
+ */
+async function runOnePath(renderPath: RenderPath, f: Fixture, adapter: Adapter): Promise<void> {
+  const key = `xpath-${adapter.name}-${f.label}-${renderPath}`
+  const Comp = makeComponent(renderPath, f, adapter, key)
+  const expected = f.asymmetry?.[renderPath] ?? f.expected
+  const where = `${f.label} [${adapter.name}/${renderPath}]`
+
+  const warnings: string[] = []
+  const capture = (...args: unknown[]): void => {
+    warnings.push(args.map((a) => String(a)).join(' '))
+  }
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(capture)
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(capture)
+
+  try {
+    const html = await renderToString(createSSRApp(Comp).use(createAttaform()))
+
+    // Ground-truth + no-flash: the value/checked/selected the browser parses
+    // before any client JS runs.
+    const root = parse(html)
+    document.body.appendChild(root)
+    expect(signalFrom(root, f), `${where}: SSR signal pre-hydration`).toEqual(expected)
+    if (f.leakString !== undefined) {
+      expect(html, `${where}: no model leak`).not.toContain(f.leakString)
+    }
+
+    // Clean hydration over the planted markup.
+    const app = createSSRApp(Comp).use(createAttaform())
+    app.mount(root)
+    await settle()
+    const mismatches = warnings.filter((w) => /hydrat|mismatch/i.test(w))
+    const falseWarns = warnings.filter(
+      (w) => w.includes('is a no-op') || w.includes('no parent registerValue')
+    )
+    expect(mismatches, `${where}: hydration mismatch warnings`).toEqual([])
+    expect(falseWarns, `${where}: false v-register warnings`).toEqual([])
+    app.unmount()
+    root.remove()
+  } finally {
+    warnSpy.mockRestore()
+    errorSpy.mockRestore()
+  }
+}
+
+/**
+ * The matrix entry point: render the fixture through BOTH paths and assert
+ * each matches its per-path expectation. A single `expected` drives both
+ * paths for non-asymmetric variants, so the two paths are locked in step --
+ * you cannot author one side's expectation differently from the other's by
+ * accident.
+ */
+export async function assertCrossPathParity(f: Fixture, adapter: Adapter): Promise<void> {
+  await runOnePath('compiled', f, adapter)
+  await runOnePath('runtime', f, adapter)
+}
+
+/** Capture console.warn/error for the duration of `fn`; returns the lines. */
+export async function withWarnCapture(fn: () => Promise<void>): Promise<string[]> {
+  const warnings: string[] = []
+  const capture = (...args: unknown[]): void => {
+    warnings.push(args.map((a) => String(a)).join(' '))
+  }
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(capture)
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(capture)
+  try {
+    await fn()
+  } finally {
+    warnSpy.mockRestore()
+    errorSpy.mockRestore()
+  }
+  return warnings
+}
+
+export { settle }


### PR DESCRIPTION
## What

Adds a table-driven SSR parity matrix that renders one shared fixture set through **both** of Attaform's SSR form-state paths (the compiled node transforms and the runtime `getSSRProps`) and asserts they stay in lockstep.

Closes #378.

## Why

Attaform emits `value` / `checked` / `selected` for SSR through two disjoint mechanisms. The suite tested each path independently against the spec, but nothing asserted the two paths emit **equivalent** output for the same state, which is the exact blind spot behind #370, #374 (one dropped-value symptom, two unrelated fixes in two paths), and #394. The "two paths never disagree" guarantee was a code comment with no test guarding it.

## How

- One curated fixture table (variant x value-shape x type-binding), run under both zod adapters.
- A single declared expectation drives both paths for every non-asymmetric variant, so a new input variant becomes one fixture row checked on both paths automatically.
- The one deliberate asymmetry (runtime `<select>` omits option-level `selected`; compiled emits it) is encoded as an explicit per-path override, so the matrix asserts the gap instead of false-failing on it.
- Each row also asserts **no-flash** (signal present in the parsed pre-hydration DOM) and **clean hydration** (no mismatch warning, no false `v-register` no-op warn, folding #370 in).
- An integration row exercises the realistic `useRegister()` wrapper shape on both paths; a dedicated row covers the async-hydration timing race (#370) under `<Suspense>`.

## Scope of the guard (documented in the test)

A cross-path equality check catches the two paths **diverging**. It is blind to shared-core semantic bugs where both paths read the same helper and agree on the same **wrong** answer, e.g. the autoAria `aria-required` class (#381 / #404) through shared `resolveAriaValue`. The docblock states this so the guard is not over-trusted.

## Verification

- `pnpm test test/ssr-bare-vue/cross-path-parity.test.ts`: 36 green (both adapters).
- Mutation-checked: falsely claiming the runtime select emits `selected` turns the row red, confirming the guard bites.
- Full `pnpm test` (4309 passed), `pnpm typecheck`, `pnpm lint` all clean.
- Test-only: no `src` change, no new deps, zero bundle impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)