### PR TITLE
feat(inject): sharpen injectForm/injectWizard miss diagnostics

### DIFF
--- a/src/runtime/composables/inject-wizard.ts
+++ b/src/runtime/composables/inject-wizard.ts
@@ -45,8 +45,10 @@ export type InjectWizardInput = {
  * constructed with `useWizard({ steps, key })` to be reachable.
  *
  * Returns `null` when no matching wizard exists (no ambient ancestor,
- * or the named key isn't registered). A dev-mode warning points at the
- * call site to help diagnose typos. Always narrow before using:
+ * or the named key isn't registered yet). A dev-mode warning points at
+ * the call site, lists the registered keys, and flags the mount-timing
+ * case (a wizard created by a child or sibling isn't registered until
+ * its own setup runs). Always narrow before using:
  *
  * ```ts
  * const wizard = injectWizard('signup')
@@ -117,6 +119,11 @@ function warnMiss(detail: string, ssr: boolean, hint?: string): void {
   const frame = captureUserCallSite()
   const parts = [`[attaform] injectWizard: ${detail}. Returning null.`]
   if (hint !== undefined) parts.push(hint)
+  parts.push(
+    `A wizard created by a child or sibling component is not registered until that ` +
+      `component's own setup runs, which happens after this point. Lift its ` +
+      `useWizard({ key }) call to a common ancestor, or read the wizard after mount.`
+  )
   if (frame !== undefined) parts.push(frame)
   console.warn(parts.join(' '))
 }

--- a/src/runtime/composables/use-form-context.ts
+++ b/src/runtime/composables/use-form-context.ts
@@ -8,6 +8,7 @@ import {
 } from 'vue'
 import { buildFormApi } from '../core/build-form-api'
 import type { FormStore } from '../core/create-form-store'
+import { RESERVED_KEY_PREFIX } from '../core/defaults'
 import { __DEV__ } from '../core/dev'
 import { captureUserCallSite } from '../core/dev-stack-trace'
 import type { HistoryModule } from '../core/history'
