### PR TITLE
feat(v-register): warn on a redundant binding beside v-register (#464)

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -282,7 +282,11 @@ export default [
     // create-form-store's markHostConnected, the RegisterValue host delegates,
     // and the directly-bound-container own-record field-state fold all ship in
     // the shared eager core. Measured at 44.28 KB.
-    limit: '45 KB',
+    //
+    // Raised 45 -> 46 KB tracking the #464 redundant-binding guard: the
+    // directive's eager `warnRedundantStateBinding` dev-warn lands in the
+    // shared core this bundle ships. Measured at 44.94 KB.
+    limit: '46 KB',
     gzip: true,
     modifyEsbuildConfig: asEsm,
   },
@@ -459,7 +463,10 @@ export default [
     // registerValue strip + RegisterValue host delegates + markHostConnected +
     // the directly-bound-container field-state fold). The unified entry bundles
     // both adapters, so it absorbs the full delta. Measured at 59.31 KB.
-    limit: '60 KB',
+    //
+    // Raised 60 -> 61 KB tracking the #464 redundant-binding guard's eager
+    // dev-warn in the shared core. Measured at 59.97 KB.
+    limit: '61 KB',
     gzip: true,
     ignore: ['zod'],
     modifyEsbuildConfig: asEsm,
@@ -591,7 +598,10 @@ export default [
     // bump (same shared core chunk: directive component-host branch +
     // registerValue strip + RegisterValue host delegates + markHostConnected +
     // the directly-bound-container field-state fold). Measured at 53.26 KB.
-    limit: '54 KB',
+    //
+    // Raised 54 -> 55 KB tracking the #464 redundant-binding guard's eager
+    // dev-warn in the shared core. Measured at 53.92 KB.
+    limit: '55 KB',
     gzip: true,
     ignore: ['zod'],
     modifyEsbuildConfig: asEsm,
@@ -976,7 +986,18 @@ export default [
     // not a tree-shake leak. zod-v3.mjs is the tightest { useForm } tripwire,
     // so it bound first; v4's still has ~0.5 KB headroom (46.46 KB) and the
     // full entries are under cap. Measured at 48.01 KB.
-    limit: '49 KB',
+    //
+    // Raised 49 -> 50 KB tracking the #464 redundant-binding guard: the
+    // directive's `created` hook gains `warnRedundantStateBinding` (the
+    // dev-only runtime warn that flags a redundant `:value` / `:checked` /
+    // `v-model` beside v-register), its module-level dedupe Set, and the
+    // `V_REGISTER_COMPILED_MODIFIER` read. All `__DEV__`-gated, so a
+    // consumer's production build folds it out; this tripwire defines no
+    // `process.env.NODE_ENV`, so it measures the raw dist and moves in
+    // lockstep like the branch above -- a legitimate feature addition, not a
+    // tree-shake leak. zod-v3.mjs stays the tightest { useForm } tripwire, so
+    // it bound first. Measured at 49.03 KB.
+    limit: '50 KB',
     gzip: true,
     ignore: ['zod'],
     modifyEsbuildConfig: asEsm,
@@ -993,7 +1014,11 @@ export default [
     // Raised 23 → 24 KB tracking the v-register third-party-component branch:
     // the directive's component-host branch + the registerValue strip ship in
     // the shared core that injectForm reaches too. Measured at 23.51 KB.
-    limit: '24 KB',
+    //
+    // Raised 24 -> 25 KB tracking the #464 redundant-binding guard: the
+    // eager dev-warn ships in the shared core injectForm reaches too.
+    // Measured at 23.98 KB.
+    limit: '25 KB',
     gzip: true,
     ignore: ['zod'],
     modifyEsbuildConfig: asEsm,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Added
 
+- **A redundant state binding beside `v-register` now warns.** `v-register` already
+  drives a field's value, so a co-located `:value` / `v-model` (on a text input or
+  `<select>`), `:checked` (on a checkbox or radio), or `:selected` (on an `<option>`) is
+  redundant, and the two can fight over the DOM. Attaform now flags it in two places: a
+  dev-console warning in every app, and a build-time warning on every compile, including
+  CI, when you run the Vite or Nuxt plugin, so a bespoke lint for it can retire. The
+  `:value` that gives a radio or an `<option>` its identity is expected and stays silent.
+  Warnings only, never a failed build; zero new dependencies. (#464)
+
 - **`useWizard({ steps })` accepts `null` and `undefined` as absent steps.** A
   step slot that is `null` or `undefined`, whether a literal array element or the
   return of a function or `lazy()` slot, drops out of the compiled list, so a

--- a/docs/binding-inputs/v-register.md
+++ b/docs/binding-inputs/v-register.md
@@ -37,6 +37,34 @@ The directive runs four pieces of plumbing for you:
 3. **Coerces** the DOM string to the schema's leaf type: `type="number"` inputs land in storage as a number, checkboxes as a boolean, radio groups pick the option `value`.
 4. **Tracks** field state (`touched`, `focused`, `blurred`, `blank`) and surfaces it through `form.fields.<path>`.
 
+## Let `v-register` own the value
+
+Because the directive already reads and writes the field's value, a second binding for the same value is redundant, and the two can end up fighting over the DOM. Leave off `:value` or `v-model` on a text input or `<select>`, `:checked` on a checkbox or radio, and `:selected` on an `<option>`:
+
+```vue
+<!-- Redundant: v-register already drives the value -->
+<input v-register="form.register('email')" :value="form.values.email" />
+
+<!-- Correct: v-register owns it -->
+<input v-register="form.register('email')" />
+```
+
+The one `:value` that stays is an identity rather than state: the value a radio or an `<option>` stands for. Attaform reads that to decide which option is selected, so keep it.
+
+```vue
+<label v-for="flavor in flavors" :key="flavor">
+  <input type="radio" v-register="form.register('flavor')" :value="flavor" />
+  {{ flavor }}
+</label>
+```
+
+Two guards keep this right without you thinking about it:
+
+- A dev-console warning in every app, the moment the field mounts.
+- A build-time warning when you run Attaform's [Vite or Nuxt plugin](/docs/server-and-ssr/ssr-bare-vue), on every compile, so CI catches it too.
+
+Each names the offending attribute and leaves the radio and `<option>` identity `:value` alone.
+
 ## Auto-installed
 
 `createAttaform()` registers the directive globally, in bare Vue and in Nuxt. You don't import it.

--- a/docs/devtools-and-debugging/troubleshooting.md
+++ b/docs/devtools-and-debugging/troubleshooting.md
@@ -61,6 +61,19 @@ The fix: call `useRegister()` in the child's setup and re-bind `v-register` onto
 
 The dev-mode console warning `v-register on <div> is a no-op …` points here.
 
+## "Console warns that a `:value` / `:checked` is redundant beside v-register"
+
+`v-register` already drives the field's value, so a co-located `:value` / `v-model` (text or `<select>`), `:checked` (checkbox or radio), or `:selected` (`<option>`) is redundant, and the two can fight over the DOM. Drop the extra binding and keep `v-register` alone:
+
+```vue
+<!-- Before -->
+<input v-register="form.register('email')" :value="form.values.email" />
+<!-- After -->
+<input v-register="form.register('email')" />
+```
+
+A `:value` that gives a radio or an `<option>` its identity is expected and never flagged. The warning fires in the dev console for every app, and at build time (including CI) when you run Attaform's [Vite or Nuxt plugin](/docs/server-and-ssr/ssr-bare-vue). See [Let v-register own the value](/docs/binding-inputs/v-register#let-v-register-own-the-value) for the full rundown.
+
 ## "Submit fails with 'No value supplied' on a field the user can leave blank"
 
 The path is in the form's `blankPaths` set and bound to a required schema. Three resolutions:

--- a/src/runtime/core/directive.ts
+++ b/src/runtime/core/directive.ts
@@ -23,6 +23,7 @@ import {
   isTransforming,
   REGISTER_OWNER_MARKER,
   SSR_COMPONENT_HOST_MODIFIER,
+  V_REGISTER_COMPILED_MODIFIER,
   V_REGISTER_MARKER,
 } from './register-protocol'
 import { __DEV__ } from './dev'
@@ -1040,6 +1041,18 @@ const warnedUnsupportedElements: WeakSet<HTMLElement> | null = __DEV__
   ? new WeakSet<HTMLElement>()
   : null
 
+// Dev-warn dedupe for a redundant state binding (:value / :checked /
+// v-model) co-located with v-register. Keyed by a coarse misuse
+// SIGNATURE (`tag:type:binding`, e.g. `input:checkbox::checked`) rather
+// than element identity, on purpose: the same redundant binding
+// repeated across a v-for'd field-array row is the common case, and an
+// element-keyed set would print one warning per row. The signature
+// space is tiny and bounded (a handful of tag / type / binding
+// combinations), so a plain Set never grows without limit. The precise,
+// per-element coverage is the compile layer's job (it runs once per
+// element per build); the runtime only needs to surface the pattern once.
+const warnedRedundantBindings: Set<string> | null = __DEV__ ? new Set<string>() : null
+
 // Per-host-root record of the component-host branch's outcome, read back at
 // `beforeUnmount` to tear down symmetrically. Maps a host root element to the
 // inner control it latched, or `null` when it took the no-latch (markHost
@@ -1259,6 +1272,13 @@ const vRegisterDynamic: RegisterModelDynamicCustomDirective = {
     // the gated display state for async ticks. No-op when the binding
     // disabled aria or carries no display-state accessor.
     if (isRegisterValue(binding.value)) setupAria(el as AriaCarrier, binding.value, vnode)
+
+    // Dev diagnostic: flag a redundant `:value` / `:checked` / `v-model`
+    // co-located with v-register. No-op in production, and stands down
+    // when the compile-time transforms already own detection (see
+    // warnRedundantStateBinding). Runs last so the binding is fully set
+    // up first — a diagnostic never affects the field's behaviour.
+    if (__DEV__) warnRedundantStateBinding(el, binding, vnode)
   },
   mounted(el, binding, vnode) {
     callModelHook(el, binding, vnode, null, 'mounted')
@@ -1479,6 +1499,68 @@ function resolveDynamicModel(tagName: string, type: unknown) {
   if (type === 'checkbox') return vRegisterCheckbox
   if (type === 'radio') return vRegisterRadio
   return vRegisterText
+}
+
+/**
+ * Dev diagnostic (#464): warn when a redundant STATE binding sits
+ * beside `v-register` on a native control. `v-register` already owns
+ * value / checked, so a co-located `:value` / `:checked` / `v-model`
+ * is redundant at best and a dual-binding bug at worst.
+ *
+ * Runs ONLY when Attaform's compile-time transforms did NOT process
+ * this directive (`V_REGISTER_COMPILED_MODIFIER` absent). With the
+ * bundler plugin, `inputTextAreaNodeTransform` has stripped the
+ * author's value / checked and injected its own, so `vnode.props`
+ * reflects the injection, not what the author wrote — reading it would
+ * flag every field. There the compile layer owns detection. Without the
+ * plugin (CSR-only, the common case) nothing rewrites the props, so
+ * `vnode.props` IS what the author wrote and is authoritative.
+ *
+ * Carve-out: a radio's `:value` (`<input type="radio" :value="opt">`)
+ * and a checkbox's `:value` (array / Set member) are the IDENTITY
+ * channel `v-register` reads, never flagged — only the state attr for
+ * each kind warns. `<option :selected>` is a child of the `<select>`,
+ * not the bound element, so it's left to the compile layer.
+ */
+function warnRedundantStateBinding(el: HTMLElement, binding: DirectiveBinding, vnode: VNode): void {
+  if (warnedRedundantBindings === null) return // production
+  if (!INTERACTIVE_TAG_NAMES.has(el.tagName)) return // native controls only
+  // Compile layer active: it owns detection, and vnode.props is
+  // post-injection (not what the author wrote), so stand down.
+  if (binding.modifiers[V_REGISTER_COMPILED_MODIFIER] === true) return
+
+  const props = vnode.props
+  if (props == null) return
+
+  const variant = resolveDynamicModel(el.tagName, props['type'])
+  if (variant === vRegisterFile) return // out of scope: browser rejects `value`
+
+  // Native v-model desugars to an `onUpdate:modelValue` prop. The
+  // transforms never emit that key, so its presence is an author-only
+  // signal for every variant (text / select / checkbox / radio).
+  const hasVModel = 'onUpdate:modelValue' in props
+  // Radio / checkbox: `:value` is the option identity; only `:checked`
+  // is redundant state. Everything else is value-driven.
+  const stateAttr =
+    variant === vRegisterCheckbox || variant === vRegisterRadio ? 'checked' : 'value'
+  const hasStateAttr = stateAttr in props
+
+  if (!hasVModel && !hasStateAttr) return
+
+  const tag = el.tagName.toLowerCase()
+  const redundant = hasVModel ? 'v-model' : `:${stateAttr}`
+  // The resolved `type` is part of the key so a redundant `:checked` on
+  // a checkbox and on a radio are counted apart (their messages read the
+  // same, but they're distinct misuses).
+  const signature = `${tag}:${String(props['type'] ?? '')}:${redundant}`
+  if (warnedRedundantBindings.has(signature)) return
+  warnedRedundantBindings.add(signature)
+  warn(
+    `[attaform] \`${redundant}\` is redundant beside v-register on ` +
+      `<${tag}>. v-register already drives this field's value, ` +
+      `so keep v-register alone and drop \`${redundant}\`. (An identity \`:value\` on a ` +
+      `radio or <option> is expected and stays silent.)`
+  )
 }
 
 /**

--- a/src/runtime/core/register-protocol.ts
+++ b/src/runtime/core/register-protocol.ts
@@ -47,6 +47,27 @@ export const REGISTER_OWNER_MARKER: unique symbol = Symbol.for('attaform:registe
 export const SSR_COMPONENT_HOST_MODIFIER = 'attaformComponentHost'
 
 /**
+ * Directive modifier the `redundantBindingWarnTransform` stamps onto
+ * every `v-register` it processes. It is the compile-time -> runtime
+ * signal that Attaform's template transforms are active, and it lets the
+ * runtime redundant-binding diagnostic (in the directive's `created`
+ * hook) stand down.
+ *
+ * The hand-off matters because `inputTextAreaNodeTransform` strips the
+ * author's `value` / `checked` and injects its own. Once that has run,
+ * `vnode.props` no longer reflects what the author wrote, so a runtime
+ * check would flag every field. With this marker present the compile
+ * layer owns detection (it reads the authored props BEFORE injection);
+ * with it absent (no bundler plugin) the runtime layer reads the
+ * untouched `vnode.props` directly. Exactly one layer fires per
+ * consumer, never both.
+ *
+ * Namespaced to avoid collision with any author-written modifier, like
+ * `SSR_COMPONENT_HOST_MODIFIER` above.
+ */
+export const V_REGISTER_COMPILED_MODIFIER = 'attaformCompiled'
+
+/**
  * Type guard for a `RegisterValue`. Returns `true` when `val` looks
  * like the object returned from `form.register(path)`.
  *

--- a/src/runtime/lib/core/transforms/redundant-binding-warn-transform.ts
+++ b/src/runtime/lib/core/transforms/redundant-binding-warn-transform.ts
@@ -1,0 +1,238 @@
+import {
+  createSimpleExpression,
+  ElementTypes,
+  NodeTypes,
+  type AttributeNode,
+  type DirectiveNode,
+  type ElementNode,
+  type NodeTransform,
+  type TemplateChildNode,
+} from '@vue/compiler-core'
+import { V_REGISTER_COMPILED_MODIFIER } from '../../../core/register-protocol'
+
+/**
+ * `redundantBindingWarnTransform` — the compile-time half of the
+ * redundant-binding guard (#464). For every element carrying a
+ * `v-register` directive it does two things:
+ *
+ *   1. Warns (at build time, on `console.warn`) when a redundant STATE
+ *      binding sits beside `v-register` — a `:value` / `v-model` on a
+ *      text input or `<select>`, a `:checked` / `v-model` on a
+ *      checkbox or radio, or a `:selected` on an `<option>` inside a
+ *      `v-register`'d `<select>`. `v-register` already drives all of
+ *      these, so the extra binding is redundant at best and a
+ *      dual-binding bug at worst.
+ *
+ *   2. Stamps `V_REGISTER_COMPILED_MODIFIER` on the directive so the
+ *      runtime diagnostic in `core/directive.ts` stands down. This
+ *      transform runs BEFORE `inputTextAreaNodeTransform` /
+ *      `componentBridgeTransform` strip and inject the value channel,
+ *      so it sees the author's props verbatim; the runtime, which only
+ *      sees the post-injection props, cannot. Exactly one layer fires
+ *      per consumer.
+ *
+ * The carve-out: a `:value` (or static `value=`) is the legitimate
+ * IDENTITY channel for a radio (`<input type="radio" :value="opt">`)
+ * and an `<option>` (`<option :value="opt">`), and `v-register` READS
+ * it. Those never warn. Only the STATE attrs do.
+ *
+ * A dynamic `:type` can't be classified at compile time, so its input
+ * is skipped for the warn (best-effort, mirroring how
+ * `inputTextAreaNodeTransform` and the runtime `resolveDynamicModel`
+ * treat a non-static type). The marker is still stamped so the runtime
+ * layer, which sees the resolved type, doesn't double-report.
+ *
+ * Not `__DEV__`-gated: it fires on every compile, including production
+ * and CI builds, which is what lets a consumer retire a bespoke
+ * SFC-lint gate. Warnings only — a redundant binding never fails the
+ * build (the Vue compiler gives transforms no error channel, and a
+ * library shouldn't nuke a consumer's build over a lint-level issue).
+ *
+ * Wired first in the `nodeTransforms` array by `attaform/vite` and
+ * `attaform/nuxt`. Use directly only when integrating with a custom
+ * bundler.
+ */
+
+// Node types that hold iterable children worth recursing into when
+// walking a <select> for slotted <option>s. Mirrors the whitelist in
+// component-bridge-transform.ts: skip text / interpolation / comment
+// nodes, and don't crash on a future Vue node type we don't know.
+const RECURSABLE_NODE_TYPES: ReadonlySet<number> = new Set<number>([
+  NodeTypes.ELEMENT,
+  NodeTypes.FOR,
+  NodeTypes.IF,
+  NodeTypes.IF_BRANCH,
+])
+
+/**
+ * The author-facing display form of the first redundant STATE binding
+ * among `props` whose name is in `stateNames`, or `null` if none. A
+ * static attribute renders as its bare name (`value`), a `:`-bind as
+ * `:value`, and `v-model` as `v-model` — each is what the author would
+ * search their template for. `value` / `checked` are the state names;
+ * `stateNames` deliberately omits `value` for radio / checkbox, where
+ * it is the identity channel.
+ */
+function findRedundantStateBinding(
+  props: (AttributeNode | DirectiveNode)[],
+  stateNames: readonly string[]
+): string | null {
+  for (const prop of props) {
+    if (prop.type === NodeTypes.ATTRIBUTE) {
+      if (stateNames.includes(prop.name)) return prop.name
+      continue
+    }
+    // v-model on a native control is always redundant beside v-register,
+    // regardless of the element's kind.
+    if (prop.name === 'model') return 'v-model'
+    if (
+      prop.name === 'bind' &&
+      prop.arg?.type === NodeTypes.SIMPLE_EXPRESSION &&
+      prop.arg.isStatic &&
+      stateNames.includes(prop.arg.content)
+    ) {
+      return `:${prop.arg.content}`
+    }
+  }
+  return null
+}
+
+/**
+ * Classify a `<input>` by its statically-known `type`, mirroring the
+ * runtime `resolveDynamicModel`. Returns `'dynamic'` when `type` is a
+ * non-literal binding (`:type="kind"`) that can't be read at compile
+ * time, and `'file'` for file inputs (out of scope: browsers reject
+ * `value` there).
+ */
+function classifyInput(
+  props: (AttributeNode | DirectiveNode)[]
+): 'text' | 'checkbox' | 'radio' | 'file' | 'dynamic' {
+  let staticType: string | null = null
+  for (const prop of props) {
+    if (prop.type === NodeTypes.ATTRIBUTE) {
+      if (prop.name === 'type') staticType = prop.value?.content ?? null
+      continue
+    }
+    if (
+      prop.name === 'bind' &&
+      prop.arg?.type === NodeTypes.SIMPLE_EXPRESSION &&
+      prop.arg.isStatic &&
+      prop.arg.content === 'type'
+    ) {
+      // `:type="'radio'"` carries a literal simple expression we could
+      // read, but the common `:type="kind"` does not. Treat any dynamic
+      // `:type` as unclassifiable — conservative, matches the runtime
+      // and the input/textarea transform's own `isDynamicTypeValue`.
+      return 'dynamic'
+    }
+  }
+  if (staticType === 'checkbox') return 'checkbox'
+  if (staticType === 'radio') return 'radio'
+  if (staticType === 'file') return 'file'
+  // text / number / email / no explicit type / anything else scalar.
+  return 'text'
+}
+
+function emitRedundantWarning(tag: string, binding: string): void {
+  console.warn(
+    `[attaform] \`${binding}\` is redundant beside v-register on <${tag}>. ` +
+      `v-register already drives this field's value, so keep v-register alone and ` +
+      `drop \`${binding}\`. (An identity \`:value\` on a radio or <option> is expected ` +
+      `and stays silent.)`
+  )
+}
+
+// Walk a <select v-register>'s children for a redundant <option :selected>.
+// The option's own `:value` / `value=` is its identity (silent); only a
+// `:selected` / `selected` is redundant, since the component-bridge transform
+// drives option selection from the select's single register. Options can be
+// nested under v-for / v-if, so recurse the same node types the bridge does.
+function walkOptionsForSelected(selectNode: ElementNode): void {
+  const visit = (candidate: TemplateChildNode): void => {
+    if (candidate.type === NodeTypes.ELEMENT && candidate.tag === 'option') {
+      const found = findRedundantStateBinding(candidate.props, ['selected'])
+      if (found !== null) emitRedundantWarning('option', found)
+      return // an <option>'s own children never hold another <option>
+    }
+    if (!RECURSABLE_NODE_TYPES.has(candidate.type)) return
+    if (!('children' in candidate)) return
+    for (const child of candidate.children) {
+      if (typeof child === 'string' || typeof child === 'symbol') continue
+      if (child.type === NodeTypes.SIMPLE_EXPRESSION) continue
+      visit(child)
+    }
+  }
+  for (const child of selectNode.children) visit(child)
+}
+
+// Warn for a native <input> / <select> / <textarea>. Component and
+// custom-element hosts are skipped: there a `:value` / `v-model` is the
+// legitimate prop channel, not a redundant state binding.
+function warnIfRedundant(node: ElementNode): void {
+  if (node.tagType !== ElementTypes.ELEMENT) return
+  const tag = node.tag
+
+  if (tag === 'select') {
+    const found = findRedundantStateBinding(node.props, ['value'])
+    if (found !== null) emitRedundantWarning('select', found)
+    walkOptionsForSelected(node)
+    return
+  }
+
+  if (tag === 'textarea') {
+    const found = findRedundantStateBinding(node.props, ['value'])
+    if (found !== null) emitRedundantWarning('textarea', found)
+    return
+  }
+
+  if (tag !== 'input') return
+
+  const kind = classifyInput(node.props)
+  // Dynamic type: can't classify at compile time. File: out of scope.
+  if (kind === 'dynamic' || kind === 'file') return
+  // Radio / checkbox omit `value` — it's the option identity, not state.
+  const stateNames = kind === 'checkbox' || kind === 'radio' ? ['checked'] : ['value']
+  const found = findRedundantStateBinding(node.props, stateNames)
+  if (found !== null) emitRedundantWarning('input', found)
+}
+
+/**
+ * Vue compiler node transform that warns about a redundant state
+ * binding co-located with `v-register`, and stamps the
+ * compile-active marker so the runtime diagnostic stands down.
+ *
+ * Must run BEFORE `inputTextAreaNodeTransform` and
+ * `componentBridgeTransform` so it reads the author's props before they
+ * are stripped / injected. Wired first by `attaform/vite` and
+ * `attaform/nuxt`.
+ */
+export const redundantBindingWarnTransform: NodeTransform = (node) => {
+  try {
+    if (node.type !== NodeTypes.ELEMENT) return
+    const registerProp = node.props.find(
+      (prop): prop is DirectiveNode => prop.type === NodeTypes.DIRECTIVE && prop.name === 'register'
+    )
+    if (registerProp === undefined) return
+
+    // Idempotency: a doubly-applied pipeline (test combinatorics, some
+    // bundler configs) would otherwise warn twice and stamp twice. The
+    // marker is our own record that we've processed this directive.
+    const alreadyProcessed = registerProp.modifiers.some(
+      (modifier) =>
+        modifier.type === NodeTypes.SIMPLE_EXPRESSION &&
+        modifier.content === V_REGISTER_COMPILED_MODIFIER
+    )
+    if (alreadyProcessed) return
+
+    // Warn selectively (native, statically-classifiable controls); stamp
+    // unconditionally (every v-register, so the runtime always stands down).
+    warnIfRedundant(node)
+    registerProp.modifiers.push(createSimpleExpression(V_REGISTER_COMPILED_MODIFIER, true))
+  } catch (err) {
+    // AST shape drift across @vue/compiler-core versions, or a malformed
+    // directive: skip. The guard is a diagnostic; skipping it never
+    // affects a correct template's output. Matches every sibling
+    // transform's fail-safe posture.
+    console.error('[attaform] redundant-binding warn transform failed, skipping:', err)
+  }
+}

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -11,21 +11,30 @@
  * transforms to Vue's template compiler manually:
  *
  *   import {
+ *     redundantBindingWarnTransform,
  *     componentBridgeTransform,
  *     inputTextAreaNodeTransform,
  *     vRegisterPreambleTransform,
  *     vRegisterHintTransform,
  *   } from 'attaform/transforms'
  *
- * Order matters: `vRegisterPreambleTransform` MUST run before
- * `vRegisterHintTransform`. The preamble's pre-order captures each
- * `v-register` expression in its un-wrapped form; the hint transform
- * then mutates the directive's expression to wrap it in the
- * optimistic-mark IIFE. Reverse order would leak the IIFE wrapper
- * into the preamble's collected text.
+ * Order matters, on two counts:
+ *   - `redundantBindingWarnTransform` MUST run before
+ *     `componentBridgeTransform` and `inputTextAreaNodeTransform`. It
+ *     reads the author's props to warn about a redundant `:value` /
+ *     `:checked` / `:selected` beside `v-register`; those two transforms
+ *     strip and re-inject that channel, so any later transform sees the
+ *     injected props, not what the author wrote.
+ *   - `vRegisterPreambleTransform` MUST run before
+ *     `vRegisterHintTransform`. The preamble's pre-order captures each
+ *     `v-register` expression in its un-wrapped form; the hint transform
+ *     then mutates the directive's expression to wrap it in the
+ *     optimistic-mark IIFE. Reverse order would leak the IIFE wrapper
+ *     into the preamble's collected text.
  */
 
 export { componentBridgeTransform } from './runtime/lib/core/transforms/component-bridge-transform'
 export { inputTextAreaNodeTransform } from './runtime/lib/core/transforms/input-text-area-transform'
+export { redundantBindingWarnTransform } from './runtime/lib/core/transforms/redundant-binding-warn-transform'
 export { vRegisterHintTransform } from './runtime/lib/core/transforms/v-register-hint-transform'
 export { vRegisterPreambleTransform } from './runtime/lib/core/transforms/v-register-preamble-transform'

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -37,6 +37,7 @@ import type { Plugin } from 'vite'
 import { resolveZodAliasTarget, ZOD_UNIFIED_SPECIFIER } from './core/detect-zod-major'
 import { componentBridgeTransform } from './runtime/lib/core/transforms/component-bridge-transform'
 import { inputTextAreaNodeTransform } from './runtime/lib/core/transforms/input-text-area-transform'
+import { redundantBindingWarnTransform } from './runtime/lib/core/transforms/redundant-binding-warn-transform'
 import { vRegisterHintTransform } from './runtime/lib/core/transforms/v-register-hint-transform'
 import { vRegisterPreambleTransform } from './runtime/lib/core/transforms/v-register-preamble-transform'
 import { transformSsrAccessed } from './runtime/lib/core/transforms/ssr-accessed-transform'
@@ -133,14 +134,23 @@ export function attaform(options: AttaformVitePluginOptions = {}): Plugin {
       // sentinel via reference equality; user-supplied transforms with
       // the same name don't collide.
       if (!existing.includes(vRegisterPreambleTransform as unknown)) {
-        // vRegisterPreambleTransform MUST come before vRegisterHintTransform
-        // — the preamble's pre-order captures each `v-register` expression
-        // in its raw (un-wrapped) form, and the hint then mutates the same
-        // directive's `exp` to wrap it. Reversing the order would have the
-        // preamble pick up an already-wrapped IIFE, double-wrapping it
-        // when injected at the root.
+        // Two ordering constraints:
+        //   1. redundantBindingWarnTransform MUST come before
+        //      componentBridgeTransform and inputTextAreaNodeTransform. It
+        //      reads the author's props to warn about a redundant :value /
+        //      :checked / :selected beside v-register; those two transforms
+        //      strip and re-inject that channel, so anything after them sees
+        //      the injected props, not what the author wrote.
+        //   2. vRegisterPreambleTransform MUST come before
+        //      vRegisterHintTransform — the preamble's pre-order captures each
+        //      `v-register` expression in its raw (un-wrapped) form, and the
+        //      hint then mutates the same directive's `exp` to wrap it.
+        //      Reversing the order would have the preamble pick up an
+        //      already-wrapped IIFE, double-wrapping it when injected at the
+        //      root.
         api.options.template.compilerOptions.nodeTransforms = [
           ...existing,
+          redundantBindingWarnTransform,
           componentBridgeTransform,
           inputTextAreaNodeTransform,
           vRegisterPreambleTransform,

--- a/test/composables/v-register-redundant-binding-prod.test.ts
+++ b/test/composables/v-register-redundant-binding-prod.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+//
+// Prod gate for the runtime redundant-binding warn (#464). `__DEV__` (in
+// src/runtime/core/dev.ts) is computed at module-load time from
+// process.env.NODE_ENV, so exercising the prod branch needs the mock
+// hoisted above the directive import — hence a separate file (the main
+// runtime suite has `__DEV__` cached at `true`). Mirrors
+// transforms-prod-log.test.ts.
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../src/runtime/core/dev', () => ({ __DEV__: false }))
+
+import { createApp, defineComponent, h, withDirectives, type App } from 'vue'
+import { z } from 'zod'
+import { useForm } from '../../src/zod'
+import { vRegister } from '../../src/runtime/core/directive'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import { waitUntil } from '../utils/form-harness'
+
+const schema = z.object({ name: z.string() })
+
+describe('v-register runtime redundant-binding warn — production gate', () => {
+  let app: App | undefined
+  afterEach(() => {
+    app?.unmount()
+    app = undefined
+    document.body.innerHTML = ''
+  })
+
+  it('stays silent in production even with a redundant :value', async () => {
+    const warns: string[] = []
+    const spy = vi.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+      warns.push(args.map((a) => String(a)).join(' '))
+    })
+
+    const Comp = defineComponent({
+      setup() {
+        const form = useForm({ schema, key: `rb-prod-${Math.random().toString(36).slice(2)}` })
+        const rv = form.register('name')
+        return () => withDirectives(h('input', { value: 'x' }), [[vRegister, rv]])
+      },
+    })
+
+    app = createApp(Comp).use(createAttaform())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    await waitUntil(() => (root.firstElementChild !== null ? true : null))
+    spy.mockRestore()
+
+    expect(warns.filter((w) => w.includes('redundant beside v-register'))).toHaveLength(0)
+  })
+})

--- a/test/composables/v-register-redundant-binding.test.ts
+++ b/test/composables/v-register-redundant-binding.test.ts
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+//
+// Runtime half of the #464 redundant-binding guard. These mount via `h()`
+// + `withDirectives` — no compiler plugin runs, so the compile-active
+// marker is ABSENT and the runtime detection path is live (the CSR-only
+// consumer, "most apps" per the docs). The compile layer is covered by
+// test/transforms/redundant-binding-warn.test.ts.
+//
+// The runtime dedupe is keyed by a coarse `tag:type:binding` signature and
+// lives at module scope, so every case below is chosen to have a DISTINCT
+// signature (or to add none at all). That keeps the suite robust under
+// vitest's shuffled order — no two tests race on the same key.
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, withDirectives, type App, type VNode } from 'vue'
+import { z } from 'zod'
+import { useForm, type UseFormReturn } from '../../src/zod'
+import { vRegister } from '../../src/runtime/core/directive'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import { V_REGISTER_COMPILED_MODIFIER } from '../../src/runtime/core/register-protocol'
+import { waitUntil } from '../utils/form-harness'
+
+const schema = z.object({
+  name: z.string(),
+  agree: z.boolean(),
+  fruit: z.string(),
+  country: z.string(),
+})
+type Form = UseFormReturn<typeof schema>
+
+let app: App | undefined
+afterEach(() => {
+  app?.unmount()
+  app = undefined
+  document.body.innerHTML = ''
+})
+
+// Mount a render function under a fresh attaform app, capturing every
+// console.warn, and return only the redundant-binding diagnostics (so an
+// unrelated dev-warn from another variant can't skew the count).
+async function redundantWarnsFromRender(build: (form: Form) => () => VNode): Promise<string[]> {
+  const warns: string[] = []
+  const spy = vi.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+    warns.push(args.map((a) => String(a)).join(' '))
+  })
+  const Comp = defineComponent({
+    setup() {
+      const form = useForm({ schema, key: `rb-${Math.random().toString(36).slice(2)}` })
+      return build(form)
+    },
+  })
+  app = createApp(Comp).use(createAttaform())
+  const root = document.createElement('div')
+  document.body.appendChild(root)
+  app.mount(root)
+  await waitUntil(() => (root.firstElementChild !== null ? true : null))
+  spy.mockRestore()
+  return warns.filter((w) => w.includes('redundant beside v-register'))
+}
+
+describe('v-register runtime redundant-binding warn — state bindings warn', () => {
+  it('warns on a native text input with v-model beside v-register', async () => {
+    // Native v-model desugars to an `onUpdate:modelValue` prop; that key
+    // is the author-only signal (the transforms never emit it).
+    const warns = await redundantWarnsFromRender((form) => {
+      const rv = form.register('name')
+      return () =>
+        withDirectives(h('input', { 'onUpdate:modelValue': () => undefined }), [[vRegister, rv]])
+    })
+    expect(warns).toHaveLength(1)
+    expect(warns[0]).toContain('v-model')
+    expect(warns[0]).toContain('<input>')
+  })
+
+  it('warns on a checkbox with :checked', async () => {
+    const warns = await redundantWarnsFromRender((form) => {
+      const rv = form.register('agree')
+      return () =>
+        withDirectives(h('input', { type: 'checkbox', checked: true }), [[vRegister, rv]])
+    })
+    expect(warns).toHaveLength(1)
+    expect(warns[0]).toContain(':checked')
+  })
+
+  it('warns on a radio with :checked (its :value identity is untouched)', async () => {
+    const warns = await redundantWarnsFromRender((form) => {
+      const rv = form.register('fruit')
+      return () =>
+        withDirectives(h('input', { type: 'radio', value: 'apple', checked: true }), [
+          [vRegister, rv],
+        ])
+    })
+    expect(warns).toHaveLength(1)
+    expect(warns[0]).toContain(':checked')
+  })
+
+  it('warns on a select with :value', async () => {
+    const warns = await redundantWarnsFromRender((form) => {
+      const rv = form.register('country')
+      return () =>
+        withDirectives(h('select', { value: 'us' }, [h('option', { value: 'us' }, 'US')]), [
+          [vRegister, rv],
+        ])
+    })
+    expect(warns).toHaveLength(1)
+    expect(warns[0]).toContain('<select>')
+  })
+})
+
+describe('v-register runtime redundant-binding warn — identity carve-out stays silent', () => {
+  it('is silent on a radio with :value (radio identity)', async () => {
+    const warns = await redundantWarnsFromRender((form) => {
+      const rv = form.register('fruit')
+      return () => withDirectives(h('input', { type: 'radio', value: 'apple' }), [[vRegister, rv]])
+    })
+    expect(warns).toHaveLength(0)
+  })
+
+  it('is silent on a checkbox with :value (member identity)', async () => {
+    const warns = await redundantWarnsFromRender((form) => {
+      const rv = form.register('agree')
+      return () => withDirectives(h('input', { type: 'checkbox', value: 'x' }), [[vRegister, rv]])
+    })
+    expect(warns).toHaveLength(0)
+  })
+})
+
+describe('v-register runtime redundant-binding warn — dedupe and stand-down', () => {
+  it('warns once for a v-for of identical redundant text inputs', async () => {
+    // Five distinct elements, one shared misuse signature (input::value):
+    // the coarse dedupe collapses a field-array footgun to a single line.
+    const warns = await redundantWarnsFromRender((form) => {
+      const rv = form.register('name')
+      return () =>
+        h(
+          'div',
+          [0, 1, 2, 3, 4].map((i) =>
+            withDirectives(h('input', { key: i, value: `v${i}` }), [[vRegister, rv]])
+          )
+        )
+    })
+    expect(warns).toHaveLength(1)
+  })
+
+  it('stands down when the compile-active marker is present (no double-warn, no false positive)', async () => {
+    // A plugin consumer's compiled directive carries the marker. The
+    // runtime must not read vnode.props (post-injection there) — the
+    // compile layer already owns detection.
+    const warns = await redundantWarnsFromRender((form) => {
+      const rv = form.register('name')
+      return () =>
+        withDirectives(h('input', { value: 'x' }), [
+          [vRegister, rv, undefined, { [V_REGISTER_COMPILED_MODIFIER]: true }],
+        ])
+    })
+    expect(warns).toHaveLength(0)
+  })
+
+  it('is silent on a non-interactive host root (component-binding channel)', async () => {
+    // A v-register on a <div> host with a :value is the component-binding
+    // path, not a redundant native binding — the runtime guard only fires
+    // on INPUT / SELECT / TEXTAREA.
+    const warns = await redundantWarnsFromRender((form) => {
+      const rv = form.register('name')
+      return () => withDirectives(h('div', { value: 'x' }), [[vRegister, rv]])
+    })
+    expect(warns).toHaveLength(0)
+  })
+})

--- a/test/transforms/redundant-binding-warn.test.ts
+++ b/test/transforms/redundant-binding-warn.test.ts
@@ -1,0 +1,252 @@
+import { baseCompile } from '@vue/compiler-core'
+import { describe, expect, it, vi } from 'vitest'
+import { componentBridgeTransform } from '../../src/runtime/lib/core/transforms/component-bridge-transform'
+import { inputTextAreaNodeTransform } from '../../src/runtime/lib/core/transforms/input-text-area-transform'
+import { redundantBindingWarnTransform } from '../../src/runtime/lib/core/transforms/redundant-binding-warn-transform'
+import { vRegisterHintTransform } from '../../src/runtime/lib/core/transforms/v-register-hint-transform'
+import { vRegisterPreambleTransform } from '../../src/runtime/lib/core/transforms/v-register-preamble-transform'
+
+/**
+ * The compile-time half of the #464 redundant-binding guard. Compile a
+ * template through @vue/compiler-core with the transform registered and
+ * capture the `console.warn` output (the diagnostic channel — the Vue
+ * compiler gives transforms no onWarn hook).
+ */
+
+// The transforms in the exact production order attaform/vite installs
+// them. redundantBindingWarnTransform runs FIRST, before the two that
+// strip/inject the value channel — the ordering this suite locks in.
+const FULL_PIPELINE = [
+  redundantBindingWarnTransform,
+  componentBridgeTransform,
+  inputTextAreaNodeTransform,
+  vRegisterPreambleTransform,
+  vRegisterHintTransform,
+]
+
+function redundantWarnsFor(
+  template: string,
+  transforms: typeof FULL_PIPELINE | [typeof redundantBindingWarnTransform] = [
+    redundantBindingWarnTransform,
+  ]
+): string[] {
+  const warns: string[] = []
+  const spy = vi.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+    warns.push(args.map((a) => String(a)).join(' '))
+  })
+  try {
+    baseCompile(template, { nodeTransforms: [...transforms], mode: 'module' })
+  } finally {
+    spy.mockRestore()
+  }
+  return warns.filter((w) => w.includes('redundant beside v-register'))
+}
+
+function compile(template: string): string {
+  return baseCompile(template, { nodeTransforms: [redundantBindingWarnTransform], mode: 'module' })
+    .code
+}
+
+describe('redundantBindingWarnTransform — state bindings warn', () => {
+  it('warns on a text input with :value', () => {
+    const warns = redundantWarnsFor(`<input v-register="reg" :value="x" />`)
+    expect(warns).toHaveLength(1)
+    expect(warns[0]).toContain(':value')
+    expect(warns[0]).toContain('<input>')
+  })
+
+  it('warns on a text input with a static value= attribute', () => {
+    const warns = redundantWarnsFor(`<input v-register="reg" value="hi" />`)
+    expect(warns).toHaveLength(1)
+    expect(warns[0]).toContain('value')
+  })
+
+  it('warns on a text input with v-model', () => {
+    const warns = redundantWarnsFor(`<input v-register="reg" v-model="x" />`)
+    expect(warns).toHaveLength(1)
+    expect(warns[0]).toContain('v-model')
+  })
+
+  it('warns on a textarea with :value', () => {
+    const warns = redundantWarnsFor(`<textarea v-register="reg" :value="x" />`)
+    expect(warns).toHaveLength(1)
+    expect(warns[0]).toContain('<textarea>')
+  })
+
+  it('warns on a checkbox with :checked', () => {
+    const warns = redundantWarnsFor(`<input type="checkbox" v-register="reg" :checked="x" />`)
+    expect(warns).toHaveLength(1)
+    expect(warns[0]).toContain(':checked')
+  })
+
+  it('warns on a radio with :checked', () => {
+    const warns = redundantWarnsFor(`<input type="radio" v-register="reg" :checked="x" />`)
+    expect(warns).toHaveLength(1)
+    expect(warns[0]).toContain(':checked')
+  })
+
+  it('warns on a select with :value', () => {
+    const warns = redundantWarnsFor(
+      `<select v-register="reg" :value="x"><option value="a">A</option></select>`
+    )
+    expect(warns).toHaveLength(1)
+    expect(warns[0]).toContain('<select>')
+  })
+
+  it('warns on a select with v-model', () => {
+    const warns = redundantWarnsFor(
+      `<select v-register="reg" v-model="x"><option value="a">A</option></select>`
+    )
+    expect(warns).toHaveLength(1)
+    expect(warns[0]).toContain('v-model')
+  })
+
+  it('warns on an <option :selected> inside a v-register-d select', () => {
+    const warns = redundantWarnsFor(
+      `<select v-register="reg"><option :value="o" :selected="s">A</option></select>`
+    )
+    expect(warns).toHaveLength(1)
+    expect(warns[0]).toContain(':selected')
+    expect(warns[0]).toContain('<option>')
+  })
+
+  it('warns on a static <option selected> inside a v-register-d select', () => {
+    const warns = redundantWarnsFor(
+      `<select v-register="reg"><option value="a" selected>A</option></select>`
+    )
+    expect(warns).toHaveLength(1)
+    expect(warns[0]).toContain('selected')
+  })
+
+  it('warns on an <option :selected> nested under v-for', () => {
+    const warns = redundantWarnsFor(
+      `<select v-register="reg"><option v-for="o in opts" :value="o" :selected="o === sel">{{ o }}</option></select>`
+    )
+    expect(warns).toHaveLength(1)
+    expect(warns[0]).toContain(':selected')
+  })
+})
+
+describe('redundantBindingWarnTransform — identity carve-out stays silent', () => {
+  it('is silent on a radio with :value (radio identity)', () => {
+    expect(redundantWarnsFor(`<input type="radio" v-register="reg" :value="opt" />`)).toHaveLength(
+      0
+    )
+  })
+
+  it('is silent on a radio with a static value= (radio identity)', () => {
+    expect(redundantWarnsFor(`<input type="radio" v-register="reg" value="opt" />`)).toHaveLength(0)
+  })
+
+  it('is silent on a checkbox with :value (member identity)', () => {
+    expect(
+      redundantWarnsFor(`<input type="checkbox" v-register="reg" :value="opt" />`)
+    ).toHaveLength(0)
+  })
+
+  it('is silent on an <option :value> (option identity)', () => {
+    expect(
+      redundantWarnsFor(`<select v-register="reg"><option :value="o">X</option></select>`)
+    ).toHaveLength(0)
+  })
+
+  it('is silent on a static <option value="x"> (option identity)', () => {
+    expect(
+      redundantWarnsFor(`<select v-register="reg"><option value="x">X</option></select>`)
+    ).toHaveLength(0)
+  })
+
+  it('is silent on a clean text input (no co-located binding)', () => {
+    expect(redundantWarnsFor(`<input v-register="reg" />`)).toHaveLength(0)
+  })
+
+  it('is silent on a clean select', () => {
+    expect(
+      redundantWarnsFor(`<select v-register="reg"><option value="a">A</option></select>`)
+    ).toHaveLength(0)
+  })
+})
+
+describe('redundantBindingWarnTransform — classification edge cases', () => {
+  it('skips a dynamic :type input (cannot classify at compile time)', () => {
+    expect(redundantWarnsFor(`<input :type="kind" v-register="reg" :value="x" />`)).toHaveLength(0)
+  })
+
+  it('skips a file input (browser rejects value)', () => {
+    expect(redundantWarnsFor(`<input type="file" v-register="reg" :value="x" />`)).toHaveLength(0)
+  })
+
+  it('ignores an element with no v-register', () => {
+    expect(redundantWarnsFor(`<input :value="x" />`)).toHaveLength(0)
+  })
+
+  it('ignores a component host (:value is a legit prop channel there)', () => {
+    expect(redundantWarnsFor(`<MyInput v-register="reg" :value="x" />`)).toHaveLength(0)
+  })
+})
+
+describe('redundantBindingWarnTransform — marker stamping', () => {
+  it('stamps the compile-active modifier on a native v-register', () => {
+    expect(compile(`<input v-register="reg" />`)).toContain('attaformCompiled')
+  })
+
+  it('stamps the marker on a component host too (so the runtime stands down)', () => {
+    expect(compile(`<MyInput v-register="reg" :value="x" />`)).toContain('attaformCompiled')
+  })
+
+  it('is idempotent — a doubly-applied pipeline warns once and stamps once', () => {
+    const warns: string[] = []
+    const spy = vi.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+      warns.push(args.map((a) => String(a)).join(' '))
+    })
+    try {
+      // The same transform twice in the array simulates a doubly-registered
+      // pipeline (test combinatorics / a re-run bundler config).
+      baseCompile(`<input v-register="reg" :value="x" />`, {
+        nodeTransforms: [redundantBindingWarnTransform, redundantBindingWarnTransform],
+        mode: 'module',
+      })
+    } finally {
+      spy.mockRestore()
+    }
+    expect(warns.filter((w) => w.includes('redundant beside v-register'))).toHaveLength(1)
+  })
+})
+
+describe('redundantBindingWarnTransform — ordering / full pipeline (load-bearing)', () => {
+  it('does NOT cry wolf on our own injected :value (clean input through the real pipeline)', () => {
+    // inputTextAreaNodeTransform strips + injects :value on EVERY
+    // v-register'd input. Because our transform runs FIRST, it sees the
+    // authored props (none here) before the injection, so a clean input
+    // must produce zero warnings even though the compiled output carries
+    // an injected :value. This is the whole reason the ordering matters.
+    expect(redundantWarnsFor(`<input v-register="reg" />`, FULL_PIPELINE)).toHaveLength(0)
+  })
+
+  it('warns exactly once on an authored :value through the real pipeline', () => {
+    expect(redundantWarnsFor(`<input v-register="reg" :value="x" />`, FULL_PIPELINE)).toHaveLength(
+      1
+    )
+  })
+
+  it('warns once for a v-for of identical redundant inputs (one template node)', () => {
+    // A v-for compiles the inner <input> to a single template node, so
+    // the build-time warning fires once no matter the row count — the
+    // clean "warn once for the pattern" story the runtime can't give a
+    // non-plugin consumer.
+    const warns = redundantWarnsFor(
+      `<div v-for="i in 3" :key="i"><input v-register="reg" :value="i" /></div>`,
+      FULL_PIPELINE
+    )
+    expect(warns).toHaveLength(1)
+  })
+
+  it('stays silent for a clean select with options through the real pipeline', () => {
+    expect(
+      redundantWarnsFor(
+        `<select v-register="reg"><option value="a">A</option><option value="b">B</option></select>`,
+        FULL_PIPELINE
+      )
+    ).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Closes #464 (proposal 1). Proposal 2 (a standalone eslint plugin) is deliberately deferred; see "Out of scope" below.

Migrating a real app to `v-register`, the most-repeated mistake, hit by an experienced user *and* the maintainer in the same review, was leaving a state-binding attribute next to `v-register`: `:value` / `v-model` on a text input or `<select>`, `:checked` on a checkbox or radio, `:selected` on an `<option>`. `v-register` already drives all of these, so the extra binding is redundant at best and the dual-binding/SSR bug the migration was fixing at worst. Two experts tripping in one sitting is a strong signal for a mechanical guard.

This ships that guard as **two complementary layers**, so exactly one fires per consumer, with no false positives.

## The carve-out

The subtlety that makes it error-prone: the same `:value` is legitimate as an **identity** and `v-register` *reads* it, on a radio (`<input type="radio" :value="opt">`) and an `<option>`. So only the *state* attrs warn; the *identity* `:value` on a radio or `<option>` stays silent.

| Resolved kind | Warns on | Silent (identity) |
| --- | --- | --- |
| text / number / textarea | `:value`, `v-model` | — |
| checkbox | `:checked`, `v-model` | `:value` (member) |
| radio | `:checked`, `v-model` | `:value` (radio identity) |
| select | `:value`, `v-model` | — |
| `<option>` | `:selected` | `:value` (option identity) |
| file | out of scope | browsers reject `value` |

## Two layers, one hand-off

- **Compile-time** (`redundantBindingWarnTransform`, new): fires at build on `console.warn`, **every compile including CI**, so a consumer can retire a bespoke SFC-lint gate. Build-time safety is on-brand for what Attaform sells.
- **Runtime** (in the directive's `created` hook): the universal floor for consumers who don't run the compiler plugin (CSR-only apps, "most apps" per the docs). Fires in the dev console.

The hand-off is the crux. `inputTextAreaNodeTransform` **strips** the author's `value`/`checked` and **injects** its own, so for a plugin user `vnode.props.value` at runtime is *always* the injected value; a naive runtime check would false-positive on every field. Resolution: the compile transform stamps a reserved `V_REGISTER_COMPILED_MODIFIER` on each `v-register`, and the runtime **stands down** when it sees it. Net: **plugin user → build-warn only; non-plugin user → runtime-warn only. Never both, never a false positive.**

Ordering is load-bearing: the new transform runs **first**, before the two that strip/inject, so it reads the author's props verbatim. The integration test compiles a clean `<input v-register>` through the *full real pipeline* and asserts **zero** warnings even though the output carries an injected `:value`; and `pnpm build:site` shows **0** redundant-binding warnings across every demo/fixture (the ultimate cry-wolf gate).

Runtime dedupe is keyed by a coarse `tag:type:binding` signature, not element identity, so a redundant binding repeated across a `v-for`'d field-array row warns once, not once per row.

## Tests

- **Compile-time** (`test/transforms/redundant-binding-warn.test.ts`, 29 cases): every state case warns, every carve-out stays silent, `<option :selected>` (including under `v-for`) warns, dynamic `:type` / file / component host skip, marker stamped, idempotent under a doubly-applied pipeline, and the full-pipeline ordering guard.
- **Runtime** (`v-register-redundant-binding.test.ts` + a `-prod.test.ts` gate): state warns, identity carve-out silent, `v-for` dedupe, marker stand-down, and silence under `__DEV__: false`.

## Verification

- `pnpm test`: **347 files, 4421 passed / 4 skipped**
- `pnpm typecheck`, lint, prettier: clean
- `pnpm build:site`: builds, link-checker 0/187 failing, **0 redundant-binding warnings on our own templates**, SSR prerendered 430 routes
- `pnpm check:bundled-types`: clean for both zod v3 and v4 consumers (`attaform/transforms` now exports `redundantBindingWarnTransform`)

## Out of scope

- **eslint-plugin-attaform (proposal 2): deferred.** A separate published package with its own release pipeline is disproportionate for one rule; the build-warn already delivers static/CI coverage. Revisit if more rules accumulate.
- **No hard build failure.** The Vue compiler gives transforms no error channel, and a library shouldn't nuke a consumer's build over a lint-level binding. Warnings only.
- Zero new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
