### PR TITLE
feat(demos): persist playground edits on-device with reset + clear-all

### DIFF
--- a/apps/site/components/demo/DemoRepl.vue
+++ b/apps/site/components/demo/DemoRepl.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+  import { HardDrive, RotateCcw } from 'lucide-vue-next'
+
   // SSR-safe shell for the homepage + /demos interactive REPL.
   //
   // Two responsibilities:
@@ -39,9 +41,26 @@
       // (scoped to that wrapper, see scripts/demo-styles/codegen.mjs) applies.
       // Undefined for the default shipment demo, which is self-styled.
       scopeSlug?: string
+      // Stable key this playground persists edits under (#469). Forwarded
+      // to `<DemoReplEditor>`; when set, the editor restores saved files
+      // on mount, auto-saves on edit, and this shell shows the
+      // "saved on this device" strip + Reset control below the editor.
+      persistKey?: string
     }>(),
     { height: '37.5rem' }
   )
+
+  // Whether the editor's buffer diverges from the shipped seed. Driven by
+  // the editor's `update:dirty`; gates the Reset control in the strip.
+  const dirty = ref(false)
+  // Handle on the client-only editor so the strip's Reset button can call
+  // its exposed `reset()`. Populated once the editor mounts, which is
+  // strictly before `dirty` can turn true, so it's never null when Reset
+  // is visible.
+  const editor = useTemplateRef<{ reset: () => void }>('editor')
+  function handleReset() {
+    editor.value?.reset()
+  }
 
   const showEditor = ref(false)
   onMounted(async () => {
@@ -126,10 +145,46 @@
            hydration, so its Sandbox iframe installs into a settled DOM. -->
       <DemoReplEditor
         v-if="showEditor"
+        ref="editor"
         :initial-source="props.initialSource"
         :initial-files="props.initialFiles"
         :scope-slug="props.scopeSlug"
+        :persist-key="props.persistKey"
+        @update:dirty="dirty = $event"
       />
+    </div>
+
+    <!-- Persistence strip (#469). A sibling of the top hint so it's
+         SSR-rendered at a fixed height: no layout shift when the editor
+         swaps in, nor when its dirty state flips. Present only when this
+         playground persists (has a `persistKey`). Spells out that edits
+         are kept on the reader's own device, offers a Reset back to the
+         shipped source, and points at the Demos page to clear them all. -->
+    <div
+      v-if="props.persistKey"
+      class="flex shrink-0 items-center justify-between gap-3 border-t border-border bg-surface/60 px-3 py-1.5 text-xs text-fg-subtle"
+    >
+      <p class="flex min-w-0 items-center gap-1.5">
+        <HardDrive class="h-3.5 w-3.5 shrink-0" :stroke-width="2" aria-hidden="true" />
+        <span v-if="dirty" class="truncate">
+          Saved on this device. Clear everything from the
+          <NuxtLink
+            to="/demos"
+            class="text-fg-muted underline decoration-border-strong underline-offset-2 transition-colors hover:text-fg"
+            >Demos page</NuxtLink
+          >.
+        </span>
+        <span v-else class="truncate">Your edits save on this device as you type.</span>
+      </p>
+      <button
+        v-if="dirty"
+        type="button"
+        class="inline-flex shrink-0 items-center gap-1.5 rounded-md px-2 py-1 font-medium text-fg-muted transition-colors duration-(--duration-fast) hover:bg-surface hover:text-fg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg-subtle"
+        @click="handleReset"
+      >
+        <RotateCcw class="h-3.5 w-3.5" :stroke-width="2" aria-hidden="true" />
+        Reset demo
+      </button>
     </div>
   </div>
 </template>

--- a/apps/site/components/demo/DemoReplEditor.client.vue
+++ b/apps/site/components/demo/DemoReplEditor.client.vue
@@ -34,6 +34,10 @@
     vRegisterHintTransform,
   } from 'attaform/transforms'
 
+  // On-device persistence for the reader's edits (#469). A refresh or an
+  // accidental swipe-back would otherwise discard whatever they'd typed.
+  import { getDemoFiles, setDemoFiles, deleteDemoFiles } from '~/utils/playgroundStorage'
+
   const props = withDefaults(
     defineProps<{
       initialSource?: string
@@ -45,9 +49,19 @@
       // root with `demo-<slug>` so the demo's wrapper-scoped stylesheet applies
       // (see scopeClassCode below). Undefined for the self-styled default.
       scopeSlug?: string
+      // Stable key this playground persists its edits under (#469). When
+      // set, the editor restores saved files from IndexedDB on mount and
+      // auto-saves on edit; when absent, the playground stays seed-once and
+      // ephemeral (the original behaviour).
+      persistKey?: string
     }>(),
     { initialSource: () => shipmentDemoSource }
   )
+
+  // Announce whether the live buffer diverges from the shipped seed. The
+  // parent `<DemoRepl>` shell uses it to show the "saved on this device"
+  // strip and gate the Reset control.
+  const emit = defineEmits<{ 'update:dirty': [boolean] }>()
 
   // Sizing + lifecycle (SSR skeleton, deferred mount, route-leave
   // guard) live on the parent `<DemoRepl>` shell. This component is
@@ -779,6 +793,53 @@ declare module '@primeuix/themes/aura';
     }
   }
 
