### PR TITLE
Surface a thrown onSubmit as a form error; make onError validation-only

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -946,7 +946,11 @@ export default [
     // component-host branch + registerValue strip + host delegates +
     // markHostConnected + the directly-bound-container field-state fold).
     // Measured at 53.45 KB.
-    limit: '54 KB',
+    //
+    // Raised 54 → 55 KB for submit-throw surfacing (process-form's catch-block
+    // inject piping a thrown onSubmit into the user-error layer). Measured at
+    // 54.04 KB.
+    limit: '55 KB',
     gzip: true,
     ignore: ['zod'],
     modifyEsbuildConfig: asEsm,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,15 @@ _No unreleased changes yet._
   statically known. It is no longer identity-equal to the raw per-step handle;
   reach for `wizard.forms[key]` when you need that exact object. (#471)
 
+- **`onError` fires only when validation rejects a submit.** The two
+  `handleSubmit` callbacks dispatch on Attaform's validation verdict: `onSubmit`
+  runs when validation passes, `onError` when it fails. A `setErrors` (or a
+  throw) inside a callback that has already run is your own outcome, not a second
+  verdict, so it no longer routes back through `onError`. It still marks the
+  submit unsuccessful (`form.meta.submitted` stays `false`) and pulls focus to
+  the first error. If you were relying on `onError` firing after a `setErrors`,
+  move that handling into the `onSubmit` callback itself.
+
 ### Fixed
 
 - **A required field left blank now takes focus on an invalid submit, the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,8 @@ _No unreleased changes yet._
   reads, with no `try` / `catch` of your own. A bare `throw new Error(...)`
   lands form-level (the root `[]` bucket); throw a `{ path, message, code? }`,
   or an array of them, to land it on a specific field under your own code. A
-  non-Error throw still surfaces, carrying a diagnostic message, and warns in
-  development.
+  non-Error throw still surfaces as an `Unknown error` (consistent with
+  `setErrors`) and warns in development.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,17 @@ _No unreleased changes yet._
   the one-line banner accessor for a form-level error from a root `.refine()`
   or a path-less `setErrors`. (#489)
 
+- **A throw or rejection out of an `onSubmit` callback now surfaces as a form
+  error, not just on `form.meta.submitError`.** `handleSubmit` still parks the
+  raw `Error` on `submitError` for inspection, and now also pipes a normalized
+  copy into the error layer, so a failed submit shows on `form.errors`,
+  `form.meta.ownErrors`, and `form.meta.firstOwnError` where your UI already
+  reads, with no `try` / `catch` of your own. A bare `throw new Error(...)`
+  lands form-level (the root `[]` bucket); throw a `{ path, message, code? }`,
+  or an array of them, to land it on a specific field under your own code. A
+  non-Error throw still surfaces, carrying a diagnostic message, and warns in
+  development.
+
 ### Changed
 
 - **`form.errors([])` now returns the whole-form aggregate, the same as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ _No unreleased changes yet._
   lands form-level (the root `[]` bucket); throw a `{ path, message, code? }`,
   or an array of them, to land it on a specific field under your own code. A
   non-Error throw still surfaces as an `Unknown error` (consistent with
-  `setErrors`) and warns in development.
+  `setErrors`) and warns in development. (#490)
 
 ### Changed
 
@@ -100,7 +100,7 @@ _No unreleased changes yet._
   verdict, so it no longer routes back through `onError`. It still marks the
   submit unsuccessful (`form.meta.submitted` stays `false`) and pulls focus to
   the first error. If you were relying on `onError` firing after a `setErrors`,
-  move that handling into the `onSubmit` callback itself.
+  move that handling into the `onSubmit` callback itself. (#490)
 
 ### Fixed
 

--- a/docs/reading-the-form/meta.md
+++ b/docs/reading-the-form/meta.md
@@ -107,11 +107,13 @@ The form-summary pattern reads three:
 
 ## submitError lifecycle
 
-`submitError` mirrors what the callback threw or rejected with. `handleSubmit` catches the throw, routes it through `onError`, and writes it to `form.meta.submitError` for reactive read-out.
+`submitError` mirrors what the callback threw or rejected with, coerced to a real `Error` (a non-`Error` throw keeps its origin on `.cause`). `handleSubmit` catches the throw rather than re-raising it, so a rejected `onSubmit` never escapes as an unhandled rejection.
 
 - `null` at form mount, between attempts, and on success.
 - Set to the thrown / rejected value on callback failure.
 - Cleared at the start of the next submit attempt.
+
+A thrown callback surfaces twice. `submitError` is the raw-`Error` inspection channel above; the same failure is also piped into the error layer as a `ValidationError`. A bare `throw new Error(...)` lands form-level (the root `[]` bucket), where [`form.meta.firstOwnError`](#templates) and `form.meta.ownErrors` read it for a banner; throw a `{ path, message, code? }` (or an array of them) to land it on a specific field, where it joins `form.errors.<path>` under your own `code`. Either way it also rolls into `form.meta.errors`. This is separate from the `setErrors` path, which never touches `submitError`.
 
 Reach for it when an inline failure banner needs to react to submit errors without your own `try { await onSubmit() }` wrapper:
 

--- a/docs/submitting/handle-submit.md
+++ b/docs/submitting/handle-submit.md
@@ -48,9 +48,9 @@ When the returned handler fires:
 3. Async refinements are awaited.
 4. If every refinement passes, `onSubmit(values)` is called with the **parsed** Zod output: `.transform`-aware, fully typed.
 5. The submit counts as a success, flipping `form.meta.submitted` to `true`, only when `onSubmit` resolves without throwing and leaves no errors set. A callback that hands a server rejection to `setErrors` and returns is a failed submit (see [server-side errors](/docs/submitting/server-side-errors)).
-6. On any failure, whether a validation error, a thrown callback, or errors the callback set with `setErrors`, focus pulls to the first invalid field and `onError(errors)` fires (when supplied).
+6. Every failure pulls focus to the first invalid field. They differ in one respect: a **validation** failure (step 4 rejected, so `onSubmit` never ran) also calls `onError(errors)` when supplied. A failure your callback produces after it runs, a throw or a `setErrors` and return, does not. `onError` is the verdict on Attaform's own validation, and by then that had already passed. A thrown callback additionally lands on `form.meta.submitError` and surfaces on `form.errors`.
 
-While step 4 is awaiting your `onSubmit` callback, `form.meta.submitting` is `true`. It flips back when the callback resolves or rejects (`handleSubmit` catches and surfaces errors through `onError`).
+While step 4 is awaiting your `onSubmit` callback, `form.meta.submitting` is `true`. It flips back when the callback resolves or rejects. A rejection is caught, not re-thrown, so it never escapes as an unhandled rejection: the raw error lands on `form.meta.submitError`, and a normalized copy joins `form.errors` (form-level, or path-scoped when you throw a `{ path, message }`), so a banner reading [`form.meta.firstOwnError`](/docs/reading-the-form/meta) catches it.
 
 ## Without onError
 

--- a/docs/submitting/server-side-errors.md
+++ b/docs/submitting/server-side-errors.md
@@ -46,7 +46,7 @@ const onSubmit = form.handleSubmit(async (values) => {
 
 `response.errors` is a `ValidationError[]`: each entry carries a `message`, an optional `path`, an optional `code`, and an optional `data` payload. An entry with a `path` lands at that field; an entry with no path lands at the form level, in the global `[]` bucket. `form.setErrors` stamps the form key on every entry as it lands, so errors stay isolated to this form.
 
-Returning after `setErrors` is a failed submit, treated exactly like a schema failure: `form.meta.submitted` stays `false`, focus pulls to the first error, and your `onError` callback fires with the errors you set. You do not need to throw to signal the rejection, and you do not need to call `form.focusFirstError()` by hand. Reserve a thrown error for the unexpected (a network drop, a 500), which lands on `form.meta.submitError` instead.
+Returning after `setErrors` is a failed submit: `form.meta.submitted` stays `false` and focus pulls to the first error. It does not fire `onError`, though, that callback is the verdict on Attaform's own validation, which already passed here. You do not need to throw to signal the rejection, and you do not need to call `form.focusFirstError()` by hand. Reserve a thrown error for the unexpected (a network drop, a 500), which also lands on `form.meta.submitError` for inspection.
 
 ## `setErrors` and `clearErrors`
 

--- a/scripts/check-eager-size.mjs
+++ b/scripts/check-eager-size.mjs
@@ -264,7 +264,17 @@ export async function measureEager(define = PROD_DEFINE) {
 // complete and lands eager at ~45_080 bytes, ~0.41 kB under this budget -- about the
 // conventional drift headroom, so the phase-wide estimate held and the budget stays
 // at 45_500. Never loosen further without a recorded reason.
-const BUDGET_GZ = 45_500
+//
+// Submit-throw surfacing: a thrown / rejected `onSubmit` callback is now piped
+// into the user-error layer as a `ValidationError` (alongside the raw
+// `submitError`), so it shows on `form.errors` / `meta.ownErrors` /
+// `firstOwnError`. The eager cost is process-form's catch-block inject path
+// (deriveSubmitErrors + isErrorInputLike + the per-path grouping write +
+// focus-first-error + a dev-only messageless-throw warn); it reuses the hoisted
+// `normalizeErrorInput`, so the net add is ~242 bytes gz, landing the eager set
+// at ~45_742 bytes. Budget raised 45_500 → 46_500 to restore ~0.5 kB headroom
+// for minifier drift.
+const BUDGET_GZ = 46_500
 
 const isMain = import.meta.url === pathToFileURL(realpathSync(argv[1])).href
 if (isMain) {

--- a/src/runtime/core/build-form-api.ts
+++ b/src/runtime/core/build-form-api.ts
@@ -22,6 +22,7 @@ import type { DeepPartial, DefaultValuesInput, GenericForm } from '../types/type
 import type { FormStore } from './create-form-store'
 import { structuralSnapshot } from './diff-apply'
 import { AttaformErrorCode } from './error-codes'
+import { normalizeErrorInputs } from './errors'
 import { buildErrorsProxy } from './errors-proxy'
 import { buildFieldArrayApi } from './field-arrays'
 import {
@@ -543,39 +544,6 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
     | ErrorInput[]
     | ((prev: ValidationError[]) => ErrorInput | ErrorInput[])
 
-  function normalizeErrorInput(item: ErrorInput, scope: Path | undefined): ValidationError {
-    if (item instanceof Error) {
-      return {
-        message: item.message.length > 0 ? item.message : 'Unknown error',
-        path: scope !== undefined ? [...scope] : [],
-        formKey: state.formKey,
-        code: AttaformErrorCode.UserError,
-      }
-    }
-    const entry: ValidationError = {
-      message:
-        typeof item.message === 'string' && item.message.length > 0
-          ? item.message
-          : 'Unknown error',
-      path: scope !== undefined ? [...scope] : Array.isArray(item.path) ? [...item.path] : [],
-      formKey: state.formKey,
-      code:
-        typeof item.code === 'string' && item.code.length > 0
-          ? item.code
-          : AttaformErrorCode.UserError,
-    }
-    if (item.data !== undefined) entry.data = item.data
-    return entry
-  }
-
-  function normalizeErrorInputs(
-    input: ErrorInput | ErrorInput[],
-    scope: Path | undefined
-  ): ValidationError[] {
-    const items = Array.isArray(input) ? input : [input]
-    return items.map((item) => normalizeErrorInput(item, scope))
-  }
-
   function flattenUserErrors(): ValidationError[] {
     const all: ValidationError[] = []
     for (const errs of state.userErrors.values()) all.push(...errs)
@@ -595,12 +563,17 @@ export function buildFormApi<Form extends GenericForm, GetValueFormType extends 
       const input = arg2 as SetErrorsArg
       const resolved =
         typeof input === 'function' ? input((state.userErrors.get(key) ?? []).slice()) : input
-      state.setUserErrorsForPath(segments, normalizeErrorInputs(resolved, segments))
+      state.setUserErrorsForPath(
+        segments,
+        normalizeErrorInputs(resolved, segments, state.formKey, AttaformErrorCode.UserError)
+      )
       return
     }
     const input = arg1 as SetErrorsArg
     const resolved = typeof input === 'function' ? input(flattenUserErrors()) : input
-    state.setAllUserErrors(normalizeErrorInputs(resolved, undefined))
+    state.setAllUserErrors(
+      normalizeErrorInputs(resolved, undefined, state.formKey, AttaformErrorCode.UserError)
+    )
   }
 
   function clearErrors(path?: string | (string | number)[]): void {

--- a/src/runtime/core/error-codes.ts
+++ b/src/runtime/core/error-codes.ts
@@ -66,6 +66,17 @@ export const AttaformErrorCode = {
    * Override it per error by passing your own `code` (`api:…`, `auth:…`).
    */
   UserError: 'atta:user-error',
+  /**
+   * Stamped on a `ValidationError` synthesized from a throw or rejection
+   * out of a `handleSubmit` `onSubmit` callback. The raw error also lands
+   * on `form.meta.submitError` (a raw-`Error` inspection channel); this
+   * code marks the copy piped into the user-error layer so the failure
+   * also surfaces on `form.errors` / `meta.ownErrors` / `firstOwnError`
+   * where the UI already reads. A throw carrying its own `path` / `code`
+   * keeps them; a bare `Error` or a non-Error throw defaults here at the
+   * form-level path `[]`.
+   */
+  SubmitError: 'atta:submit-error',
 } as const
 
 export type AttaformErrorCode = (typeof AttaformErrorCode)[keyof typeof AttaformErrorCode]

--- a/src/runtime/core/errors.ts
+++ b/src/runtime/core/errors.ts
@@ -10,6 +10,9 @@
  * keeps working.
  */
 
+import type { ErrorInput, FormKey, ValidationError } from '../types/types-api'
+import type { Path } from './paths'
+
 /**
  * Base for every error class thrown by `attaform`. Sets
  * `this.name` from the constructor's `new.target.name`, so subclasses
@@ -85,6 +88,61 @@ export function toError(value: unknown): Error {
       ? value
       : `Submit callback threw a non-Error value (${typeof value})`
   return new Error(message, { cause: value })
+}
+
+/**
+ * Coerce one lenient `ErrorInput` (a real `Error`, or a partial
+ * `{ message?, path?, code?, data? }`) into a firm `ValidationError`.
+ * The form always stamps its own `formKey`; a missing or empty `message`
+ * coerces to `"Unknown error"` and a missing or empty `code` to
+ * `defaultCode`, so the result is always well-formed — library code
+ * never throws into the consumer app over a malformed error input.
+ *
+ * `scope` pins the path: pass the canonical segments for a path-scoped
+ * write (`setErrors(path, …)`), or `undefined` to honor the input's own
+ * `path` (which defaults to the form-level `[]`).
+ *
+ * Shared by `form.setErrors` (default code `atta:user-error`) and the
+ * `handleSubmit` throw-surfacing path (default code `atta:submit-error`).
+ */
+export function normalizeErrorInput(
+  item: ErrorInput,
+  scope: Path | undefined,
+  formKey: FormKey,
+  defaultCode: string
+): ValidationError {
+  if (item instanceof Error) {
+    return {
+      message: item.message.length > 0 ? item.message : 'Unknown error',
+      path: scope !== undefined ? [...scope] : [],
+      formKey,
+      code: defaultCode,
+    }
+  }
+  const entry: ValidationError = {
+    message:
+      typeof item.message === 'string' && item.message.length > 0 ? item.message : 'Unknown error',
+    path: scope !== undefined ? [...scope] : Array.isArray(item.path) ? [...item.path] : [],
+    formKey,
+    code: typeof item.code === 'string' && item.code.length > 0 ? item.code : defaultCode,
+  }
+  if (item.data !== undefined) entry.data = item.data
+  return entry
+}
+
+/**
+ * Normalize a single `ErrorInput` or an array of them into a
+ * `ValidationError[]`, applying `normalizeErrorInput` to each. See it for
+ * the `scope` / `formKey` / `defaultCode` semantics.
+ */
+export function normalizeErrorInputs(
+  input: ErrorInput | ErrorInput[],
+  scope: Path | undefined,
+  formKey: FormKey,
+  defaultCode: string
+): ValidationError[] {
+  const items = Array.isArray(input) ? input : [input]
+  return items.map((item) => normalizeErrorInput(item, scope, formKey, defaultCode))
 }
 
 /**

--- a/src/runtime/core/process-form.ts
+++ b/src/runtime/core/process-form.ts
@@ -407,9 +407,13 @@ export function buildProcessForm<F extends GenericForm, Out extends GenericForm 
   }
 
   /**
-   * handleSubmit(onSubmit, onError?) builds a submit handler. On success:
-   * clear errors, call onSubmit. On failure: populate errors via
-   * setAllErrors, then call onError if provided.
+   * handleSubmit(onSubmit, onError?) builds a submit handler. The two
+   * callbacks dispatch on Attaform's validation verdict: when pre-dispatch
+   * validation fails, populate the schema-error store and call `onError`
+   * (never `onSubmit`); when it passes, call `onSubmit` with the parsed
+   * data. `onError` fires iff validation rejected the submit — a throw, a
+   * `setErrors`, or a clean return out of `onSubmit` is the dev's own
+   * outcome and never routes back through `onError`.
    *
    * If the user's onError throws/rejects, the thrown value is wrapped in
    * SubmitErrorHandlerError so inspection can tell "my error handler
@@ -572,26 +576,23 @@ export function buildProcessForm<F extends GenericForm, Out extends GenericForm 
           state.clearSchemaErrors()
         }
         await onSubmit(merged.data)
-        // #438: a callback that left errors in the user-error layer did not
-        // succeed. The entry-clear above means any user error present now was
-        // set by this callback (the documented setErrors-and-return
-        // server-rejection path). Route it through the same failure path as a
-        // client validation failure rather than flipping `submitted`: focus
-        // the first error (generation-gated, like the validation-failure
-        // branch) and run `onError` with what the callback left behind. On the
-        // success-then-setErrors path schema errors were just cleared and
-        // validation passed, so `userErrors` is the complete current error set
-        // and doubles as the `onError` payload.
+        // A callback that left errors in the user-error layer did not
+        // succeed (the documented `setErrors(...); return` server-rejection
+        // path — the entry-clear at submit start means any user error
+        // present now was set by this callback). Focus the first error
+        // (generation-gated, like the validation-failure branch) and leave
+        // `submitted` false.
+        //
+        // `onError` is deliberately NOT called here. The two `handleSubmit`
+        // callbacks are a dispatch on Attaform's *validation* verdict:
+        // `onError` fires iff pre-dispatch validation rejected the submit
+        // (so `onSubmit` never ran). Once `onSubmit` has run, Attaform
+        // already ruled the submit valid; the dev's own `setErrors` is a
+        // state write, not a re-verdict, so it must not route back through
+        // the `onError` arm.
         if (state.userErrors.size > 0) {
           if (state.submissionGeneration.value === genAtEntry) {
             applyInvalidSubmitPolicy(state, formInstanceId, invalidPolicy)
-          }
-          if (onError !== undefined) {
-            try {
-              await onError(Array.from(state.userErrors.values()).flat())
-            } catch (cause) {
-              throw new SubmitErrorHandlerError('User-provided onError threw', { cause })
-            }
           }
           return
         }

--- a/src/runtime/core/process-form.ts
+++ b/src/runtime/core/process-form.ts
@@ -56,8 +56,9 @@ function isErrorInputLike(value: unknown): value is ErrorInput {
  * is normalized honoring its own `path` / `code`, so a dev who threw
  * `{ path: ['email'], message }` gets a field-scoped error and a bare
  * `Error` lands form-level (`[]`). A garbage throw still injects one
- * form-level entry carrying `toError`'s diagnostic message, and reports
- * `messageless` so the caller can nudge the dev in development.
+ * form-level entry with the normalizer's canonical `Unknown error`
+ * fallback (consistent with `setErrors`), and reports `messageless` so
+ * the caller can nudge the dev in development.
  */
 function deriveSubmitErrors(
   err: unknown,
@@ -77,10 +78,13 @@ function deriveSubmitErrors(
       messageless: false,
     }
   }
+  // Garbage: a primitive, null, undefined, a shapeless object, or an array
+  // with a non-ErrorInput element. Run an empty ErrorInput through the SAME
+  // normalizer `setErrors` uses so the rendered message is its canonical
+  // `Unknown error` fallback, not a bespoke submit string. `toError`'s raw
+  // diagnostic still lands on `submitError`; this is the consistent projection.
   return {
-    entries: [
-      { message: toError(err).message, path: [], formKey, code: AttaformErrorCode.SubmitError },
-    ],
+    entries: [normalizeErrorInput({}, undefined, formKey, AttaformErrorCode.SubmitError)],
     messageless: true,
   }
 }

--- a/src/runtime/core/process-form.ts
+++ b/src/runtime/core/process-form.ts
@@ -1,5 +1,7 @@
 import { getCurrentScope, onScopeDispose, ref, watchEffect, type Ref } from 'vue'
 import type {
+  ErrorInput,
+  FormKey,
   HandleSubmit,
   OnError,
   OnInvalidSubmitPolicy,
@@ -14,7 +16,7 @@ import type { GenericForm } from '../types/types-core'
 import type { FormStore } from './create-form-store'
 import { __DEV__ } from './dev'
 import { AttaformErrorCode } from './error-codes'
-import { SubmitErrorHandlerError, toError } from './errors'
+import { normalizeErrorInput, SubmitErrorHandlerError, toError } from './errors'
 import { canonicalizePath, segmentsForPathKey, type Path, type Segment } from './paths'
 
 /**
@@ -28,6 +30,60 @@ import { canonicalizePath, segmentsForPathKey, type Path, type Segment } from '.
 const warnedNoScopeStores: WeakSet<FormStore<GenericForm>> | null = __DEV__
   ? new WeakSet<FormStore<GenericForm>>()
   : null
+
+/**
+ * Does `value` look like a well-constructed `ErrorInput` — something the
+ * shared normalizer can turn into a meaningful `ValidationError`? A real
+ * `Error` qualifies; so does a plain object carrying a non-empty string
+ * `message` and/or an array `path` (a thrown `{ path, message, code? }`).
+ * Everything else (a bare primitive, `null`, `undefined`, a shapeless
+ * object) is garbage that would normalize to an empty "Unknown error", so
+ * the submit-throw path treats it separately.
+ */
+function isErrorInputLike(value: unknown): value is ErrorInput {
+  if (value instanceof Error) return true
+  if (typeof value !== 'object' || value === null) return false
+  const shape = value as { message?: unknown; path?: unknown }
+  return (
+    (typeof shape.message === 'string' && shape.message.length > 0) || Array.isArray(shape.path)
+  )
+}
+
+/**
+ * Turn whatever a `handleSubmit` `onSubmit` callback threw into the
+ * `ValidationError[]` to pipe into the user-error layer, all under the
+ * `atta:submit-error` code. A well-constructed throw (or array of them)
+ * is normalized honoring its own `path` / `code`, so a dev who threw
+ * `{ path: ['email'], message }` gets a field-scoped error and a bare
+ * `Error` lands form-level (`[]`). A garbage throw still injects one
+ * form-level entry carrying `toError`'s diagnostic message, and reports
+ * `messageless` so the caller can nudge the dev in development.
+ */
+function deriveSubmitErrors(
+  err: unknown,
+  formKey: FormKey
+): { entries: ValidationError[]; messageless: boolean } {
+  if (Array.isArray(err) && err.length > 0 && err.every(isErrorInputLike)) {
+    return {
+      entries: err.map((item) =>
+        normalizeErrorInput(item, undefined, formKey, AttaformErrorCode.SubmitError)
+      ),
+      messageless: false,
+    }
+  }
+  if (isErrorInputLike(err)) {
+    return {
+      entries: [normalizeErrorInput(err, undefined, formKey, AttaformErrorCode.SubmitError)],
+      messageless: false,
+    }
+  }
+  return {
+    entries: [
+      { message: toError(err).message, path: [], formKey, code: AttaformErrorCode.SubmitError },
+    ],
+    messageless: true,
+  }
+}
 
 /**
  * validate + handleSubmit, both built against a FormStore<F>. Replaces
@@ -367,7 +423,12 @@ export function buildProcessForm<F extends GenericForm, Out extends GenericForm 
    *     question, independent of whether anything awaited.
    *   - `submitError` clears at entry and captures anything thrown from
    *     the user callback (or the wrapped error-handler error), coerced to
-   *     a real `Error` via `toError`. The handler does NOT re-throw: a
+   *     a real `Error` via `toError`. A throw out of `onSubmit` is ALSO
+   *     piped into the user-error layer under `atta:submit-error`, so it
+   *     surfaces on `form.errors` / `meta.ownErrors` / `firstOwnError`
+   *     (path-scoped when the throw was well-constructed, form-level `[]`
+   *     otherwise); a wrapped `SubmitErrorHandlerError` is the exception
+   *     and stays `submitError`-only. The handler does NOT re-throw: a
    *     rejecting `onSubmit` bound to `@submit.prevent` would otherwise
    *     surface as a `window` unhandledrejection (a phantom crash for an
    *     already-handled server failure). Both template and imperative
@@ -563,6 +624,49 @@ export function buildProcessForm<F extends GenericForm, Out extends GenericForm 
         // submit never strands the button.
         if (state.submissionGeneration.value === genAtEntry) {
           state.submitError.value = toError(err)
+          // `submitError` alone is a raw-`Error` inspection channel most
+          // templates never render, so a thrown submit would otherwise be
+          // invisible in the UI. Pipe the throw into the user-error layer
+          // too (the same normalizer `setErrors` uses) so it surfaces on
+          // `form.errors` / `meta.ownErrors` / `firstOwnError` where the
+          // form already reads: path-scoped when the dev threw a
+          // well-constructed `{ path, message }`, form-level (`[]`)
+          // otherwise. `submitError` keeps the raw Error; this is the
+          // rendered projection of the same failure, not a duplicate.
+          //
+          // Excludes `SubmitErrorHandlerError`: that wraps a crash in the
+          // dev's *validation* `onError` handler, not a failed submit, so
+          // it stays a pure `submitError` diagnostic and is never shown as
+          // a form error.
+          if (!(err instanceof SubmitErrorHandlerError)) {
+            const { entries, messageless } = deriveSubmitErrors(err, state.formKey)
+            // Group by path so a thrown array spanning several fields writes
+            // one bucket per path. Per-path writes MERGE: a bucket the
+            // callback set at another path via `setErrors` before it threw
+            // survives, while a bucket at a colliding path is replaced (the
+            // throw is the newer verdict).
+            const byPath = new Map<string, { segments: Path; entries: ValidationError[] }>()
+            for (const entry of entries) {
+              const { key } = canonicalizePath(entry.path)
+              const bucket = byPath.get(key)
+              if (bucket === undefined) byPath.set(key, { segments: entry.path, entries: [entry] })
+              else bucket.entries.push(entry)
+            }
+            for (const { segments, entries: bucket } of byPath.values()) {
+              state.setUserErrorsForPath(segments, bucket)
+            }
+            // Focus the first error, mirroring the validation-failure and
+            // leftover-errors branches. A form-level `[]` error owns no
+            // element, so this is a no-op in that case.
+            applyInvalidSubmitPolicy(state, formInstanceId, invalidPolicy)
+            if (__DEV__ && messageless) {
+              console.warn(
+                '[attaform] handleSubmit callback threw a non-Error value; throw an ' +
+                  'Error or a ValidationError ({ message, path? }) so the failure ' +
+                  'surfaces with a usable message.'
+              )
+            }
+          }
         }
       } finally {
         // If validation threw before we decremented, drop the counter now

--- a/test/composables/submit-success-semantics.test.ts
+++ b/test/composables/submit-success-semantics.test.ts
@@ -15,7 +15,11 @@ import { waitUntil } from '../utils/form-harness'
  * errors in the user-error layer has NOT submitted successfully:
  *
  *   - `meta.submitted` must stay `false`.
- *   - `onError` must fire with the errors that were set.
+ *   - `onError` must NOT fire: it is the validation-verdict handler
+ *     (fires iff validation rejects the submit and `onSubmit` never
+ *     runs). Once `onSubmit` has run, a `setErrors` inside it is the
+ *     dev's own state write, not a re-verdict, so it does not route back
+ *     through `onError`.
  *
  * A clean return that leaves no errors behind is the only success
  * (the positive control guards against over-correction). Validation
@@ -81,7 +85,7 @@ describe('handleSubmit success semantics (#438)', () => {
     expect(api.meta.submitted).toBe(false)
   })
 
-  it('fires onError with the errors the callback left behind', async () => {
+  it('does NOT call onError when the callback sets errors and returns', async () => {
     const { app, api } = mountForm(schema, { email: 'user@example.com' })
     apps.push(app)
     const onError = vi.fn()
@@ -90,10 +94,15 @@ describe('handleSubmit success semantics (#438)', () => {
     }, onError)
     await handler(new Event('submit'))
     await waitUntil(() => api.meta.submissionAttempts === 1)
-    expect(onError).toHaveBeenCalledTimes(1)
-    const errors = onError.mock.calls[0]?.[0] ?? []
+    // onError is the validation-verdict handler. Validation passed here,
+    // so onSubmit ran; the setErrors inside it is the dev's own state
+    // write, not a re-verdict, and must not route back through onError.
+    expect(onError).not.toHaveBeenCalled()
+    // The error the callback set is still recorded — submitted stays false
+    // and it shows in the user-error layer — it just doesn't fire onError.
+    expect(api.meta.submitted).toBe(false)
     expect(
-      errors.some(
+      api.meta.errors.some(
         (e: { message: string }) => e.message === 'Service unavailable, try again shortly.'
       )
     ).toBe(true)

--- a/test/composables/submit-throw-surfaces.test.ts
+++ b/test/composables/submit-throw-surfaces.test.ts
@@ -142,7 +142,7 @@ describe.each(adapters)('handleSubmit throw surfacing — $name', ({ useForm, z 
     expect(emailOwn[0]?.code).toBe(AttaformErrorCode.SubmitError)
   })
 
-  it('injects a diagnostic entry and warns in dev on a non-Error throw', async () => {
+  it('injects an Unknown error entry and warns in dev on a non-Error throw', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const api = mountForm(valid)
     const handler = api.handleSubmit(async () => {
@@ -153,10 +153,14 @@ describe.each(adapters)('handleSubmit throw surfacing — $name', ({ useForm, z 
 
     expect(api.meta.ownErrors).toHaveLength(1)
     const entry: ValidationError = api.meta.ownErrors[0]
-    expect(entry.message).toBe('Submit callback threw a non-Error value (undefined)')
+    // Consistent with setErrors([{}]): the rendered message is the shared
+    // `Unknown error` fallback, not a bespoke submit diagnostic.
+    expect(entry.message).toBe('Unknown error')
     expect(entry.code).toBe(AttaformErrorCode.SubmitError)
-    // submitError is coerced to a real Error carrying the diagnostic.
+    // submitError keeps toError's raw diagnostic on the inspection channel
+    // (raw vs rendered): the two channels intentionally differ here.
     expect(api.meta.submitError).toBeInstanceOf(Error)
+    expect(String(api.meta.submitError?.message)).toContain('non-Error value')
     // Dev-mode nudge to throw a real Error / ValidationError next time.
     expect(warnSpy).toHaveBeenCalledTimes(1)
     expect(String(warnSpy.mock.calls[0]?.[0])).toContain('non-Error value')

--- a/test/composables/submit-throw-surfaces.test.ts
+++ b/test/composables/submit-throw-surfaces.test.ts
@@ -1,0 +1,211 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, type App } from 'vue'
+import { z as zV4 } from 'zod'
+import { z as zV3 } from 'zod-v3'
+import { useForm as useFormV4 } from '../../src/zod-v4'
+import { useForm as useFormV3 } from '../../src/zod-v3'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import { AttaformErrorCode } from '../../src/runtime/core/error-codes'
+import { waitUntil } from '../utils/form-harness'
+import type { ValidationError } from '../../src/runtime/types/types-api'
+
+/**
+ * A throw or rejection out of a `handleSubmit` `onSubmit` callback is
+ * surfaced two ways: the raw `Error` parks on `form.meta.submitError`
+ * (an inspection channel), AND a normalized copy is piped into the
+ * user-error layer under `atta:submit-error` so it shows on
+ * `form.errors` / `meta.ownErrors` / `firstOwnError` — the surfaces a UI
+ * already renders. A well-constructed throw (`{ path, message, code? }`,
+ * or an array of them) lands path-scoped with its own code; a bare
+ * `Error` or a non-Error throw lands form-level (`[]`).
+ *
+ * `onError` is the validation-verdict handler and never fires on a
+ * throw: by the time `onSubmit` ran, validation had already passed.
+ * A crashed *validation* `onError` (wrapped as `SubmitErrorHandlerError`)
+ * is the one throw that stays `submitError`-only and is NOT injected.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyUseForm = (opts: any) => any
+
+const adapters = [
+  { name: 'zod v3', useForm: useFormV3 as AnyUseForm, z: zV3 as unknown as typeof zV4 },
+  { name: 'zod v4', useForm: useFormV4 as AnyUseForm, z: zV4 },
+] as const
+
+let keySeq = 0
+
+describe.each(adapters)('handleSubmit throw surfacing — $name', ({ useForm, z }) => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  // `email` carries a `min(3)` so an invalid default (`'ab'`) drives the
+  // validation-failure path used by the SubmitErrorHandlerError test;
+  // every other test mounts with a valid default so `onSubmit` runs.
+  const schema = z.object({ email: z.string().min(3), password: z.string() })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function mountForm(defaultValues: { email: string; password: string }): any {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const handle: { api?: any } = {}
+    const Host = defineComponent({
+      setup() {
+        handle.api = useForm({
+          schema,
+          key: `submit-throw-${keySeq++}`,
+          strict: false,
+          defaultValues,
+        })
+        return () => h('div')
+      },
+    })
+    const app = createApp(Host).use(createAttaform())
+    app.config.warnHandler = () => {}
+    app.config.errorHandler = () => {}
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    apps.push(app)
+    if (handle.api === undefined) throw new Error('mountForm: api never set')
+    return handle.api
+  }
+
+  const valid = { email: 'user@example.com', password: 'secret' }
+
+  it('surfaces a thrown Error as a form-level error and keeps submitError', async () => {
+    const api = mountForm(valid)
+    const boom = new Error('Payment declined')
+    const onError = vi.fn()
+    const handler = api.handleSubmit(async () => {
+      throw boom
+    }, onError)
+    await handler(new Event('submit'))
+    await waitUntil(() => api.meta.submissionAttempts >= 1)
+
+    // Injected into the user-error layer at the form-level [] bucket.
+    expect(api.meta.ownErrors).toHaveLength(1)
+    const entry: ValidationError = api.meta.ownErrors[0]
+    expect(entry.message).toBe('Payment declined')
+    expect(entry.path).toEqual([])
+    expect(entry.code).toBe(AttaformErrorCode.SubmitError)
+    // #489 banner accessor now also catches the thrown submit error.
+    expect(api.meta.firstOwnError?.message).toBe('Payment declined')
+
+    // The raw Error is still the submitError, byte-identical (not re-wrapped).
+    expect(api.meta.submitError).toBe(boom)
+
+    // A throw is not a success and not a validation verdict.
+    expect(api.meta.submitted).toBe(false)
+    expect(api.meta.valid).toBe(false)
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it('routes a well-constructed thrown object to its path with its code', async () => {
+    const api = mountForm(valid)
+    const handler = api.handleSubmit(async () => {
+      throw { path: ['email'], message: 'Already taken', code: 'api:dupe' }
+    })
+    await handler(new Event('submit'))
+    await waitUntil(() => api.meta.submissionAttempts >= 1)
+
+    const own: ValidationError[] = api.fields.email.ownErrors
+    expect(own).toHaveLength(1)
+    expect(own[0]?.message).toBe('Already taken')
+    expect(own[0]?.code).toBe('api:dupe')
+    expect(own[0]?.path).toEqual(['email'])
+    // Path-scoped: the root [] bucket stays clean.
+    expect(api.meta.ownErrors).toHaveLength(0)
+    expect(api.meta.submitted).toBe(false)
+  })
+
+  it('spreads a thrown array of errors across multiple paths', async () => {
+    const api = mountForm(valid)
+    const handler = api.handleSubmit(async () => {
+      throw [
+        { path: ['email'], message: 'Bad email' },
+        { path: ['password'], message: 'Bad password' },
+      ]
+    })
+    await handler(new Event('submit'))
+    await waitUntil(() => api.meta.submissionAttempts >= 1)
+
+    const emailOwn: ValidationError[] = api.fields.email.ownErrors
+    const passwordOwn: ValidationError[] = api.fields.password.ownErrors
+    expect(emailOwn[0]?.message).toBe('Bad email')
+    expect(passwordOwn[0]?.message).toBe('Bad password')
+    // Both default to the submit-error code.
+    expect(emailOwn[0]?.code).toBe(AttaformErrorCode.SubmitError)
+  })
+
+  it('injects a diagnostic entry and warns in dev on a non-Error throw', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const api = mountForm(valid)
+    const handler = api.handleSubmit(async () => {
+      throw undefined
+    })
+    await handler(new Event('submit'))
+    await waitUntil(() => api.meta.submissionAttempts >= 1)
+
+    expect(api.meta.ownErrors).toHaveLength(1)
+    const entry: ValidationError = api.meta.ownErrors[0]
+    expect(entry.message).toBe('Submit callback threw a non-Error value (undefined)')
+    expect(entry.code).toBe(AttaformErrorCode.SubmitError)
+    // submitError is coerced to a real Error carrying the diagnostic.
+    expect(api.meta.submitError).toBeInstanceOf(Error)
+    // Dev-mode nudge to throw a real Error / ValidationError next time.
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(String(warnSpy.mock.calls[0]?.[0])).toContain('non-Error value')
+  })
+
+  it('clears an injected throw error on the next submit', async () => {
+    const api = mountForm(valid)
+    let calls = 0
+    const handler = api.handleSubmit(async () => {
+      calls += 1
+      if (calls === 1) throw new Error('transient')
+    })
+
+    await handler(new Event('submit'))
+    await waitUntil(() => api.meta.submissionAttempts >= 1)
+    expect(api.meta.ownErrors).toHaveLength(1)
+
+    await handler(new Event('submit'))
+    await waitUntil(() => api.meta.submitted)
+    // Entry-clear at submit start wiped the prior injection; a clean
+    // second run submits successfully with an empty error layer.
+    expect(api.meta.ownErrors).toHaveLength(0)
+    expect(api.meta.submitted).toBe(true)
+    expect(api.meta.submitError).toBe(null)
+  })
+
+  it('keeps a crashed validation onError as submitError-only, never injected', async () => {
+    // Invalid default → validation fails → onError runs (onSubmit never
+    // does). The onError itself throws, which wraps as
+    // SubmitErrorHandlerError and must NOT pipe into the error layer.
+    const api = mountForm({ email: 'ab', password: 'secret' })
+    const handler = api.handleSubmit(
+      async () => {
+        throw new Error('should not run')
+      },
+      () => {
+        throw new Error('handler boom')
+      }
+    )
+    await handler(new Event('submit'))
+    await waitUntil(() => api.meta.submissionAttempts >= 1)
+
+    // The wrapped handler crash is parked for inspection...
+    expect(api.meta.submitError).toBeInstanceOf(Error)
+    // ...the validation error is present...
+    expect(api.meta.errors.length).toBeGreaterThan(0)
+    // ...but nothing was injected under the submit-error code.
+    expect(
+      api.meta.errors.every((e: ValidationError) => e.code !== AttaformErrorCode.SubmitError)
+    ).toBe(true)
+  })
+})


### PR DESCRIPTION
> **Stacked on #489** (base `feat/own-errors-489`). It depends on that branch's `ownErrors` / `firstOwnError` accessors, so land #489 first; this PR's diff is just the 4 commits on top.

Two coupled changes to `handleSubmit`'s post-callback model, plus infra and a size rebaseline.

## 1. Surface a thrown `onSubmit` as a form error

A throw or rejection out of an `onSubmit` callback used to be invisible in the UI: it only parked the raw `Error` on `form.meta.submitError`, a channel most templates never render. It now **also** pipes a normalized `ValidationError` into the user-error layer under a new code `atta:submit-error`, so the failure shows on `form.errors` / `form.meta.ownErrors` / `form.meta.firstOwnError` where the UI already reads, with no consumer `try` / `catch`.

- A bare `throw new Error(...)` lands form-level (root `[]` bucket).
- A thrown `{ path, message, code? }` (or an array of them) lands path-scoped with its own code.
- A non-Error throw (`throw undefined`) still injects a diagnostic entry and `console.warn`s in dev.
- A wrapped `SubmitErrorHandlerError` (a crashed *validation* `onError`) is excluded and stays `submitError`-only.

`submitError` still holds the raw `Error` (raw-vs-rendered, not a duplicate).

## 2. `onError` is validation-only

`onError` now fires iff pre-dispatch validation rejects the submit (so `onSubmit` never ran). A `setErrors(...); return` (or a throw) inside a callback that already ran is the dev's own outcome, not a second verdict, so it no longer routes back through `onError`. It still focuses the first error and keeps `submitted` false. This also corrects a pre-existing docs overclaim that a thrown callback fired `onError` (the code never did).

The `submitted` / `done` contract is unchanged.

## Infra + size

- `normalizeErrorInput` / `normalizeErrorInputs` hoisted out of `build-form-api`'s closure into `errors.ts` (required `formKey` + `defaultCode` params); `setErrors` rewired to the shared version.
- Eager budgets rebaselined for the +242 B gz catch-block inject: `check:eager` 45_500 → 46_500, size-limit `useForm only` 54 → 55 KB, each with a recorded-reason comment.

## Tests + docs

- New `test/composables/submit-throw-surfaces.test.ts` (zod v3 + v4): Error → form-level, well-constructed object → path-scoped + code preserved, thrown array → multi-path, garbage throw → diagnostic + dev-warn, next-submit clears the injection, `SubmitErrorHandlerError` not injected.
- Flipped the #438 leftover-`onError` test to assert it is not called.
- Docs: `meta.md` submitError lifecycle, `handle-submit.md` dispatch contract, `server-side-errors.md`; CHANGELOG Added + Changed.

## Verification

Full suite (4427 pass) · typecheck · `check:bundled-types` (v3 + v4) · eslint · `build:site` (link-checker clean, 432 routes) · demo smoke · `check:eager` · `check:size`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
