### PR TITLE
fix(focus): target blank required fields on invalid submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,19 @@
   statically known. It is no longer identity-equal to the raw per-step handle;
   reach for `wizard.forms[key]` when you need that exact object. (#471)
 
+### Fixed
+
+- **A required field left blank now takes focus on an invalid submit, the same
+  as any field with a schema error.** Attaform's focus-and-scroll-to-error walk
+  (the `onInvalidSubmit` policy, plus `form.focusFirstError()` and
+  `form.scrollToFirstError()`) consulted only the schema and user error
+  channels, so a required field failing purely because it was left blank was
+  passed over: a form submitted empty moved focus nowhere, and a blank field
+  sitting above an invalid one was skipped. The walk now routes through the same
+  merged error read that `form.errors` and `field.errors` already use, so the
+  first field a reader needs to fill, in document order, is exactly where focus
+  and scroll land. Both zod v3 and zod v4. (#468)
+
 ## v0.24.4
 ### Added
 

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -3944,10 +3944,15 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
       if (!entry.element.isConnected) continue
       if (entry.element.offsetParent === null) continue
 
-      const { key } = canonicalizePath(entry.path)
-      const hasSchemaErr = (schemaErrors.get(key)?.length ?? 0) > 0
-      const hasUserErr = (userErrors.get(key)?.length ?? 0) > 0
-      if (!hasSchemaErr && !hasUserErr) continue
+      // Route through the canonical merged read so focus / scroll target
+      // exactly the paths that surface an error in `form.errors` /
+      // `field.errors`. The blank-required class lives only in
+      // `derivedBlankErrors` (never `schemaErrors`), so consulting the
+      // schema / user stores alone silently skipped the first empty
+      // required field — the very class this policy exists to jump to
+      // (#468). `getErrorsForPath` folds in all three channels, keeping the
+      // focus target and the visible error set from ever drifting apart.
+      if (getErrorsForPath(entry.path).length === 0) continue
 
       return { path: entry.path, element: entry.element }
     }

--- a/test/composables/focus-scroll.test.ts
+++ b/test/composables/focus-scroll.test.ts
@@ -1,8 +1,11 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, nextTick, ref } from 'vue'
+import { z } from 'zod'
 import { useForm } from '../../src'
+import { unset, useForm as useZodForm, type UseFormReturn } from '../../src/zod'
 import { injectForm } from '../../src/runtime/composables/use-form-context'
+import { AttaformErrorCode } from '../../src/runtime/core/error-codes'
 import type { Path } from '../../src/runtime/core/paths'
 import { createAttaform } from '../../src/runtime/core/plugin'
 import { fakeSchema } from '../utils/fake-schema'