+  // Two key namespaces are in play, and conflating them is a bug.
+  // @vue/repl stores files under `src/`-prefixed names internally
+  // (`store.files`, and the maps we hand to `setFiles` / `reseedFiles`),
+  // but `store.getFiles()` returns them with the `src/` prefix STRIPPED
+  // (`src/App.vue` → `App.vue`, `src/playground-globals.d.ts` →
+  // `playground-globals.d.ts`). `tsconfig.json` / `import-map.json` carry
+  // no prefix in either space. So the persistence layer, which reads and
+  // compares through `getFiles()`, must work in the stripped space, while
+  // `reseedFiles` (which mutates `store.files`) works in the internal one.
+  //
+  // Files @vue/repl needs but the reader never edits: the hidden globals
+  // declaration, the Volar tsconfig, and @vue/repl's own import-map file.
+  // They seed fresh on every mount, so they're excluded from persistence
+  // (see playgroundStorage.ts), from the dirty comparison, and from Reset.
+  function stripSrcPrefix(name: string): string {
+    return name.replace(/^src\//, '')
+  }
+  const PROTECTED_INTERNAL: ReadonlySet<string> = new Set([
+    'src/playground-globals.d.ts',
+    'tsconfig.json',
+    'import-map.json',
+  ])
+  // The same set as `getFiles()` names them (derived, so it can't drift).
+  const PROTECTED_STRIPPED: ReadonlySet<string> = new Set(
+    Array.from(PROTECTED_INTERNAL, stripSrcPrefix)
+  )
+  // Return the subset of a filename→code map whose names pass `keep`.
+  function filterFiles(
+    files: Record<string, string>,
+    keep: (name: string) => boolean
+  ): Record<string, string> {
+    const out: Record<string, string> = {}
+    for (const [name, code] of Object.entries(files)) {
+      if (keep(name)) out[name] = code
+    }
+    return out
+  }
+  // Shallow value-equality of two filename→code maps.
+  function filesShallowEqual(a: Record<string, string>, b: Record<string, string>): boolean {
+    const aKeys = Object.keys(a)
+    if (aKeys.length !== Object.keys(b).length) return false
+    for (const key of aKeys) {
+      if (a[key] !== b[key]) return false
+    }
+    return true
+  }
+
   // Seed the store. `initialFiles` (a multi-file map) wins over
   // `initialSource` (the single-file shorthand). Both routes always
   // augment with `src/playground-globals.d.ts` (the toast + `*.css`
@@ -790,16 +851,110 @@ declare module '@primeuix/themes/aura';
     'src/playground-globals.d.ts': TOAST_AMBIENT_DTS + ASSET_AMBIENT_DTS + THIRD_PARTY_AMBIENT_DTS,
     'tsconfig.json': JSON.stringify(replTsConfig, null, 2),
   }
