### PR TITLE
feat(wizard): accept null/undefined step slots and slide the pin forward on drop

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -789,7 +789,15 @@ export default [
     // registerValue strip + RegisterValue host delegates + markHostConnected +
     // the directly-bound-container field-state fold). zod-v3.mjs, the tightest
     // adapter bundle, crossed 54. Measured at 54.62 KB.
-    limit: '55 KB',
+    //
+    // Raised 55 → 56 KB on the wizard nullish-steps branch (#467):
+    // use-wizard.ts gains the forward-continuity watch that re-points
+    // activeKey when the active step drops out of the compiled list, plus
+    // the null / undefined slot guards in resolveSlot / resolveSlotResult.
+    // Ships in the shared core reached by every wizard-bearing entry;
+    // zod-v3.mjs, the tightest adapter bundle, crossed 55 first (the other
+    // full entries hold 0.25-0.33 KB headroom). Measured at 55.04 KB.
+    limit: '56 KB',
     gzip: true,
     ignore: ['zod'],
     modifyEsbuildConfig: asEsm,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Added
 
+- **`useWizard({ steps })` accepts `null` and `undefined` as absent steps.** A
+  step slot that is `null` or `undefined`, whether a literal array element or the
+  return of a function or `lazy()` slot, drops out of the compiled list, so a
+  conditional step can read inline as `cond ? form : null` without pre-filtering
+  the array. A form kept behind such a conditional still maps to its key on
+  `wizard.forms`, and a tuple whose steps can all drop keeps `wizard.currentStep`
+  honestly `| undefined`. (#467)
+
 - **`wizard.tryNext()`: validate the active step, then advance only if it
   passes.** Bind it straight to a Next button (`@click="wizard.tryNext()"`) with
   no captured handler: it runs the active step's validation, advances on a clean
@@ -16,6 +24,13 @@
   `wizard.handleSubmit`. (#471)
 
 ### Changed
+
+- **When the active step drops out of a wizard mid-flight, the pin slides forward
+  instead of snapping to the first step.** A function or `lazy()` slot that stops
+  yielding the active step now re-points the wizard at the step that took its
+  place (clamping to the new last step when the dropped one was last), so
+  `wizard.currentStep`, `wizard.activeForm`, and index navigation stay consistent
+  from the new position. (#467)
 
 - **`wizard.handleSubmit` now submits the whole wizard from any step, and
   navigation is its own verb.** One call validates every step's form in

--- a/docs/multistep/step-slots.md
+++ b/docs/multistep/step-slots.md
@@ -11,7 +11,7 @@ metaRows:
     value: '{ key, form }'
     kind: code
   - label: Drop behavior
-    value: 'function slot returns undefined => drop'
+    value: 'null / undefined slot => drop'
     kind: code
 ---
 
@@ -91,9 +91,25 @@ useWizard({ steps: ['welcome', shipping, 'welcome'] }) // duplicate 'welcome'
 
 First occurrence wins. The second dev-warns and drops. The wizard still navigates without crashing.
 
+## Conditional steps
+
+Any position in the array can be `null` or `undefined`, and the wizard drops it from the compiled list. That lets a step appear or disappear on a condition written inline, with no imperative pre-filtering of the array:
+
+```ts
+const wizard = useWizard({
+  steps: [account, needsShipping ? shipping : null, payment, isGuest ? null : 'account-review'],
+})
+```
+
+A literal `null` element evaluates once, when the array is built, so it fits a condition that is fixed for the wizard's life: a plan tier, a feature flag. For a condition that changes as the user works, reach for a [function slot](#function-slots) that returns `null`, so the step's presence tracks the value reactively.
+
+`null` and `undefined` are interchangeable here; both mean "no step." The idiom is `cond ? form : null`, not `cond && form`: a bare `&&` yields `false`, and `false` is not a step (nor is there a step a `true` could stand for), so the wizard accepts only the nullish forms.
+
+A form kept behind a conditional stays fully typed: with `steps: [account, show ? shipping : null]`, `wizard.forms.shipping` still resolves to the concrete `shipping` handle. When every position in the array can drop, `wizard.currentStep` reads as `FormKey | undefined`, since the compiled list might be empty.
+
 ## Function slots
 
-A function that picks one of the three slot kinds at runtime: `(ctx) => Form | string | undefined`. The wizard re-invokes function slots reactively whenever the reads inside them change, so branching logic stays in sync with live form values.
+A function that picks one of the three slot kinds at runtime: `(ctx) => Form | string | null | undefined`. The wizard re-invokes function slots reactively whenever the reads inside them change, so branching logic stays in sync with live form values.
 
 ```ts
 const account = useForm({ schema: accountSchema, key: 'account' })
@@ -113,11 +129,11 @@ When the user picks `'business'` on the account step, the branching slot resolve
 
 ### Return values
 
-| Return           | Result                                                                                                                                                                                       |
-| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| An `AnyForm` ref | The slot compiles to `{ key: form.key, form }`.                                                                                                                                              |
-| A `string` key   | The slot resolves to a noop affordance step under that key. New keys are built on the fly; the same key returned twice reuses the same noop. No pre-declaration needed elsewhere in `steps`. |
-| `undefined`      | The slot is dropped from the compiled list. Useful for "this branch isn't relevant right now"; the step rail shortens accordingly.                                                           |
+| Return               | Result                                                                                                                                                                                       |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| An `AnyForm` ref     | The slot compiles to `{ key: form.key, form }`.                                                                                                                                              |
+| A `string` key       | The slot resolves to a noop affordance step under that key. New keys are built on the fly; the same key returned twice reuses the same noop. No pre-declaration needed elsewhere in `steps`. |
+| `null` / `undefined` | The slot is dropped from the compiled list. Useful for "this branch isn't relevant right now"; the step rail shortens accordingly.                                                           |
 
 ### Reactive re-evaluation
 
@@ -135,7 +151,7 @@ const wizard = useWizard({
 })
 ```
 
-When the user toggles `needsId` off, the middle slot drops. `wizard.count` falls from 3 to 2; `wizard.activeIndex` and `wizard.currentStep` re-anchor; navigation buttons reflect the new positions.
+When the user toggles `needsId` off, the middle slot drops. `wizard.count` falls from 3 to 2, and navigation buttons reflect the new positions. If the wizard was sitting on the dropped step, the pin slides forward to the step that took its slot, clamping to the new last step when the dropped one was last, so `wizard.currentStep` and `wizard.activeForm` stay on a live step instead of snapping back to the first.
 
 ## Lazy slots (`lazy()`)
 
@@ -183,11 +199,11 @@ lazy(() => buildShippingFormForRegion(initialRegion))
 
 ### Resolution semantics
 
-| Return           | Behavior                                                                                                                                                |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| An `AnyForm` ref | The form caches at that position. Subsequent reads reuse it until a tracked dep changes or `reset()` invalidates the cache.                             |
-| A `string` key   | Resolves to a noop affordance step under that key, building one on the fly if needed. Result caches under the same dep-tracking rules as a form return. |
-| `undefined`      | The slot drops from the compiled list. The drop caches; a tracked dep change or `reset()` re-fires the resolver.                                        |
+| Return               | Behavior                                                                                                                                                |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| An `AnyForm` ref     | The form caches at that position. Subsequent reads reuse it until a tracked dep changes or `reset()` invalidates the cache.                             |
+| A `string` key       | Resolves to a noop affordance step under that key, building one on the fly if needed. Result caches under the same dep-tracking rules as a form return. |
+| `null` / `undefined` | The slot drops from the compiled list. The drop caches; a tracked dep change or `reset()` re-fires the resolver.                                        |
 
 Use `lazy()` when the resolution is expensive enough that thrash matters. For everyday branching on live values, plain function slots are simpler. They re-evaluate freely with the compiled list, and the wizard pays no cache-bookkeeping cost.
 
@@ -248,10 +264,11 @@ for (const step of wizard.steps) {
 A few rules govern how the source slot list compiles down to the final step list:
 
 - **Duplicate keys.** Two slots producing the same step key (string slot vs form ref, or two functions returning the same form): first occurrence wins. Later duplicates dev-warn and drop. Keeps `wizard.steps` linearly addressable.
-- **`undefined` from a function slot.** The slot drops; subsequent reads of `wizard.steps` reflect the shortened list. Re-running the slot (a reactive read changed) can reintroduce the position.
-- **`undefined` from a `lazy()` slot.** The slot drops. The drop caches; a tracked-dep change or `reset()` re-fires the resolver, and if it returns `undefined` again, the slot drops again.
+- **Literal `null` / `undefined` element.** Dropped when the array compiles, so a `cond ? form : null` conditional needs no pre-filtering. See [Conditional steps](#conditional-steps).
+- **`null` / `undefined` from a function slot.** The slot drops; subsequent reads of `wizard.steps` reflect the shortened list. Re-running the slot (a reactive read changed) can reintroduce the position. If the dropped slot was the active step, the pin slides forward to the step that took its place.
+- **`null` / `undefined` from a `lazy()` slot.** The slot drops. The drop caches; a tracked-dep change or `reset()` re-fires the resolver, and if it returns nullish again, the slot drops again.
 - **Function or `lazy()` slot returns a new string key.** The wizard builds a noop affordance step on the fly under that key and threads it into the compiled list, the statuses surface, and the rail. The same key returned by a later slot reuses the same noop (first-build wins). No pre-declaration anywhere in `steps` is required.
-- **Empty compiled list.** If every slot drops at runtime, `wizard.currentStep` reads as `undefined`, navigation refuses with a dev-warn, and the surrounding app keeps rendering. See [Degenerate inputs](/docs/multistep/use-wizard#degenerate-inputs).
+- **Empty compiled list.** If every slot drops (including an array that is entirely nullish), `wizard.currentStep` reads as `undefined`, navigation refuses with a dev-warn, and the surrounding app keeps rendering. See [Degenerate inputs](/docs/multistep/use-wizard#degenerate-inputs).
 
 ## Where to next
 

--- a/src/runtime/composables/use-wizard.ts
+++ b/src/runtime/composables/use-wizard.ts
@@ -253,7 +253,7 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
   // The map is keyed by slot index in `rawSteps`; population happens
   // eagerly below so cross-test mounts get fresh per-index closures.
   const lazyEpoch = ref(0)
-  type LazyResult = AnyForm | string | undefined
+  type LazyResult = AnyForm | string | null | undefined
   const lazyComputeds = new Map<number, ComputedRef<LazyResult>>()
 
   // `activeKey` is the canonical source of truth for the active step.
@@ -322,6 +322,9 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
    * function so the steps computed stays readable.
    */
   function resolveSlot(slot: StepSlot, index: number, ctx: WizardCtx): AnyForm | undefined {
+    // A `null` / `undefined` slot (a literal absence in the steps array,
+    // e.g. `cond ? form : null`) drops out of the compiled list.
+    if (slot === undefined || slot === null) return undefined
     if (typeof slot === 'string') {
       // Top-level string slots are pre-built into `noopForms` at
       // construction. The lazy builder hits the cache; the unified
@@ -340,15 +343,15 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
       return c === undefined ? undefined : resolveSlotResult(c.value)
     }
     if (typeof slot === 'function') {
-      const result = (slot as (ctx: WizardCtx) => AnyForm | string | undefined)(ctx)
+      const result = (slot as (ctx: WizardCtx) => AnyForm | string | null | undefined)(ctx)
       return resolveSlotResult(result)
     }
     if (isAnyForm(slot)) return slot
     return undefined
   }
 
-  function resolveSlotResult(result: AnyForm | string | undefined): AnyForm | undefined {
-    if (result === undefined) return undefined
+  function resolveSlotResult(result: AnyForm | string | null | undefined): AnyForm | undefined {
+    if (result === undefined || result === null) return undefined
     if (typeof result === 'string') {
       // Function and lazy slot string returns build a noop on first
       // reference. Subsequent returns of the same string hit the
@@ -425,13 +428,11 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
 
   // `currentStep` and `activeForm` resolve through the same
   // `activeIndex`-aware lookup so they can never disagree on which
-  // step the wizard is on. A function slot that previously
-  // resolved to the active form and now returns `undefined` drops
-  // the matching index to `-1`; both reads then fall back to the
-  // first compiled step uniformly (W-BRITTLE-1). Pre-fix
-  // `currentStep` trusted `activeKey` verbatim and could return the
-  // dropped form's key while `activeForm` fell back to the first
-  // compiled step.
+  // step the wizard is on. The forward-continuity watch below keeps
+  // `activeKey` pointed at a live step, so in steady state
+  // `activeIndex` is in range; the `list[0]` fallback here only covers
+  // the sub-tick before that watch flushes, and the degenerate
+  // empty-key case.
   const currentStep = computed<FormKey | undefined>(() => {
     const list = compiledSteps.value
     const idx = activeIndex.value
@@ -450,6 +451,28 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
     }
     const first = list[0]
     return first === undefined ? undefined : first.form
+  })
+
+  // Forward-continuity guard. When the active step drops out of the
+  // compiled list (a function or lazy slot that used to yield the active
+  // form now returns nullish), re-point `activeKey` at the step that took
+  // its place so the flow continues from there rather than snapping back
+  // to the first step. Clamp to the new last when the dropped step was
+  // last; an emptied wizard falls back to the degenerate empty key.
+  // Re-pinning at the source keeps `activeIndex` / `currentStep` /
+  // `activeForm` and index-based navigation consistent, instead of
+  // leaving `activeKey` stranded on a dead key.
+  watch(compiledSteps, (list, prevList) => {
+    const key = activeKey.value
+    if (key === '') return
+    if (list.some((step) => step.key === key)) return
+    if (list.length === 0) {
+      activeKey.value = ''
+      return
+    }
+    const oldIndex = prevList.findIndex((step) => step.key === key)
+    const slid = list[oldIndex < 0 ? 0 : Math.min(oldIndex, list.length - 1)]
+    if (slid !== undefined) activeKey.value = slid.key
   })
 
   // `wizard.activeForm` returns this single facade (when the wizard is

--- a/src/runtime/core/wizard-lazy.ts
+++ b/src/runtime/core/wizard-lazy.ts
@@ -41,14 +41,14 @@ const LAZY_BRAND = Symbol.for('attaform/wizard-lazy')
  *    this one.
  *  - `wizard.reset()` clears every lazy slot's cache so a reboot truly
  *    resolves from scratch.
- *  - Resolving to `undefined` drops the slot from the compiled list
- *    until the resolver next re-fires.
+ *  - Resolving to `null` or `undefined` drops the slot from the compiled
+ *    list until the resolver next re-fires.
  *
  * The runtime brand returned by `lazy()` is opaque. Use
  * {@link isLazyMarker} to detect it.
  */
 export function lazy<Ctx = WizardCtx>(
-  resolve: (ctx: Ctx) => AnyForm | string | undefined
+  resolve: (ctx: Ctx) => AnyForm | string | null | undefined
 ): LazyMarker<Ctx> {
   return { [LAZY_BRAND]: true, resolve } as unknown as LazyMarker<Ctx>
 }

--- a/src/runtime/types/types-wizard.ts
+++ b/src/runtime/types/types-wizard.ts
@@ -148,27 +148,33 @@ declare const _lazyBrand: unique symbol
  */
 export type LazyMarker<Ctx = WizardCtx> = {
   readonly [_lazyBrand]: true
-  readonly resolve: (ctx: Ctx) => AnyForm | string | undefined
+  readonly resolve: (ctx: Ctx) => AnyForm | string | null | undefined
 }
 
 /**
  * One position in the source `useWizard({ steps })` array. Each slot
- * resolves to a compiled `{ key, form }` step:
+ * resolves to a compiled `{ key, form }` step, or drops out:
  *
  *  - `AnyForm`         — a form declared via `useForm`. Surfaced as-is.
  *  - `string`          — bare key. The wizard generates a noop form
  *                        under the hood so the external surface stays
  *                        uniform across affordance positions (intro,
  *                        terms, congratulations, review surfaces).
+ *  - `null` / `undefined` — a literal absence, dropped from the compiled
+ *                        list. Lets a conditional step read inline as
+ *                        `cond ? form : null` without pre-filtering the
+ *                        array.
  *  - function          — eager slot, re-evaluates reactively. Returns
- *                        one of the above, or `undefined` to drop the
- *                        slot from the compiled list.
+ *                        one of the above, or `null` / `undefined` to
+ *                        drop the slot from the compiled list.
  *  - `LazyMarker`      — memoized function slot (see `lazy`).
  */
 export type StepSlot<Ctx = WizardCtx> =
   | AnyForm
   | string
-  | ((ctx: Ctx) => AnyForm | string | undefined)
+  | null
+  | undefined
+  | ((ctx: Ctx) => AnyForm | string | null | undefined)
   | LazyMarker<Ctx>
 
 /**
@@ -327,25 +333,41 @@ export type WizardOptions = {
 }
 
 /**
+ * True when a single slot is guaranteed to contribute exactly one
+ * compiled step: a bare form or affordance string that is neither
+ * nullish nor a (maybe-absent) function / `lazy()` slot. One of these
+ * anywhere in the tuple proves the compiled list is non-empty.
+ */
+type IsGuaranteedStep<T> = [null] extends [T]
+  ? false
+  : [undefined] extends [T]
+    ? false
+    : T extends LazyMarker | ((...args: unknown[]) => unknown)
+      ? false
+      : T extends string
+        ? true
+        : T extends { readonly key: string }
+          ? true
+          : false
+
+/**
  * Predicate: is the steps tuple statically guaranteed to compile to a
- * non-empty list? A tuple passes when (a) it's not the empty array
- * literal and (b) it carries no function or `lazy()` slot — those
- * slot kinds can resolve to `undefined` at runtime and drop the
- * compiled position. Form slots and bare-string affordance slots
- * always preserve their position; a tuple made of only those kinds is
- * statically safe.
+ * non-empty list? True when at least one element is a guaranteed step
+ * (see `IsGuaranteedStep`). Function / `lazy()` slots may resolve to
+ * nothing, and `null` / `undefined` (a literal absence or a
+ * `cond ? form : null` union) is an explicit drop, so none of those
+ * prove non-emptiness; a tuple of only maybe-absent slots stays
+ * honestly `| undefined`.
  *
  * Used to narrow `currentStep` / `activeForm` to their non-`undefined`
  * shapes in the common-case wizard, while keeping the honest union
  * everywhere a runtime drop is reachable.
  */
-export type StaticallyNonEmpty<S> = S extends readonly []
-  ? false
-  : S extends readonly (infer Item)[]
-    ? Item extends LazyMarker | ((...args: unknown[]) => unknown)
-      ? false
-      : true
-    : false
+export type StaticallyNonEmpty<S> = S extends readonly [infer First, ...infer Rest]
+  ? IsGuaranteedStep<First> extends true
+    ? true
+    : StaticallyNonEmpty<Rest>
+  : false
 
 /** Active step's key, narrowed to `string` when `S` is statically safe. */
 export type CurrentStepOf<S> = StaticallyNonEmpty<S> extends true ? FormKey : FormKey | undefined
@@ -365,6 +387,21 @@ export type ActiveFormOf<S> =
     : UseFormReturnType<GenericForm> | undefined
 
 /**
+ * Per-slot contribution to {@link FormsRecordOf}. Strips a `null` /
+ * `undefined` (a literal absence or a `cond ? form : null` union) off the
+ * slot first, so a conditionally-present form still maps to its key and
+ * stays concretely typed on `wizard.forms`; a purely nullish slot
+ * contributes nothing.
+ */
+type SlotRecord<First, F = Exclude<First, null | undefined>> = [F] extends [never]
+  ? unknown
+  : F extends string
+    ? { readonly [P in F]: AnyForm }
+    : F extends { readonly key: infer K extends string }
+      ? { readonly [P in K]: F }
+      : unknown
+
+/**
  * Recursive tuple walk that builds the static portion of
  * `wizard.forms`. Each step slot contributes to the record:
  *
@@ -375,7 +412,9 @@ export type ActiveFormOf<S> =
  *    the form's own `key` becomes the record key, and the value is
  *    the concrete form handle type — so drilling
  *    `wizard.forms.shipping.values.address` carries the schema-derived
- *    field types through.
+ *    field types through. A form kept behind a `cond ? form : null`
+ *    conditional still maps to its key.
+ *  - **`null` / `undefined` slot**: contributes nothing.
  *  - **Function / `lazy()` slot**: contributes nothing to the static
  *    map. Runtime-resolved forms are still reachable via the
  *    catch-all index signature on `WizardForms` (typed as `AnyForm`).
@@ -387,12 +426,7 @@ export type FormsRecordOf<S> = S extends readonly [
   infer First,
   ...infer Rest extends ReadonlyArray<StepSlot>,
 ]
-  ? (First extends string
-      ? { readonly [P in First]: AnyForm }
-      : First extends { readonly key: infer K extends string }
-        ? { readonly [P in K]: First }
-        : unknown) &
-      FormsRecordOf<Rest>
+  ? SlotRecord<First> & FormsRecordOf<Rest>
   : unknown
 
 /**

--- a/test/composables/wizard-active-step-reconciliation.test.ts
+++ b/test/composables/wizard-active-step-reconciliation.test.ts
@@ -7,15 +7,15 @@ import { useWizard } from '../../src/runtime/composables/use-wizard'
 import { createAttaform } from '../../src/runtime/core/plugin'
 
 /**
- * COMP-W5 / W-BRITTLE-1: when the active step's slot becomes
- * un-resolvable mid-flight (a function slot that previously returned
- * a form now returns `undefined`), `wizard.currentStep` and
- * `wizard.activeForm` must agree on the same step. Pre-fix they
- * could disagree — `currentStep` trusted `activeKey` verbatim and
- * returned the dropped form's key, while `activeForm` fell back to
- * the first compiled step. The fix routes `currentStep` through
- * the same `activeIndex`-aware fallback so both reads stay in
- * lockstep.
+ * COMP-W5 / forward-continuity: when the active step's slot becomes
+ * un-resolvable mid-flight (a function or lazy slot that previously
+ * returned a form now returns nullish), the wizard re-points the pin at
+ * the step that took the dropped slot's place rather than snapping back
+ * to the first step, and `wizard.currentStep` / `wizard.activeForm` stay
+ * in lockstep. Earlier the reads fell back to the first compiled step
+ * (the "W-BRITTLE-1" behavior); the pin is now re-anchored at its source
+ * via a watch on the compiled list, so index-based navigation stays
+ * consistent from the new position too.
  */
 
 const schema = z.object({ email: z.string().optional() })
@@ -35,13 +35,13 @@ function mountHarness<R>(setup: () => R): { app: App; result: R } {
   return { app, result: handle.result as R }
 }
 
-describe('useWizard — currentStep / activeForm reconciliation (W-BRITTLE-1)', () => {
+describe('useWizard — active-step forward-continuity when a slot drops', () => {
   const apps: App[] = []
   afterEach(() => {
     while (apps.length > 0) apps.pop()?.unmount()
   })
 
-  it('agrees on the fallback step when the active slot drops mid-flight', async () => {
+  it('slides the pin forward to the step that took the dropped slot', async () => {
     const showMiddle = ref(true)
     const { app, result } = mountHarness(() => {
       const entry = useForm({ schema, key: 'w-brittle-entry' })
@@ -70,12 +70,12 @@ describe('useWizard — currentStep / activeForm reconciliation (W-BRITTLE-1)', 
     await nextTick()
 
     // The compiled list contracts to [entry, final]. The active key
-    // ('w-brittle-middle') is no longer in the list, so both reads
-    // must agree on the fallback (the first compiled step).
+    // ('w-brittle-middle') is gone, so the pin slides forward to the
+    // step that took its slot ('w-brittle-final') rather than snapping
+    // back to the first step. currentStep and activeForm stay in lockstep.
     expect(result.steps.map((s) => s.key)).toEqual(['w-brittle-entry', 'w-brittle-final'])
-    expect(result.activeForm?.key).toBe('w-brittle-entry')
-    // Pre-fix: returned 'w-brittle-middle' (stale activeKey).
-    // Post-fix: returns 'w-brittle-entry' (matches activeForm).
+    expect(result.activeForm?.key).toBe('w-brittle-final')
+    expect(result.currentStep).toBe('w-brittle-final')
     expect(result.currentStep).toBe(result.activeForm?.key)
   })
 

--- a/test/composables/wizard-nullish-steps.test.ts
+++ b/test/composables/wizard-nullish-steps.test.ts
@@ -1,0 +1,172 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, nextTick, ref, type App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { useWizard } from '../../src/runtime/composables/use-wizard'
+import { lazy } from '../../src/runtime/core/wizard-lazy'
+import { createAttaform } from '../../src/runtime/core/plugin'
+
+/**
+ * Issue #467: `useWizard({ steps })` accepts `null`, `undefined`, and
+ * function / lazy slots that resolve to them, all treated as "no step
+ * here" and filtered out of the compiled list. Conditional steps read
+ * inline as `cond ? form : null` without pre-filtering the array. When a
+ * function slot flips its active step to nullish mid-flight, the pin
+ * slides forward to the step that took its place.
+ */
+
+const schema = z.object({ email: z.string().optional() })
+
+function mountHarness<R>(setup: () => R): { app: App; result: R } {
+  const handle: { result?: R } = {}
+  const App = defineComponent({
+    setup() {
+      handle.result = setup()
+      return () => h('div')
+    },
+  })
+  const app = createApp(App).use(createAttaform())
+  app.config.warnHandler = () => {}
+  app.config.errorHandler = () => {}
+  app.mount(document.createElement('div'))
+  return { app, result: handle.result as R }
+}
+
+describe('useWizard — nullish step slots (#467)', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+  })
+
+  it('filters literal null and undefined array elements', () => {
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema, key: 'nz-a' })
+      const b = useForm({ schema, key: 'nz-b' })
+      return useWizard({
+        steps: [a, null, 'affordance', undefined, b],
+        restore: false,
+        persist: false,
+      })
+    })
+    apps.push(app)
+    expect(result.steps.map((s) => s.key)).toEqual(['nz-a', 'affordance', 'nz-b'])
+    expect(result.count).toBe(3)
+    expect(result.currentStep).toBe('nz-a')
+  })
+
+  it('filters a function slot that returns null, at parity with undefined', () => {
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema, key: 'nz-fn-a' })
+      const b = useForm({ schema, key: 'nz-fn-b' })
+      return useWizard({
+        steps: [a, () => null, () => undefined, b],
+        restore: false,
+        persist: false,
+      })
+    })
+    apps.push(app)
+    expect(result.steps.map((s) => s.key)).toEqual(['nz-fn-a', 'nz-fn-b'])
+  })
+
+  it('filters a lazy slot that resolves to null', () => {
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema, key: 'nz-lazy-a' })
+      const b = useForm({ schema, key: 'nz-lazy-b' })
+      return useWizard({
+        steps: [a, lazy(() => null), b],
+        restore: false,
+        persist: false,
+      })
+    })
+    apps.push(app)
+    expect(result.steps.map((s) => s.key)).toEqual(['nz-lazy-a', 'nz-lazy-b'])
+  })
+
+  it('compiles an all-nullish steps list to a degenerate empty wizard without throwing', () => {
+    const { app, result } = mountHarness(() =>
+      useWizard({ steps: [null, undefined, () => null], restore: false, persist: false })
+    )
+    apps.push(app)
+    expect(result.steps).toEqual([])
+    expect(result.count).toBe(0)
+    expect(result.currentStep).toBeUndefined()
+    expect(result.activeForm).toBeUndefined()
+  })
+
+  it('reactively adds and drops a step as a function slot flips between form and null', async () => {
+    const show = ref(false)
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema, key: 'nz-react-a' })
+      const opt = useForm({ schema, key: 'nz-react-opt' })
+      const b = useForm({ schema, key: 'nz-react-b' })
+      return useWizard({
+        steps: [a, () => (show.value ? opt : null), b],
+        restore: false,
+        persist: false,
+      })
+    })
+    apps.push(app)
+    expect(result.steps.map((s) => s.key)).toEqual(['nz-react-a', 'nz-react-b'])
+    show.value = true
+    await nextTick()
+    expect(result.steps.map((s) => s.key)).toEqual(['nz-react-a', 'nz-react-opt', 'nz-react-b'])
+    show.value = false
+    await nextTick()
+    expect(result.steps.map((s) => s.key)).toEqual(['nz-react-a', 'nz-react-b'])
+  })
+
+  it('slides the pin forward when the active step flips to null', async () => {
+    const showMiddle = ref(true)
+    const { app, result } = mountHarness(() => {
+      const entry = useForm({ schema, key: 'nz-slide-entry' })
+      const middle = useForm({ schema, key: 'nz-slide-middle' })
+      const final = useForm({ schema, key: 'nz-slide-final' })
+      return useWizard({
+        steps: [entry, () => (showMiddle.value ? middle : null), final],
+        restore: false,
+        persist: false,
+      })
+    })
+    apps.push(app)
+    await result.next()
+    expect(result.currentStep).toBe('nz-slide-middle')
+
+    showMiddle.value = false
+    await nextTick()
+
+    // The dropped 'middle' slot's place is taken by 'final'; the pin
+    // slides there rather than snapping to the first step.
+    expect(result.steps.map((s) => s.key)).toEqual(['nz-slide-entry', 'nz-slide-final'])
+    expect(result.currentStep).toBe('nz-slide-final')
+    expect(result.activeForm?.key).toBe('nz-slide-final')
+
+    // Navigation stays consistent from the re-pinned position.
+    result.back()
+    expect(result.currentStep).toBe('nz-slide-entry')
+  })
+
+  it('clamps to the new last step when the dropped active step was last', async () => {
+    const showLast = ref(true)
+    const { app, result } = mountHarness(() => {
+      const a = useForm({ schema, key: 'nz-last-a' })
+      const b = useForm({ schema, key: 'nz-last-b' })
+      const last = useForm({ schema, key: 'nz-last-c' })
+      return useWizard({
+        steps: [a, b, () => (showLast.value ? last : null)],
+        restore: false,
+        persist: false,
+      })
+    })
+    apps.push(app)
+    await result.next()
+    await result.next()
+    expect(result.currentStep).toBe('nz-last-c')
+
+    showLast.value = false
+    await nextTick()
+
+    expect(result.steps.map((s) => s.key)).toEqual(['nz-last-a', 'nz-last-b'])
+    expect(result.currentStep).toBe('nz-last-b')
+  })
+})

