### PR TITLE
feat(wizard): whole-wizard handleSubmit, live activeForm, and tryNext (#471)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Added
+
+- **`wizard.tryNext()`: validate the active step, then advance only if it
+  passes.** Bind it straight to a Next button (`@click="wizard.tryNext()"`) with
+  no captured handler: it runs the active step's validation, advances on a clean
+  pass, and reveals the step's errors in place when it fails. It resolves to
+  whether the pin moved, so `if (await wizard.tryNext())` can run follow-up work
+  like moving focus to the new step. It is the inline-friendly shorthand for the
+  `wizard.activeForm.handleSubmit(() => wizard.next())` composition; reach for the
+  composition directly when you want custom valid or invalid callbacks. Pure
+  navigation stays `wizard.next()`; the whole-wizard submit stays
+  `wizard.handleSubmit`. (#471)
+
 ### Changed
 
 - **`wizard.handleSubmit` now submits the whole wizard from any step, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,28 @@
 
 ## Unreleased
 
-_No unreleased changes yet._
+### Changed
+
+- **`wizard.handleSubmit` now submits the whole wizard from any step, and
+  navigation is its own verb.** One call validates every step's form in
+  parallel, regardless of which step is active, and runs your `onSubmit` once
+  with every step's values; a clean pass latches `wizard.done`, and a failure
+  surfaces every step's errors at once through `onError`. It never moves the
+  pin. To advance a step only when it is valid, compose the active step's own
+  submit with navigation: `const onNext = wizard.activeForm.handleSubmit(() =>
+  wizard.next())`. For a non-blocking step, call `wizard.next()` directly. The
+  choice of verb is the policy, so there is no mode flag to remember.
+  `ctx.isFinal` stays on the context as positional information: it tells you
+  where the submit fired, never what got validated. (#471)
+
+- **`wizard.activeForm` is now a live view of the active step's form.**
+  Operating through it always targets the current step, so a handler captured
+  once at setup time, like `wizard.activeForm.handleSubmit(() => wizard.next())`,
+  stays correct as the wizard advances instead of pinning to the step it was
+  created on. It surfaces the full form handle (values, meta, history,
+  `handleSubmit`), schema-erased because the active step's schema is not
+  statically known. It is no longer identity-equal to the raw per-step handle;
+  reach for `wizard.forms[key]` when you need that exact object. (#471)
 
 ## v0.24.4
 ### Added

--- a/apps/site/docs-demos/step-slots/App.vue
+++ b/apps/site/docs-demos/step-slots/App.vue
@@ -108,8 +108,7 @@
   })
 
   const onSubmit = wizard.handleSubmit(
-    async ({ values, isFinal }) => {
-      if (!isFinal) return
+    async ({ values }) => {
       await new Promise((resolve) => setTimeout(resolve, 400))
       toast.success('Registration submitted!', { description: values })
     },

--- a/apps/site/docs-demos/use-wizard/App.vue
+++ b/apps/site/docs-demos/use-wizard/App.vue
@@ -39,8 +39,6 @@
       toast.error('Submit blocked, check the errors above.', { description: errors })
     }
   )
-
-  const onNext = wizard.activeForm.handleSubmit(() => wizard.next())
 </script>
 
 <template>
@@ -124,7 +122,7 @@
         type="button"
         class="primary"
         :disabled="wizard.submitting"
-        @click="onNext"
+        @click="wizard.tryNext()"
       >
         Next →
       </button>

--- a/apps/site/docs-demos/use-wizard/App.vue
+++ b/apps/site/docs-demos/use-wizard/App.vue
@@ -30,9 +30,8 @@
 
   const wizard = useWizard({ steps: [account, profile, review] })
 
-  const onSubmit = wizard.handleSubmit(
+  const onFinish = wizard.handleSubmit(
     async (ctx) => {
-      if (!ctx.isFinal) return
       await new Promise((resolve) => setTimeout(resolve, 400))
       toast.success(`Welcome ${ctx.get(profile).name || 'aboard'}`, { description: ctx.values })
     },
@@ -40,6 +39,8 @@
       toast.error('Submit blocked, check the errors above.', { description: errors })
     }
   )
+
+  const onNext = wizard.activeForm.handleSubmit(() => wizard.next())
 </script>
 
 <template>
@@ -123,11 +124,11 @@
         type="button"
         class="primary"
         :disabled="wizard.submitting"
-        @click="wizard.next()"
+        @click="onNext"
       >
         Next →
       </button>
-      <button v-else type="button" class="primary" :disabled="wizard.submitting" @click="onSubmit">
+      <button v-else type="button" class="primary" :disabled="wizard.submitting" @click="onFinish">
         {{ wizard.submitting ? 'Submitting…' : 'Finish' }}
       </button>
     </div>

--- a/apps/site/repl-demos/shipment-demo.vue
+++ b/apps/site/repl-demos/shipment-demo.vue
@@ -550,16 +550,14 @@
   )
 
   // ─── Submit ──────────────────────────────────────────────────────
-  // `wizard.handleSubmit` validates the active form on intermediate
-  // steps (advances on success) and every form on the final step
-  // (awaits each async refinement: postal lookups, SKU checks,
-  // capacity, signature). On the final step we read each form's
-  // typed values via `ctx.get(form)` to assemble the booking payload.
+  // `wizard.handleSubmit` validates every form (awaiting each async
+  // refinement: postal lookups, SKU checks, capacity, signature) and
+  // never advances. We read each form's typed values via `ctx.get(form)`
+  // to assemble the booking payload.
   const submitError = ref<string | null>(null)
   const onSubmit = wizard.handleSubmit(
     (ctx) => {
       submitError.value = null
-      if (!ctx.isFinal) return
       const payload = {
         reference: ctx.get(refForm),
         cargo: ctx.get(cargoForm),
@@ -570,9 +568,8 @@
       resetAll()
     },
     () => {
-      submitError.value = wizard.isFinalStep
-        ? 'One or more steps need fixes. Use the summary below to jump to the offending field.'
-        : 'Please fix the highlighted fields on this step before continuing.'
+      submitError.value =
+        'One or more steps need fixes. Use the summary below to jump to the offending field.'
     }
   )
 
@@ -618,13 +615,12 @@
     },
   ])
 
