### PR TITLE
fix(focus): request focusVisible when moving focus to the first error

### DIFF
--- a/src/runtime/core/build-form-api.ts
+++ b/src/runtime/core/build-form-api.ts
@@ -957,7 +957,12 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
   const focusFirstError = (options?: { preventScroll?: boolean }): boolean => {
     const target = state.getFirstErrorElement(formInstanceId)
     if (target === null) return false
-    target.element.focus(options)
+    // `focusVisible: true` requests the focus ring even though the move
+    // is programmatic — so non-text controls (radio / checkbox / custom
+    // widgets) focused right after a pointer submit still show where
+    // focus landed. Honored where supported, ignored elsewhere; the
+    // caller's `options` (e.g. `preventScroll`) layer over it.
+    target.element.focus({ focusVisible: true, ...options })
     return true
   }
 

--- a/src/runtime/core/process-form.ts
+++ b/src/runtime/core/process-form.ts
@@ -675,11 +675,18 @@ export function applyInvalidSubmitPolicy<F extends GenericForm>(
     return
   }
   if (policy === 'focus-first-error') {
-    target.element.focus()
+    // `focusVisible: true` asks the UA to paint a focus ring as if
+    // `:focus-visible` matched. Without it, focus moved by script right
+    // after a pointer-driven submit doesn't satisfy the heuristic for
+    // non-text controls (radio / checkbox / custom widgets), so the
+    // field is focused but ringless and the user can't see where focus
+    // landed. Honored where supported, silently ignored elsewhere.
+    target.element.focus({ focusVisible: true })
     return
   }
   // 'both' — scroll first, then focus with preventScroll so the
-  // browser doesn't undo the explicit scroll.
+  // browser doesn't undo the explicit scroll. `focusVisible` paints the
+  // ring on the moved-to field even for non-text controls.
   target.element.scrollIntoView()
-  target.element.focus({ preventScroll: true })
+  target.element.focus({ preventScroll: true, focusVisible: true })
 }

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -786,6 +786,14 @@ export type ReactiveValidationStatus<Form> = PendingValidationStatus | SettledVa
  *   manually via `form.focusFirstError()` or `form.scrollToFirstError()`
  *   from an `onError` callback.
  *
+ * Both focusing policies request `focusVisible: true`, so the browser
+ * paints a focus ring even though the move is programmatic. Where a UA
+ * doesn't yet support that hint, non-text controls (radio, checkbox,
+ * custom widgets) may end up focused without a visible ring after a
+ * pointer-driven submit; if you target those browsers, pair the policy
+ * with your own indicator (e.g. a `:focus-within` ring on the option
+ * wrapper).
+ *
  * If no errored field has a currently mounted, visible element, the
  * policy silently no-ops.
  */
@@ -4112,6 +4120,12 @@ export type UseFormReturnType<
    * Pass `{ preventScroll: true }` if you're scrolling separately
    * (e.g. via `scrollToFirstError`) and don't want the browser to
    * fight the explicit scroll.
+   *
+   * Requests `focusVisible: true` so the UA paints a focus ring even
+   * though the move is programmatic. Honored where supported; on
+   * browsers without it, non-text controls focused after a pointer
+   * submit may show no ring, so you may still want an app-side
+   * indicator.
    */
   focusFirstError: (options?: { preventScroll?: boolean }) => boolean
 

--- a/test/composables/focus-scroll.test.ts
+++ b/test/composables/focus-scroll.test.ts
@@ -140,17 +140,29 @@ describe('focusFirstError / scrollToFirstError', () => {
     app.unmount()
   })
 
-  it('focusFirstError focuses the first errored field', () => {
+  it('focusFirstError focuses the first errored field, requesting focusVisible', () => {
     const { api, app } = mountWith({ errorsFor: ['email', 'password'] })
     // Populate errors by running handleSubmit (the validator above
     // returns failure with the listed fields).
     const submit = api.handleSubmit(async () => {})
     return submit().then(() => {
       expect(api.focusFirstError()).toBe(true)
-      expect(focusSpy).toHaveBeenCalled()
+      // `focusVisible: true` is always requested so the moved-to field
+      // paints a ring even when focus is programmatic (#472).
+      expect(focusSpy).toHaveBeenCalledWith({ focusVisible: true })
       // Instance on which focus was called should be the 'email' input.
       const focusedEl = focusSpy.mock.instances[0] as HTMLInputElement | undefined
       expect(focusedEl?.getAttribute('data-field')).toBe('email')
+      app.unmount()
+    })
+  })
+
+  it('focusFirstError layers caller options over the focusVisible hint', () => {
+    const { api, app } = mountWith({ errorsFor: ['email'] })
+    const submit = api.handleSubmit(async () => {})
+    return submit().then(() => {
+      expect(api.focusFirstError({ preventScroll: true })).toBe(true)
+      expect(focusSpy).toHaveBeenCalledWith({ focusVisible: true, preventScroll: true })
       app.unmount()
     })
   })
@@ -220,7 +232,7 @@ describe('onInvalidSubmit policy wiring', () => {
       onInvalidSubmit: 'focus-first-error',
     })
     await api.handleSubmit(async () => {})()
-    expect(focusSpy).toHaveBeenCalled()
+    expect(focusSpy).toHaveBeenCalledWith({ focusVisible: true })
     expect(scrollSpy).not.toHaveBeenCalled()
     app.unmount()
   })