+  // The shipped seed's editable files in STRIPPED space, so it compares
+  // byte-for-byte against `currentUserFiles()` (also stripped). `File`
+  // stores `code` verbatim, so stripping the seed's keys reproduces
+  // exactly what `getFiles()` reports for an untouched seed: at rest the
+  // two are equal, so nothing is ever persisted for a demo just viewed.
+  const seedUserFiles = filterFiles(
+    Object.fromEntries(
+      Object.entries(seedFiles).map(([name, code]) => [stripSrcPrefix(name), code])
+    ),
+    (name) => !PROTECTED_STRIPPED.has(name)
+  )
+  // The protected seed files in INTERNAL space, merged fresh on restore.
+  const protectedSeedFiles = filterFiles(seedFiles, (name) => PROTECTED_INTERNAL.has(name))
+
+  // The reader-editable files as `getFiles()` reports them (stripped),
+  // protected files removed.
+  function currentUserFiles(): Record<string, string> {
+    return filterFiles(store.getFiles(), (name) => !PROTECTED_STRIPPED.has(name))
+  }
+  // True while the live buffer diverges from the shipped seed. Emitted up
+  // to the shell, which shows the "saved on this device" strip + Reset.
+  const dirty = ref(false)
+  watch(dirty, (value) => emit('update:dirty', value))
+  function syncDirtyState() {
+    dirty.value = !filesShallowEqual(currentUserFiles(), seedUserFiles)
+  }
+
   // Flips true once the initial async setFiles has landed. Guards the
-  // dev-only re-seed below from racing the bootstrap (the comment near
-  // TOAST_AMBIENT_DTS above documents how interleaved mutations get
-  // discarded by an in-flight setFiles overwrite).
+  // persistence + dev re-seed watchers from racing the bootstrap (the
+  // comment near TOAST_AMBIENT_DTS above documents how interleaved
+  // mutations get discarded by an in-flight setFiles overwrite).
   const initialSeedReady = ref(false)
