### PR TITLE
docs(inject): document the key resolution contract

### DIFF
--- a/docs/cross-cutting-state/inject-form.md
+++ b/docs/cross-cutting-state/inject-form.md
@@ -90,6 +90,30 @@ Floating save buttons, sidebar status widgets, anything in a different branch of
 
 Pass the same `key` you passed to `useForm({ key: 'signup' })`. If no form is registered under that key when the component mounts, `injectForm` returns `null` and dev mode logs the unresolved key at the call site. Reach for the form with `?.` at every consumption site so a missing form degrades to no-ops instead of crashing. See [When resolution fails](#when-resolution-fails) below.
 
+## How a key resolves
+
+A key is a name, not a location. What `injectForm('signup')` resolves to is fixed by two properties, and it helps to hold both at once.
+
+**It is position-independent.** A keyed form lives in Attaform's app-level registry, not in the component tree. `injectForm('signup')` reaches it from any component in the app: a sibling branch, a floating toolbar, a modal teleported to the document body. Extracting a wrapper or changing how deep a component sits never changes what a key resolves to.
+
+**It is time-dependent.** The registry entry appears when the form's own `useForm({ key: 'signup' })` runs its setup, and not a moment before. So the one thing a key cannot do is hand back a form that has not been created yet.
+
+Together they give a single rule: **resolve downward.** Vue runs a parent's setup before its children's, so:
+
+- A descendant reaching an ancestor's keyed form always resolves. The ancestor's `useForm` ran first, so the entry is already there.
+- An ancestor reaching a descendant's form gets `null`. At the ancestor's setup the descendant has not run, so nothing is registered under that key yet.
+
+Create a form where it is owned, and reach for it at or below that point. If you catch yourself reaching upward, or sideways for a form a sibling creates, that is the cue to lift the `useForm({ key })` up to a common ancestor so the form exists before anyone asks for it.
+
+| Resolution       | Keyed: `injectForm('signup')`                          | Ambient: `injectForm()`                         |
+| ---------------- | ------------------------------------------------------ | ----------------------------------------------- |
+| Resolves through | Attaform's app-level registry                          | Vue `provide` / `inject`                        |
+| Reaches          | any component in the app                               | descendants of the owning `useForm`             |
+| Ready            | once the owner's `useForm({ key })` setup has run      | always, from a descendant (the owner ran first) |
+| On a miss        | `null`, plus a dev warning listing the registered keys | `null`, silently                                |
+
+The dev warning on a keyed miss names this timing case directly and points at the call site, so a form that simply registered late reads differently from a typo.
+
 ## Do I need to pass a `key` to `useForm`?
 
 The two resolution modes are cleanly split:
@@ -146,7 +170,7 @@ Both resolution modes ref-count on the form's registry entry. In practice:
 `injectForm` returns `T | null` rather than throwing, so descendants are robust to mount-order quirks (children rendered before the parent's `useForm` runs, conditional ancestors, dynamic imports). Two cases produce `null`:
 
 - **No ambient form**: `injectForm()` with no ancestor `useForm` and no key. Returns `null` silently. Ambient lookup is opportunistic, so a downstream component library reading the ambient slot stays quiet in trees that don't have a form rather than spamming consumers' consoles.
-- **Key not registered**: `injectForm('key-name')` but nothing is registered under that key. Dev mode logs the unresolved key at the call site.
+- **Key not registered**: `injectForm('key-name')` but nothing is registered under that key. Dev mode logs the unresolved key at the call site. If the form is created lower in the tree, it registers after this call runs; see [How a key resolves](#how-a-key-resolves).
 
 Keep the return as `T | null` and reach for it with `?.` at the consumption sites. The directive accepts `undefined` peacefully, optional chains short-circuit cleanly through reactive reads, and the child still works the moment the form becomes available:
 

--- a/docs/multistep/inject-wizard.md
+++ b/docs/multistep/inject-wizard.md
@@ -115,6 +115,12 @@ Pass the same `key` the parent passed to `useWizard({ key: 'checkout-wizard' })`
 
 `injectWizard` accepts an object form too: `injectWizard({ key: 'checkout-wizard' })`. The positional and object forms are equivalent; pick whichever spreads better into the surrounding setup.
 
+## How a key resolves
+
+`injectWizard('checkout-wizard')` resolves through the same registry that backs `injectForm`, with the same two properties. It is **position-independent** (the handle lives in Attaform's app-level registry, so any component reaches it regardless of branch or depth) and **time-dependent** (the entry appears once the wizard's own `useWizard({ key })` setup has run, and not before). The [How a key resolves](/docs/cross-cutting-state/inject-form#how-a-key-resolves) section on `injectForm` walks the shared mechanism and the resolve-downward rule in full.
+
+One corollary is specific to wizards. The form steps you pass to `useWizard({ steps })` are `useForm` handles, so they follow the same ordering: they have to exist when the wizard's setup runs. A form created inside a step's own child component does not exist yet at that point, which is why the checkout example above creates `shipping` and `payment` in the same component as the `useWizard` call. Create the step forms alongside the wizard, or above it, and the wizard has them the moment it is built.
+
 ## Do I need to pass a `key` to `useWizard`?
 
 The two resolution modes are cleanly split:
@@ -154,7 +160,7 @@ Mixing modes is fine. Keyed wizards don't interfere with an ambient sibling. A p
 `injectWizard` returns `null` rather than throwing, so descendants are robust to mount-order quirks (a sidebar widget that renders before the wizard's parent setup runs, a conditional wizard ancestor, dynamic imports). Two cases produce `null`:
 
 - **No ambient wizard.** `injectWizard()` called from a tree with no ancestor `useWizard` and no key. Returns `null` silently. Ambient lookup is opportunistic, so a floating widget reading the ambient slot stays quiet in trees that don't have a wizard rather than spamming consumers' consoles.
-- **Key not registered.** `injectWizard('checkout-wizard')` called when nothing is registered under that key. Dev mode logs the unresolved key alongside any keys that ARE registered, so a typo surfaces at a glance.
+- **Key not registered.** `injectWizard('checkout-wizard')` called when nothing is registered under that key. Dev mode logs the unresolved key alongside any keys that ARE registered, so a typo surfaces at a glance. If the wizard is created lower in the tree, it registers after this call runs; see [How a key resolves](#how-a-key-resolves).
 
 Guard the return so the consumer disappears cleanly when the wizard isn't mounted:
 


### PR DESCRIPTION
## Summary

Candidate (c) from #470: document the resolution contract that the sharpened keyed-miss warning (shipped in #479) now points at.

Both `injectForm` and `injectWizard` already covered ambient vs keyed resolution and the `null` return. What was missing is the *mechanism*: a key is **position-independent** (it lives in Attaform's app-level registry, reachable from any branch) yet **time-dependent** (the entry appears only once its own `useForm` / `useWizard` setup has run). Those two combine into a single teachable rule, **resolve downward**, which is exactly what the new dev warning tells you when a keyed miss is really a mount-timing issue rather than a typo.

## What changed

- **`injectForm` → new `How a key resolves` section** (the canonical home): the two properties, the resolve-downward rule (a descendant always resolves an ancestor's form; an ancestor gets `null` for a descendant's; lift `useForm({ key })` to a common ancestor if reaching up or sideways), and a keyed-vs-ambient summary table.
- **`injectWizard` → shorter mirror** that links to the injectForm section for the shared mechanism and adds the wizard-specific corollary: the form steps you pass to `useWizard({ steps })` are `useForm` handles, so they must exist when the wizard's setup runs (which is why the checkout example creates its step forms alongside the `useWizard` call).
- Both **"Key not registered"** bullets gained a same-page pointer to the new section.

## Notes

- Docs house style held: no em-dashes, Attaform named, `?.` not `!`, constructive framing.
- Builds on the behavior shipped in #479 (the keyed-miss warning that lists registered keys and flags the timing case).

## Still open from #470 (separate)

- Whether the *ambient* (unkeyed) silent miss should get an opt-in `{ required }` signal, a default-behavior question worth its own thread.

## Testing

- `pnpm build:site`: Nuxt Link Checker 0 failing / 0 errors / 0 warnings across 187 pages, 430 routes prerendered (validates the new cross-page `inject-form#how-a-key-resolves` anchor and both same-page anchors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