@@ -81,8 +82,10 @@ export type InjectFormInput = {
  * independent of component-tree position.
  *
  * Returns `null` when no matching form exists (no ambient ancestor, or
- * the named key isn't registered). A dev-mode warning points at the
- * call site to help diagnose typos. Always narrow before using:
+ * the named key isn't registered yet). A dev-mode warning points at the
+ * call site, lists the registered keys, and flags the mount-timing case
+ * (a form created by a child or sibling isn't registered until its own
+ * setup runs). Always narrow before using:
  *
  * ```ts
  * const form = injectForm<Shape>('signup')
@@ -181,10 +184,12 @@ export function injectForm<Form extends GenericForm, GetValueFormType extends Ge
  * when no key was passed). Returns `null` on miss; the caller propagates
  * that null straight out to the consumer.
  *
- * Keyed misses log a dev-mode warning carrying the user's call-site frame
- * so a typo reads as "[attaform] injectForm: no form registered for key
- * 'userz'. Returning null. (pages/profile.vue:42)". Ambient misses stay
- * silent: ambient lookup is opportunistic (a component library built on
+ * Keyed misses log a dev-mode warning carrying three diagnostic parts:
+ * the registry's addressable keys (so a typo reads against the real
+ * list), a mount-timing note (a child or sibling form is not registered
+ * until its own setup runs, so it is not yet resolvable from an earlier
+ * caller), and the user's call-site frame. Ambient misses stay silent:
+ * ambient lookup is opportunistic (a component library built on
  * `injectForm()` shouldn't spam consumers' consoles when no parent has
  * provided one), so descendants narrow on `null` and degrade.
  */
@@ -195,7 +200,7 @@ function resolveState<Form extends GenericForm>(
   if (key !== undefined) {
     const stored = registry.forms.get(key) as FormStore<Form> | undefined
     if (stored === undefined) {
-      warnMiss(`no form registered for key '${key}'`, registry.ssr)
+      warnMiss(`no form registered for key '${key}'`, registry.ssr, registry.forms)
       return null
     }
     return stored
@@ -207,19 +212,48 @@ function resolveState<Form extends GenericForm>(
 }
 
 /**
+ * Formats the registry's addressable form keys for a keyed-miss warning,
+ * so the miss distinguishes a typo (the intended key sits right there in
+ * the list) from a form that simply has not registered yet. Synthetic
+ * keys (anonymous forms under the reserved `__atta:` prefix) are filtered
+ * out: they are not addressable by `injectForm(key)`, so surfacing them
+ * would only add noise. Returns `undefined` when nothing addressable is
+ * registered, which drops the hint from the message entirely.
+ */
+function availableKeysHint(forms: Map<FormKey, FormStore<GenericForm>>): string | undefined {
+  const addressable = [...forms.keys()].filter((key) => !key.startsWith(RESERVED_KEY_PREFIX))
+  if (addressable.length === 0) return undefined
+  return `Registered keys: ${addressable.map((key) => `'${key}'`).join(', ')}.`
+}
+
+/**
  * Skipped on SSR — Nuxt's `dev:ssr-logs` hook forwards server warns to
  * the browser console alongside the client-side warn that fires from
  * the hydration setup, so the same miss would surface twice per page
  * load. The signal is identical on both passes (registry state is
  * deterministic across SSR/client), so emitting only on the client is
  * lossless and halves dev-mode noise. Production stays silent on both.
+ *
+ * Assembles the headline plus three diagnostic parts: the addressable
+ * keys (typo signal), the mount-timing note (a child or sibling form is
+ * not registered until its own setup runs, so it is not yet resolvable
+ * from an earlier caller), and the user's call-site frame. The hint
+ * computation lives inside the `__DEV__` guard so it, and the literals
+ * it carries, tree-shake out of production.
  */
-function warnMiss(detail: string, ssr: boolean): void {
+function warnMiss(detail: string, ssr: boolean, forms: Map<FormKey, FormStore<GenericForm>>): void {
   if (!__DEV__ || ssr) return
   const frame = captureUserCallSite()
-  console.warn(
-    `[attaform] injectForm: ${detail}. Returning null.` + (frame !== undefined ? ` ${frame}` : '')
+  const parts = [`[attaform] injectForm: ${detail}. Returning null.`]
+  const keys = availableKeysHint(forms)
+  if (keys !== undefined) parts.push(keys)
+  parts.push(
+    `A form created by a child or sibling component is not registered until that ` +
+      `component's own setup runs, which happens after this point. Lift its ` +
+      `useForm({ key }) call to a common ancestor, or read the form after mount.`
   )
+  if (frame !== undefined) parts.push(frame)
+  console.warn(parts.join(' '))
 }
 
 /**

--- a/test/composables/inject-form.test.ts
+++ b/test/composables/inject-form.test.ts
@@ -160,6 +160,59 @@ describe('injectForm — ambient provide/inject', () => {
       const message = String(calls[0]?.[0] ?? '')
       expect(message).toMatch(/no form registered/)
       expect(message).toContain("'never-registered'")
+      expect(message).toMatch(/not registered until that component's own setup runs/)
+      expect(message).toMatch(/common ancestor/)
+      app.unmount()
+    })
+
+    it("keyed miss lists the registry's addressable keys as a typo signal", () => {
+      let captured: ReturnType<typeof injectForm<Form>> | undefined
+      const Child = defineComponent({
+        setup() {
+          captured = injectForm<Form>('emial')
+          return () => h('div')
+        },
+      })
+      const Parent = defineComponent({
+        setup() {
+          useForm<Form>({ schema: fakeSchema(defaults), key: 'email' })
+          useForm<Form>({ schema: fakeSchema(defaults), key: 'profile' })
+          return () => h(Child)
+        },
+      })
+      const app = createApp(Parent).use(createAttaform())
+      app.mount(document.createElement('div'))
+      expect(captured).toBeNull()
+      const message = String(matchingWarnCalls()[0]?.[0] ?? '')
+      expect(message).toMatch(/Registered keys:/)
+      expect(message).toContain("'email'")
+      expect(message).toContain("'profile'")
+      app.unmount()
+    })
+
+    it('omits the registered-keys hint when only synthetic anonymous forms exist', () => {
+      // Anonymous forms live under the reserved `__atta:` prefix and are
+      // not addressable by `injectForm(key)`, so the hint filters them
+      // out rather than dangling an un-typeable key in front of the user.
+      let captured: ReturnType<typeof injectForm<Form>> | undefined
+      const Child = defineComponent({
+        setup() {
+          captured = injectForm<Form>('cart')
+          return () => h('div')
+        },
+      })
+      const Parent = defineComponent({
+        setup() {
+          useForm<Form>({ schema: fakeSchema(defaults) })
+          return () => h(Child)
+        },
+      })
+      const app = createApp(Parent).use(createAttaform())
+      app.mount(document.createElement('div'))
+      expect(captured).toBeNull()
+      const message = String(matchingWarnCalls()[0]?.[0] ?? '')
+      expect(message).toMatch(/no form registered/)
+      expect(message).not.toMatch(/Registered keys:/)
       app.unmount()
     })
 

--- a/test/composables/inject-wizard.test.ts
+++ b/test/composables/inject-wizard.test.ts
@@ -276,6 +276,9 @@ describe('injectWizard — miss modes (keyed warns, ambient silent)', () => {
     expect(warns.length).toBeGreaterThan(0)
     expect(String(warns[0]?.[0] ?? '')).toMatch(/no wizard registered/)
     expect(String(warns[0]?.[0] ?? '')).toMatch(/miss-1-wiz/)
+    expect(String(warns[0]?.[0] ?? '')).toMatch(
+      /not registered until that component's own setup runs/
+    )
   })
 
   it('returns null silently when called with no ancestor wizard', () => {


### PR DESCRIPTION
## Summary

The diagnostics half of #470. A keyed `injectForm` / `injectWizard` miss returned `null` with a bare "no form/wizard registered" warning, which left the reader unable to tell a **typo** from a **real form that just isn't registered from here yet** (the mount-timing trap at the heart of #470). This enriches the keyed-miss dev warning with two parts and brings the two composables back into symmetry.

## What changed

**Available-keys hint on `injectForm`** (closing the asymmetry: `injectWizard` already emitted one). Lists the registry's addressable keys so a typo reads against the real list. Synthetic anonymous keys (the reserved `__atta:` prefix) are filtered out, since they aren't addressable by `injectForm(key)`.

**Mount-timing note on both.** Names the #470 trap directly: a keyed form is reachable from anywhere in the app (the registry is app-level), but only *after* its own setup runs, and a parent's setup runs before its children's. The note points at the fix: lift the `useForm({ key })` call to a common ancestor, or read the form after mount.

Example (typo case, keys present):

```text
[attaform] injectForm: no form registered for key 'cart'. Returning null. Registered keys: 'email', 'profile'. A form created by a child or sibling component is not registered until that component's own setup runs, which happens after this point. Lift its useForm({ key }) call to a common ancestor, or read the form after mount. (pages/checkout.vue:42)
```

When nothing addressable is registered, the `Registered keys:` clause drops out.

## Notes

- **Prod-clean.** The hint assembly lives inside `warnMiss`'s `__DEV__` guard, so `availableKeysHint` and its literals tree-shake out of production.
- **No public API or type change.** Only `warnMiss`'s internal signature moved (one caller). Both public docblocks were refreshed (they described the warning as typo-only).
- **Why no `injectFormOrThrow`.** #470 floated a throwing variant; declined. It is off Attaform's house style (warn-in-dev + safe fallback + `?.`), and it would make the timing case *throw* during a structural refactor instead of degrading to `null` — louder, not safer.

## Still open from #470 (separate, not in this PR)

- A docs page stating the resolution contract explicitly (keyed = position-independent, time-dependent; ambient = descendant-scoped).
- Whether the *ambient* (unkeyed) silent miss should get an opt-in `{ required }` signal — a default-behavior question worth its own thread.

## Testing

- Full `pnpm test`: 4369 passed / 4 skipped
- `pnpm typecheck` and `pnpm lint` clean
- Extended the keyed-miss tests to lock the timing note (both composables); added two `injectForm` tests for the keys hint (lists real keys; filters synthetic-only registries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