--- a/tests/fixtures/bundled-types/mixed-wizard.ts
+++ b/tests/fixtures/bundled-types/mixed-wizard.ts
@@ -150,3 +150,42 @@ function _neverInvoked() {
   void [steps, active]
 }
 void _neverInvoked
+
+// Issue #467: null / undefined step slots (literal, and function / lazy
+// returns) are accepted and filtered. A form kept behind a
+// `cond ? form : null` conditional still maps to its concrete key on
+// `wizard.forms`; a tuple whose sole slot can drop keeps `currentStep`
+// honestly `| undefined`.
+function _neverInvokedNullishSteps() {
+  const login = useForm({ schema: loginSchema, key: 'login' as const })
+  const profile = useForm({ schema: profileSchema, key: 'profile' as const })
+  const confirm = useForm({ schema: confirmSchema, key: 'confirm' as const })
+  const gate = true as boolean
+
+  const wizard = useWizard({
+    steps: [
+      'welcome',
+      login,
+      gate ? profile : null,
+      null,
+      undefined,
+      (ctx) => (ctx.currentKey === 'login' ? confirm : null),
+      lazy(() => (gate ? confirm : undefined)),
+    ],
+  })
+
+  // The conditionally-present form still carries its concrete key + type.
+  const profileHandle = wizard.forms.profile
+  const bio: string = profileHandle.values.bio
+  void [profileHandle, bio]
+
+  // A tuple whose only slot can drop keeps `currentStep` honestly
+  // `FormKey | undefined`, not narrowed to a bare key.
+  const maybeEmpty = useWizard({ steps: [gate ? login : null] })
+  const maybeAt: string | undefined = maybeEmpty.currentStep
+  // @ts-expect-error currentStep is `FormKey | undefined` here, so it is
+  // not assignable to a bare `string`.
+  const mustBeString: string = maybeEmpty.currentStep
+  void [maybeAt, mustBeString]
+}
+void _neverInvokedNullishSteps