-  void store.setFiles(seedFiles, 'src/App.vue').then(() => {
+  // Bootstrap. When this mount owns a persistence key and IndexedDB holds
+  // saved edits for it, hydrate with those instead of the shipped source
+  // (protected files still come fresh); otherwise seed the original.
+  // Either path is a single setFiles, so the editor compiles once with no
+  // restore flash. Saved edits win over a changed seed by design: the
+  // point is to never lose the reader's work, and Reset returns them to
+  // whatever the current shipped source is.
+  async function bootstrap() {
+    let filesToSeed = seedFiles
+    if (props.persistKey) {
+      const saved = await getDemoFiles(props.persistKey)
+      if (saved) {
+        // `saved` is stripped-space user files. Drop any protected name
+        // defensively (a stale entry can't smuggle globals back in), then
+        // merge the fresh protected seed; setFiles re-adds the `src/`
+        // prefix to the stripped user keys.
+        const savedUser = filterFiles(saved, (name) => !PROTECTED_STRIPPED.has(name))
+        filesToSeed = { ...savedUser, ...protectedSeedFiles }
+      }
+    }
+    await store.setFiles(filesToSeed, 'src/App.vue')
     const dts = store.files['src/playground-globals.d.ts']
     if (dts) dts.hidden = true
+    syncDirtyState()
     initialSeedReady.value = true
+  }
+  void bootstrap()
+
+  // Auto-save. On every edit past the seed, recompute dirty state and,
+  // debounced, persist the editable files. When the buffer matches the
+  // shipped seed again (a hand-revert, or Reset), drop the entry so a
+  // clean demo leaves the "clear all" tally.
+  const PERSIST_DEBOUNCE_MS = 400
+  let persistTimer: ReturnType<typeof setTimeout> | null = null
+  function flushPersist() {
+    const key = props.persistKey
+    if (!key) return
+    const userFiles = currentUserFiles()
+    if (filesShallowEqual(userFiles, seedUserFiles)) void deleteDemoFiles(key)
+    else void setDemoFiles(key, userFiles)
+  }
+  watch(
+    () => store.files,
+    () => {
+      syncDirtyState()
+      if (!initialSeedReady.value || !props.persistKey) return
+      if (persistTimer) clearTimeout(persistTimer)
+      persistTimer = setTimeout(() => {
+        persistTimer = null
+        flushPersist()
+      }, PERSIST_DEBOUNCE_MS)
+    },
+    { deep: true }
+  )
+  onBeforeUnmount(() => {
+    // Flush a pending debounce so edits from the last few hundred ms
+    // before a navigation aren't lost.
+    if (persistTimer === null) return
+    clearTimeout(persistTimer)
+    persistTimer = null
+    flushPersist()
   })
+
+  // Reset the editor to the shipped source and forget the saved copy.
+  // Routes through reseedFiles (the same in-place diff HMR uses) so
+  // Monaco keeps cursor / scroll / undo instead of flashing a remount.
+  function reset() {
+    reseedFiles(store, seedFiles, PROTECTED_INTERNAL)
+    if (props.persistKey) void deleteDemoFiles(props.persistKey)
+    syncDirtyState()
+  }
+  defineExpose({ reset })
 
   // Dev-only HMR-driven re-seed.
   //
@@ -817,11 +972,6 @@ declare module '@primeuix/themes/aura';
   // future runtime prop change (e.g. a route-param-driven slug) wipe a
   // reader's in-REPL edits. Production behaviour stays seed-once.
   if (import.meta.dev) {
-    const PROTECTED_FILENAMES: ReadonlySet<string> = new Set([
-      'src/playground-globals.d.ts',
-      'tsconfig.json',
-      'import-map.json',
-    ])
     watch(
       () => {
         if (props.initialFiles !== undefined) return props.initialFiles
@@ -830,7 +980,7 @@ declare module '@primeuix/themes/aura';
       },
       (next) => {
         if (!initialSeedReady.value || next === undefined) return
-        reseedFiles(store, next, PROTECTED_FILENAMES)
+        reseedFiles(store, next, PROTECTED_INTERNAL)
       },
       { deep: true }
     )
@@ -860,12 +1010,13 @@ declare module '@primeuix/themes/aura';
   const pendingDelete = ref<string | null>(null)
   // Whether the user has opted out of the confirmation prompt by
   // checking "Don't ask again" on a previous deletion. Persisted in
-  // sessionStorage rather than localStorage on purpose: the
-  // playground itself is ephemeral (files live in @vue/repl's
-  // in-memory store; close the tab and they're gone), so the opt-out
-  // preference shouldn't outlive the data it gates. Closing the tab
-  // resets to "always ask" — the natural opt-back-in path. Matches
-  // the checkbox label ("for the rest of this session") literally.
+  // sessionStorage, not localStorage, on purpose: the "stop asking me"
+  // consent is a lightweight per-visit convenience, not a durable
+  // preference, so it resets to "always ask" when the tab closes (the
+  // natural opt-back-in path). It's independent of the source buffer,
+  // which DOES persist across visits on the reader's device (see
+  // playgroundStorage.ts). Matches the checkbox label ("for the rest of
+  // this session") literally.
   const SKIP_CONFIRM_KEY = 'attaform-playground-skip-delete-confirm'
   function hasSkipConsent(): boolean {
     try {
@@ -1094,8 +1245,8 @@ declare module '@primeuix/themes/aura';
         <div class="m-4 w-full max-w-sm rounded-lg border border-border bg-bg p-6 shadow-lg">
           <h2 id="repl-delete-title" class="text-lg font-semibold text-fg"> Delete file? </h2>
           <p class="mt-3 text-sm text-fg-muted">
-            <UiInlineCode>{{ pendingDelete }}</UiInlineCode> will be removed from this playground
-            session. The deletion is local to your tab and won't affect anything else.
+            <UiInlineCode>{{ pendingDelete }}</UiInlineCode> will be removed from this playground.
+            Your edits save on this device, so use Reset to bring the original files back.
           </p>
           <label
             class="mt-5 flex cursor-pointer items-center gap-2 text-sm text-fg-muted select-none"

--- a/apps/site/pages/demos/[slug].vue
+++ b/apps/site/pages/demos/[slug].vue
@@ -142,8 +142,9 @@
             <h1 class="mt-3 text-display-md font-semibold text-fg">{{ title }}</h1>
             <p class="mt-4 text-sm text-fg-muted">
               Editing <UiInlineCode>apps/site/docs-demos/{{ sourceLabel }}</UiInlineCode
-              >. The playground is a self-contained sandbox: source edits and form state stay local
-              to this tab so you can experiment freely.
+              >. The playground runs in your browser and saves your source edits on this device, so
+              a refresh or a stray back-swipe won't lose your work. Use Reset below the editor to
+              restore the original.
             </p>
           </div>
           <div class="flex items-center gap-3 text-sm">
@@ -164,7 +165,12 @@
           </div>
         </div>
 
-        <DemoRepl height="calc(100vh - 16rem)" :initial-files="replFiles" :scope-slug="slug" />
+        <DemoRepl
+          height="calc(100vh - 16rem)"
+          :initial-files="replFiles"
+          :scope-slug="slug"
+          :persist-key="`demo:${slug}`"
+        />
       </div>
     </UiContainer>
   </div>

--- a/apps/site/pages/demos/blank.vue
+++ b/apps/site/pages/demos/blank.vue
@@ -49,7 +49,11 @@
             <NuxtLink to="/demos" class="text-accent hover:underline">all demos</NuxtLink>.
           </p>
         </div>
-        <DemoRepl height="calc(100vh - 20rem)" :initial-source="blankStarterSource" />
+        <DemoRepl
+          height="calc(100vh - 20rem)"
+          :initial-source="blankStarterSource"
+          persist-key="blank"
+        />
       </div>
     </UiContainer>
   </div>

--- a/apps/site/pages/demos/index.vue
+++ b/apps/site/pages/demos/index.vue
@@ -7,8 +7,10 @@
   // Discovery is glob-driven, so authoring a new SFC under
   // `docs-demos/` automatically surfaces it here on the next build —
   // no per-demo wiring required.
-  import { computed, ref, watch } from 'vue'
-  import { ArrowRight, FlaskConical, Rocket, Search, X } from 'lucide-vue-next'
+  import { computed, onMounted, ref, watch } from 'vue'
+  import { ArrowRight, Eraser, FlaskConical, HardDrive, Rocket, Search, X } from 'lucide-vue-next'
+  import { toast } from 'vue-sonner'
+  import { clearAllDemoFiles, listDemoKeys } from '~/utils/playgroundStorage'
 
   // Inherits the docs shell (sidebar + header + footer) so a reader
   // browsing playgrounds isn't stranded in a sidebar-less layout. The
@@ -98,6 +100,29 @@
     if (n < 1 || n > totalPages.value) return
     currentPage.value = n
   }
+
+  // Saved-code manager (#469). Every editable playground keeps a reader's
+  // edits on their own device (IndexedDB, via playgroundStorage.ts), so a
+  // refresh or a stray back-swipe never loses their work. This page is
+  // the one place to wipe them all at once. `savedCount` reads the live
+  // tally on mount; the clear runs behind a two-step confirm so a stray
+  // click can't erase everything.
+  const savedCount = ref(0)
+  const confirming = ref(false)
+  onMounted(async () => {
+    savedCount.value = (await listDemoKeys()).length
+  })
+  async function clearAllSaved() {
+    const cleared = savedCount.value
+    await clearAllDemoFiles()
+    savedCount.value = 0
+    confirming.value = false
+    toast.success(
+      cleared === 1
+        ? 'Cleared saved code from 1 demo.'
+        : `Cleared saved code from ${cleared} demos.`
+    )
+  }
 </script>
 
 <template>
@@ -140,6 +165,59 @@
         :stroke-width="2.25"
       />
     </NuxtLink>
+
+    <!-- Saved-code manager (#469). Explains the on-device storage model
+         and, when anything is saved, offers the one global "clear all"
+         across every playground. The destructive clear hides behind a
+         two-step confirm, matching the editor's own delete flow. -->
+    <div
+      class="mb-8 flex flex-col gap-3 rounded-xl border border-border bg-surface/30 p-4 sm:flex-row sm:items-center sm:justify-between"
+    >
+      <p class="flex items-start gap-2 text-sm text-fg-muted">
+        <HardDrive
+          class="mt-0.5 h-4 w-4 shrink-0 text-fg-subtle"
+          :stroke-width="2"
+          aria-hidden="true"
+        />
+        <span>
+          Every playground saves your edits in this browser via
+          <UiInlineCode>IndexedDB</UiInlineCode>, so a refresh or a stray back-swipe never loses
+          your work.
+          <template v-if="savedCount > 0">
+            {{ savedCount }} demo{{ savedCount === 1 ? '' : 's' }} on this device
+            {{ savedCount === 1 ? 'has' : 'have' }} saved changes.
+          </template>
+        </span>
+      </p>
+      <div v-if="savedCount > 0" class="flex shrink-0 items-center gap-2">
+        <button
+          v-if="!confirming"
+          type="button"
+          class="inline-flex items-center gap-1.5 rounded-md border border-border-strong bg-bg px-3 py-1.5 text-sm font-medium text-fg shadow-xs transition-[background-color] hover:bg-surface focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg-subtle"
+          @click="confirming = true"
+        >
+          <Eraser class="h-3.5 w-3.5" :stroke-width="2" aria-hidden="true" />
+          Clear saved code
+        </button>
+        <template v-else>
+          <span class="text-sm text-fg-muted">Clear all {{ savedCount }}?</span>
+          <button
+            type="button"
+            class="rounded-md border border-border-strong bg-bg px-3 py-1.5 text-sm font-medium text-fg shadow-xs transition-[background-color] hover:bg-surface focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg-subtle"
+            @click="confirming = false"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            class="rounded-md bg-danger px-3 py-1.5 text-sm font-medium text-white shadow-xs transition-[background-color] hover:bg-error-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg-subtle"
+            @click="clearAllSaved"
+          >
+            Clear
+          </button>
+        </template>
+      </div>
+    </div>
 
     <!-- Search + per-page controls. Stacked on mobile, two-up on sm+.
          Sticky just under AppHeader (which is h-16) so the filter stays

--- a/apps/site/pages/demos/shipment.vue
+++ b/apps/site/pages/demos/shipment.vue
@@ -50,7 +50,11 @@
             <NuxtLink to="/demos" class="text-accent hover:underline">all demos</NuxtLink>.
           </p>
         </div>
-        <DemoRepl height="calc(100vh - 20rem)" :initial-source="shipmentDemoSource" />
+        <DemoRepl
+          height="calc(100vh - 20rem)"
+          :initial-source="shipmentDemoSource"
+          persist-key="shipment"
+        />
       </div>
     </UiContainer>
   </div>

--- a/apps/site/pages/index.vue
+++ b/apps/site/pages/index.vue
@@ -536,7 +536,7 @@
               <ExternalLink class="h-3.5 w-3.5" :stroke-width="2" />
             </NuxtLink>
           </div>
-          <DemoRepl height="37.5rem" />
+          <DemoRepl height="37.5rem" persist-key="home" />
         </div>
       </UiContainer>
     </section>

--- a/apps/site/utils/playgroundStorage.ts
+++ b/apps/site/utils/playgroundStorage.ts
@@ -1,0 +1,116 @@
+// On-device persistence for the interactive playground editors (#469).
+//
+// Every editable demo (the homepage hero, /demos/blank, /demos/shipment,
+// and each /demos/<slug>) writes its edited files here, so a refresh or
+// an accidental swipe-back no longer discards a reader's work. State
+// lives in IndexedDB on the reader's own device: it never leaves the
+// browser, it's scoped to this origin, and it's clearable per-demo (the
+// Reset control in the editor) or all at once (the demos index page).
+//
+// IndexedDB over localStorage on purpose: writes land off the main
+// thread, so saving on each keystroke never janks the editor, and the
+// quota comfortably holds many multi-file demos. Every call is wrapped
+// so a blocked store (private-mode Safari, disabled storage, a failed
+// upgrade) degrades to a no-op instead of throwing into the editor,
+// matching the best-effort contract the rest of the demo surface keeps.
+
+const DB_NAME = 'attaform-playground'
+const STORE_NAME = 'demos'
+const DB_VERSION = 1
+
+// One persisted demo buffer. `files` holds the user-editable files only:
+// the hidden playground-globals.d.ts and tsconfig.json seed fresh on
+// every mount, so they never round-trip through storage. `savedAt` is a
+// millisecond timestamp kept for future housekeeping and display.
+export interface StoredDemo {
+  files: Record<string, string>
+  savedAt: number
+}
+
+// The open request is shared across calls: the database opens once per
+// page and every read/write reuses the resolved connection. Resolves to
+// null (never rejects) when IndexedDB is unavailable or the open fails.
+let dbPromise: Promise<IDBDatabase | null> | null = null
+
+function openDb(): Promise<IDBDatabase | null> {
+  if (dbPromise) return dbPromise
+  dbPromise = new Promise<IDBDatabase | null>((resolve) => {
+    try {
+      if (typeof indexedDB === 'undefined') {
+        resolve(null)
+        return
+      }
+      const request = indexedDB.open(DB_NAME, DB_VERSION)
+      request.onupgradeneeded = () => {
+        const db = request.result
+        if (!db.objectStoreNames.contains(STORE_NAME)) {
+          db.createObjectStore(STORE_NAME)
+        }
+      }
+      request.onsuccess = () => resolve(request.result)
+      request.onerror = () => resolve(null)
+    } catch {
+      resolve(null)
+    }
+  })
+  return dbPromise
+}
+
+// Run one request inside a transaction, resolving to its result or to
+// null on any failure. `mode` is 'readonly' for gets, 'readwrite' for
+// puts/deletes/clears.
+function runRequest<T>(
+  mode: IDBTransactionMode,
+  build: (store: IDBObjectStore) => IDBRequest<T>
+): Promise<T | null> {
+  return openDb().then(
+    (db) =>
+      new Promise<T | null>((resolve) => {
+        if (!db) {
+          resolve(null)
+          return
+        }
+        try {
+          const request = build(db.transaction(STORE_NAME, mode).objectStore(STORE_NAME))
+          request.onsuccess = () => resolve(request.result)
+          request.onerror = () => resolve(null)
+        } catch {
+          resolve(null)
+        }
+      })
+  )
+}
+
+// The saved user files for `key`, or null when nothing is stored (or
+// storage is unavailable).
+export function getDemoFiles(key: string): Promise<Record<string, string> | null> {
+  return runRequest<StoredDemo | undefined>('readonly', (store) => store.get(key)).then((result) =>
+    result && result.files ? result.files : null
+  )
+}
+
+// Persist `files` under `key`, stamping the save time. Overwrites any
+// existing entry for that key.
+export function setDemoFiles(key: string, files: Record<string, string>): Promise<void> {
+  const record: StoredDemo = { files, savedAt: Date.now() }
+  return runRequest('readwrite', (store) => store.put(record, key)).then(() => undefined)
+}
+
+// Drop the entry for one demo. Used when a reader hits Reset or hand-
+// reverts a demo back to its shipped source.
+export function deleteDemoFiles(key: string): Promise<void> {
+  return runRequest('readwrite', (store) => store.delete(key)).then(() => undefined)
+}
+
+// Every key that currently holds saved edits. Backs the count shown by
+// the demos-index "clear all" control.
+export function listDemoKeys(): Promise<string[]> {
+  return runRequest<IDBValidKey[]>('readonly', (store) => store.getAllKeys()).then((keys) =>
+    Array.isArray(keys) ? keys.filter((key): key is string => typeof key === 'string') : []
+  )
+}
+
+// Wipe every saved demo across the whole playground.
+export function clearAllDemoFiles(): Promise<void> {
+  return runRequest('readwrite', (store) => store.clear()).then(() => undefined)
+}


### PR DESCRIPTION
Closes #469.

Editable playgrounds lost the reader's work on a refresh or an accidental back-swipe. This makes every editor hold its code state on the reader's own device.

## What changed

- **`utils/playgroundStorage.ts`** — a hand-rolled IndexedDB wrapper (zero new deps). Every call degrades to a no-op when storage is blocked (private-mode Safari, disabled storage), never throwing into the editor.
- **`DemoReplEditor.client.vue`** — restores saved files before the seed (one `setFiles`, no restore flash), debounced auto-save on edit, dirty tracking, and a `reset()` that routes through the in-place reseed so Monaco keeps cursor / scroll / undo. Reverting to the shipped source drops the saved entry, so a hand-reverted demo leaves the tally on its own.
- **`DemoRepl.vue`** — an SSR-reserved footer strip (no layout shift) explaining edits are kept on-device; when dirty it offers **Reset demo** and a pointer to the demos page.
- **Four mount sites** keyed distinctly: `home`, `blank`, `shipment`, `demo:<slug>`.
- **`/demos` index** — a global **Clear saved code** control behind a two-step confirm, a live count of demos with saved edits, and a note naming IndexedDB.
- Reconciled the now-inaccurate "ephemeral / tab-local" copy on the `[slug]` page and the editor's delete dialog.

## The subtle bit

`store.getFiles()` returns filenames with the `src/` prefix **stripped**, while `reseedFiles` works on the internal prefixed names. The compare/persist layer runs in the stripped space; the two protected-file sets are derived from one another so they can't drift. Without that split, the baseline never matched `getFiles()` output, so every editor persisted a phantom edit the instant it mounted and could never revert to clean.

## Verification

- Site typecheck (vue-tsc), eslint, prettier: **pass**
- Full `nuxi build` + prerender + `nuxt-link-checker`: **0 broken links / 187 pages, 430 routes**
- Demo-tracking smoke test: **pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
