### PR TITLE
chore: migrate canonical domain to attaform.dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
 ## Unreleased
+### Changed
 
-_No unreleased changes yet._
+- **Attaform's home is now [attaform.dev](https://attaform.dev).** The docs site,
+  the npm package `homepage`, the Nuxt module's devtools docs link, and the URL
+  printed by the `useForm` configuration error now point at the new domain. The
+  former `attaform.com` address redirects to it, so existing links keep working.
 
 ## v0.24.2
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Found a vulnerability? Please report it privately through the [security policy](
 
 ## License
 
-© 2025-present [Oswald Chisala](https://www.linkedin.com/in/chisalao/). Released under the [MIT License](./LICENSE).
+© 2026 [Oswald Chisala](https://www.linkedin.com/in/chisalao/). Released under the [MIT License](./LICENSE).
 
 [npm-version-src]: https://img.shields.io/npm/v/attaform/latest.svg?style=flat&colorA=020420&colorB=00DC82
 [npm-version-href]: https://npmjs.com/package/attaform

--- a/README.md
+++ b/README.md
@@ -16,86 +16,28 @@ A type-safe, schema-driven form library for Vue 3 and Nuxt with first-class Zod 
 >
 > Because Vue and Nuxt devs deserve nice things, too.
 
-**Try it live.** Tweak a schema, edit the template, and watch the form rebind in the browser at [attaform.dev/demos](https://attaform.dev/demos). No install needed.
+**[Try it live →](https://attaform.dev/demos)** Tweak a schema, edit the template, and watch the form rebind in your browser. No install needed.
 
-## Installation
+## Quick start
 
 ```bash
 npm install attaform zod
 ```
 
-That's it for client-side rendering. Forms render and validate the moment you call `useForm`; the registry self-installs on first use.
-
-### Going further
-
-**Nuxt 3 / 4.** Add the module:
-
-```ts
-// nuxt.config.ts
-export default defineNuxtConfig({
-  modules: ['attaform/nuxt'],
-})
-```
-
-**Bare Vue + SSR.** Add the Vite plugin so server-rendered HTML matches the hydrated client (the plugin injects `:value` / `:checked` bindings at compile time):
-
-```ts
-// vite.config.ts
-import vue from '@vitejs/plugin-vue'
-import { attaform } from 'attaform/vite'
-
-export default defineConfig({
-  plugins: [vue(), attaform()],
-})
-```
-
-The Vite plugin also rewrites `attaform/zod` imports at build time to `attaform/zod-v3` or `attaform/zod-v4`, so your bundle ships only the adapter you actually use.
-
-**App-wide options.** Install the Vue plugin if you want to set defaults or disable devtools:
-
-```ts
-// main.ts
-import { createApp } from 'vue'
-import { createAttaform } from 'attaform'
-
-createApp(App)
-  .use(createAttaform({ defaults: { debounceMs: 100 } }))
-  .mount('#app')
-```
-
-### Recommended tsconfig
-
-Attaform pairs well with `noUncheckedIndexedAccess: true`:
-
-```json
-{
-  "compilerOptions": {
-    "strict": true,
-    "noUncheckedIndexedAccess": true
-  }
-}
-```
-
-It catches stale `form.values.contacts[N]` reads at compile time. Nuxt 3 / 4 sets this for you.
-
-> **Try it live.** Skip the install and tweak a schema in your browser at [attaform.dev/demos](https://attaform.dev/demos).
-
-## Quick start
-
 ```vue
 <script setup lang="ts">
   import { z } from 'zod'
-  import { useForm } from 'attaform/zod' // auto-detects Zod major
+  import { useForm } from 'attaform/zod' // auto-detects your Zod major
 
   const schema = z.object({
     username: z.string().min(2, 'At least 2 characters'),
     password: z.string().min(8, 'At least 8 characters'),
   })
 
-  const form = useForm({ schema, key: 'signup' })
+  const form = useForm({ schema })
 
   const onSubmit = form.handleSubmit(async (values) => {
-    await $fetch('/api/signup', { method: 'POST', body: JSON.stringify(values) })
+    await fetch('/api/signup', { method: 'POST', body: JSON.stringify(values) })
   })
 </script>
 
@@ -112,78 +54,41 @@ It catches stale `form.values.contacts[N]` reads at compile time. Nuxt 3 / 4 set
 </template>
 ```
 
-`useForm({ schema, key })` returns a Pinia-style reactive form. Read leaves directly, no `.value`:
+Hand the schema to `useForm`, bind each input with `v-register`, and Attaform owns the values, the coercion, the live errors, and the typed submit payload. That is the whole loop.
 
-- **`form.values`**: current values. `form.values.username`, `form.values.address.city`.
-- **`form.errors`**: per-field errors, keyed by dotted path. `form.errors.username?.[0]?.message`.
-- **`form.fields`**: per-field flags (`dirty`, `touched`, `errors`, `blank`, …). `form.fields.username.dirty`.
-- **`form.meta`**: form-level flags and counters (`submitting`, `submitted`, `valid`, `dirty`, `submissionAttempts`, the flat `meta.errors` aggregate, the per-mount `instanceId`, …).
-- **`form.history`**: consolidated undo/redo namespace (`undo()`, `redo()`, `clear()`, `canUndo`, `canRedo`, `size`).
-- **`form.register(path)`**: typed two-way binding. Pair with `v-register` on `<input>` / `<textarea>` / `<select>`.
-- **`form.handleSubmit(onSubmit, onError?)`**: runs validation, then dispatches. The submit callback receives the strict Zod-inferred type.
-- **`form.setValue(path, value)`**, **`form.reset()`**, field-array helpers: see [Entry points](https://attaform.dev/docs/reference/entry-points).
+**[Full walkthrough →](https://attaform.dev/docs/getting-started/quick-start)** Setting up Nuxt, Vite, or bare Vue? See the [installation guide](https://attaform.dev/docs/getting-started/installation).
 
-> **Try it live.** Tweak this schema, edit the template, and watch the form rebind in the browser at [attaform.dev/demos](https://attaform.dev/demos). No install needed.
+## Highlights
 
-## `v-register`: one line, every option
-
-`v-register` stays on the same native `<input>`. Every option you add opts into another runtime feature without touching the template structure.
-
-```vue
-<input v-register="form.register('email')" />
-```
-
-Typed two-way binding to `form.values.email`, with schema-driven coercion at the directive layer.
-
-```vue
-<input v-register="form.register('slug', { transforms: [lowercase] })" />
-```
-
-Same line. The field now runs a sync write-time transform, normalizing the value before it reaches form state.
-
-```vue
-<input v-register="form.register('slug', { transforms: [lowercase, dashify], autoAria: false })" />
-```
-
-Same line. Compose a transform pipeline and opt this field out of automatic aria wiring, all without touching the markup elsewhere.
-
-## Features
-
-- **Schema-driven types.** Every path, value, and error is inferred from your Zod schema. No `any`, no manual type plumbing.
-- **Live validation.** `validateOn: 'change'` by default with synchronous `debounceMs: 0`. `'blur'` and `'submit'` (opt-out) modes available. Async refinements await before submit dispatches.
-- **Schema-driven coercion.** String DOM input flows into the schema's typed slot (`string→number`, `string→boolean`) at the directive layer. Default-on; pass `useForm({ coerce: false })` to disable or a custom `CoercionRegistry` to extend.
-- **Register transforms.** `form.register('slug', { transforms: [lowercase, dashify] })` runs sync write-time normalization before storage commit.
-- **First-class multistep.** `useWizard` composes `useForm` instances into a flow with shared navigation, per-step validation, state retained across steps, and deep-link restore.
-- **DevTools panel.** Auto-wired in Nuxt. Walk history, edit values live, inspect every form on the page. No probes to install.
-- **Discriminated-union variant memory.** Switching a discriminator (`notify.channel: 'email' → 'sms' → 'email'`) restores the previous variant's typed subtree by default. Pass `useForm({ rememberVariants: false })` to drop on switch.
-- **Field arrays.** `append` / `prepend` / `insert` / `remove` / `swap` / `move` / `replace`, fully typed at the call site.
-- **Undo / redo.** Opt in with `useForm({ history: true })` for a bounded undo stack via `form.history` (`undo()` / `redo()` / `canUndo` / `canRedo`).
-- **Server errors.** `form.setErrors(response.errors)` mounts a server's `ValidationError[]` into the same reactive surface your template already reads. Each error carries an optional `data` payload (a captcha challenge, a lockout time); user errors survive schema revalidation.
-- **Stable error codes.** Every `ValidationError` carries `code: string`. Attaform codes (`atta:`) live on the exported `AttaformErrorCode` enum; adapter codes use a `zod:` prefix; consumers pick their own (`api:`, `auth:`, …).
-- **Clearable required fields.** The `unset` sentinel marks a field displayed-empty while storage holds the schema's slim default. Submit fails with `'No value supplied'` for required schemas; `.optional()` / `.nullable()` / `.default(N)` opt out.
-- **SSR.** Nuxt handles the payload round-trip automatically; bare Vue uses `renderAttaformState` / `hydrateAttaformState`.
+- **The schema is the form.** Types, defaults, validation, per-field errors, and the submit payload all flow from one Zod schema. No `any`, no manual type plumbing, on both Zod v3 and v4 from a single `attaform/zod` import. [Why Attaform →](https://attaform.dev/docs/getting-started/why-attaform)
+- **`useForm` is the core.** A reactive, fully typed form: read `form.values`, `form.errors`, `form.fields`, and `form.meta` directly, then write with `form.setValue`, `form.reset`, and typed field-array helpers. [The form →](https://attaform.dev/docs/reading-the-form/the-form)
+- **`useWizard` for multistep.** Compose forms into a flow with shared navigation, per-step validation, state retained across steps, and deep-link restore. [useWizard →](https://attaform.dev/docs/multistep/use-wizard)
+- **SSR-native.** Server-rendered HTML matches the hydrated client with no flash. Auto-wired in Nuxt, one Vite plugin for bare Vue. [SSR in Nuxt →](https://attaform.dev/docs/server-and-ssr/ssr-nuxt)
+- **DevTools built in.** Inspect every form on the page, walk its history, and edit values live. No probes to install. [DevTools panel →](https://attaform.dev/docs/devtools-and-debugging/devtools-panel)
+- **Secure by construction.** Zero runtime dependencies (no supply-chain surface), prototype-pollution-safe deep writes, and Attaform never throws into your app. [Security policy →](./SECURITY.md)
 
 ## Documentation
 
-Full docs live at [attaform.dev](https://attaform.dev):
+Full docs live at **[attaform.dev](https://attaform.dev)**.
 
-- [**Quick start**](https://attaform.dev/docs/getting-started/quick-start): schema, form, submit, in one page.
-- [**Why Attaform**](https://attaform.dev/docs/getting-started/why-attaform): the convictions behind the design.
-- [**Entry points**](https://attaform.dev/docs/reference/entry-points): every public export, grouped by subpath.
-- [**useWizard**](https://attaform.dev/docs/multistep/use-wizard): multistep flows with shared state and validation.
-- [**Performance**](https://attaform.dev/docs/server-and-ssr/performance): how it scales; when to worry.
-- [**Troubleshooting**](https://attaform.dev/docs/devtools-and-debugging/troubleshooting): common gotchas and fixes.
-- [**Changelog**](./CHANGELOG.md): full release history.
+- [Quick start](https://attaform.dev/docs/getting-started/quick-start): schema, form, submit, in one page.
+- [Installation](https://attaform.dev/docs/getting-started/installation): Vue, Nuxt, and Vite setup.
+- [Entry points](https://attaform.dev/docs/reference/entry-points): every public export, grouped by subpath.
+- [Performance](https://attaform.dev/docs/server-and-ssr/performance): how it scales, when to worry.
+- [Troubleshooting](https://attaform.dev/docs/devtools-and-debugging/troubleshooting): common gotchas and fixes.
+- [Changelog](./CHANGELOG.md): full release history.
 
 ## Status
 
-Pre-1.0. SemVer applies from `v1.0` onward; 0.x minor bumps may still include breaking changes, each documented in the [Changelog](./CHANGELOG.md).
+Pre-1.0. SemVer applies from `v1.0` onward; `0.x` minor bumps may still include breaking changes, each documented in the [changelog](./CHANGELOG.md).
+
+## Security
+
+Found a vulnerability? Please report it privately through the [security policy](./SECURITY.md).
 
 ## License
 
-MIT; see [LICENSE](./LICENSE).
-
-<!-- Badges -->
+MIT, see [LICENSE](./LICENSE).
 
 [npm-version-src]: https://img.shields.io/npm/v/attaform/latest.svg?style=flat&colorA=020420&colorB=00DC82
 [npm-version-href]: https://npmjs.com/package/attaform

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ It catches stale `form.values.contacts[N]` reads at compile time. Nuxt 3 / 4 set
 - **`form.meta`**: form-level flags and counters (`submitting`, `valid`, `dirty`, `submissionAttempts`, the flat `meta.errors` aggregate, the per-mount `instanceId`, …).
 - **`form.history`**: consolidated undo/redo namespace (`undo()`, `redo()`, `clear()`, `canUndo`, `canRedo`, `size`).
 - **`form.register(path)`**: typed two-way binding. Pair with `v-register` on `<input>` / `<textarea>` / `<select>`.
-- **`form.handleSubmit(onValid, onInvalid?)`**: runs validation, dispatches. The valid callback receives the strict Zod-inferred type.
+- **`form.handleSubmit(onSubmit, onError?)`**: runs validation, then dispatches. The submit callback receives the strict Zod-inferred type.
 - **`form.setValue(path, value)`**, **`form.reset()`**, field-array helpers: see [Entry points](https://attaform.dev/docs/reference/entry-points).
 
 > **Try it live.** Tweak this schema, edit the template, and watch the form rebind in the browser at [attaform.dev/demos](https://attaform.dev/demos). No install needed.
@@ -157,7 +157,7 @@ Same line. Compose a transform pipeline and opt this field out of automatic aria
 - **DevTools panel.** Auto-wired in Nuxt. Walk history, edit values live, inspect every form on the page. No probes to install.
 - **Discriminated-union variant memory.** Switching a discriminator (`notify.channel: 'email' → 'sms' → 'email'`) restores the previous variant's typed subtree by default. Pass `useForm({ rememberVariants: false })` to drop on switch.
 - **Field arrays.** `append` / `prepend` / `insert` / `remove` / `swap` / `move` / `replace`, fully typed at the call site.
-- **Undo / redo.** A bounded undo stack via `form.history` (`undo()` / `redo()` / `canUndo` / `canRedo`).
+- **Undo / redo.** Opt in with `useForm({ history: true })` for a bounded undo stack via `form.history` (`undo()` / `redo()` / `canUndo` / `canRedo`).
 - **Server errors.** `form.setErrors(response.errors)` mounts a server's `ValidationError[]` into the same reactive surface your template already reads. Each error carries an optional `data` payload (a captcha challenge, a lockout time); user errors survive schema revalidation.
 - **Stable error codes.** Every `ValidationError` carries `code: string`. Attaform codes (`atta:`) live on the exported `AttaformErrorCode` enum; adapter codes use a `zod:` prefix; consumers pick their own (`api:`, `auth:`, …).
 - **Clearable required fields.** The `unset` sentinel marks a field displayed-empty while storage holds the schema's slim default. Submit fails with `'No value supplied'` for required schemas; `.optional()` / `.nullable()` / `.default(N)` opt out.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A type-safe, schema-driven form library for Vue 3 and Nuxt with first-class Zod 
 >
 > Because Vue and Nuxt devs deserve nice things, too.
 
-**Try it live.** Tweak a schema, edit the template, and watch the form rebind in the browser at [attaform.com/demos](https://www.attaform.com/demos). No install needed.
+**Try it live.** Tweak a schema, edit the template, and watch the form rebind in the browser at [attaform.dev/demos](https://attaform.dev/demos). No install needed.
 
 ## Installation
 
@@ -78,7 +78,7 @@ Attaform pairs well with `noUncheckedIndexedAccess: true`:
 
 It catches stale `form.values.contacts[N]` reads at compile time. Nuxt 3 / 4 sets this for you.
 
-> **Try it live.** Skip the install and tweak a schema in your browser at [attaform.com/demos](https://www.attaform.com/demos).
+> **Try it live.** Skip the install and tweak a schema in your browser at [attaform.dev/demos](https://attaform.dev/demos).
 
 ## Quick start
 
@@ -121,9 +121,9 @@ It catches stale `form.values.contacts[N]` reads at compile time. Nuxt 3 / 4 set
 - **`form.history`**: consolidated undo/redo namespace (`undo()`, `redo()`, `clear()`, `canUndo`, `canRedo`, `size`).
 - **`form.register(path)`**: typed two-way binding. Pair with `v-register` on `<input>` / `<textarea>` / `<select>`.
 - **`form.handleSubmit(onValid, onInvalid?)`**: runs validation, dispatches. The valid callback receives the strict Zod-inferred type.
-- **`form.setValue(path, value)`**, **`form.reset()`**, field-array helpers: see [Entry points](https://www.attaform.com/docs/reference/entry-points).
+- **`form.setValue(path, value)`**, **`form.reset()`**, field-array helpers: see [Entry points](https://attaform.dev/docs/reference/entry-points).
 
-> **Try it live.** Tweak this schema, edit the template, and watch the form rebind in the browser at [attaform.com/demos](https://www.attaform.com/demos). No install needed.
+> **Try it live.** Tweak this schema, edit the template, and watch the form rebind in the browser at [attaform.dev/demos](https://attaform.dev/demos). No install needed.
 
 ## `v-register`: one line, every option
 
@@ -165,14 +165,14 @@ Same line. Compose a transform pipeline and opt this field out of automatic aria
 
 ## Documentation
 
-Full docs live at [www.attaform.com](https://www.attaform.com):
+Full docs live at [attaform.dev](https://attaform.dev):
 
-- [**Quick start**](https://www.attaform.com/docs/getting-started/quick-start): schema, form, submit, in one page.
-- [**Why Attaform**](https://www.attaform.com/docs/getting-started/why-attaform): the convictions behind the design.
-- [**Entry points**](https://www.attaform.com/docs/reference/entry-points): every public export, grouped by subpath.
-- [**useWizard**](https://www.attaform.com/docs/multistep/use-wizard): multistep flows with shared state and validation.
-- [**Performance**](https://www.attaform.com/docs/server-and-ssr/performance): how it scales; when to worry.
-- [**Troubleshooting**](https://www.attaform.com/docs/devtools-and-debugging/troubleshooting): common gotchas and fixes.
+- [**Quick start**](https://attaform.dev/docs/getting-started/quick-start): schema, form, submit, in one page.
+- [**Why Attaform**](https://attaform.dev/docs/getting-started/why-attaform): the convictions behind the design.
+- [**Entry points**](https://attaform.dev/docs/reference/entry-points): every public export, grouped by subpath.
+- [**useWizard**](https://attaform.dev/docs/multistep/use-wizard): multistep flows with shared state and validation.
+- [**Performance**](https://attaform.dev/docs/server-and-ssr/performance): how it scales; when to worry.
+- [**Troubleshooting**](https://attaform.dev/docs/devtools-and-debugging/troubleshooting): common gotchas and fixes.
 - [**Changelog**](./CHANGELOG.md): full release history.
 
 ## Status

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Found a vulnerability? Please report it privately through the [security policy](
 
 ## License
 
-© 2026 [Oswald Chisala](https://www.linkedin.com/in/chisalao/). Released under the [MIT License](./LICENSE).
+© 2025-present [Oswald Chisala](https://www.linkedin.com/in/chisalao/). Released under the [MIT License](./LICENSE).
 
 [npm-version-src]: https://img.shields.io/npm/v/attaform/latest.svg?style=flat&colorA=020420&colorB=00DC82
 [npm-version-href]: https://npmjs.com/package/attaform

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ It catches stale `form.values.contacts[N]` reads at compile time. Nuxt 3 / 4 set
 - **`form.values`**: current values. `form.values.username`, `form.values.address.city`.
 - **`form.errors`**: per-field errors, keyed by dotted path. `form.errors.username?.[0]?.message`.
 - **`form.fields`**: per-field flags (`dirty`, `touched`, `errors`, `blank`, …). `form.fields.username.dirty`.
-- **`form.meta`**: form-level flags and counters (`submitting`, `valid`, `dirty`, `submissionAttempts`, the flat `meta.errors` aggregate, the per-mount `instanceId`, …).
+- **`form.meta`**: form-level flags and counters (`submitting`, `submitted`, `valid`, `dirty`, `submissionAttempts`, the flat `meta.errors` aggregate, the per-mount `instanceId`, …).
 - **`form.history`**: consolidated undo/redo namespace (`undo()`, `redo()`, `clear()`, `canUndo`, `canRedo`, `size`).
 - **`form.register(path)`**: typed two-way binding. Pair with `v-register` on `<input>` / `<textarea>` / `<select>`.
 - **`form.handleSubmit(onSubmit, onError?)`**: runs validation, then dispatches. The submit callback receives the strict Zod-inferred type.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Found a vulnerability? Please report it privately through the [security policy](
 
 ## License
 
-MIT, see [LICENSE](./LICENSE).
+© 2026 [Oswald Chisala](https://www.linkedin.com/in/chisalao/). Released under the [MIT License](./LICENSE).
 
 [npm-version-src]: https://img.shields.io/npm/v/attaform/latest.svg?style=flat&colorA=020420&colorB=00DC82
 [npm-version-href]: https://npmjs.com/package/attaform

--- a/apps/site/components/OgImage/Default.satori.vue
+++ b/apps/site/components/OgImage/Default.satori.vue
@@ -116,7 +116,7 @@
         color: #71717a;
       "
     >
-      <span style="display: flex">www.attaform.com</span>
+      <span style="display: flex">attaform.dev</span>
       <span
         style="
           padding: 10px 22px;

--- a/apps/site/docs-demos/transforms-async/App.vue
+++ b/apps/site/docs-demos/transforms-async/App.vue
@@ -6,7 +6,7 @@
 
   const sample = [
     '# links.txt: one web address per line. Blank lines and # comments are skipped.',
-    'attaform.com',
+    'attaform.dev',
     'https://Example.com/Docs/Getting-Started',
     'github.com/attaform/Attaform',
     '',

--- a/apps/site/error.vue
+++ b/apps/site/error.vue
@@ -28,7 +28,7 @@
     const title = encodeURIComponent('Broken docs link')
     const route = useRequestURL()
     const body = encodeURIComponent(
-      `I hit a 404 while browsing attaform.com.\n\nURL: ${route.pathname}\nReferrer: (paste here if you came from a link)`
+      `I hit a 404 while browsing attaform.dev.\n\nURL: ${route.pathname}\nReferrer: (paste here if you came from a link)`
     )
     return `https://github.com/attaform/Attaform/issues/new?title=${title}&body=${body}`
   })

--- a/apps/site/nuxt.config.ts
+++ b/apps/site/nuxt.config.ts
@@ -356,12 +356,12 @@ export default defineNuxtConfig({
   // canonicals + OG meta + structured-data URLs all resolve against
   // `site.url`.
   //
-  // Pin to the **www** host — the apex `attaform.com` 301s to
-  // `www.attaform.com` at the Vercel layer. Emitting sitemap entries
-  // (and canonicals, and og:url) on the apex would mean every URL the
-  // crawler hits redirects, wasting crawl budget and signaling
-  // duplicate content. The canonical host is www; everything we ship
-  // points there directly.
+  // Pin to the apex host. `attaform.dev` is the canonical origin;
+  // `www.attaform.dev` and both `attaform.com` hosts 301 to it at the
+  // Vercel layer. Emitting sitemap entries (and canonicals, and og:url)
+  // on the apex means the crawler reaches the canonical URL with no
+  // redirect hop, so no crawl budget is wasted and no duplicate-content
+  // signal is sent. Everything we ship points at the apex.
   //
   // `indexable` gates the ENTIRE SEO-discovery surface on a single
   // env flag — same gate the IndexNow ping uses
@@ -390,7 +390,7 @@ export default defineNuxtConfig({
   // direct backlinks from indexable pages — which production never
   // emits to preview hostnames.
   site: {
-    url: 'https://www.attaform.com',
+    url: 'https://attaform.dev',
     name: 'Attaform',
     description: 'A type-safe, Zod-first form library for Vue 3 and Nuxt.',
     defaultLocale: 'en',

--- a/apps/site/pages/index.vue
+++ b/apps/site/pages/index.vue
@@ -120,7 +120,7 @@
       applicationCategory: 'DeveloperApplication',
       operatingSystem: 'Cross-platform',
       description: 'A type-safe, Zod-first form library for Vue 3 and Nuxt.',
-      url: 'https://www.attaform.com',
+      url: 'https://attaform.dev',
       author: { '@type': 'Person', name: 'Oswald Chisala' },
       // MIT-licensed and free — surface the price-zero offer so the
       // SoftwareApplication node validates against Google's required

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > A type-safe, schema-driven form library for Vue 3 and Nuxt with first-class Zod support. Hand a Zod schema to `useForm` and Attaform turns it into a reactive form, typed end-to-end, with live errors, automatic accessibility, and SSR out of the box.
 
-*This index is hand-maintained and may lag the live source. These things happen. If a link 404s, an export looks missing, or a signature seems off, treat the docs at [attaform.com](https://www.attaform.com), the published `attaform` types, and the source at [github.com/attaform/Attaform](https://github.com/attaform/Attaform) as canonical. When in doubt, crawl from the homepage rather than giving up on the project.*
+*This index is hand-maintained and may lag the live source. These things happen. If a link 404s, an export looks missing, or a signature seems off, treat the docs at [attaform.dev](https://attaform.dev), the published `attaform` types, and the source at [github.com/attaform/Attaform](https://github.com/attaform/Attaform) as canonical. When in doubt, crawl from the homepage rather than giving up on the project.*
 
 Attaform's core idea is that the schema IS the form. One Zod schema declares the shape, the defaults, the validation, the per-field errors, and the input/output types. Attaform builds the reactive surface around it.
 
@@ -118,100 +118,100 @@ Patterns that keep Attaform code clean.
 
 ## Getting started
 
-- [Quick start](https://www.attaform.com/docs/getting-started/quick-start): paste-and-run minimal example.
-- [Why Attaform](https://www.attaform.com/docs/getting-started/why-attaform): the design pitch and five convictions.
-- [Installation](https://www.attaform.com/docs/getting-started/installation): Vue, Nuxt, and Vite setups.
-- [Your first schema](https://www.attaform.com/docs/getting-started/your-first-schema): walks the schema-to-form arc.
-- [From schema to inputs](https://www.attaform.com/docs/getting-started/from-schema-to-inputs): binding side of the arc.
-- [From inputs to submit](https://www.attaform.com/docs/getting-started/from-inputs-to-submit): submission side of the arc.
+- [Quick start](https://attaform.dev/docs/getting-started/quick-start): paste-and-run minimal example.
+- [Why Attaform](https://attaform.dev/docs/getting-started/why-attaform): the design pitch and five convictions.
+- [Installation](https://attaform.dev/docs/getting-started/installation): Vue, Nuxt, and Vite setups.
+- [Your first schema](https://attaform.dev/docs/getting-started/your-first-schema): walks the schema-to-form arc.
+- [From schema to inputs](https://attaform.dev/docs/getting-started/from-schema-to-inputs): binding side of the arc.
+- [From inputs to submit](https://attaform.dev/docs/getting-started/from-inputs-to-submit): submission side of the arc.
 
 ## Core API
 
-- [The form](https://www.attaform.com/docs/reading-the-form/the-form): what `useForm` returns.
-- [`v-register`](https://www.attaform.com/docs/binding-inputs/v-register): the binding directive.
-- [Values](https://www.attaform.com/docs/reading-the-form/values), [errors](https://www.attaform.com/docs/reading-the-form/errors), [fields](https://www.attaform.com/docs/reading-the-form/fields), [list](https://www.attaform.com/docs/reading-the-form/list), [record](https://www.attaform.com/docs/reading-the-form/record), [meta](https://www.attaform.com/docs/reading-the-form/meta): the reactive reads.
-- [Type safety](https://www.attaform.com/docs/reading-the-form/type-safety): inference and `toRef`.
-- [`injectForm`](https://www.attaform.com/docs/cross-cutting-state/inject-form): reach a form from any descendant.
-- [`useRegister`](https://www.attaform.com/docs/binding-inputs/use-register): re-bind `v-register` inside wrapper components.
+- [The form](https://attaform.dev/docs/reading-the-form/the-form): what `useForm` returns.
+- [`v-register`](https://attaform.dev/docs/binding-inputs/v-register): the binding directive.
+- [Values](https://attaform.dev/docs/reading-the-form/values), [errors](https://attaform.dev/docs/reading-the-form/errors), [fields](https://attaform.dev/docs/reading-the-form/fields), [list](https://attaform.dev/docs/reading-the-form/list), [record](https://attaform.dev/docs/reading-the-form/record), [meta](https://attaform.dev/docs/reading-the-form/meta): the reactive reads.
+- [Type safety](https://attaform.dev/docs/reading-the-form/type-safety): inference and `toRef`.
+- [`injectForm`](https://attaform.dev/docs/cross-cutting-state/inject-form): reach a form from any descendant.
+- [`useRegister`](https://attaform.dev/docs/binding-inputs/use-register): re-bind `v-register` inside wrapper components.
 
 ## Schemas
 
-- [Abstract schema](https://www.attaform.com/docs/schemas/abstract-schema): the schema contract Attaform consumes.
-- [Defaults](https://www.attaform.com/docs/schemas/defaults): function and value forms, async hydration, SSR.
-- [Optional vs nullable](https://www.attaform.com/docs/schemas/optional-nullable): the storage-shape distinction.
-- [Nested objects](https://www.attaform.com/docs/schemas/nested-objects), [arrays and tuples](https://www.attaform.com/docs/schemas/arrays-and-tuples), [records](https://www.attaform.com/docs/schemas/records): container kinds.
-- [Discriminated unions](https://www.attaform.com/docs/schemas/discriminated-unions): variants, variant memory, merged metadata.
-- [Storage shape](https://www.attaform.com/docs/schemas/storage-shape): what actually lives in `form.values`.
+- [Abstract schema](https://attaform.dev/docs/schemas/abstract-schema): the schema contract Attaform consumes.
+- [Defaults](https://attaform.dev/docs/schemas/defaults): function and value forms, async hydration, SSR.
+- [Optional vs nullable](https://attaform.dev/docs/schemas/optional-nullable): the storage-shape distinction.
+- [Nested objects](https://attaform.dev/docs/schemas/nested-objects), [arrays and tuples](https://attaform.dev/docs/schemas/arrays-and-tuples), [records](https://attaform.dev/docs/schemas/records): container kinds.
+- [Discriminated unions](https://attaform.dev/docs/schemas/discriminated-unions): variants, variant memory, merged metadata.
+- [Storage shape](https://attaform.dev/docs/schemas/storage-shape): what actually lives in `form.values`.
 
 ## Binding inputs
 
-- [`v-register`](https://www.attaform.com/docs/binding-inputs/v-register): canonical pattern.
-- [Text, number, textarea](https://www.attaform.com/docs/binding-inputs/text-number-textarea), [checkbox](https://www.attaform.com/docs/binding-inputs/checkbox), [radio](https://www.attaform.com/docs/binding-inputs/radio), [select](https://www.attaform.com/docs/binding-inputs/select), [file](https://www.attaform.com/docs/binding-inputs/file): native input kinds.
-- [Modifiers](https://www.attaform.com/docs/binding-inputs/modifiers): `.lazy`, `.trim`, `.number`.
-- [Coercion](https://www.attaform.com/docs/binding-inputs/coercion): user input string-to-target coercion.
-- [Transforms](https://www.attaform.com/docs/binding-inputs/transforms): per-field sync transform pipeline.
-- [Custom assigners](https://www.attaform.com/docs/binding-inputs/custom-assigners): bind to non-native components.
+- [`v-register`](https://attaform.dev/docs/binding-inputs/v-register): canonical pattern.
+- [Text, number, textarea](https://attaform.dev/docs/binding-inputs/text-number-textarea), [checkbox](https://attaform.dev/docs/binding-inputs/checkbox), [radio](https://attaform.dev/docs/binding-inputs/radio), [select](https://attaform.dev/docs/binding-inputs/select), [file](https://attaform.dev/docs/binding-inputs/file): native input kinds.
+- [Modifiers](https://attaform.dev/docs/binding-inputs/modifiers): `.lazy`, `.trim`, `.number`.
+- [Coercion](https://attaform.dev/docs/binding-inputs/coercion): user input string-to-target coercion.
+- [Transforms](https://attaform.dev/docs/binding-inputs/transforms): per-field sync transform pipeline.
+- [Custom assigners](https://attaform.dev/docs/binding-inputs/custom-assigners): bind to non-native components.
 
 ## Validation
 
-- [When validation runs](https://www.attaform.com/docs/validation/when-validation-runs): `validateOn` + `debounceMs`.
-- [Showing errors](https://www.attaform.com/docs/validation/showing-errors): the `displayState` verdict (`idle` / `pending` / `error` / `success`), the `show*` projections, and custom `getDisplayState` (compose around the exported `defaultDisplayState`).
-- [Async refinements](https://www.attaform.com/docs/validation/async-refinements): debounced async checks.
-- [Per-field validation](https://www.attaform.com/docs/validation/per-field-validation): `form.validate(path)` and `form.validateAsync(path)`.
-- [Lifecycle](https://www.attaform.com/docs/validation/lifecycle): sync versus async, when errors land.
-- [Blank fields](https://www.attaform.com/docs/validation/blank): how Attaform handles "no value supplied".
+- [When validation runs](https://attaform.dev/docs/validation/when-validation-runs): `validateOn` + `debounceMs`.
+- [Showing errors](https://attaform.dev/docs/validation/showing-errors): the `displayState` verdict (`idle` / `pending` / `error` / `success`), the `show*` projections, and custom `getDisplayState` (compose around the exported `defaultDisplayState`).
+- [Async refinements](https://attaform.dev/docs/validation/async-refinements): debounced async checks.
+- [Per-field validation](https://attaform.dev/docs/validation/per-field-validation): `form.validate(path)` and `form.validateAsync(path)`.
+- [Lifecycle](https://attaform.dev/docs/validation/lifecycle): sync versus async, when errors land.
+- [Blank fields](https://attaform.dev/docs/validation/blank): how Attaform handles "no value supplied".
 
 ## Submitting
 
-- [`handleSubmit`](https://www.attaform.com/docs/submitting/handle-submit): the full lifecycle.
-- [Focus and scroll](https://www.attaform.com/docs/submitting/focus-scroll): invalid-submit policy.
-- [Server-side errors](https://www.attaform.com/docs/submitting/server-side-errors): `form.setErrors` and `form.clearErrors`.
+- [`handleSubmit`](https://attaform.dev/docs/submitting/handle-submit): the full lifecycle.
+- [Focus and scroll](https://attaform.dev/docs/submitting/focus-scroll): invalid-submit policy.
+- [Server-side errors](https://attaform.dev/docs/submitting/server-side-errors): `form.setErrors` and `form.clearErrors`.
 
 ## Writing and mutating
 
-- [`setValue`](https://www.attaform.com/docs/writing-and-mutating/set-value), [`reset`](https://www.attaform.com/docs/writing-and-mutating/reset), [`clear`](https://www.attaform.com/docs/writing-and-mutating/clear), [`unset`](https://www.attaform.com/docs/writing-and-mutating/unset): programmatic writes.
-- [Field arrays](https://www.attaform.com/docs/writing-and-mutating/field-arrays): append, insert, remove, swap, move.
-- [Variant memory](https://www.attaform.com/docs/writing-and-mutating/variant-memory): switching discriminated-union variants without losing data.
+- [`setValue`](https://attaform.dev/docs/writing-and-mutating/set-value), [`reset`](https://attaform.dev/docs/writing-and-mutating/reset), [`clear`](https://attaform.dev/docs/writing-and-mutating/clear), [`unset`](https://attaform.dev/docs/writing-and-mutating/unset): programmatic writes.
+- [Field arrays](https://attaform.dev/docs/writing-and-mutating/field-arrays): append, insert, remove, swap, move.
+- [Variant memory](https://attaform.dev/docs/writing-and-mutating/variant-memory): switching discriminated-union variants without losing data.
 
 ## Multistep
 
-- [`useWizard`](https://www.attaform.com/docs/multistep/use-wizard): the list-based step orchestrator.
-- [Step slots](https://www.attaform.com/docs/multistep/step-slots): forms, strings, function slots, `lazy()`.
-- [`injectWizard`](https://www.attaform.com/docs/multistep/inject-wizard): cross-component access.
-- [Wizard `handleSubmit`](https://www.attaform.com/docs/multistep/handle-submit): the universal submit lifecycle.
-- [URL sync](https://www.attaform.com/docs/multistep/url-sync): `?step=` round-trip, Nuxt deep-link hydration.
-- [Statuses](https://www.attaform.com/docs/multistep/statuses) and [aggregates](https://www.attaform.com/docs/multistep/aggregates): per-step state, namespaced `allValues` / `allErrors`.
-- [Patterns](https://www.attaform.com/docs/multistep/patterns): common multistep recipes.
+- [`useWizard`](https://attaform.dev/docs/multistep/use-wizard): the list-based step orchestrator.
+- [Step slots](https://attaform.dev/docs/multistep/step-slots): forms, strings, function slots, `lazy()`.
+- [`injectWizard`](https://attaform.dev/docs/multistep/inject-wizard): cross-component access.
+- [Wizard `handleSubmit`](https://attaform.dev/docs/multistep/handle-submit): the universal submit lifecycle.
+- [URL sync](https://attaform.dev/docs/multistep/url-sync): `?step=` round-trip, Nuxt deep-link hydration.
+- [Statuses](https://attaform.dev/docs/multistep/statuses) and [aggregates](https://attaform.dev/docs/multistep/aggregates): per-step state, namespaced `allValues` / `allErrors`.
+- [Patterns](https://attaform.dev/docs/multistep/patterns): common multistep recipes.
 
 ## Cross-cutting state
 
-- [`injectForm`](https://www.attaform.com/docs/cross-cutting-state/inject-form): ambient or keyed form lookup.
-- [App defaults](https://www.attaform.com/docs/cross-cutting-state/app-defaults): global config defaults.
-- [Multi-tab sync](https://www.attaform.com/docs/cross-cutting-state/multi-tab-sync): `BroadcastChannel`-backed cross-tab state.
-- [Undo and redo](https://www.attaform.com/docs/cross-cutting-state/undo-redo): `form.history`.
+- [`injectForm`](https://attaform.dev/docs/cross-cutting-state/inject-form): ambient or keyed form lookup.
+- [App defaults](https://attaform.dev/docs/cross-cutting-state/app-defaults): global config defaults.
+- [Multi-tab sync](https://attaform.dev/docs/cross-cutting-state/multi-tab-sync): `BroadcastChannel`-backed cross-tab state.
+- [Undo and redo](https://attaform.dev/docs/cross-cutting-state/undo-redo): `form.history`.
 
 ## Server and SSR
 
-- [SSR in Nuxt](https://www.attaform.com/docs/server-and-ssr/ssr-nuxt): the canonical SSR setup.
-- [SSR in bare Vue](https://www.attaform.com/docs/server-and-ssr/ssr-bare-vue): without Nuxt.
-- [Performance](https://www.attaform.com/docs/server-and-ssr/performance): measured numbers anchored against the 60 fps budget.
+- [SSR in Nuxt](https://attaform.dev/docs/server-and-ssr/ssr-nuxt): the canonical SSR setup.
+- [SSR in bare Vue](https://attaform.dev/docs/server-and-ssr/ssr-bare-vue): without Nuxt.
+- [Performance](https://attaform.dev/docs/server-and-ssr/performance): measured numbers anchored against the 60 fps budget.
 
 ## DevTools and debugging
 
-- [DevTools panel](https://www.attaform.com/docs/devtools-and-debugging/devtools-panel): the Nuxt DevTools tab.
-- [Vue DevTools](https://www.attaform.com/docs/devtools-and-debugging/vue-devtools): the Chrome extension surface.
-- [Troubleshooting](https://www.attaform.com/docs/devtools-and-debugging/troubleshooting): common pitfalls.
+- [DevTools panel](https://attaform.dev/docs/devtools-and-debugging/devtools-panel): the Nuxt DevTools tab.
+- [Vue DevTools](https://attaform.dev/docs/devtools-and-debugging/vue-devtools): the Chrome extension surface.
+- [Troubleshooting](https://attaform.dev/docs/devtools-and-debugging/troubleshooting): common pitfalls.
 
 ## Reference
 
-- [Entry points](https://www.attaform.com/docs/reference/entry-points): every package subpath (`attaform`, `attaform/zod`, `attaform/zod-v3`, `attaform/zod-v4`, `attaform/vite`, `attaform/nuxt`, `attaform/devtools-panel`).
-- [Errors](https://www.attaform.com/docs/reference/errors): `AttaformErrorCode` table and the error class hierarchy.
-- [Types](https://www.attaform.com/docs/reference/types): every exported type.
-- [Custom adapters](https://www.attaform.com/docs/reference/custom-adapters): building a non-Zod schema adapter.
+- [Entry points](https://attaform.dev/docs/reference/entry-points): every package subpath (`attaform`, `attaform/zod`, `attaform/zod-v3`, `attaform/zod-v4`, `attaform/vite`, `attaform/nuxt`, `attaform/devtools-panel`).
+- [Errors](https://attaform.dev/docs/reference/errors): `AttaformErrorCode` table and the error class hierarchy.
+- [Types](https://attaform.dev/docs/reference/types): every exported type.
+- [Custom adapters](https://attaform.dev/docs/reference/custom-adapters): building a non-Zod schema adapter.
 
 ## Interactive
 
-- [Demos](https://www.attaform.com/demos): every docs demo as a standalone editable playground.
+- [Demos](https://attaform.dev/demos): every docs demo as a standalone editable playground.
 
 ## Optional
 

--- a/apps/site/scripts/indexnow-ping.mjs
+++ b/apps/site/scripts/indexnow-ping.mjs
@@ -39,7 +39,7 @@ const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
 const SITE_ROOT = resolve(SCRIPT_DIR, '..')
 const SITEMAP_PATH = resolve(SITE_ROOT, '.output/public/sitemap.xml')
 
-const HOST = 'www.attaform.com'
+const HOST = 'attaform.dev'
 const KEY = '2e71a5ced510106b3dfca644c1ccb49d'
 const KEY_LOCATION = `https://${HOST}/${KEY}.txt`
 const ENDPOINT = 'https://api.indexnow.org/IndexNow'
@@ -69,7 +69,7 @@ async function main() {
   // The sitemap is small (one entry per public page), regex
   // extraction is enough — no XML parser dependency. Each candidate is
   // parsed via `new URL` and asserted against the production HOST so a
-  // sneaky entry like `https://www.attaform.com.evil.com/` (which
+  // sneaky entry like `https://attaform.dev.evil.com/` (which
   // satisfies a byte-prefix check) gets rejected. Closes CodeQL alert
   // #15 (rule js/file-access-to-http).
   const urls = Array.from(sitemap.matchAll(/<loc>([^<]+)<\/loc>/g))

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "type": "git",
     "url": "https://github.com/attaform/Attaform"
   },
-  "homepage": "https://attaform.com",
+  "homepage": "https://attaform.dev",
   "scripts": {
     "dev": "pnpm dev:prepare && pnpm --filter attaform-site dev",
     "dev:prepare": "unbuild --stub && nuxi prepare apps/site",

--- a/src/nuxt.ts
+++ b/src/nuxt.ts
@@ -104,7 +104,7 @@ export default defineNuxtModule<AttaformModuleOptions>({
     name: 'Attaform',
     configKey: 'attaform',
     version: pkgVersion,
-    docs: 'https://www.attaform.com/docs',
+    docs: 'https://attaform.dev/docs',
     compatibility: {
       nuxt: '>=3.0.0',
     },

--- a/src/runtime/core/errors.ts
+++ b/src/runtime/core/errors.ts
@@ -53,7 +53,7 @@ export class InvalidUseFormConfigError extends AttaformError {
     super(
       '[attaform] useForm received an invalid configuration (a schema directly, no argument, ' +
         'or no `schema` field). Pass it as `useForm({ schema })` — the schema is one of several ' +
-        'configuration options. See https://attaform.com/docs/api/use-form-return for the full ' +
+        'configuration options. See https://attaform.dev/docs/reading-the-form/the-form for the full ' +
         'configuration shape.'
     )
   }


### PR DESCRIPTION
## What

Migrates the canonical domain from `www.attaform.com` to the apex `attaform.dev`. Apex is now canonical (no `www`), reversing the previous `www`-pinned setup so the bare domain is what readers and crawlers see.

`site.url` in `nuxt.config.ts` drives the sitemap, `robots.txt`, every canonical, `og:url`, and the Schema.org JSON-LD, so that single line regenerates the whole SEO discovery surface on the new host. The rest of this diff chases the references that hardcode the host outside `site.url`.

## Changed surfaces

- **`apps/site/nuxt.config.ts`**: `site.url` to `https://attaform.dev`; comment rewritten from the `www`-pin rationale to the apex-canonical one.
- **`apps/site/scripts/indexnow-ping.mjs`**: IndexNow `HOST`. The key file (`public/2e71a5….txt`) is host-agnostic, so no rotation is needed; it serves from `.dev` automatically.
- **`apps/site/components/OgImage/Default.satori.vue`**: the social-card host label.
- **`apps/site/pages/index.vue`**: the Schema.org `SoftwareApplication` `url`.
- **`apps/site/error.vue`**: the 404 issue-report prose.
- **`README.md`, `apps/site/public/llms.txt`**: all doc links.
- **`package.json`**: `homepage` (propagates to the npm page on the next publish).
- **`src/nuxt.ts`**: the published Nuxt module's `docs` meta URL.
- **`src/runtime/core/errors.ts`**: the `useForm` config error message URL. Also repointed off the pre-rebuild `/docs/api/use-form-return` path (which now 301-bounces) to its successor `/docs/reading-the-form/the-form`.
- **`apps/site/docs-demos/transforms-async/App.vue`**: a sample-input string, for brand consistency.

## Deliberately left alone

- Historical `CHANGELOG.md` / `RELEASES.md` entries: the 301 keeps their links resolving, and rewriting release history is not the convention.
- Demos, tests, `docs/validation` examples, and `SECURITY.md` already use `.dev`.

## Out of scope (handled outside this PR)

DNS (Namecheap) and Vercel domain config are already live: `attaform.com`, `www.attaform.com`, `www.attaform.dev`, and `attaform.vercel.app` all 301 to `attaform.dev` (Production). Still to do in the consoles after merge and deploy: Google Search Console Change of Address, Bing Site Move, and resubmitting the sitemap. IndexNow re-pings automatically on the next production deploy.

## Verification

- `pnpm typecheck` (library): exit 0
- `pnpm --filter attaform-site typecheck` (site): exit 0
- `pnpm lint` (eslint + prettier): clean
- Grep audit: no stray `attaform.com` outside the intentional redirect comment and the historical entries; no `www.attaform.dev` introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