@@ -17,10 +20,12 @@ const defaults: Form = { email: '', password: '', nickname: '' }
 /**
  * The focus/scroll helpers operate on the DOM elements registered via
  * v-register. This suite mounts a real tree against jsdom so
- * registerElement sees actual HTMLElements; the helpers walk
- * schemaErrors → userErrors → state.elements to pick the first visible,
- * connected target. Schema errors take focus priority over user errors
- * at the same path (matches the merged-read iteration order).
+ * registerElement sees actual HTMLElements; the helpers walk every
+ * registered element in DOM order and pick the first visible, connected
+ * one whose merged error set is non-empty. "Merged" spans all three error
+ * channels via `getErrorsForPath` (schema refinement + blank-required +
+ * user), so a field that fails only because it's blank and required is as
+ * valid a target as a refinement failure — see the #468 block at the end.
  */
 
 function mountWith(options: {
@@ -836,6 +841,203 @@ describe('focusFirstError — instanceId inheritance through injectForm', () => 
     expect(handles.grandparent!.focusFirstError()).toBe(false)
     expect(focusSpy).not.toHaveBeenCalled()
 
+    app.unmount()
+  })
+})
+
+// --- Blank-required fields are focus / scroll targets (issue #468) ---
+//
+// The blank-required error class (a required leaf left absent / `unset`)
+// lives ONLY in `derivedBlankErrors`, never `schemaErrors` or `userErrors`.
+// `getFirstErrorElement` used to consult just the schema / user stores, so
+// it silently skipped blank required fields — the first empty field on a
+// submit never received focus. These cases use a real Zod schema because
+// the blank class is schema-driven (`isRequiredAtPath` + numeric
+// auto-mark), mirroring the issue repro where `age: z.number()` is
+// submitted blank.
+
+function mountApp(component: Parameters<typeof createApp>[0]): {
+  app: ReturnType<typeof createApp>
+  root: HTMLDivElement
+} {
+  const app = createApp(component).use(createAttaform())
+  const root = document.createElement('div')
+  document.body.appendChild(root)
+  app.mount(root)
+  return { app, root }
+}
+
+// An <input> wired to a RegisterValue through the same manual
+// registerElement path v-register drives, tagged with a data-field so
+// assertions can name the focused / scrolled element.
+function registeredInput(
+  reg: { registerElement: (el: HTMLElement) => void } | undefined,
+  field: string,
+  hide = false
+): ReturnType<typeof h> {
+  return h('input', {
+    'data-field': field,
+    style: hide ? 'display:none' : '',
+    ref: (el: unknown) => {
+      if (el instanceof HTMLInputElement && reg) reg.registerElement(el)
+    },
+  })
+}
+
+describe('getFirstErrorElement — blank-required fields (issue #468)', () => {
+  let focusSpy: ReturnType<typeof vi.spyOn>
+  let scrollSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    if (typeof HTMLElement.prototype.scrollIntoView !== 'function') {
+      HTMLElement.prototype.scrollIntoView = function scrollIntoView() {
+        return undefined
+      }
+    }
+    focusSpy = vi.spyOn(HTMLElement.prototype, 'focus')
+    scrollSpy = vi.spyOn(HTMLElement.prototype, 'scrollIntoView')
+    Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+      configurable: true,
+      get(this: HTMLElement) {
+        return this.style.display === 'none' ? null : this.parentNode
+      },
+    })
+  })
+
+  afterEach(() => {
+    focusSpy.mockRestore()
+    scrollSpy.mockRestore()
+  })
+
+  it('focus-first-error focuses a required field whose only error is blank', async () => {
+    // `age: z.number()` auto-marks blank at mount (storage 0 vs empty DOM
+    // string diverge) → a derived blank-required error, no schema error.
+    const schema = z.object({ age: z.number() })
+    const handle: { api?: UseFormReturn<typeof schema> } = {}
+    const App = defineComponent({
+      setup() {
+        handle.api = useZodForm({ schema, key: 'blank-focus-age' })
+        return () => h('form', [registeredInput(handle.api?.register('age'), 'age')])
+      },
+    })
+    const { app } = mountApp(App)
+
+    // Guard: this really is the blank-required class, not a schema error.
+    expect(handle.api?.errors.age?.[0]?.code).toBe(AttaformErrorCode.NoValueSupplied)
+
+    await handle.api!.handleSubmit(async () => {})()
+    expect(focusSpy).toHaveBeenCalledWith({ focusVisible: true })
+    const focused = focusSpy.mock.instances.at(-1) as HTMLInputElement | undefined
+    expect(focused?.getAttribute('data-field')).toBe('age')
+    app.unmount()
+  })
+
+  it('imperative focusFirstError() targets the blank field (derived at mount, no submit)', () => {
+    const schema = z.object({ age: z.number() })
+    const handle: { api?: UseFormReturn<typeof schema> } = {}
+    const App = defineComponent({
+      setup() {
+        handle.api = useZodForm({ schema, key: 'blank-imperative-focus' })
+        return () => h('form', [registeredInput(handle.api?.register('age'), 'age')])
+      },
+    })
+    const { app } = mountApp(App)
+
+    // No submit — the blank error is a pure function of state, present the
+    // moment the form mounts.
+    expect(handle.api!.focusFirstError()).toBe(true)
+    const focused = focusSpy.mock.instances.at(-1) as HTMLInputElement | undefined
+    expect(focused?.getAttribute('data-field')).toBe('age')
+    app.unmount()
+  })
+
+  it('imperative scrollToFirstError() targets the blank field', () => {
+    const schema = z.object({ age: z.number() })
+    const handle: { api?: UseFormReturn<typeof schema> } = {}
+    const App = defineComponent({
+      setup() {
+        handle.api = useZodForm({ schema, key: 'blank-imperative-scroll' })
+        return () => h('form', [registeredInput(handle.api?.register('age'), 'age')])
+      },
+    })
+    const { app } = mountApp(App)
+
+    expect(handle.api!.scrollToFirstError()).toBe(true)
+    const scrolled = scrollSpy.mock.instances.at(-1) as HTMLInputElement | undefined
+    expect(scrolled?.getAttribute('data-field')).toBe('age')
+    app.unmount()
+  })
+
+  it("policy 'both' scrolls then focuses the blank field", async () => {
+    const schema = z.object({ age: z.number() })
+    const handle: { api?: UseFormReturn<typeof schema> } = {}
+    const App = defineComponent({
+      setup() {
+        handle.api = useZodForm({ schema, key: 'blank-both', onInvalidSubmit: 'both' })
+        return () => h('form', [registeredInput(handle.api?.register('age'), 'age')])
+      },
+    })
+    const { app } = mountApp(App)
+
+    await handle.api!.handleSubmit(async () => {})()
+    expect(scrollSpy).toHaveBeenCalled()
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true, focusVisible: true })
+    const scrolled = scrollSpy.mock.instances.at(-1) as HTMLInputElement | undefined
+    const focused = focusSpy.mock.instances.at(-1) as HTMLInputElement | undefined
+    expect(scrolled?.getAttribute('data-field')).toBe('age')
+    expect(focused?.getAttribute('data-field')).toBe('age')
+    app.unmount()
+  })
+
+  it('a blank field preceding a schema-errored field wins by DOM order', async () => {
+    // `age` (blank-required, derived) renders first; `name` (schema
+    // refinement `.min(1)` on '') second. Pre-fix the picker skipped the
+    // blank `age` and mistakenly focused `name`; post-fix DOM order wins.
+    const schema = z.object({ age: z.number(), name: z.string().min(1, 'required') })
+    const handle: { api?: UseFormReturn<typeof schema> } = {}
+    const App = defineComponent({
+      setup() {
+        handle.api = useZodForm({ schema, key: 'blank-dom-order' })
+        return () =>
+          h('form', [
+            registeredInput(handle.api?.register('age'), 'age'),
+            registeredInput(handle.api?.register('name'), 'name'),
+          ])
+      },
+    })
+    const { app } = mountApp(App)
+
+    // Both channels are populated: derived blank on `age`, schema on `name`.
+    expect(handle.api?.errors.age?.[0]?.code).toBe(AttaformErrorCode.NoValueSupplied)
+    expect(handle.api?.errors.name?.[0]?.message).toBe('required')
+
+    await handle.api!.handleSubmit(async () => {})()
+    const focused = focusSpy.mock.instances.at(-1) as HTMLInputElement | undefined
+    expect(focused?.getAttribute('data-field')).toBe('age')
+    app.unmount()
+  })
+
+  it('generalizes past numerics: an explicit `unset` string field is a target', async () => {
+    // Proves the fix is not tied to numeric auto-mark: any blank + required
+    // leaf qualifies. A string opts into blank via `unset`.
+    const schema = z.object({ note: z.string() })
+    const handle: { api?: UseFormReturn<typeof schema> } = {}
+    const App = defineComponent({
+      setup() {
+        handle.api = useZodForm({
+          schema,
+          key: 'blank-unset-string',
+          defaultValues: { note: unset },
+        })
+        return () => h('form', [registeredInput(handle.api?.register('note'), 'note')])
+      },
+    })
+    const { app } = mountApp(App)
+
+    expect(handle.api?.errors.note?.[0]?.code).toBe(AttaformErrorCode.NoValueSupplied)
+    await handle.api!.handleSubmit(async () => {})()
+    const focused = focusSpy.mock.instances.at(-1) as HTMLInputElement | undefined
+    expect(focused?.getAttribute('data-field')).toBe('note')
     app.unmount()
   })
 })


