### PR TITLE
docs(changelog): note the fixes landed since v0.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,32 @@
 # Changelog
 
 ## Unreleased
+### Fixed
 
-_No unreleased changes yet._
+- **A `<select>` you wrap in your own component now keeps its server-rendered
+  selection.** Placing `v-register` on a styled wrapper whose template is
+  `<select><slot /></select>`, with the `<option>`s projected through the slot,
+  used to drop the chosen option's `selected` from the server HTML, so the first
+  option flashed in until hydration corrected it. The wrapper's slotted options
+  are now marked exactly like an inline `<select>`, at any slot depth or shape,
+  for single and multiple selection, on both zod v3 and zod v4. (#394)
+
+- **`form.meta.dirty` now notices a removal, not just an addition.** Un-checking
+  a pre-checked box in an array-bound checkbox group, removing a seeded array
+  element, or clearing an optional subtree with `setValue('profile', undefined)`
+  now flips `meta.dirty` to `true`, so a Save button bound to
+  `:disabled="!form.meta.dirty"` enables after a revoke the same way it does
+  after a grant. The field value was always right; only the structural dirty
+  verdict was asymmetric. Both zod v3 and zod v4. (#420)
+
+- **A generic helper around `useForm` can now forward `defaultValues` without a
+  type error.** Sharing form plumbing through a wrapper that is generic over its
+  schema, then passing a schema-derived `defaultValues` straight through, used to
+  trip a type error (and a depth blow-up on zod v3). The `defaultValues` slot now
+  accepts the schema's own input reflexively, so the wrapper compiles while
+  concrete call sites keep their exact per-field checking. A types-only change
+  that brings zod v3 to full parity with zod v4 across the `attaform/zod`,
+  `attaform/zod-v4`, and `attaform/zod-v3` entries. (#422)
 
 ## v0.24.1
 ### Fixed


### PR DESCRIPTION
## What

Fills in the `## Unreleased` section of `CHANGELOG.md` with the user-facing fixes merged since the `v0.24.1` tag. The release `version` hook (`scripts/promote-changelog.mjs`) promotes `Unreleased` to the tagged version automatically, so these entries ride the next release.

## Entries (all under `### Fixed`)

- **#394** — a component-wrapped `<select>` (`<select><slot /></select>`) now keeps its server-rendered selection instead of flashing the first option until hydration; single and multiple, both zod majors.
- **#420** — `form.meta.dirty` now flips on a *removal* (un-checking a seeded array box, dropping a seeded element, clearing an optional subtree), not just an addition.
- **#422** — a generic helper around `useForm` can forward a schema-derived `defaultValues` without a type error; types-only, brings zod v3 to parity with v4.

## Deliberately excluded

Two PRs merged since the tag carry no user-observable change, so they stay out of a customer changelog: the tree-shaking tripwire (#442) and the cross-render-path parity matrix (#446), both internal test/CI guards.

Brand-voice prose, no em-dashes, issue numbers cited (matching the existing house style).

🤖 Generated with [Claude Code](https://claude.com/claude-code)