### PR TITLE
chore(deploy): install from the frozen lockfile on Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "pnpm install --frozen-lockfile",
   "git": {
     "deploymentEnabled": {
       "main": false


### PR DESCRIPTION
## What

Pin Vercel's install step to `pnpm install --frozen-lockfile` so deploys build from the exact committed lockfile instead of re-resolving dependencies on each deploy.

## Why

A production deploy failed at prerender with:

```
[GET] /__nuxt_content/docs/sql_dump.txt: Cannot read properties of undefined (reading 'set')
  at setResponseHeader (h3@2.0.1-rc.22/dist/h3.mjs)
```

which then cascaded into a `/sitemap.xml` 500 once the content database failed to load.

Root cause: Vercel was doing a **non-frozen** install. The failing build resolved `crossws@0.4.6`, a version that does not exist anywhere in `pnpm-lock.yaml` (which pins `0.4.5`). That re-resolve pulled a pre-release `h3@2.0.1-rc.22` into the prerender bundle alongside Nitro's stable `h3@1.15.11`:

```
@nuxtjs/seo > nuxt-seo-utils > @unhead/bundler > @vitejs/devtools-kit > devframe > h3@2.0.1-rc.22
```

When Nitro bundled the route handlers, `@nuxt/content`'s `setResponseHeader` import bound to h3 v2, which runs `event.res.headers.set(...)` on the v1 event Nitro actually passes it, throwing `undefined.set`.

## Verification

A local production build on the committed lockfile reproduces Vercel's exact config and is green:

```
NODE_ENV=production VERCEL_ENV=production nuxi build
-> /__nuxt_content/docs/sql_dump.txt prerendered in 512ms
-> /sitemap.xml generated; 184 pages, 0 errors, 0 warnings; exit 0
```

`--frozen-lockfile` makes the deploy use that same tested resolution, and fails loudly if the lockfile ever drifts out of sync rather than silently re-resolving into a broken graph. It also composes with the existing `.npmrc` `minimumReleaseAge` gate, whose comment already notes frozen installs are the intended CI path.

## Follow-up (not in this PR)

The pre-release `h3` remains a latent landmine even with frozen installs: a future lockfile regen could re-trip the skew. A `pnpm.overrides` pin to evict h3 v2 from the graph would harden against that, but it needs a verifying build (the devtools sub-chain wants v2), so it is left as a separate, verified change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