-  // Undo/redo targets the form that owns the active step — each form
-  // has its own history stack so an undo on cargo doesn't roll back
-  // an address edit. `wizard.activeForm` widens to `AnyForm`; cast back
-  // to the actual form-handle union so the template can reach
-  // `history.canUndo` / `history.undo()` statically.
-  type WizardForm = typeof refForm | typeof cargoForm | typeof serviceForm | typeof reviewForm
-  const activeForm = computed(() => wizard.activeForm as WizardForm)
+  // Undo/redo targets the form that owns the active step: each form has
+  // its own history stack, so an undo on cargo doesn't roll back an
+  // address edit. `wizard.activeForm` is a live view of the active step's
+  // form, so reading `history.canUndo` / `history.undo()` through it
+  // always targets the current step.
+  const activeForm = computed(() => wizard.activeForm)
   const canGoNext = computed(() => wizard.statuses[wizard.currentStep]?.valid === true)
   const isAnyValidating = computed(() =>
     wizard.steps.some(

--- a/docs/multistep/aggregates.md
+++ b/docs/multistep/aggregates.md
@@ -158,7 +158,7 @@ Submitting the wizard via `wizard.handleSubmit` is what populates `allErrors` wi
 
 ## `wizard.submissionAttempts` vs per-form attempts
 
-Each form keeps its own `meta.submissionAttempts`, incremented by `wizard.handleSubmit` whenever that form is in the validation set (intermediate steps validate only the active form; final-step submits validate every form). The wizard-level `wizard.submissionAttempts` increments once per `handleSubmit` invocation, regardless of how many forms were involved. For "did the user click Finish?" reach for `wizard.submissionAttempts`; for "has the user tried this step?" reach for the form's own `meta.submissionAttempts`.
+Each form keeps its own `meta.submissionAttempts`, incremented by `wizard.handleSubmit` for every form, since it always validates the whole step list. A gated Next built on `wizard.activeForm.handleSubmit(...)` bumps only the active form. The wizard-level `wizard.submissionAttempts` increments once per `handleSubmit` invocation, regardless of how many forms were involved. For "did the user submit the wizard?" reach for `wizard.submissionAttempts`; for "has the user tried this step?" reach for the form's own `meta.submissionAttempts`.
 
 ## Where to next
 

--- a/docs/multistep/handle-submit.md
+++ b/docs/multistep/handle-submit.md
@@ -1,6 +1,6 @@
 ---
 title: handleSubmit
-description: wizard.handleSubmit(onSubmit, onError?) returns one event handler that fits every step. Intermediate calls validate the active form and advance; the final call validates every form in parallel and stays put. Same context shape on every step, with isFinal as the only differentiator.
+description: wizard.handleSubmit(onSubmit, onError?) returns one event handler that validates the entire wizard from any step and calls onSubmit once with every step's values. It never advances; gate advancing a step on its validity with a one-line composition.
 metaRows:
   - label: Category
     value: Submission
@@ -17,14 +17,14 @@ metaRows:
 
 # `handleSubmit`
 
-> `wizard.handleSubmit(onSubmit, onError?)` returns one event handler that fits every Next-and-Finish button in the wizard. Intermediate calls validate the active form and advance on success; the final call validates every form in parallel, calls `onSubmit` once, and stays on the terminal step. `isFinal` on the context is the only difference the consumer needs to switch on.
+> `wizard.handleSubmit(onSubmit, onError?)` returns one event handler that validates the entire step list, no matter which step is active, and calls `onSubmit` once with every step's parsed values. It never advances the wizard. Gating a Next button on the active step's validity is a one-line composition, so submission and navigation stay separate verbs.
 
 ::docs-meta-table
 ::
 
-## The same handler binds to every button
+## `handleSubmit` submits the whole wizard
 
-`wizard.handleSubmit` returns an event handler. Bind it once and reuse it for every Next button, every Finish button, and any submit-via-keyboard path:
+`wizard.handleSubmit` returns an event handler. It validates every step in parallel, and on a clean pass calls `onSubmit` once with the full values map. Bind it to your Finish button, or any submit-everything action:
 
 ```vue
 <script setup lang="ts">
@@ -32,8 +32,7 @@ metaRows:
 
   const wizard = useWizard({ steps: [shipping, payment, review] })
 
-  const onSubmit = wizard.handleSubmit(async (ctx) => {
-    if (!ctx.isFinal) return
+  const onFinish = wizard.handleSubmit(async (ctx) => {
     await api.checkout({
       shipping: ctx.get(shipping),
       payment: ctx.get(payment),
@@ -42,16 +41,14 @@ metaRows:
 </script>
 
 <template>
-  <form @submit.prevent="onSubmit">
+  <form @submit.prevent="onFinish">
     <!-- step body -->
-    <button :disabled="wizard.submitting" type="submit">
-      {{ wizard.isFinalStep ? 'Finish' : 'Next' }}
-    </button>
+    <button :disabled="wizard.submitting" type="submit">Finish</button>
   </form>
 </template>
 ```
 
-The handler accepts an optional `Event` argument and calls `preventDefault()` when one is passed, so `@submit` and `@click` both work. Bare imperative calls (`onSubmit()` with no event) are also fine; the handler just skips the prevent step.
+Because it validates the whole wizard from any step, you can call it the moment every step is filled, whether or not the user has walked to the last one. The handler accepts an optional `Event` and calls `preventDefault()` when one is passed, so `@submit` and `@click` both work. Bare imperative calls (`onFinish()` with no event) are fine too; the handler just skips the prevent step.
 
 ## The submit context
 
@@ -66,20 +63,13 @@ type WizardSubmitContext = {
 }
 ```
 
-- `ctx.values` is the namespaced parsed payload, keyed by step key. Mirrors `wizard.allValues` for forms that validated successfully on this call. Affordance steps contribute an empty record.
-- `ctx.get(formRef)` is the typed accessor: pass a form ref, get back the parsed output narrowed to that form's schema. The handy shape when you've already closed over the form refs at construction.
+- `ctx.values` is the namespaced parsed payload, keyed by step key, carrying every step (since `handleSubmit` validates them all). Affordance steps contribute an empty record.
+- `ctx.get(formRef)` is the typed accessor: pass a form ref, get back the parsed output narrowed to that form's schema. The handy shape when you have already closed over the form refs at construction.
 - `ctx.currentKey` is the key of the step that fired this submission.
-- `ctx.isFinal` is `true` when `currentKey` is the last position in `wizard.steps`. Use it to fork between "advance to the next step" (nothing to do here) and "actually call the API."
+- `ctx.isFinal` is `true` when `currentKey` is the last position in `wizard.steps`. It is positional information only: it tells you where the submit fired, never what got validated. A user who steps back, edits, and submits from the middle sees `isFinal === false`, and the whole wizard is still processed.
 
 ```ts
-const onSubmit = wizard.handleSubmit(async (ctx) => {
-  if (!ctx.isFinal) {
-    // Intermediate steps: validation passed. Track a step-complete event;
-    // the wizard advances once this callback returns without setting errors.
-    analytics.track('wizard_step_complete', { step: ctx.currentKey })
-    return
-  }
-  // Final step: validate-everything passed, run the actual mutation.
+const onFinish = wizard.handleSubmit(async (ctx) => {
   const order = await api.checkout({
     shipping: ctx.get(shipping),
     payment: ctx.get(payment),
@@ -88,23 +78,27 @@ const onSubmit = wizard.handleSubmit(async (ctx) => {
 })
 ```
 
-## Intermediate vs final
+## Gating advance per step
 
-The two calls do different work:
+`wizard.handleSubmit` submits; navigation is a separate verb. `wizard.next()`, `wizard.back()`, and `wizard.goTo()` move the pin and never validate. To advance a step only when it is valid, compose the active step's own submit with `next()`:
 
-- **Intermediate call** (`ctx.isFinal === false`). Validates the active form only. On a clean pass, `onSubmit` runs from the current step and the wizard then advances to the next compiled step. The advance is gated on the result: if validation fails, or if the callback hands a server rejection to `setErrors` and returns, the wizard stays put and `onError` fires.
-- **Final call** (`ctx.isFinal === true`). Validates every form in parallel. On success, `onSubmit` runs once and `wizard.done` flips to `true` (monotonic, only `reset()` flips it back). `done` flips only when the callback also leaves no errors set, so a `setErrors`-and-return server rejection keeps it `false`. On a validation failure, the wizard stays on the terminal step and `onError` fires.
+```ts
+const onNext = wizard.activeForm.handleSubmit(() => wizard.next())
+```
 
-The two paths share one handler and one context shape, so the consumer never has to choose between "fire the mutation now" and "fire it later" until the `if (!ctx.isFinal) return` guard at the top of the callback.
+`wizard.activeForm` is a live view of the current step, so this one `const`, captured once, is correct on every step: it validates whichever step is active when the button is clicked and advances only on a clean pass. To advance unconditionally (an autosave-style flow that defers the error waterfall to the final submit), call `wizard.next()` directly.
+
+The choice of verb is the blocking policy: `activeForm.handleSubmit(() => wizard.next())` for a blocking Next, `wizard.next()` for a non-blocking one. There is no mode flag and no `{ validate }` option to remember.
+
+> `wizard.handleSubmit` and `wizard.activeForm.handleSubmit` are the same verb at two scopes: the first submits every step, the second submits just the active step. Reach for the wizard's when you want the whole thing, the active form's when you want to gate one step.
 
 ## Error aggregation with `onError`
 
-The optional `onError` callback receives every error the submission produced, flat:
+The optional `onError` callback receives every error the submission produced, flat, across every step:
 
 ```ts
-const onSubmit = wizard.handleSubmit(
+const onFinish = wizard.handleSubmit(
   async (ctx) => {
-    if (!ctx.isFinal) return
     await api.checkout(ctx.values)
   },
   (errors) => {
@@ -115,7 +109,7 @@ const onSubmit = wizard.handleSubmit(
 )
 ```
 
-Each error carries `formKey`, `path`, `message`, and an optional `code`. The list combines validation errors from every form processed on this call, any errors the callback set with `setErrors`, and any activation failures (e.g., a form whose async `defaultValues` rejected). For wizard-wide error summaries that persist between submissions, drive them off [`wizard.allErrors`](/docs/multistep/aggregates#allerrors-for-wizard-wide-summaries) instead.
+Each error carries `formKey`, `path`, `message`, and an optional `code`. Because `handleSubmit` validates the whole wizard, the list spans every failing step at once, not just the active one, plus any errors the callback set with `setErrors` and any activation failures (e.g., a form whose async `defaultValues` rejected). For wizard-wide error summaries that persist between submissions, drive them off [`wizard.allErrors`](/docs/multistep/aggregates#allerrors-for-wizard-wide-summaries) instead.
 
 ## `focusFirstError`
 
@@ -128,7 +122,7 @@ const wizard = useWizard({
 })
 ```
 
-With the focus jump disabled, the wizard stays on the terminal step and leaves navigation to the consumer's `onError` callback. Useful when you've built a custom error-summary panel that owns the click-to-jump behavior.
+With the focus jump disabled, the wizard stays where it is and leaves navigation to the consumer's `onError` callback. Useful when you have built a custom error-summary panel that owns the click-to-jump behavior.
 
 ## `wizard.submitting` for re-entrance
 
@@ -148,11 +142,11 @@ Disabling the button is belt-and-braces; the wizard refuses re-entry on its own.
 
 - **Empty steps list.** `handleSubmit` dev-warns and resolves no-op. `onSubmit` and `onError` are never invoked.
 - **Re-entrant submission.** The second call dev-warns and resolves no-op; the first call continues to settle.
-- **No `Event` argument.** Imperative calls (`onSubmit()` with no event) work the same as `<form @submit.prevent>`; the `preventDefault` step is skipped.
+- **No `Event` argument.** Imperative calls (`onFinish()` with no event) work the same as `<form @submit.prevent>`; the `preventDefault` step is skipped.
 
 ## Where to next
 
 - [`useWizard`](/docs/multistep/use-wizard) for the construction signature and the full wizard handle.
 - [Aggregates](/docs/multistep/aggregates) for `wizard.allValues` and `wizard.allErrors`, which mirror the data `ctx.values` carries.
 - [Statuses](/docs/multistep/statuses) for the per-step `FormStatus` rollup that flips `submitted: true` when the callback succeeds.
-- [Patterns](/docs/multistep/patterns) for branching flows that lean on `wizard.handleSubmit` for the final-step validation sweep.
+- [Patterns](/docs/multistep/patterns) for branching flows and the gated-advance composition in context.

--- a/docs/multistep/handle-submit.md
+++ b/docs/multistep/handle-submit.md
@@ -1,6 +1,6 @@
 ---
 title: handleSubmit
-description: wizard.handleSubmit(onSubmit, onError?) returns one event handler that validates the entire wizard from any step and calls onSubmit once with every step's values. It never advances; gate advancing a step on its validity with a one-line composition.
+description: wizard.handleSubmit(onSubmit, onError?) returns one event handler that validates the entire wizard from any step and calls onSubmit once with every step's values. It never advances; gate advancing a step on its validity with wizard.tryNext().
 metaRows:
   - label: Category
     value: Submission
@@ -80,17 +80,41 @@ const onFinish = wizard.handleSubmit(async (ctx) => {
 
 ## Gating advance per step
 
-`wizard.handleSubmit` submits; navigation is a separate verb. `wizard.next()`, `wizard.back()`, and `wizard.goTo()` move the pin and never validate. To advance a step only when it is valid, compose the active step's own submit with `next()`:
+`wizard.handleSubmit` submits; navigation is a separate verb. `wizard.next()`, `wizard.back()`, and `wizard.goTo()` move the pin and never validate. To advance a step only when it is valid, reach for `wizard.tryNext()`:
 
-```ts
-const onNext = wizard.activeForm.handleSubmit(() => wizard.next())
+```vue
+<template>
+  <button type="button" @click="wizard.tryNext()">Next</button>
+</template>
 ```
 
-`wizard.activeForm` is a live view of the current step, so this one `const`, captured once, is correct on every step: it validates whichever step is active when the button is clicked and advances only on a clean pass. To advance unconditionally (an autosave-style flow that defers the error waterfall to the final submit), call `wizard.next()` directly.
+`wizard.tryNext()` validates the active step, advances only on a clean pass, and reveals the step's errors in place when it fails. No captured handler and no setup `const`: it binds straight to the button. To advance unconditionally (an autosave-style flow that defers the error waterfall to the final submit), call `wizard.next()` directly.
 
-The choice of verb is the blocking policy: `activeForm.handleSubmit(() => wizard.next())` for a blocking Next, `wizard.next()` for a non-blocking one. There is no mode flag and no `{ validate }` option to remember.
+The choice of verb is the blocking policy: `wizard.tryNext()` for a blocking Next, `wizard.next()` for a non-blocking one. There is no mode flag and no `{ validate }` option to remember.
 
-> `wizard.handleSubmit` and `wizard.activeForm.handleSubmit` are the same verb at two scopes: the first submits every step, the second submits just the active step. Reach for the wizard's when you want the whole thing, the active form's when you want to gate one step.
+`tryNext()` resolves to whether the pin moved, so it doubles as the seam for post-advance work. Moving focus to the new step is the common one: the pin flips synchronously, but the new step's DOM lands a tick later, so await `nextTick()` before reaching for the element (and give a heading or container focus target `tabindex="-1"`, since those are not focusable on their own).
+
+```ts
+if (await wizard.tryNext()) {
+  await nextTick()
+  heading.value?.focus()
+}
+```
+
+### Custom valid or invalid handling
+
+`tryNext()` is the shorthand for composing the active step's own submit with `next()`. When you want custom valid or invalid callbacks (a toast, an analytics ping, a different advance target), compose them directly:
+
+```ts
+const onNext = wizard.activeForm.handleSubmit(
+  () => wizard.next(),
+  (errors) => toast.error(`${errors.length} to fix before continuing.`)
+)
+```
+
+`wizard.activeForm` is a live view of the current step, so this one `const`, captured once, is correct on every step: it validates whichever step is active when invoked and advances only on a clean pass.
+
+> `wizard.handleSubmit`, `wizard.activeForm.handleSubmit`, and `wizard.tryNext()` are one verb at three reaches: submit every step, submit the active step, or submit-and-advance the active step. Reach for the wizard's when you want the whole thing, the active form's (or `tryNext`) when you want to gate one step.
 
 ## Error aggregation with `onError`
 

--- a/docs/multistep/inject-wizard.md
+++ b/docs/multistep/inject-wizard.md
@@ -102,7 +102,6 @@ Sticky finish buttons, sidebar status widgets, or any component in a different b
   const wizard = injectWizard('checkout-wizard')
 
   const finish = wizard?.handleSubmit(async (ctx) => {
-    if (!ctx.isFinal) return
     await api.checkout(ctx.values)
   })
 </script>

--- a/docs/multistep/patterns.md
+++ b/docs/multistep/patterns.md
@@ -40,14 +40,16 @@ const review = useForm({ schema: reviewSchema, key: 'signup-review' })
 const wizard = useWizard({ steps: [account, profile, review] })
 ```
 
-To advance only when the active step is valid, compose its submit with `next()`. `wizard.activeForm` is a live view of the current step, so one `const` captured here stays correct on every step:
+To advance only when the active step is valid, reach for `wizard.tryNext()`. It validates the active step and advances on a clean pass, binding straight to the button:
+
+```vue
+<button v-if="wizard.canAdvance" @click="wizard.tryNext()">Next</button>
+```
+
+For custom valid or invalid handling, compose the active step's submit with `next()` instead. `wizard.activeForm` is a live view of the current step, so one `const` captured here stays correct on every step:
 
 ```ts
 const onNext = wizard.activeForm.handleSubmit(() => wizard.next())
-```
-
-```vue
-<button v-if="wizard.canAdvance" @click="onNext()">Next</button>
 ```
 
 For a non-blocking flow (autosave, deferring the error waterfall to the final submit), wire the button to plain `wizard.next()` instead.

--- a/docs/multistep/patterns.md
+++ b/docs/multistep/patterns.md
@@ -23,7 +23,7 @@ metaRows:
 
 ## Linear wizards
 
-The default shape: a list of forms in reading order. `wizard.next()` validates the active step before advancing; `wizard.back()` retreats. Out-of-bounds calls dev-warn and no-op.
+The default shape: a list of forms in reading order. `wizard.next()` advances and `wizard.back()` retreats; neither validates (navigation and submission are separate verbs). Out-of-bounds calls dev-warn and no-op.
 
 ```ts
 import { useForm, useWizard } from 'attaform/zod'
@@ -40,11 +40,17 @@ const review = useForm({ schema: reviewSchema, key: 'signup-review' })
 const wizard = useWizard({ steps: [account, profile, review] })
 ```
 
-`wizard.next()` validates the active form for you, so the template wires straight to it:
+To advance only when the active step is valid, compose its submit with `next()`. `wizard.activeForm` is a live view of the current step, so one `const` captured here stays correct on every step:
+
+```ts
+const onNext = wizard.activeForm.handleSubmit(() => wizard.next())
+```
 
 ```vue
-<button v-if="wizard.canAdvance" @click="wizard.next()">Next</button>
+<button v-if="wizard.canAdvance" @click="onNext()">Next</button>
 ```
+
+For a non-blocking flow (autosave, deferring the error waterfall to the final submit), wire the button to plain `wizard.next()` instead.
 
 Mix in affordance steps (bare strings) wherever the flow benefits from a screen that presents rather than collects:
 
@@ -183,7 +189,7 @@ A keyboard shortcut bound to the active step:
 </template>
 ```
 
-`wizard.activeForm` is identity-equal to the form in `wizard.forms[wizard.currentStep]`, so undo / redo dispatches to the right chain.
+`wizard.activeForm` is a live view of the current step's form, so undo / redo always dispatches to the active chain. It is no longer identity-equal to `wizard.forms[wizard.currentStep]`; reach for that record when you need a specific step's raw handle.
 
 Each step's history is independent: undoing on the `cargo` step doesn't retreat changes the user made on `billing`. That matches the user's mental model: "undo what I just typed here," not "undo the entire flow."
 

--- a/docs/multistep/step-slots.md
+++ b/docs/multistep/step-slots.md
@@ -79,7 +79,7 @@ Every downstream surface treats the string slot identically to a form slot:
 - `wizard.steps[i]` reads as `{ key: 'welcome', form: <noopForm> }`.
 - `wizard.statuses['welcome']` reads as `{ valid: true, errorCount: 0, ... }`.
 - `wizard.allValues['welcome']` is the empty record `{}`.
-- `wizard.handleSubmit` on an affordance step validates as `{}` and advances.
+- `wizard.handleSubmit` validates the affordance step trivially as `{}`, along with every other step.
 
 The noop form is real: it carries a key, sits in the per-app registry, and participates in `injectForm('welcome')` lookups the same way any other form does. Affordance steps are first-class building blocks, not edge cases.
 

--- a/docs/multistep/use-wizard.md
+++ b/docs/multistep/use-wizard.md
@@ -1,6 +1,6 @@
 ---
 title: useWizard
-description: useWizard takes an ordered list of step slots and produces a reactive wizard. Forms gather data, bare string keys mark affordance steps (intros, terms, review surfaces), function slots branch on live values, and lazy() memoizes heavy slots by their own tracked reactive reads. Universal handleSubmit, namespaced aggregates, automatic URL sync.
+description: useWizard takes an ordered list of step slots and produces a reactive wizard. Forms gather data, bare string keys mark affordance steps (intros, terms, review surfaces), function slots branch on live values, and lazy() memoizes heavy slots by their own tracked reactive reads. Whole-wizard handleSubmit, namespaced aggregates, automatic URL sync.
 metaRows:
   - label: Category
     value: Composable
@@ -17,12 +17,12 @@ metaRows:
 
 # useWizard
 
-> Compose a reactive wizard from an ordered list of step slots. Each slot holds a form, an affordance key for a screen with no data collection, or a function that picks one or the other at runtime. Attaform threads the same handle through navigation, status aggregation, URL sync, and a universal `handleSubmit` that validates the right scope on every call.
+> Compose a reactive wizard from an ordered list of step slots. Each slot holds a form, an affordance key for a screen with no data collection, or a function that picks one or the other at runtime. Attaform threads the same handle through navigation, status aggregation, URL sync, and a `handleSubmit` that validates the whole wizard on every call.
 
 ::docs-meta-table
 ::
 
-A linear three-step wizard. Each step keeps its own `useForm` call, its own schema, and its own reactive surface. The rail highlights `wizard.currentStep`, the progress bar reflects `wizard.progress`, and `wizard.handleSubmit` fires on the final step.
+A linear three-step wizard. Each step keeps its own `useForm` call, its own schema, and its own reactive surface. The rail highlights `wizard.currentStep`, the progress bar reflects `wizard.progress`, each Next gates advance on the active step, and Finish runs `wizard.handleSubmit` over the whole wizard.
 
 ::docs-demo{slug="use-wizard" label="Wizard Demo"}
 ::
@@ -89,53 +89,52 @@ See [Step slots](/docs/multistep/step-slots) for the full slot reference, includ
 
 `useWizard` takes one options bag. `steps` is required; the rest default sensibly for the common URL-synchronized wizard case.
 
-| Option            | Type                                                               | Default             | What it does                                                                                                                                                               |
-| ----------------- | ------------------------------------------------------------------ | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `steps`           | `Array<StepSlot>`                                                  | required            | Ordered list of slots that compile into the wizard's step list. See [Step slots](/docs/multistep/step-slots).                                                              |
-| `key`             | `string`                                                           | synthetic           | Identifier registered in the per-app registry for [`injectWizard`](/docs/multistep/inject-wizard). Anonymous wizards get a synthetic SSR-stable key under the hood.        |
-| `defaultStatuses` | `Record<key, FormStatus>` &#124; sync factory &#124; async factory | unset               | Seed payload used while a form's defaults are still resolving. See [Statuses](/docs/multistep/statuses).                                                                   |
-| `progress`        | `(steps) => number`                                                | valid-step fraction | Override the default `progress` computation. The override is invoked inside a `computed`, so read reactive sources only.                                                   |
-| `focusFirstError` | `boolean`                                                          | `true`              | On final-step submission failure, jump to the first failing form and run its `applyInvalidSubmitPolicy()` (focus / scroll per the form's `onInvalidSubmit` configuration). |
-| `restore`         | `() => { step? }` &#124; `false`                                   | URL `?step=<key>`   | Source of truth for the active step. Watched reactively; re-applies on URL changes. See [URL sync](/docs/multistep/url-sync).                                              |
-| `persist`         | `({ step }) => void` &#124; `false`                                | URL `?step=<key>`   | Destination for the active step. Invoked when `currentStep` changes (diffed to break the restore-persist loop). See [URL sync](/docs/multistep/url-sync).                  |
+| Option            | Type                                                               | Default             | What it does                                                                                                                                                        |
+| ----------------- | ------------------------------------------------------------------ | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `steps`           | `Array<StepSlot>`                                                  | required            | Ordered list of slots that compile into the wizard's step list. See [Step slots](/docs/multistep/step-slots).                                                       |
+| `key`             | `string`                                                           | synthetic           | Identifier registered in the per-app registry for [`injectWizard`](/docs/multistep/inject-wizard). Anonymous wizards get a synthetic SSR-stable key under the hood. |
+| `defaultStatuses` | `Record<key, FormStatus>` &#124; sync factory &#124; async factory | unset               | Seed payload used while a form's defaults are still resolving. See [Statuses](/docs/multistep/statuses).                                                            |
+| `progress`        | `(steps) => number`                                                | valid-step fraction | Override the default `progress` computation. The override is invoked inside a `computed`, so read reactive sources only.                                            |
+| `focusFirstError` | `boolean`                                                          | `true`              | On submission failure, jump to the first failing form and run its `applyInvalidSubmitPolicy()` (focus / scroll per the form's `onInvalidSubmit` configuration).     |
+| `restore`         | `() => { step? }` &#124; `false`                                   | URL `?step=<key>`   | Source of truth for the active step. Watched reactively; re-applies on URL changes. See [URL sync](/docs/multistep/url-sync).                                       |
+| `persist`         | `({ step }) => void` &#124; `false`                                | URL `?step=<key>`   | Destination for the active step. Invoked when `currentStep` changes (diffed to break the restore-persist loop). See [URL sync](/docs/multistep/url-sync).           |
 
 ## The wizard handle
 
 `useWizard` returns a reactive handle. Every reactive read is a plain getter, no `.value`. Use the rail of links below to reach the page that covers each surface in depth.
 
-| Member               | What it is                                                                                                                                    |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `key`                | The wizard's identifier (explicit or synthetic).                                                                                              |
-| `currentStep`        | The active step's key. Typed `string` when the slot tuple is statically non-empty; `string` &#124; `undefined` when a function slot can drop. |
-| `activeForm`         | The active step's form handle, identity-equal to `wizard.forms[currentStep]`. Narrows in lockstep with `currentStep`.                         |
-| `activeIndex`        | Zero-based position of the active step.                                                                                                       |
-| `isFinalStep`        | `true` when `activeIndex === count - 1`. Gates the Next-vs-Finish split in templates.                                                         |
-| `count`              | `steps.length`. Includes affordance positions.                                                                                                |
-| `steps`              | Ordered list of compiled `{ key, form }` slots. See [Step slots](/docs/multistep/step-slots).                                                 |
-| `forms`              | Record indexable by step key. See [Aggregates](/docs/multistep/aggregates).                                                                   |
-| `canAdvance`         | `true` when a next step exists. Pure positional check.                                                                                        |
-| `canGoBack`          | `true` when a prior step exists.                                                                                                              |
-| `complete`           | Forward-looking: `isFinalStep && every-form-valid`. See [Statuses](/docs/multistep/statuses).                                                 |
-| `done`               | Monotonic: `true` once `handleSubmit` lands on the final step; only `reset()` flips it back. See [Statuses](/docs/multistep/statuses).        |
-| `submitting`         | `true` while a `wizard.handleSubmit` call is in flight. Global re-entrance guard.                                                             |
-| `submissionAttempts` | Count of `wizard.handleSubmit` invocations.                                                                                                   |
-| `visited`            | Append-only breadcrumb of navigated step keys.                                                                                                |
-| `progress`           | Fraction in `[0, 1]`. Defaults to valid-step ratio.                                                                                           |
-| `statuses`           | Per-key `FormStatus` proxy. See [Statuses](/docs/multistep/statuses).                                                                         |
-| `allValues`          | Namespaced record of each step's values. See [Aggregates](/docs/multistep/aggregates).                                                        |
-| `allErrors`          | Namespaced record of each step's validation errors. See [Aggregates](/docs/multistep/aggregates).                                             |
-| `next` / `back`      | Positional navigation. Refuses while `submitting`.                                                                                            |
-| `goTo`               | Jump to a specific step by key. Dev-warn on unknown keys.                                                                                     |
-| `handleSubmit`       | Universal submission handler. See [handleSubmit](/docs/multistep/handle-submit).                                                              |
-| `reset`              | Zeros wizard lifecycle, resets every form, returns to `steps[0]`, clears the persisted step, flips `done` back.                               |
+| Member               | What it is                                                                                                                                                                                                                  |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `key`                | The wizard's identifier (explicit or synthetic).                                                                                                                                                                            |
+| `currentStep`        | The active step's key. Typed `string` when the slot tuple is statically non-empty; `string` &#124; `undefined` when a function slot can drop.                                                                               |
+| `activeForm`         | A live view of the active step's form; operating through it always targets the current step. No longer identity-equal to `wizard.forms[currentStep]` (use that for the raw handle). Narrows in lockstep with `currentStep`. |
+| `activeIndex`        | Zero-based position of the active step.                                                                                                                                                                                     |
+| `isFinalStep`        | `true` when `activeIndex === count - 1`. Gates the Next-vs-Finish split in templates.                                                                                                                                       |
+| `count`              | `steps.length`. Includes affordance positions.                                                                                                                                                                              |
+| `steps`              | Ordered list of compiled `{ key, form }` slots. See [Step slots](/docs/multistep/step-slots).                                                                                                                               |
+| `forms`              | Record indexable by step key. See [Aggregates](/docs/multistep/aggregates).                                                                                                                                                 |
+| `canAdvance`         | `true` when a next step exists. Pure positional check.                                                                                                                                                                      |
+| `canGoBack`          | `true` when a prior step exists.                                                                                                                                                                                            |
+| `complete`           | Forward-looking: `isFinalStep && every-form-valid`. See [Statuses](/docs/multistep/statuses).                                                                                                                               |
+| `done`               | Monotonic: `true` once a `handleSubmit` succeeds; only `reset()` flips it back. See [Statuses](/docs/multistep/statuses).                                                                                                   |
+| `submitting`         | `true` while a `wizard.handleSubmit` call is in flight. Global re-entrance guard.                                                                                                                                           |
+| `submissionAttempts` | Count of `wizard.handleSubmit` invocations.                                                                                                                                                                                 |
+| `visited`            | Append-only breadcrumb of navigated step keys.                                                                                                                                                                              |
+| `progress`           | Fraction in `[0, 1]`. Defaults to valid-step ratio.                                                                                                                                                                         |
+| `statuses`           | Per-key `FormStatus` proxy. See [Statuses](/docs/multistep/statuses).                                                                                                                                                       |
+| `allValues`          | Namespaced record of each step's values. See [Aggregates](/docs/multistep/aggregates).                                                                                                                                      |
+| `allErrors`          | Namespaced record of each step's validation errors. See [Aggregates](/docs/multistep/aggregates).                                                                                                                           |
+| `next` / `back`      | Positional navigation. Refuses while `submitting`.                                                                                                                                                                          |
+| `goTo`               | Jump to a specific step by key. Dev-warn on unknown keys.                                                                                                                                                                   |
+| `handleSubmit`       | Whole-wizard submission handler; never advances. See [handleSubmit](/docs/multistep/handle-submit).                                                                                                                         |
+| `reset`              | Zeros wizard lifecycle, resets every form, returns to `steps[0]`, clears the persisted step, flips `done` back.                                                                                                             |
 
 ## Submission, in one place
 
-`wizard.handleSubmit(onSubmit, onError?)` returns one event handler that fits every step. Intermediate calls validate the active form and advance; the final call validates every form and stays put. The same handler binds to every Next-and-Finish button.
+`wizard.handleSubmit(onSubmit, onError?)` returns one event handler that validates the entire step list, from any step, and calls `onSubmit` once with every step's values. It never advances; bind it to your Finish button.
 
 ```ts
-const onSubmit = wizard.handleSubmit(async (ctx) => {
-  if (!ctx.isFinal) return
+const onFinish = wizard.handleSubmit(async (ctx) => {
   await api.checkout({
     shipping: ctx.get(shipping),
     payment: ctx.get(payment),
@@ -143,7 +142,13 @@ const onSubmit = wizard.handleSubmit(async (ctx) => {
 })
 ```
 
-See [handleSubmit](/docs/multistep/handle-submit) for the universal handler depth, including `focusFirstError`, re-entrance, error aggregation, and the `ctx` shape.
+To gate a Next button on the active step's validity, compose the active form's submit with `next()`:
+
+```ts
+const onNext = wizard.activeForm.handleSubmit(() => wizard.next())
+```
+
+See [handleSubmit](/docs/multistep/handle-submit) for the whole-wizard handler in depth, including the gated-advance composition, `focusFirstError`, re-entrance, error aggregation, and the `ctx` shape.
 
 ## Navigation
 
@@ -153,7 +158,7 @@ wizard.back() // retreat one position
 wizard.goTo('shipping-review') // jump to a specific step by key
 ```
 
-`next` / `back` / `goTo` are pure positional navigation. None of them validate; that's `handleSubmit`'s job. Out-of-bounds calls dev-warn and no-op; mid-submission navigation is blocked until `wizard.submitting` clears. A wizard wired into a checkout or signup never throws on navigation.
+`next` / `back` / `goTo` are pure positional navigation. None of them validate. To gate an advance on the active step, compose `wizard.activeForm.handleSubmit(() => wizard.next())`. Out-of-bounds calls dev-warn and no-op; mid-submission navigation is blocked until `wizard.submitting` clears. A wizard wired into a checkout or signup never throws on navigation.
 
 ## URL sync, on by default
 

--- a/docs/multistep/use-wizard.md
+++ b/docs/multistep/use-wizard.md
@@ -22,7 +22,7 @@ metaRows:
 ::docs-meta-table
 ::
 
-A linear three-step wizard. Each step keeps its own `useForm` call, its own schema, and its own reactive surface. The rail highlights `wizard.currentStep`, the progress bar reflects `wizard.progress`, each Next gates advance on the active step, and Finish runs `wizard.handleSubmit` over the whole wizard.
+A linear three-step wizard. Each step keeps its own `useForm` call, its own schema, and its own reactive surface. The rail highlights `wizard.currentStep`, the progress bar reflects `wizard.progress`, each Next calls `wizard.tryNext()` to gate advance on the active step, and Finish runs `wizard.handleSubmit` over the whole wizard.
 
 ::docs-demo{slug="use-wizard" label="Wizard Demo"}
 ::
@@ -126,6 +126,7 @@ See [Step slots](/docs/multistep/step-slots) for the full slot reference, includ
 | `allErrors`          | Namespaced record of each step's validation errors. See [Aggregates](/docs/multistep/aggregates).                                                                                                                           |
 | `next` / `back`      | Positional navigation. Refuses while `submitting`.                                                                                                                                                                          |
 | `goTo`               | Jump to a specific step by key. Dev-warn on unknown keys.                                                                                                                                                                   |
+| `tryNext`            | Validate the active step, advance iff valid; resolves to whether the pin moved. The inline-bindable gated Next. See [handleSubmit](/docs/multistep/handle-submit#gating-advance-per-step).                                  |
 | `handleSubmit`       | Whole-wizard submission handler; never advances. See [handleSubmit](/docs/multistep/handle-submit).                                                                                                                         |
 | `reset`              | Zeros wizard lifecycle, resets every form, returns to `steps[0]`, clears the persisted step, flips `done` back.                                                                                                             |
 
@@ -142,11 +143,13 @@ const onFinish = wizard.handleSubmit(async (ctx) => {
 })
 ```
 
-To gate a Next button on the active step's validity, compose the active form's submit with `next()`:
+To gate a Next button on the active step's validity, reach for `wizard.tryNext()`:
 
 ```ts
-const onNext = wizard.activeForm.handleSubmit(() => wizard.next())
+await wizard.tryNext() // validate the active step, advance only on a clean pass
 ```
+
+`wizard.tryNext()` binds straight to a control (`@click="wizard.tryNext()"`) and resolves to whether the pin moved. For custom valid or invalid handling, compose the active form's submit with `next()` instead: `wizard.activeForm.handleSubmit(() => wizard.next())`.
 
 See [handleSubmit](/docs/multistep/handle-submit) for the whole-wizard handler in depth, including the gated-advance composition, `focusFirstError`, re-entrance, error aggregation, and the `ctx` shape.
 
@@ -158,7 +161,7 @@ wizard.back() // retreat one position
 wizard.goTo('shipping-review') // jump to a specific step by key
 ```
 
-`next` / `back` / `goTo` are pure positional navigation. None of them validate. To gate an advance on the active step, compose `wizard.activeForm.handleSubmit(() => wizard.next())`. Out-of-bounds calls dev-warn and no-op; mid-submission navigation is blocked until `wizard.submitting` clears. A wizard wired into a checkout or signup never throws on navigation.
+`next` / `back` / `goTo` are pure positional navigation. None of them validate. To gate an advance on the active step, use `wizard.tryNext()` (or compose `wizard.activeForm.handleSubmit(() => wizard.next())` when you need custom valid or invalid handling). Out-of-bounds calls dev-warn and no-op; mid-submission navigation is blocked until `wizard.submitting` clears. A wizard wired into a checkout or signup never throws on navigation.
 
 ## URL sync, on by default
 

--- a/src/runtime/composables/use-wizard.ts
+++ b/src/runtime/composables/use-wizard.ts
@@ -1061,6 +1061,50 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
     moveTo(target.key)
   }
 
+  // Validate the active step, then advance iff it passed. The inline-
+  // bindable shorthand for the gated-advance composition
+  // `activeForm.handleSubmit(() => next())`: wire it straight to a
+  // control (`@click="wizard.tryNext()"`) with no captured handler.
+  // Invalid input keeps the pin put under the form's own reveal (first
+  // error focused, display state advanced); a clean step advances.
+  // Resolves to whether the pin moved, so `if (await wizard.tryNext())`
+  // can branch on the outcome. Pure navigation stays `next()`; the
+  // whole-wizard submit stays `handleSubmit`. No-ops to `false` on a
+  // degenerate or final-step wizard, mirroring `next()`.
+  async function tryNext(): Promise<boolean> {
+    if (submitting.value) {
+      if (__DEV__) {
+        console.warn(`[attaform] wizard.tryNext(): blocked while a submit is in flight.`)
+      }
+      return false
+    }
+    const list = compiledSteps.value
+    if (list.length === 0) {
+      if (__DEV__) {
+        console.warn(`[attaform] wizard.tryNext(): wizard has no compiled steps; no-op.`)
+      }
+      return false
+    }
+    const idx = activeIndex.value
+    if (idx < 0 || idx >= list.length - 1) {
+      if (__DEV__) {
+        console.warn(
+          `[attaform] wizard.tryNext(): already on the final step ("${activeKey.value}"). Use wizard.handleSubmit() to submit.`
+        )
+      }
+      return false
+    }
+    const form = activeForm.value
+    if (form === undefined) return false
+    let advanced = false
+    await asHandleSubmitSource(form).handleSubmit(() => {
+      const before = activeKey.value
+      next()
+      advanced = activeKey.value !== before
+    })()
+    return advanced
+  }
+
   function back(): void {
     if (submitting.value) {
       if (__DEV__) {
@@ -1383,6 +1427,7 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
     next,
     back,
     goTo,
+    tryNext,
     handleSubmit,
     reset,
     get currentStep(): CurrentStepOf<S> {

--- a/src/runtime/composables/use-wizard.ts
+++ b/src/runtime/composables/use-wizard.ts
@@ -131,9 +131,10 @@ function asHandleSubmitSource(form: AnyForm): Pick<UseFormReturnType<GenericForm
  *
  * The wizard's surface is read-only from the consumer's side:
  * navigation (`next` / `back` / `goTo`) walks positional indices,
- * `handleSubmit` validates the active form on intermediate steps and
- * the whole wizard on the final step, and URL synchronization rides on
- * `restore` / `persist` callbacks that default to `?step=<key>`.
+ * `handleSubmit` validates the whole step list from any step and never
+ * advances (gate advance with `activeForm.handleSubmit(() =>
+ * wizard.next())`), and URL synchronization rides on `restore` /
+ * `persist` callbacks that default to `?step=<key>`.
  */
 export function useWizard<const S extends ReadonlyArray<StepSlot>>(
   options: WizardOptions & { readonly steps: S }
@@ -992,10 +993,10 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
   // of re-thrown, so binding the handler to `@submit.prevent` never
   // manufactures a `window` unhandledrejection.
   const submitError = ref<Error | null>(null)
-  // Monotonic latch: flips true the first time a final-step
-  // `handleSubmit` resolves without throwing, and stays true through
-  // subsequent edits or invalidations. Only `reset()` flips it back
-  // (a new run starts a new history). Distinct accounting from
+  // Monotonic latch: flips true the first time a `handleSubmit` resolves
+  // without throwing (and leaves no errors on any step), and stays true
+  // through subsequent edits or invalidations. Only `reset()` flips it
+  // back (a new run starts a new history). Distinct accounting from
   // `complete`, which is forward-looking and reactive to current form
   // validity.
   const done = ref(false)
@@ -1163,9 +1164,8 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
   // aggregate shape. The post-callback mirror of `collectErrors` (#438):
   // after a clean validation pass, a callback that called `setErrors` on
   // a step left those errors here. Scoped to the keys the submit actually
-  // processed (final = every step, intermediate = the active one),
-  // matching the entry-clear scope, so a stale error on an unprocessed
-  // step never fails the submit.
+  // processed (every step, since `handleSubmit` is whole-wizard), matching
+  // the entry-clear scope.
   function collectCallbackErrors(keys: Iterable<FormKey>): WizardAggregateError[] {
     const out: WizardAggregateError[] = []
     for (const key of keys) {
@@ -1222,36 +1222,29 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
       submitError.value = null
       try {
         const currentKey = activeKey.value
+        // Positional only: surfaced as `ctx.isFinal`. Nothing branches on
+        // it — `handleSubmit` processes the whole wizard from any step.
         const final = isFinalStep.value
         const list = compiledSteps.value
         const results = new Map<FormKey, ValidationResponse<unknown>>()
 
-        if (final) {
-          // Final-step submission: validate every step. Run in parallel
-          // so latency is bounded by the slowest form rather than the
-          // sum of all forms.
-          await Promise.all(
-            list.map(async (step) => {
-              // Entry-clear user-set errors before validating, mirroring
-              // form.handleSubmit: a fresh attempt starts each PROCESSED
-              // form from a clean user-error slate. A final submit
-              // re-validates every step, so every step is cleared.
-              registry.forms.get(step.key)?.clearUserErrors()
-              const result = await processOne(step.form)
-              results.set(step.key, result)
-            })
-          )
-        } else {
-          // Intermediate submission: validate the active form only and
-          // advance on success. The empty-list short-circuit above
-          // guarantees `activeForm.value` is defined here. Only the active
-          // form is processed, so only its user errors are cleared — other
-          // steps keep theirs.
-          const active = activeForm.value as AnyForm
-          registry.forms.get(active.key)?.clearUserErrors()
-          const result = await processOne(active)
-          results.set(active.key, result)
-        }
+        // Validate every step, regardless of which step fired the submit:
+        // `wizard.handleSubmit` always submits the whole wizard. Gating
+        // advance on a single step's validity is the composition
+        // `activeForm.handleSubmit(() => wizard.next())`, which runs on the
+        // form side. Run in parallel so latency is bounded by the slowest
+        // form rather than the sum of all forms.
+        await Promise.all(
+          list.map(async (step) => {
+            // Entry-clear user-set errors before validating, mirroring
+            // form.handleSubmit: a fresh attempt starts each form from a
+            // clean user-error slate. Every step is processed, so every
+            // step is cleared.
+            registry.forms.get(step.key)?.clearUserErrors()
+            const result = await processOne(step.form)
+            results.set(step.key, result)
+          })
+        )
 
         // Bump per-form submissionAttempts for every form we just
         // processed (noops included — accounting-distinct counters per
@@ -1290,8 +1283,7 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
           // server-rejection path) has NOT succeeded. The entry-clear above
           // means any user error present now was set by this callback. Route
           // it through the same failure path as a validation failure: focus
-          // the first error, fire onError, and return WITHOUT completing
-          // (final) or advancing past the rejected step (intermediate).
+          // the first error, fire onError, and return WITHOUT latching `done`.
           const callbackErrors = collectCallbackErrors(results.keys())
           if (callbackErrors.length > 0) {
             await focusFirstWizardError(callbackErrors)
@@ -1304,17 +1296,10 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
             }
             return
           }
-          if (final) {
-            done.value = true
-          } else {
-            // Intermediate success → record departure + advance to next
-            // step. Mirrors the navigation arm so the URL and visited
-            // trail stay coherent.
-            recordDeparture(currentKey)
-            const idx = activeIndex.value
-            const target = list[idx + 1]
-            if (target !== undefined) moveTo(target.key)
-          }
+          // Whole-wizard success: every step validated and the callback
+          // left no errors. Latch `done`; never move the pin. Advancing a
+          // step lives in the gated-advance composition, not here.
+          done.value = true
         } else {
           // Apply the invalid-submit focus policy BEFORE onError, mirroring
           // form.handleSubmit: the consumer's onError can override the

--- a/src/runtime/composables/use-wizard.ts
+++ b/src/runtime/composables/use-wizard.ts
@@ -49,7 +49,12 @@ import type {
   WizardRestoreState,
   WizardSubmitContext,
 } from '../types/types-wizard'
-import type { FormKey, UseFormReturnType, ValidationResponse } from '../types/types-api'
+import type {
+  FormKey,
+  HandleSubmit,
+  UseFormReturnType,
+  ValidationResponse,
+} from '../types/types-api'
 import type { GenericForm } from '../types/types-core'
 
 /** Default URL search param when the consumer doesn't supply a custom
@@ -108,6 +113,12 @@ function asStatusSource(form: AnyForm): StatusSourceForm {
 }
 function asSubmissionSource(form: AnyForm): SubmissionSourceForm {
   return form as unknown as SubmissionSourceForm
+}
+// Centers the `AnyForm → handleSubmit` coercion for the live `activeForm`
+// facade. The slot type omits `handleSubmit`; at runtime every
+// participating form carries it.
+function asHandleSubmitSource(form: AnyForm): Pick<UseFormReturnType<GenericForm>, 'handleSubmit'> {
+  return form as unknown as Pick<UseFormReturnType<GenericForm>, 'handleSubmit'>
 }
 
 /**
@@ -438,6 +449,57 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
     }
     const first = list[0]
     return first === undefined ? undefined : first.form
+  })
+
+  // `wizard.activeForm` returns this single facade (when the wizard is
+  // non-degenerate) on every read, so a handler captured once at setup
+  // time stays correct as the wizard advances:
+  //
+  //   const onNext = wizard.activeForm.handleSubmit(() => wizard.next())
+  //
+  // `handleSubmit` is late-bound: the returned submit handler resolves
+  // the active form when it RUNS, not when `.handleSubmit(...)` was
+  // called, so `onNext` validates whichever step is current at click
+  // time instead of pinning to step one. Every other access forwards to
+  // the current form. Reach for `wizard.forms[key]` when you need a
+  // specific step's raw handle. The Proxy target is inert: all behavior
+  // comes from the traps, which read the reactive `activeForm` computed
+  // at access time (so reactivity tracks through the stable identity)
+  // and no-op safely when the wizard has no steps.
+  const activeFormFacade = new Proxy({} as UseFormReturnType<GenericForm>, {
+    get(_target, prop) {
+      const form = activeForm.value
+      if (form === undefined) return undefined
+      if (prop === 'handleSubmit') {
+        const lateBound: HandleSubmit<GenericForm> = (onValid, onInvalid) => {
+          return (event?: Event): Promise<void> => {
+            const current = activeForm.value
+            if (current === undefined) return Promise.resolve()
+            return asHandleSubmitSource(current).handleSubmit(onValid, onInvalid)(event)
+          }
+        }
+        return lateBound
+      }
+      return Reflect.get(form, prop, form)
+    },
+    has(_target, prop) {
+      const form = activeForm.value
+      return form === undefined ? false : Reflect.has(form, prop)
+    },
+    ownKeys(_target) {
+      const form = activeForm.value
+      return form === undefined ? [] : Reflect.ownKeys(form)
+    },
+    getOwnPropertyDescriptor(_target, prop) {
+      const form = activeForm.value
+      if (form === undefined) return undefined
+      const descriptor = Reflect.getOwnPropertyDescriptor(form, prop)
+      if (descriptor === undefined) return undefined
+      // Force `configurable: true` so the Proxy invariant (a descriptor
+      // reported for a key absent from the inert target must be
+      // configurable) holds regardless of how the handle defines the key.
+      return { ...descriptor, configurable: true }
+    },
   })
 
   const isFinalStep = computed<boolean>(() => {
@@ -1342,7 +1404,10 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
       return currentStep.value as CurrentStepOf<S>
     },
     get activeForm(): ActiveFormOf<S> {
-      return activeForm.value as ActiveFormOf<S>
+      // Live facade (built once above) so a handler captured at setup
+      // time retargets the current step on every call. `undefined`
+      // preserved for the degenerate (no-steps) wizard.
+      return (activeForm.value === undefined ? undefined : activeFormFacade) as ActiveFormOf<S>
     },
     get activeIndex(): number {
       return activeIndex.value

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -3327,8 +3327,8 @@ export type FormMeta<F = unknown> = FieldState<F> & {
    * `getDisplayState` predicates) but does NOT drive the library's
    * default `getDisplayState` heuristic. The reveal-on-submit story
    * runs entirely through `submissionAttempts`, which
-   * `wizard.handleSubmit` bumps on the active form at intermediate
-   * steps and on every form at the final step.
+   * `wizard.handleSubmit` bumps on every form (it always validates the
+   * whole step list).
    *
    * Distinct from `submissionAttempts`, which counts `handleSubmit`
    * passes only — wizard departures and form submissions are tracked

--- a/src/runtime/types/types-wizard.ts
+++ b/src/runtime/types/types-wizard.ts
@@ -198,8 +198,9 @@ export type WizardPersistFn = (state: WizardRestoreState) => void
 
 /**
  * Submit context passed to the `onSubmit` callback registered via
- * `wizard.handleSubmit(onSubmit, onError?)`. Same shape on every step;
- * `isFinal` distinguishes intermediate vs final calls.
+ * `wizard.handleSubmit(onSubmit, onError?)`. `handleSubmit` always
+ * processes the whole step list, so `values` carries every form's
+ * parsed output regardless of which step fired the submit.
  *
  *  - `values` — namespaced aggregate keyed by form key, mirroring
  *               `wizard.allValues`. Reflects parsed output for every
@@ -210,9 +211,11 @@ export type WizardPersistFn = (state: WizardRestoreState) => void
  *               because the form ref carries its schema info.
  *  - `currentKey` — key of the step that fired this submission.
  *  - `isFinal`   — `true` when `currentKey` is the last position in
- *               `wizard.steps`. Intermediate calls validate the active
- *               form only and advance; final calls validate every form
- *               and stay on the terminal step.
+ *               `wizard.steps`. Positional only: it reports where the
+ *               submit fired, never what got validated. A user who steps
+ *               back, edits, and submits from the middle sees
+ *               `isFinal === false`, yet the whole list is still
+ *               processed and `done` still latches on success.
  */
 export type WizardSubmitContext = {
   readonly values: Readonly<Record<FormKey, unknown>>
@@ -229,9 +232,11 @@ export type WizardOnSubmit = (ctx: WizardSubmitContext) => void | Promise<void>
 
 /**
  * Optional `onError` callback registered via `wizard.handleSubmit`.
- * Receives the aggregate error list. Entries originate from per-form
- * validation, activation failures (`atta:activation-failed`), and a
- * submit callback that left errors on a processed step (the
+ * Receives the aggregate error list spanning EVERY step (handleSubmit
+ * validates the whole wizard), so a failed submit surfaces every form's
+ * errors at once, not just the active step's. Entries originate from
+ * per-form validation, activation failures (`atta:activation-failed`),
+ * and a submit callback that left errors on a processed step (the
  * `setErrors(...); return` server-rejection path). Sync or async; the
  * returned promise gates `wizard.submitting`.
  */
@@ -458,13 +463,13 @@ export type WizardForms<S> = FormsRecordOf<S> & Readonly<Record<FormKey, AnyForm
  *                    Forward-looking; reactive to current form
  *                    validity. Gates "Finish button enable" style UI.
  *  - `done`        — monotonic latch: flips `true` the first time a
- *                    final-step `handleSubmit` resolves without throwing
- *                    AND leaves no errors set on any step, and stays
- *                    `true` through subsequent edits or invalidations. A
- *                    callback that calls `setErrors` and returns (the
- *                    documented server-rejection path) is a failed submit,
- *                    so it does not flip `done`. Only `reset()` flips it
- *                    back. Gates "show success card" style UI that should
+ *                    `handleSubmit` resolves without throwing AND leaves
+ *                    no errors set on any step, and stays `true` through
+ *                    subsequent edits or invalidations. A callback that
+ *                    calls `setErrors` and returns (the documented
+ *                    server-rejection path) is a failed submit, so it
+ *                    does not flip `done`. Only `reset()` flips it back.
+ *                    Gates "show success card" style UI that should
  *                    reflect submission history rather than current
  *                    validity.
  *  - `submitting`  — `true` while a `wizard.handleSubmit` call is in
@@ -488,11 +493,15 @@ export type WizardForms<S> = FormsRecordOf<S> & Readonly<Record<FormKey, AnyForm
  *                    `back()` does not pop; the trail is the audit
  *                    log, not the back-stack.
  *  - `next/back/goTo` — pure navigation. Refuses while `submitting`.
- *  - `handleSubmit(onSubmit, onError?)` — universal across all steps.
- *                    Intermediate calls validate the active form and
- *                    advance; final calls validate every form. Returns
- *                    an event handler suitable for `<form @submit>` or
- *                    imperative use.
+ *  - `handleSubmit(onSubmit, onError?)` — always validates the entire
+ *                    step list, from any step, and never advances the
+ *                    pin: on success it latches `done`; on any error it
+ *                    focuses the first failing step and fires `onError`
+ *                    with errors spanning every step. To gate advancing
+ *                    a step on its own validity, compose with the active
+ *                    form's submit: `activeForm.handleSubmit(() =>
+ *                    wizard.next())`. Returns an event handler suitable
+ *                    for `<form @submit>` or imperative use.
  *  - `reset()`     — zeros wizard lifecycle (`submissionAttempts`,
  *                    `visited`), resets every form, returns
  *                    `currentStep` to `steps[0].key`, and invokes

--- a/src/runtime/types/types-wizard.ts
+++ b/src/runtime/types/types-wizard.ts
@@ -15,7 +15,8 @@
  * refs and through `wizard.handleSubmit`'s `ctx.get(formRef)` accessor.
  */
 
-import type { FormKey } from './types-api'
+import type { FormKey, UseFormReturnType } from './types-api'
+import type { GenericForm } from './types-core'
 
 /**
  * Minimum structural shape the wizard requires from a participating
@@ -344,8 +345,19 @@ export type StaticallyNonEmpty<S> = S extends readonly []
 /** Active step's key, narrowed to `string` when `S` is statically safe. */
 export type CurrentStepOf<S> = StaticallyNonEmpty<S> extends true ? FormKey : FormKey | undefined
 
-/** Active step's form handle, narrowed to `AnyForm` when `S` is statically safe. */
-export type ActiveFormOf<S> = StaticallyNonEmpty<S> extends true ? AnyForm : AnyForm | undefined
+/**
+ * Active step's form handle, schema-erased to `UseFormReturnType<GenericForm>`
+ * and narrowed to non-`undefined` when `S` is statically safe. The runtime
+ * value is a live facade over the active step, so reads (`.values`, `.meta`,
+ * `.history`) and `.handleSubmit` always target the current step. Values are
+ * loose here because the active step's schema is not statically known; reach
+ * for the original form ref or `ctx.get(ref)` when you need typed per-step
+ * values.
+ */
+export type ActiveFormOf<S> =
+  StaticallyNonEmpty<S> extends true
+    ? UseFormReturnType<GenericForm>
+    : UseFormReturnType<GenericForm> | undefined
 
 /**
  * Recursive tuple walk that builds the static portion of
@@ -412,9 +424,15 @@ export type WizardForms<S> = FormsRecordOf<S> & Readonly<Record<FormKey, AnyForm
  *                    slots). Otherwise reads as `string | undefined`
  *                    so the degenerate case (empty list at runtime)
  *                    surfaces honestly.
- *  - `activeForm`  — the active step's form handle. Same narrowing as
- *                    `currentStep`. Noop forms cover string slots in
- *                    the normal path.
+ *  - `activeForm`  — a LIVE view of the active step's form. Operating
+ *                    through it always targets the current step, so a
+ *                    handler captured once at setup
+ *                    (`wizard.activeForm.handleSubmit(() =>
+ *                    wizard.next())`) retargets as the wizard advances.
+ *                    No longer `===` the raw per-step handle; reach for
+ *                    `wizard.forms[key]` when you need raw identity.
+ *                    Same `undefined` narrowing as `currentStep`. Noop
+ *                    forms cover string slots in the normal path.
  *  - `activeIndex` — 0-based position of the active step.
  *  - `isFinalStep` — `true` when `currentStep === steps[count - 1].key`.
  *  - `steps`       — ordered list of compiled `{ key, form }` slots.

--- a/src/runtime/types/types-wizard.ts
+++ b/src/runtime/types/types-wizard.ts
@@ -493,6 +493,14 @@ export type WizardForms<S> = FormsRecordOf<S> & Readonly<Record<FormKey, AnyForm
  *                    `back()` does not pop; the trail is the audit
  *                    log, not the back-stack.
  *  - `next/back/goTo` — pure navigation. Refuses while `submitting`.
+ *  - `tryNext()`   — validate the active step, then advance iff it
+ *                    passed; invalid input keeps the pin put under the
+ *                    form's standard error reveal (first error focused,
+ *                    display state advanced). The inline-bindable
+ *                    shorthand for `activeForm.handleSubmit(() =>
+ *                    next())`. Resolves to whether the pin moved. No-ops
+ *                    to `false` on a degenerate or final-step wizard
+ *                    (finish via `handleSubmit`).
  *  - `handleSubmit(onSubmit, onError?)` — always validates the entire
  *                    step list, from any step, and never advances the
  *                    pin: on success it latches `done`; on any error it
@@ -531,6 +539,7 @@ export type UseWizardReturnType<S extends ReadonlyArray<StepSlot> = ReadonlyArra
   readonly next: () => Promise<void>
   readonly back: () => void
   readonly goTo: (key: string) => void
+  readonly tryNext: () => Promise<boolean>
   readonly handleSubmit: (
     onSubmit: WizardOnSubmit,
     onError?: WizardOnError

--- a/test/composables/wizard-active-form.test.ts
+++ b/test/composables/wizard-active-form.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it } from 'vitest'
-import { createApp, defineComponent, h, type App } from 'vue'
+import { createApp, defineComponent, h, nextTick, type App } from 'vue'
 import { z } from 'zod'
 import { useForm } from '../../src/zod'
 import { useWizard } from '../../src/runtime/composables/use-wizard'
@@ -11,12 +11,15 @@ import { createAttaform } from '../../src/runtime/core/plugin'
  *
  *   - `currentStep` — the active step's key. Always defined (steps list
  *                     is non-empty by construction).
- *   - `activeForm`  — the active step's form handle. Always defined
- *                     (noop forms cover string slots).
+ *   - `activeForm`  — a live facade over the active step's form. Always
+ *                     defined (noop forms cover string slots); reports
+ *                     the active step but is not `===` the raw handle.
  *   - `activeIndex` — the active step's 0-based index.
  *
  * `activeForm` and `activeIndex` are derived getters — they update
- * synchronously when `goTo` / `next` / `back` flips `currentStep`.
+ * synchronously when `goTo` / `next` / `back` flips `currentStep`. The
+ * `activeForm` facade is built once and late-binds `handleSubmit`, so a
+ * handler captured at setup time always targets the current step.
  */
 
 const schema = z.object({ email: z.string().optional() })
@@ -76,16 +79,77 @@ describe('useWizard — activeForm + activeIndex', () => {
     expect(result.activeIndex).toBe(1)
   })
 
-  it('activeForm tracks the same form identity as the steps[i].form entry', async () => {
+  it('activeForm is a live facade keyed to the active step; forms[key] keeps raw identity', async () => {
     const { app, result } = mountWizardHarness(() => {
       const a = useForm({ schema, key: 'a' })
       const b = useForm({ schema, key: 'b' })
       return useWizard({ steps: [a, b], restore: false, persist: false })
     })
     apps.push(app)
-    expect(result.activeForm).toBe(result.steps[0]?.form)
+    // The facade reports the active step's key but is NOT the raw handle.
+    expect(result.activeForm?.key).toBe('a')
+    expect(result.activeForm).not.toBe(result.steps[0]?.form)
+    // The raw per-step handle stays reachable (and identity-stable) via forms[key].
+    expect(result.forms.a).toBe(result.steps[0]?.form)
     await result.next()
-    expect(result.activeForm).toBe(result.steps[1]?.form)
+    expect(result.activeForm?.key).toBe('b')
+    expect(result.forms.b).toBe(result.steps[1]?.form)
+  })
+
+  it('facade reads (key / values) reflect the active step, with a stable identity', async () => {
+    const { app, result } = mountWizardHarness(() => {
+      const a = useForm({ schema, key: 'a' })
+      const b = useForm({ schema, key: 'b' })
+      return useWizard({ steps: [a, b], restore: false, persist: false })
+    })
+    apps.push(app)
+    result.forms.a.setValue('email', 'a-val')
+    result.forms.b.setValue('email', 'b-val')
+    await nextTick()
+    // Stable identity: every read returns the one built-once facade.
+    const live = result.activeForm
+    expect(result.activeForm).toBe(live)
+    // The captured reference tracks the active step's key + values live.
+    expect(live?.key).toBe('a')
+    expect(live?.values['email']).toBe('a-val')
+    await result.next()
+    expect(live?.key).toBe('b')
+    expect(live?.values['email']).toBe('b-val')
+  })
+
+  it('a handler captured from activeForm on step 1 validates whichever step is active when it runs', async () => {
+    const requiredSchema = z.object({ email: z.string().min(1, 'Required') })
+    let onNext: (event?: Event) => Promise<void> = async () => {}
+    const { app, result } = mountWizardHarness(() => {
+      const a = useForm({ schema: requiredSchema, key: 'a' })
+      const b = useForm({ schema: requiredSchema, key: 'b' })
+      const c = useForm({ schema: requiredSchema, key: 'c' })
+      const wizard = useWizard({ steps: [a, b, c], restore: false, persist: false })
+      // Captured ONCE, on step 1: the canonical gated-advance composition.
+      onNext = wizard.activeForm.handleSubmit(() => wizard.next())
+      return wizard
+    })
+    apps.push(app)
+
+    // Move to step 2 without using onNext.
+    result.goTo('b')
+    await nextTick()
+    expect(result.currentStep).toBe('b')
+
+    // The step-1-captured handler validates step 2 (the current step), not
+    // step 1: b is empty so it stays put, b counts the attempt, a is untouched.
+    await onNext()
+    expect(result.currentStep).toBe('b')
+    expect(result.forms.b.meta.errorCount).toBeGreaterThan(0)
+    expect(result.forms.b.meta.submissionAttempts).toBe(1)
+    expect(result.forms.a.meta.submissionAttempts).toBe(0)
+
+    // Make step 2 valid, invoke again: the same captured handler now
+    // advances from step 2 to step 3.
+    result.forms.b.setValue('email', 'b@example.com')
+    await nextTick()
+    await onNext()
+    expect(result.currentStep).toBe('c')
   })
 
   it('activeForm tracks string-slot noop forms', () => {

--- a/test/composables/wizard-depart-attempts.test.ts
+++ b/test/composables/wizard-depart-attempts.test.ts
@@ -167,7 +167,7 @@ describe('departAttempts and submissionAttempts stay accounting-distinct', () =>
     while (apps.length > 0) apps.pop()?.unmount()
   })
 
-  it('failed intermediate handleSubmit bumps submissionAttempts but NOT departAttempts', async () => {
+  it('a failed handleSubmit bumps submissionAttempts on every form but departAttempts on none', async () => {
     const { app, result } = mountHarness(() => {
       const a = useForm({ schema: strictSchema, key: 'acc-1-a' })
       const b = useForm({ schema: strictSchema, key: 'acc-1-b' })
@@ -177,9 +177,11 @@ describe('departAttempts and submissionAttempts stay accounting-distinct', () =>
     apps.push(app)
     const onSubmit = result.wizard.handleSubmit(async () => {})
     await onSubmit()
+    // handleSubmit validates the whole wizard, so every form counts the
+    // attempt; nothing departed, so departAttempts stay 0. The pin never moves.
     expect(result.wizard.currentStep).toBe('acc-1-a')
-    expect(result.a.meta.submissionAttempts).toBeGreaterThan(0)
-    expect(result.b.meta.submissionAttempts).toBe(0)
+    expect(result.a.meta.submissionAttempts).toBe(1)
+    expect(result.b.meta.submissionAttempts).toBe(1)
     expect(result.a.meta.departAttempts).toBe(0)
     expect(result.b.meta.departAttempts).toBe(0)
   })

--- a/test/composables/wizard-flow-introspection.test.ts
+++ b/test/composables/wizard-flow-introspection.test.ts
@@ -82,7 +82,10 @@ describe('wizard.steps + wizard.forms — positional introspection', () => {
     })
     apps.push(app)
     expect(result.steps.map((s) => s.key)).toEqual(['f-4-only'])
-    expect(result.forms['f-4-only']).toBe(result.activeForm)
+    // `activeForm` is a live facade keyed to the active step; the raw
+    // per-step handle stays reachable via `forms[key]`.
+    expect(result.activeForm?.key).toBe('f-4-only')
+    expect(result.forms['f-4-only']).toBe(result.steps[0]?.form)
   })
 })
 

--- a/test/composables/wizard-handle-submit.test.ts
+++ b/test/composables/wizard-handle-submit.test.ts
@@ -5,23 +5,27 @@ import { z } from 'zod'
 import { useForm } from '../../src/zod'
 import { useWizard } from '../../src/runtime/composables/use-wizard'
 import { createAttaform } from '../../src/runtime/core/plugin'
-import type { WizardSubmitContext } from '../../src/runtime/types/types-wizard'
+import type {
+  WizardAggregateError,
+  WizardSubmitContext,
+} from '../../src/runtime/types/types-wizard'
 
 /**
- * `wizard.handleSubmit` — universal submit handler across every step.
+ * `wizard.handleSubmit` — universal submit handler that always validates
+ * the entire step list, from any step.
  *
- *  - On intermediate steps, validates the active form only and
- *    advances to the next step on success.
- *  - On the final step, validates every compiled form (in parallel)
- *    and stays put; the consumer's `onSubmit` ships values via
- *    `ctx.values` + `ctx.get(form)`.
+ *  - Validates every compiled form (in parallel) regardless of which
+ *    step fired the submit, and never advances the pin; the consumer's
+ *    `onSubmit` ships values via `ctx.values` + `ctx.get(form)`, and a
+ *    clean submit latches `done`.
+ *  - Gating advance on a step's own validity is the composition
+ *    `activeForm.handleSubmit(() => wizard.next())`, exercised in
+ *    wizard-active-form.test.ts.
  *  - `submitting` gates re-entrance globally; navigation also refuses
  *    while a submit is in flight.
- *  - `focusFirstError` (default true) routes to the first failing
- *    form on final-step validation failure and fires that form's
- *    `applyInvalidSubmitPolicy()`.
- *  - String slots (noop forms) validate trivially — a `handleSubmit`
- *    on an affordance step is a clean advance.
+ *  - `focusFirstError` (default true) routes to the first failing form
+ *    and fires that form's `applyInvalidSubmitPolicy()`.
+ *  - String slots (noop forms) validate trivially.
  */
 
 const accountSchema = z.object({
@@ -255,7 +259,7 @@ describe('useWizard — handleSubmit on the final step', () => {
     expect(result.wizard.done).toBe(false)
   })
 
-  it('intermediate step: validates the active form only and advances on success', async () => {
+  it('a submit fired from an intermediate step validates the whole wizard and does not advance', async () => {
     const onSubmit = vi.fn<(ctx: WizardSubmitContext) => void>()
     const { app, result } = mountHarness(() => {
       const account = useForm({
@@ -266,10 +270,9 @@ describe('useWizard — handleSubmit on the final step', () => {
       const profile = useForm({
         schema: profileSchema,
         key: 'hs-5-profile',
-        // Empty `name` would fail validation, but the wizard is on
-        // `account` here — the intermediate path validates the active
-        // form only.
-        defaultValues: { city: 'Cambridge' },
+        // Valid: handleSubmit validates EVERY step, so profile must pass
+        // even though the wizard is parked on `account`.
+        defaultValues: { name: 'Ada', city: 'Cambridge' },
       })
       const review = useForm({
         schema: reviewSchema,
@@ -290,9 +293,15 @@ describe('useWizard — handleSubmit on the final step', () => {
     await result.wizard.handleSubmit(onSubmit)()
     expect(onSubmit).toHaveBeenCalledTimes(1)
     const ctx = onSubmit.mock.calls[0]?.[0] as WizardSubmitContext
+    // `isFinal` is positional (fired from an intermediate step), but the
+    // whole wizard was validated: every step's values are present.
     expect(ctx.isFinal).toBe(false)
     expect(ctx.currentKey).toBe('hs-5-account')
-    expect(result.wizard.currentStep).toBe('hs-5-profile')
+    expect(ctx.values['hs-5-profile']).toMatchObject({ name: 'Ada' })
+    expect(ctx.values['hs-5-review']).toMatchObject({ tos: true })
+    // Never advances the pin; a clean whole-wizard submit latches `done`.
+    expect(result.wizard.currentStep).toBe('hs-5-account')
+    expect(result.wizard.done).toBe(true)
   })
 
   it('intermediate step: failed validation keeps the active step and bumps submissionAttempts', async () => {
@@ -302,7 +311,7 @@ describe('useWizard — handleSubmit on the final step', () => {
       const account = useForm({
         schema: accountSchema,
         key: 'hs-6-account',
-        // Missing password — intermediate validation must fail.
+        // Missing password — whole-wizard validation must fail.
         defaultValues: { email: 'a@b.c' },
       })
       const review = useForm({
@@ -324,6 +333,80 @@ describe('useWizard — handleSubmit on the final step', () => {
     expect(onError).toHaveBeenCalledTimes(1)
     expect(result.wizard.currentStep).toBe('hs-6-account')
     expect(result.wizard.submissionAttempts).toBe(1)
+  })
+
+  it('back-edit: submitting from a stepped-back position validates the whole list and latches done', async () => {
+    const onSubmit = vi.fn<(ctx: WizardSubmitContext) => void>()
+    const { app, result } = mountHarness(() => {
+      const account = useForm({
+        schema: accountSchema,
+        key: 'hs-back-account',
+        defaultValues: { email: 'a@b.c', password: 'passw0rd' },
+      })
+      const profile = useForm({
+        schema: profileSchema,
+        key: 'hs-back-profile',
+        defaultValues: { name: 'Ada', city: 'Cambridge' },
+      })
+      const review = useForm({
+        schema: reviewSchema,
+        key: 'hs-back-review',
+        defaultValues: { tos: true as const },
+      })
+      return {
+        wizard: useWizard({ steps: [account, profile, review], restore: false, persist: false }),
+        profile,
+      }
+    })
+    apps.push(app)
+    // Walk to the final step, then step back and edit a middle field.
+    result.wizard.goTo('hs-back-review')
+    result.wizard.goTo('hs-back-profile')
+    expect(result.wizard.isFinalStep).toBe(false)
+    result.profile.setValue('city', 'Oxford')
+    await nextTick()
+
+    // Submitting from the middle still processes the whole wizard.
+    await result.wizard.handleSubmit(onSubmit)()
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    const ctx = onSubmit.mock.calls[0]?.[0] as WizardSubmitContext
+    // `isFinal` reports where the submit fired (false), not what validated.
+    expect(ctx.isFinal).toBe(false)
+    expect(ctx.currentKey).toBe('hs-back-profile')
+    expect(ctx.values['hs-back-account']).toMatchObject({ email: 'a@b.c' })
+    expect(ctx.values['hs-back-profile']).toMatchObject({ city: 'Oxford' })
+    expect(ctx.values['hs-back-review']).toMatchObject({ tos: true })
+    expect(result.wizard.done).toBe(true)
+  })
+
+  it('a failed whole-wizard submit reports errors spanning every step, not just the active one', async () => {
+    const onError = vi.fn<(errors: readonly WizardAggregateError[]) => void>()
+    const { app, result } = mountHarness(() => {
+      const account = useForm({
+        schema: accountSchema,
+        key: 'hs-allerr-account',
+        // Invalid: missing password.
+        defaultValues: { email: 'a@b.c' },
+      })
+      const profile = useForm({
+        schema: profileSchema,
+        key: 'hs-allerr-profile',
+        // Invalid: empty name.
+        defaultValues: { city: 'Cambridge' },
+      })
+      return {
+        wizard: useWizard({ steps: [account, profile], restore: false, persist: false }),
+      }
+    })
+    apps.push(app)
+    // Fired from the FIRST step; pre-#471 this saw only the active form's errors.
+    expect(result.wizard.currentStep).toBe('hs-allerr-account')
+    await result.wizard.handleSubmit(() => {}, onError)()
+    expect(onError).toHaveBeenCalledTimes(1)
+    const errors = onError.mock.calls[0]?.[0] ?? []
+    const failedKeys = new Set(errors.map((e) => e.formKey))
+    expect(failedKeys.has('hs-allerr-account')).toBe(true)
+    expect(failedKeys.has('hs-allerr-profile')).toBe(true)
   })
 
   it('re-entrancy: a second handleSubmit while in flight dev-warns and no-ops', async () => {
@@ -599,7 +682,7 @@ describe('useWizard — handleSubmit on string slots (noop forms)', () => {
     while (apps.length > 0) apps.pop()?.unmount()
   })
 
-  it('handleSubmit on an intermediate string slot advances without validation drama', async () => {
+  it('handleSubmit fired from an intermediate string slot validates the whole wizard and does not advance', async () => {
     const onSubmit = vi.fn<(ctx: WizardSubmitContext) => void>()
     const { app, result } = mountHarness(() => {
       const account = useForm({
@@ -620,7 +703,11 @@ describe('useWizard — handleSubmit on string slots (noop forms)', () => {
     const ctx = onSubmit.mock.calls[0]?.[0] as WizardSubmitContext
     expect(ctx.currentKey).toBe('hs-noop-1-intro')
     expect(ctx.isFinal).toBe(false)
-    expect(result.currentStep).toBe('hs-noop-1-account')
+    // The whole wizard is processed (account included); the pin stays on
+    // the intro slot.
+    expect(ctx.values['hs-noop-1-account']).toMatchObject({ email: 'a@b.c' })
+    expect(result.currentStep).toBe('hs-noop-1-intro')
+    expect(result.done).toBe(true)
   })
 
   it('handleSubmit on a final string slot fires onSubmit with every step in values', async () => {

--- a/test/composables/wizard-submit-clears-user-errors.test.ts
+++ b/test/composables/wizard-submit-clears-user-errors.test.ts
@@ -11,11 +11,8 @@ import type { ValidationError } from '../../src/runtime/types/types-api'
  * Parity with `form.handleSubmit` (submit-clears-user-errors.test.ts):
  * `wizard.handleSubmit` clears user-set errors on the forms it PROCESSES
  * at entry, so a fresh attempt starts each from a clean user-error slate.
- *
- *   - A final-step submit validates every form → clears every form's
- *     user errors.
- *   - An intermediate submit validates only the active form → clears only
- *     the active form's user errors; the other steps are untouched.
+ * `handleSubmit` always validates the whole step list, so the entry-clear
+ * spans every form regardless of which step fired the submit.
  *
  * Errors set DURING the callback survive (the clear runs before the
  * callback), and the clear fires even when validation fails.
@@ -80,7 +77,7 @@ describe('wizard.handleSubmit clears user-set errors on processed forms at entry
     expect(formLevel(result.review.meta.errors)).toHaveLength(0)
   })
 
-  it('an intermediate submit clears only the active form’s user errors', async () => {
+  it('every submit clears user errors on every form, even from an intermediate step', async () => {
     const { app, result } = mountHarness(() => {
       const account = useForm({
         schema: accountSchema,
@@ -105,16 +102,16 @@ describe('wizard.handleSubmit clears user-set errors on processed forms at entry
       return { wizard, account, profile, review }
     })
     apps.push(app)
-    // On the first (active) step; set errors on the active form and a
-    // later, unprocessed one.
+    // On the first step; set user errors on the active form and a later one.
     result.account.setErrors([{ message: 'acct err' }])
     result.profile.setErrors([{ message: 'profile err' }])
     expect(result.wizard.currentStep).toBe('wc-mid-account')
 
     await result.wizard.handleSubmit(() => {})(new Event('submit'))
-    // Active form's user errors cleared; the untouched step keeps its own.
+    // handleSubmit validates the whole wizard, so the entry-clear spans
+    // every form, not just the active step's.
     expect(formLevel(result.account.meta.errors)).toHaveLength(0)
-    expect(formLevel(result.profile.meta.errors)).toHaveLength(1)
+    expect(formLevel(result.profile.meta.errors)).toHaveLength(0)
   })
 
   it('clears even when a final-step validation fails', async () => {

--- a/test/composables/wizard-submit-no-rethrow.test.ts
+++ b/test/composables/wizard-submit-no-rethrow.test.ts
@@ -156,7 +156,7 @@ describe('wizard.handleSubmit — a rejecting callback does not re-throw', () =>
     expect(result.submitting).toBe(false)
   })
 
-  it('an intermediate-step onSubmit throw parks the error and does not advance', async () => {
+  it('an onSubmit throw from an intermediate step parks the error without advancing or latching done', async () => {
     const { app, result } = mountHarness(() => validWizard('intermediate'))
     apps.push(app)
     expect(result.currentStep).toBe('wnr-intermediate-account')
@@ -164,8 +164,9 @@ describe('wizard.handleSubmit — a rejecting callback does not re-throw', () =>
       throw new Error('intermediate boom')
     })(new Event('submit'))
     expect(result.submitError).toBeInstanceOf(Error)
-    // The throw aborts the advance — still on the first step.
+    // The whole-wizard submit threw in the callback: pin unmoved, no done.
     expect(result.currentStep).toBe('wnr-intermediate-account')
+    expect(result.done).toBe(false)
     expect(result.submitting).toBe(false)
   })
 

--- a/test/composables/wizard-submit-success-semantics.test.ts
+++ b/test/composables/wizard-submit-success-semantics.test.ts
@@ -8,18 +8,17 @@ import { createAttaform } from '../../src/runtime/core/plugin'
 
 /**
  * Parity with `form.handleSubmit` success semantics (#438), applied to
- * `wizard.handleSubmit`. A wizard callback that leaves errors on a
- * processed step form has NOT submitted that step successfully:
+ * `wizard.handleSubmit`, which always validates the whole step list. A
+ * wizard callback that leaves errors on a processed step has NOT
+ * submitted successfully:
  *
- *   - Final step: `wizard.done` must stay `false` (a server rejection
- *     is not completion).
- *   - Intermediate step: the wizard must NOT advance past a step the
- *     server just rejected.
- *   - `onError` must fire in both cases.
+ *   - `wizard.done` must stay `false` (a server rejection is not
+ *     completion), whether the submit fired from the final step or an
+ *     earlier one.
+ *   - `onError` must fire.
  *
- * The clean-return positive controls guard against over-correction:
- * a final submit that leaves no errors completes, and an intermediate
- * one advances.
+ * The clean-return positive control guards against over-correction: a
+ * clean submit latches `done` and never advances the pin.
  */
 
 const accountSchema = z.object({
@@ -78,7 +77,7 @@ describe('wizard.handleSubmit success semantics (#438)', () => {
     expect(onError).toHaveBeenCalledTimes(1)
   })
 
-  it('intermediate setErrors inside onSubmit does not advance past the rejected step', async () => {
+  it('setErrors inside onSubmit fails the submit even when fired from an intermediate step', async () => {
     const { app, result } = mountHarness(() => {
       const account = useForm({
         schema: accountSchema,
@@ -101,7 +100,10 @@ describe('wizard.handleSubmit success semantics (#438)', () => {
       result.account.setErrors([{ message: 'This email is already taken.' }])
     }, onError)(new Event('submit'))
 
+    // A clean validation pass whose callback leaves a user error is a
+    // failed submit (#438): no `done`, onError fires. The pin never moves.
     expect(result.wizard.currentStep).toBe('ws-mid-account')
+    expect(result.wizard.done).toBe(false)
     expect(onError).toHaveBeenCalledTimes(1)
   })
 
@@ -130,7 +132,7 @@ describe('wizard.handleSubmit success semantics (#438)', () => {
     expect(onError).not.toHaveBeenCalled()
   })
 
-  it('positive control: a clean intermediate submit advances to the next step', async () => {
+  it('positive control: a clean submit from an intermediate step latches done without advancing', async () => {
     const { app, result } = mountHarness(() => {
       const account = useForm({
         schema: accountSchema,
@@ -150,6 +152,8 @@ describe('wizard.handleSubmit success semantics (#438)', () => {
 
     await result.wizard.handleSubmit(() => {})(new Event('submit'))
 
-    expect(result.wizard.currentStep).toBe('ws-adv-review')
+    // Whole-wizard submit never advances the pin; a clean pass latches `done`.
+    expect(result.wizard.currentStep).toBe('ws-adv-account')
+    expect(result.wizard.done).toBe(true)
   })
 })

--- a/test/composables/wizard-try-next.test.ts
+++ b/test/composables/wizard-try-next.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, nextTick, type App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { useWizard } from '../../src/runtime/composables/use-wizard'
+import { createAttaform } from '../../src/runtime/core/plugin'
+
+/**
+ * `wizard.tryNext()` is the inline-bindable gated advance: validate the
+ * active step, advance iff it passed, and resolve to whether the pin
+ * moved. It is the shorthand for `activeForm.handleSubmit(() => next())`,
+ * so it is step-scoped (only the active form validates, unlike the
+ * whole-wizard `handleSubmit`) and never advances on invalid input.
+ */
+
+const requiredSchema = z.object({ email: z.string().min(1, 'Required') })
+
+function mountWizardHarness<R>(setup: () => R): { app: App; result: R } {
+  const handle: { result?: R } = {}
+  const App = defineComponent({
+    setup() {
+      handle.result = setup()
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  app.config.warnHandler = () => {}
+  app.config.errorHandler = () => {}
+  app.mount(document.createElement('div'))
+  return { app, result: handle.result as R }
+}
+
+describe('useWizard — tryNext', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('advances and resolves true when the active step is valid', async () => {
+    const { app, result } = mountWizardHarness(() => {
+      const a = useForm({ schema: requiredSchema, key: 'a' })
+      const b = useForm({ schema: requiredSchema, key: 'b' })
+      return useWizard({ steps: [a, b], restore: false, persist: false })
+    })
+    apps.push(app)
+    result.forms.a.setValue('email', 'a@example.com')
+    await nextTick()
+    const advanced = await result.tryNext()
+    expect(advanced).toBe(true)
+    expect(result.currentStep).toBe('b')
+  })
+
+  it('stays put, reveals errors, and resolves false when the active step is invalid', async () => {
+    const { app, result } = mountWizardHarness(() => {
+      const a = useForm({ schema: requiredSchema, key: 'a' })
+      const b = useForm({ schema: requiredSchema, key: 'b' })
+      return useWizard({ steps: [a, b], restore: false, persist: false })
+    })
+    apps.push(app)
+    const advanced = await result.tryNext()
+    expect(advanced).toBe(false)
+    expect(result.currentStep).toBe('a')
+    expect(result.forms.a.meta.errorCount).toBeGreaterThan(0)
+    expect(result.forms.a.meta.submissionAttempts).toBe(1)
+  })
+
+  it('validates only the active step, leaving sibling forms untouched', async () => {
+    const { app, result } = mountWizardHarness(() => {
+      const a = useForm({ schema: requiredSchema, key: 'a' })
+      const b = useForm({ schema: requiredSchema, key: 'b' })
+      return useWizard({ steps: [a, b], restore: false, persist: false })
+    })
+    apps.push(app)
+    // a is invalid: tryNext validates a only; b is never touched (unlike
+    // whole-wizard handleSubmit, which bumps every form).
+    await result.tryNext()
+    expect(result.forms.a.meta.submissionAttempts).toBe(1)
+    expect(result.forms.b.meta.submissionAttempts).toBe(0)
+  })
+
+  it('walks the wizard step by step, gating each advance on validity', async () => {
+    const { app, result } = mountWizardHarness(() => {
+      const a = useForm({ schema: requiredSchema, key: 'a' })
+      const b = useForm({ schema: requiredSchema, key: 'b' })
+      const c = useForm({ schema: requiredSchema, key: 'c' })
+      return useWizard({ steps: [a, b, c], restore: false, persist: false })
+    })
+    apps.push(app)
+    result.forms.a.setValue('email', 'a@example.com')
+    await nextTick()
+    expect(await result.tryNext()).toBe(true)
+    expect(result.currentStep).toBe('b')
+    // b is empty: tryNext refuses to advance and reveals its errors.
+    expect(await result.tryNext()).toBe(false)
+    expect(result.currentStep).toBe('b')
+    result.forms.b.setValue('email', 'b@example.com')
+    await nextTick()
+    expect(await result.tryNext()).toBe(true)
+    expect(result.currentStep).toBe('c')
+  })
+
+  it('no-ops to false on the final step without validating', async () => {
+    const { app, result } = mountWizardHarness(() => {
+      const a = useForm({ schema: requiredSchema, key: 'a' })
+      const b = useForm({ schema: requiredSchema, key: 'b' })
+      return useWizard({ steps: [a, b], restore: false, persist: false })
+    })
+    apps.push(app)
+    result.goTo('b')
+    await nextTick()
+    expect(result.isFinalStep).toBe(true)
+    const advanced = await result.tryNext()
+    expect(advanced).toBe(false)
+    expect(result.currentStep).toBe('b')
+    // The final step is not validated: finishing is handleSubmit's job.
+    expect(result.forms.b.meta.submissionAttempts).toBe(0)
+  })
+
+  it('resolves false on a degenerate (no-steps) wizard without throwing', async () => {
+    const { app, result } = mountWizardHarness(() => {
+      return useWizard({ steps: [], restore: false, persist: false })
+    })
+    apps.push(app)
+    await expect(result.tryNext()).resolves.toBe(false)
+  })
+})

--- a/tests/fixtures/bundled-types/mixed-wizard.ts
+++ b/tests/fixtures/bundled-types/mixed-wizard.ts
@@ -15,8 +15,9 @@
  *     per-form), `currentKey`, `isFinal`.
  *   - Namespaced aggregation: `wizard.allValues`, `wizard.allErrors`,
  *     `wizard.forms.<key>`.
- *   - Navigation handles: `next` / `back` / `goTo` / `reset` —
- *     including the `(key: string) => void` signature on `goTo`.
+ *   - Navigation handles: `next` / `back` / `goTo` / `tryNext` / `reset`
+ *     — including the `(key: string) => void` signature on `goTo` and the
+ *     `() => Promise<boolean>` gated advance on `tryNext`.
  *   - Other v2 fields: `currentStep`, `activeForm`, `activeIndex`,
  *     `isFinalStep`, `steps`, `count`, `canAdvance`, `canGoBack`,
  *     `complete`, `submitting`, `submissionAttempts`, `visited`,
@@ -126,6 +127,10 @@ function _neverInvoked() {
   void wizard.back
   void wizard.reset
   wizard.goTo('welcome')
+  // `tryNext()` validates the active step and advances iff valid,
+  // resolving to whether the pin moved.
+  const advanced: Promise<boolean> = wizard.tryNext()
+  void advanced
 
   // Other v2 surface fields.
   const at: string | undefined = wizard.currentStep


### PR DESCRIPTION
## Summary

Closes #471. Three coupled changes land one coherent rule: **`wizard.handleSubmit` submits the whole wizard; `next` / `back` / `goTo` navigate; gating a step's advance on its validity is `wizard.tryNext()`.**

## What changed

**`wizard.handleSubmit` always submits the whole wizard (#471 core).** One call validates every step's form in parallel, from any step, and runs `onSubmit` once with every step's values. It never moves the pin: a clean pass latches `wizard.done`, a failure surfaces every step's errors at once through `onError`. This removes the old position-dependent behavior (validate-active-and-advance on intermediate steps) and the latent footgun where a non-final `onError` only ever saw the active step's errors. `ctx.isFinal` stays on the context as positional information only.

**`wizard.activeForm` is a live view of the active step's form.** Operating through it always targets the current step, so a handler captured once at setup (`wizard.activeForm.handleSubmit(() => wizard.next())`) retargets as the wizard advances instead of pinning to the step it was created on. It is no longer identity-equal to the raw per-step handle; reach for `wizard.forms[key]` for raw identity. Typed as the schema-erased full form handle.

**New: `wizard.tryNext(): Promise<boolean>`.** The inline-bindable gated advance: `@click="wizard.tryNext()"` validates the active step, advances only on a clean pass, reveals the step's errors on failure, and resolves to whether the pin moved (the seam for post-advance work like moving focus). It is the shorthand for the `wizard.activeForm.handleSubmit(() => wizard.next())` composition, which stays available for custom valid / invalid callbacks. There is no `{ validate }` flag and no mode to remember: the verb is the policy.

## Notes

- Pre-1.0, no back-compat shims. Gating advance is now `wizard.tryNext()` (or the composition); `wizard.next()` stays pure navigation.
- Focus-on-advance is intentionally a consumer concern (await the nav, then move focus); there is no `autoFocus` option. The shipment REPL demo models the pattern.
- Docs across `docs/multistep/*` lead with the new verbs; the signup demo binds Next straight to `wizard.tryNext()`.

## Testing

- `pnpm typecheck` and full `pnpm test` (4367 passed, 4 skipped)
- `pnpm check:bundled-types` for v3 + v4 consumers (a `Promise<boolean>` assertion was added to the mixed-wizard fixture)
- `pnpm build:site`: 0 link errors / 0 warnings, 430 routes prerendered, REPL bundle rebuilt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