### PR DESCRIPTION
## Summary

Closes #467. `useWizard({ steps })` now accepts `null` and `undefined` as absent steps, so a conditional step reads inline as `cond ? form : null` instead of forcing a pre-filtered array. As a coupled fix, when the active step drops out mid-flight the pin slides forward to the step that took its place rather than snapping back to the first step.

## What changed

**Nullish steps.** A step slot that is `null` or `undefined`, whether a literal array element or the return of a function or `lazy()` slot, drops out of the compiled list. Function / lazy slots that returned `undefined` were already filtered; this extends the same treatment to `null` (previously a `() => null` was mistaken for a form) and to literal array elements. We deliberately hold the line at nullish: `false` is not accepted, since there is no coherent meaning for `true` as a step, so `cond && form` stays a type error and conditional steps use `cond ? form : null`.

**Types.** `StepSlot` accepts nullish elements and the function / lazy return widens to include `null`; `FormsRecordOf` strips nullish so a form kept behind a `cond ? form : null` conditional still maps to its concrete key on `wizard.forms`; and `StaticallyNonEmpty` goes conservative on nullish, so a tuple whose steps can all drop keeps `wizard.currentStep` honestly `| undefined`.

**Forward-continuity on drop (the pin fix).** Previously, when a function / lazy slot stopped yielding the active step, `activeKey` was left pointing at the dead key and the `currentStep` / `activeForm` reads fell back to the first step, which also left `activeIndex` at `-1` so `next()` / `back()` misbehaved. Now a watch on the compiled list re-points `activeKey` at the step that took the dropped slot's place (clamping to the new last when the dropped step was last), fixing it at the source so `currentStep`, `activeForm`, and index-based navigation all stay consistent from the new position.

**Docs.** The `step-slots` page gains a "Conditional steps" section (the `cond ? form : null` idiom and why `cond && form` is rejected), the function / lazy drop language and tables widen to `null`, and the forward-continuity behavior is described where slots drop.

## Testing

- New `wizard-nullish-steps.test.ts`: literal null/undefined filtering, `() => null` and `lazy(() => null)` filtering, all-nullish degenerate wizard, reactive add/drop, forward-slide, and last-step clamp.
- Updated `wizard-active-step-reconciliation.test.ts` to the forward-continuity behavior.
- `mixed-wizard.ts` bundled-types fixture: nullish elements accepted, `cond ? form : null` still types `wizard.forms`, and a droppable-only tuple keeps `currentStep` as `| undefined`.
- Full `pnpm test` (4376 passed / 4 skipped), `pnpm typecheck`, `pnpm lint`, `pnpm check:bundled-types` (v3 + v4), and `pnpm build:site` (link-checker 0 errors / 0 warnings) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
