### PR TITLE
chore(ci): exempt sharp's native libvips binaries from the license check

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -122,17 +122,17 @@ jobs:
           # og-image module (see #452). Add new platform purls here if sharp's
           # native platform set changes.
           allow-dependencies-licenses: >-
-            pkg:npm/%40img/sharp-libvips-darwin-arm64,
-            pkg:npm/%40img/sharp-libvips-darwin-x64,
-            pkg:npm/%40img/sharp-libvips-linux-arm,
-            pkg:npm/%40img/sharp-libvips-linux-arm64,
-            pkg:npm/%40img/sharp-libvips-linux-ppc64,
-            pkg:npm/%40img/sharp-libvips-linux-riscv64,
-            pkg:npm/%40img/sharp-libvips-linux-s390x,
-            pkg:npm/%40img/sharp-libvips-linux-x64,
-            pkg:npm/%40img/sharp-libvips-linuxmusl-arm64,
-            pkg:npm/%40img/sharp-libvips-linuxmusl-x64,
-            pkg:npm/%40img/sharp-wasm32,
-            pkg:npm/%40img/sharp-win32-arm64,
-            pkg:npm/%40img/sharp-win32-ia32,
-            pkg:npm/%40img/sharp-win32-x64
+            pkg:npm/@img/sharp-libvips-darwin-arm64,
+            pkg:npm/@img/sharp-libvips-darwin-x64,
+            pkg:npm/@img/sharp-libvips-linux-arm,
+            pkg:npm/@img/sharp-libvips-linux-arm64,
+            pkg:npm/@img/sharp-libvips-linux-ppc64,
+            pkg:npm/@img/sharp-libvips-linux-riscv64,
+            pkg:npm/@img/sharp-libvips-linux-s390x,
+            pkg:npm/@img/sharp-libvips-linux-x64,
+            pkg:npm/@img/sharp-libvips-linuxmusl-arm64,
+            pkg:npm/@img/sharp-libvips-linuxmusl-x64,
+            pkg:npm/@img/sharp-wasm32,
+            pkg:npm/@img/sharp-win32-arm64,
+            pkg:npm/@img/sharp-win32-ia32,
+            pkg:npm/@img/sharp-win32-x64

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -107,3 +107,32 @@ jobs:
             Unlicense,
             WTFPL,
             Zlib
+          # Per-package carve-out from the license check. This is NOT a change
+          # to the allow-list above: strong copyleft stays excluded for every
+          # other dependency. sharp's native libvips binaries are
+          # LGPL-3.0-or-later (`@img/sharp-libvips-*`), and its win32 / wasm
+          # wrappers statically bundle libvips (`Apache-2.0 AND
+          # LGPL-3.0-or-later`). The strong-copyleft exclusion above guards
+          # against LGPL *JS* a consumer would bundle statically; it does not
+          # apply to these. They are native binaries, used only at BUILD time
+          # by the docs site (apps/site) for OG-image generation via sharp,
+          # never bundled into consumer JS, and absent from the published
+          # `attaform` package (zero runtime deps), so they never reach a
+          # consumer's install. Pulled in transitively by @nuxtjs/seo's
+          # og-image module (see #452). Add new platform purls here if sharp's
+          # native platform set changes.
+          allow-dependencies-licenses: >-
+            pkg:npm/%40img/sharp-libvips-darwin-arm64,
+            pkg:npm/%40img/sharp-libvips-darwin-x64,
+            pkg:npm/%40img/sharp-libvips-linux-arm,
+            pkg:npm/%40img/sharp-libvips-linux-arm64,
+            pkg:npm/%40img/sharp-libvips-linux-ppc64,
+            pkg:npm/%40img/sharp-libvips-linux-riscv64,
+            pkg:npm/%40img/sharp-libvips-linux-s390x,
+            pkg:npm/%40img/sharp-libvips-linux-x64,
+            pkg:npm/%40img/sharp-libvips-linuxmusl-arm64,
+            pkg:npm/%40img/sharp-libvips-linuxmusl-x64,
+            pkg:npm/%40img/sharp-wasm32,
+            pkg:npm/%40img/sharp-win32-arm64,
+            pkg:npm/%40img/sharp-win32-ia32,
+            pkg:npm/%40img/sharp-win32-x64


### PR DESCRIPTION
## Why

The Dependabot group bump in #452 fails the `Review dependency changes` check. `@nuxtjs/seo` 5.3.0's og-image module pulls in `sharp`, whose native libvips backend is LGPL-3.0:

- 10× `@img/sharp-libvips-*` -> `LGPL-3.0-or-later`
- 4× `@img/sharp-{wasm32,win32-arm64,win32-ia32,win32-x64}` -> `Apache-2.0 AND LGPL-3.0-or-later` (these statically bundle libvips)

The dependency-review `allow-licenses` list is permissive-only and intentionally excludes strong copyleft, because an LGPL **JS runtime dep** would impose copyleft on a consumer's static bundle.

## Why a carve-out, not allowing LGPL globally

That guard is worth keeping: it protects consumers (including downstream govt customers) from copyleft landing in their bundle. These sharp packages don't fall under it. They are **native binaries** (not bundled JS), used **only at build time** by the docs site for OG-image generation, and **absent from the published `attaform` package** (zero runtime deps), so they never reach a consumer's install.

So this carves out exactly those 14 packages via `allow-dependencies-licenses`, leaving the permissive-only `allow-licenses` (and its LGPL-in-bundled-JS guard) in force for everything else. The rationale lives in a comment next to the carve-out for future auditors.

## Effect

Once merged, re-run #452's `Review dependency changes` and it goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