@@ -243,14 +255,14 @@ describe('onInvalidSubmit policy wiring', () => {
     })
     await api.handleSubmit(async () => {})()
     expect(scrollSpy).toHaveBeenCalled()
-    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true })
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true, focusVisible: true })
     app.unmount()
   })
 
   it('default (focus-first-error): submit failure focuses the first errored field', async () => {
     const { api, app } = mountWith({ errorsFor: ['email'] })
     await api.handleSubmit(async () => {})()
-    expect(focusSpy).toHaveBeenCalled()
+    expect(focusSpy).toHaveBeenCalledWith({ focusVisible: true })
     expect(scrollSpy).not.toHaveBeenCalled()
     app.unmount()
   })
@@ -338,7 +350,7 @@ describe('applyInvalidSubmitPolicy — public API', () => {
     focusSpy.mockClear()
     scrollSpy.mockClear()
     api.applyInvalidSubmitPolicy()
-    expect(focusSpy).toHaveBeenCalled()
+    expect(focusSpy).toHaveBeenCalledWith({ focusVisible: true })
     expect(scrollSpy).not.toHaveBeenCalled()
     app.unmount()
   })
@@ -389,7 +401,7 @@ describe('applyInvalidSubmitPolicy — public API', () => {
     scrollSpy.mockClear()
     api.applyInvalidSubmitPolicy('both')
     expect(scrollSpy).toHaveBeenCalled()
-    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true })
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true, focusVisible: true })
     app.unmount()
   })
 


### PR DESCRIPTION
Closes #472.

## Problem

Error-focus moved focus with a plain `.focus()` that never requested `focusVisible`. After a **pointer-triggered** submit, the UA's `:focus-visible` heuristic doesn't match for non-text controls (radio, checkbox, custom widgets), so the moved-to field ended up **focused but ringless**: the user saw the inline error message but got no visual cue of *where* focus landed. Text inputs masked the bug (they always match `:focus-visible`), so it bit hardest exactly the fields where "where did focus just go?" matters most.

## Fix (issue candidates a + c)

Pass `focusVisible: true` at the three focus sites that share the same intent (carry the user's attention to the first error), all routing through one shared path:

- `applyInvalidSubmitPolicy` `'focus-first-error'` -> `focus({ focusVisible: true })`
- `applyInvalidSubmitPolicy` `'both'` -> `focus({ preventScroll: true, focusVisible: true })` (keeps the explicit-scroll guard)
- public `form.focusFirstError()` -> `focus({ focusVisible: true, ...options })`, so a caller's `preventScroll` still layers over the hint

`wizard.handleSubmit`'s error focus is covered **transitively**: `focusFirstWizardError` delegates to the failing form's `applyInvalidSubmitPolicy`, the same patched path. No second focus site exists in the wizard.

The hint is honored where supported (Firefox; Chromium/WebKit landing) and silently ignored elsewhere, so it's safe to always send; for text inputs it's a no-op since they already match `:focus-visible`.

Per discussion, the public `focusFirstError` option **type stays minimal** (`{ preventScroll?: boolean }`) and the hint is injected non-overridably; teams that want to own focus styling entirely use `onInvalidSubmit: 'none'` + their own focus call. No form-level config knob added (issue candidate b deliberately skipped).

## Docs (candidate c)

Docblocks on `OnInvalidSubmitPolicy` and `focusFirstError` now note that on UAs without `focusVisible` support, non-text controls may still focus without a ring, so apps may want their own indicator (e.g. a `:focus-within` ring on the option wrapper).

## Tests

`focus-scroll.test.ts` assertions tightened to verify `focusVisible: true` across the policy paths, the public method, and `applyInvalidSubmitPolicy`, plus a new test that caller options layer over the hint. `typecheck` confirms `FocusOptions.focusVisible` resolves with no cast (TS 6.0.3 `lib.dom.d.ts` carries it).

Green: `focus-scroll` + `wizard-handle-submit` (42 tests), `typecheck`, `lint`. `check:bundled-types` unaffected (the `focusFirstError` signature is unchanged; only docblock prose changed).

Related: #470, #471 (surfaced in the same dogfooding pass; unrelated, not touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)