### PR DESCRIPTION
Closes #468.

A required field left blank never took focus on an invalid submit. A form submitted empty moved focus nowhere; a blank field sitting above an invalid one was skipped, so focus landed on the wrong field.

## Root cause

Attaform keeps errors in three stores: `schemaErrors` (refinement), `derivedBlankErrors` (the blank-and-required class, a reactive computed off `blankPaths` × `isRequiredAtPath`), and `userErrors` (`setErrors`). The merged read `getErrorsForPath` folds all three, and `form.errors` / `field.errors` / `meta.valid` all consult it.

But `getFirstErrorElement` — the picker behind the `onInvalidSubmit` policy, `form.focusFirstError()`, and `form.scrollToFirstError()` — hand-checked only `schemaErrors` + `userErrors`. A field failing purely because it was blank-and-required has its error only in `derivedBlankErrors`, so the picker skipped it even though the UI showed the error.

## The fix

`getFirstErrorElement` now routes through `getErrorsForPath`:

```ts
if (getErrorsForPath(entry.path).length === 0) continue
```

The focus target is now defined as exactly the paths that surface an error everywhere else, so the two can't drift again. It's the single choke point behind all three entry points, so one change fixes the policy and both imperative methods.

Every other error reader (`meta.valid`, `FieldState`, `form.errors`) already counted the blank channel — the picker was the sole straggler.

## Tests

Six regression cases in `focus-scroll.test.ts` over a real Zod schema (mirroring the issue repro):

- `focus-first-error` focuses a field whose only error is blank
- imperative `focusFirstError()` / `scrollToFirstError()` target it (derived at mount, no submit)
- the `both` policy scrolls then focuses it
- **DOM order wins** when a blank field precedes a schema-errored one
- an `unset` string field is a target too (the fix is not numeric-specific)

All six fail without the change (confirmed by reverting the one-line fix).

## Verification

- Full suite: **344 files, 4382 passed / 4 pre-existing skips**
- `pnpm typecheck`: clean · eslint + prettier: clean
- `CHANGELOG.md`: `### Fixed` entry under Unreleased; behavior holds on zod v3 and v4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
