### PR TITLE
feat(auto-imports): Nuxt auto-imports + zero-dep Vite preset

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -869,6 +869,13 @@ export default [
     //     shared core chunk
     //   - SSR active-step seeding via getServerActiveStep
     // Measured at 12.56 KB.
+    //
+    // Held at 14 KB through the auto-import work: the module now registers
+    // the full auto-import manifest (src/runtime/auto-imports) behind the
+    // `autoImports` toggle instead of a single useForm entry, but the
+    // manifest is a tiny static array and the persist / onchange /
+    // multi-tab removals since #221 freed ~5 KB of headroom. Measured at
+    // 8.39 KB.
     limit: '14 KB',
     gzip: true,
     ignore: ['@nuxt/kit', 'nuxt/app'],
@@ -900,6 +907,11 @@ export default [
     //   - wizard SSR / hydration handshake helpers visible to the
     //     transform side
     // Measured at 12.05 KB.
+    //
+    // Held at 13 KB when attaform/vite began re-exporting the auto-import
+    // manifest + imports-map (src/runtime/auto-imports) for the
+    // unplugin-auto-import preset — a small static data re-export, no
+    // runtime weight. Measured at 7.89 KB.
     limit: '13 KB',
     gzip: true,
     ignore: ['vite'],

--- a/src/nuxt.ts
+++ b/src/nuxt.ts
@@ -2,6 +2,7 @@ import { createRequire } from 'node:module'
 import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { addImports, addPlugin, addVitePlugin, createResolver, defineNuxtModule } from '@nuxt/kit'
+import { attaformAutoImports } from './runtime/auto-imports'
 import type { AttaformDefaults } from './runtime/types/types-api'
 import { attaform as attaformVitePlugin } from './vite'
 
@@ -42,6 +43,19 @@ export interface AttaformModuleOptions {
    * the rewrite and ship the runtime-dispatch unified entry instead.
    */
   resolveZodAlias?: boolean
+  /**
+   * Auto-import Attaform's form composables (`useForm`, `useWizard`,
+   * `injectForm`, `injectWizard`, `fieldMeta`, `withMeta`, `lazy`) so
+   * components can call them without an explicit `import`. Default
+   * `true`. The set is declared in Attaform's auto-import manifest and
+   * resolves from `attaform/zod`, so the build-time adapter rewrite
+   * still ships a single Zod major. Set to `false` to suppress the
+   * names entirely and import the composables yourself. Note a Nuxt
+   * auto-import already loses to an explicit or local binding of the
+   * same name, so opting out is only needed to keep the names out of
+   * global scope altogether.
+   */
+  autoImports?: boolean
 }
 
 /**
@@ -164,22 +178,31 @@ export default defineNuxtModule<AttaformModuleOptions>({
 
     const resolver = createResolver(import.meta.url)
 
-    // Auto-import `useForm` — the framework-agnostic core composable (same
-    // binding as `attaform`'s top-level `useForm` export, which
-    // is the abstract form composable). Consumers who want the zod-typed
-    // wrapper must import from `attaform/zod` or `/zod-v3`
-    // explicitly.
+    // Auto-import the Zod-default form composables so a component can
+    // reach for `useForm` / `useWizard` / `injectForm` / `injectWizard` /
+    // `fieldMeta` / `withMeta` / `lazy` with no import line. The manifest
+    // in `./runtime/auto-imports` is the single source of truth, shared
+    // with the `attaform/vite` preset re-export.
     //
-    // We point at the public package entry rather than a relative
-    // `./runtime/…` path on purpose: in the published package the
-    // `src/runtime/composables/use-abstract-form` path has no matching
-    // `dist/runtime/…` file (build.config's entries don't include it),
-    // so a `resolver.resolve(...)` would raise ENOENT at Nuxt's auto-
-    // import step. Importing from `attaform` resolves through
-    // the shared chunk, identical to what `attaform/zod`
-    // consumers bundle — single registry instance across both import
-    // surfaces.
-    addImports([{ name: 'useForm', from: 'attaform' }])
+    // Each entry resolves from `attaform/zod`, not the bare `attaform`
+    // barrel: the Vite/bundler plugin rewrites the exact `attaform/zod`
+    // specifier to the one installed Zod major at build time, so a Nuxt
+    // consumer's bundle ships a single adapter instead of the runtime
+    // dispatcher. After the schema-entry re-partition the two surfaces
+    // are byte-identical (`attaform` re-exports exactly what
+    // `attaform/zod` does), so pointing at `/zod` costs nothing and buys
+    // the lean bundle for free. Resolving a public subpath rather than a
+    // relative `./runtime/…` path also keeps the published package honest
+    // — `attaform/zod` maps to a real `dist/zod.mjs`, so Nuxt's
+    // auto-import step never chases a source path with no built artifact.
+    //
+    // A Nuxt auto-import always loses to an explicit or local binding, so
+    // registering these never shadows a consumer's own `useForm`. The
+    // `autoImports: false` option suppresses the whole set for consumers
+    // who prefer explicit imports everywhere.
+    if (_options.autoImports !== false) {
+      addImports(attaformAutoImports)
+    }
 
     // Plugin that installs `createAttaform()` on the Vue app and
     // wires the payload serialize/hydrate bridge. Uses a physical

--- a/src/runtime/auto-imports.ts
+++ b/src/runtime/auto-imports.ts
@@ -1,0 +1,70 @@
+/**
+ * Attaform's auto-import manifest: the single source of truth for the
+ * composables a form author reaches for inside `<script setup>` without
+ * writing an `import`. One declaration, two consumers:
+ *
+ *   - `attaform/nuxt` feeds `attaformAutoImports` to Nuxt's `addImports`
+ *     (gated behind the module's `autoImports` option, default on).
+ *   - `attaform/vite` re-exports both this flat list and the derived
+ *     `attaformAutoImportsMap` so a plain-Vite project registers the same
+ *     set through `unplugin-auto-import`.
+ *
+ * Every entry resolves from `attaform/zod`, not the bare `attaform`
+ * barrel. The reason is the build-time adapter rewrite: the Vite and
+ * bundler plugins intercept the exact `attaform/zod` specifier and
+ * collapse it to the one installed Zod major, so a consumer's bundle
+ * ships a single adapter instead of the runtime dispatcher. The two
+ * surfaces are byte-identical after the schema-entry re-partition
+ * (`attaform` re-exports exactly what `attaform/zod` does), so pointing
+ * the auto-imports at `/zod` costs the consumer nothing and earns the
+ * lean bundle for free.
+ *
+ * Deliberately absent (reach for these with an explicit import):
+ *   - `useAbstractForm` — the schema-agnostic escape hatch on
+ *     `attaform/abstract`, an advanced surface, not the default form.
+ *   - `createAttaform` — the plugin install, a setup-level one-liner that
+ *     belongs beside the app bootstrap, not in every component's scope.
+ *   - `useRegister` and the serialize helpers — low-level plumbing.
+ *
+ * A name earns a slot here only if a form author calls it directly on a
+ * normal page. The manifest test pins the set so a casual addition of a
+ * setup-level symbol to the global scope fails loudly.
+ */
+
+/**
+ * One auto-imported binding: the exported `name` and the module it is
+ * imported `from`. This is the minimal shape of unimport's `Import`,
+ * which is exactly what Nuxt's `addImports` accepts.
+ */
+export interface AttaformAutoImport {
+  readonly name: string
+  readonly from: string
+}
+
+/**
+ * The flat manifest, ready to hand to `addImports` (Nuxt) verbatim.
+ */
+export const attaformAutoImports: AttaformAutoImport[] = [
+  { name: 'useForm', from: 'attaform/zod' },
+  { name: 'useWizard', from: 'attaform/zod' },
+  { name: 'injectForm', from: 'attaform/zod' },
+  { name: 'injectWizard', from: 'attaform/zod' },
+  { name: 'fieldMeta', from: 'attaform/zod' },
+  { name: 'withMeta', from: 'attaform/zod' },
+  { name: 'lazy', from: 'attaform/zod' },
+]
+
+/**
+ * The same set grouped by module, i.e. `{ 'attaform/zod': ['useForm',
+ * ...] }`. This is `unplugin-auto-import`'s `ImportsMap` shape, a drop-in
+ * for its `imports` array (which does not accept a flat `Import[]`).
+ * Derived from `attaformAutoImports` so the two never drift.
+ */
+export const attaformAutoImportsMap: Record<string, string[]> = attaformAutoImports.reduce<
+  Record<string, string[]>
+>((map, entry) => {
+  const names = map[entry.from] ?? []
+  names.push(entry.name)
+  map[entry.from] = names
+  return map
+}, {})

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -321,3 +321,35 @@ export function attaform(options: AttaformVitePluginOptions = {}): Plugin {
     },
   }
 }
+
+/**
+ * Attaform's auto-import manifest, re-exported for plain-Vite projects
+ * that drive auto-imports with `unplugin-auto-import`. A Vite consumer
+ * already reaches for `attaform/vite` to register this plugin, so the
+ * preset rides along on the same entry, with no second Attaform import
+ * path to remember.
+ *
+ * `unplugin-auto-import`'s `imports` array takes an imports-map keyed by
+ * module, which is exactly `attaformAutoImportsMap`:
+ *
+ * ```ts
+ * // vite.config.ts
+ * import AutoImport from 'unplugin-auto-import/vite'
+ * import vue from '@vitejs/plugin-vue'
+ * import { attaform, attaformAutoImportsMap } from 'attaform/vite'
+ *
+ * export default defineConfig({
+ *   plugins: [
+ *     AutoImport({ imports: ['vue', attaformAutoImportsMap] }),
+ *     vue(),
+ *     attaform(),
+ *   ],
+ * })
+ * ```
+ *
+ * The flat `attaformAutoImports` (`{ name, from }[]`) is exported too for
+ * tooling that wants the raw list, e.g. Nuxt's `addImports` shape. Nuxt
+ * users need neither: `attaform/nuxt` registers the same manifest.
+ */
+export { attaformAutoImports, attaformAutoImportsMap } from './runtime/auto-imports'
+export type { AttaformAutoImport } from './runtime/auto-imports'

--- a/test/fixtures/auto-imports/app.vue
+++ b/test/fixtures/auto-imports/app.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+  // No attaform import lines: every composable referenced below is
+  // auto-imported by attaform/nuxt. If the module failed to register any
+  // of them, this component would fail to compile or ReferenceError
+  // during SSR, and the e2e assertions would never see their markers.
+  import { z } from 'zod'
+
+  const schema = z.object({ greeting: z.string().default('auto-import-ok') })
+  const form = useForm({ schema, key: 'auto-import-probe' })
+
+  // The non-throwing ancestor lookup with no provider present.
+  const parent = injectForm()
+
+  // Reference the rest of the auto-imported surface so a missing
+  // registration surfaces here. A name that is not auto-imported at all
+  // would ReferenceError during SSR (500); a name that is injected but is
+  // not a real export of attaform/zod would resolve to `undefined`. Both
+  // are caught. Note `fieldMeta` is a registry object, not a function
+  // (used as `schema.register(fieldMeta, payload)`), so this checks for a
+  // defined binding rather than a callable.
+  const surface: Record<string, unknown> = {
+    useForm,
+    useWizard,
+    injectForm,
+    injectWizard,
+    fieldMeta,
+    withMeta,
+    lazy,
+  }
+  const missing = Object.keys(surface).filter((k) => surface[k] === undefined)
+  const allResolved = missing.length === 0
+</script>
+
+<template>
+  <div>
+    <span id="probe-greeting">{{ form.values.greeting }}</span>
+    <span id="probe-parent">{{ parent ? 'has-parent' : 'no-parent' }}</span>
+    <span id="probe-surface">{{
+      allResolved ? 'all-composables-resolved' : `missing-composable:${missing.join(',')}`
+    }}</span>
+  </div>
+</template>

--- a/test/fixtures/auto-imports/nuxt.config.ts
+++ b/test/fixtures/auto-imports/nuxt.config.ts
@@ -1,0 +1,16 @@
+import { fileURLToPath } from 'node:url'
+import { defineNuxtConfig, type DefineNuxtConfig } from 'nuxt/config'
+import MyModule from '../../../src/nuxt'
+
+// The module auto-imports the form composables from `attaform/zod`.
+// Resolve that subpath to source (exactly as apps/site does in dev) so
+// the e2e build is deterministic and never picks up the `unbuild --stub`
+// jiti shim that lives in dist during development. See project memory:
+// "unbuild --stub jiti leak".
+const zodEntry = fileURLToPath(new URL('../../../src/zod.ts', import.meta.url))
+const attaformAlias = { 'attaform/zod': zodEntry }
+
+export default defineNuxtConfig({
+  modules: [MyModule],
+  alias: attaformAlias,
+}) as DefineNuxtConfig

--- a/test/fixtures/auto-imports/package.json
+++ b/test/fixtures/auto-imports/package.json
@@ -1,0 +1,5 @@
+{
+  "private": true,
+  "name": "auto-imports-fixture",
+  "type": "module"
+}

--- a/test/fixtures/ssr/nuxt.config.ts
+++ b/test/fixtures/ssr/nuxt.config.ts
@@ -1,9 +1,20 @@
+import { fileURLToPath } from 'node:url'
 import { defineNuxtConfig, type DefineNuxtConfig } from 'nuxt/config'
 import MyModule from '../../../src/nuxt'
+
+// The Nuxt module auto-imports the form composables from `attaform/zod`
+// (src/runtime/auto-imports). Source-alias that subpath to src so the
+// build resolves real TS instead of the `unbuild --stub` jiti shim in
+// dist, whose `node:module` / `createRequire` imports leak into the
+// browser bundle and fail the Rollup build. Mirrors
+// test/fixtures/auto-imports and apps/site. See project memory:
+// "unbuild --stub jiti leak".
+const zodEntry = fileURLToPath(new URL('../../../src/zod.ts', import.meta.url))
 
 export default defineNuxtConfig({
   modules: [MyModule],
   alias: {
     '@runtime': '../../../src/runtime',
+    'attaform/zod': zodEntry,
   },
 }) as DefineNuxtConfig

--- a/test/nuxt-auto-imports.e2e.test.ts
+++ b/test/nuxt-auto-imports.e2e.test.ts
@@ -1,0 +1,32 @@
+import { $fetch, setup } from '@nuxt/test-utils/e2e'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * End-to-end proof that attaform/nuxt's auto-imports resolve in a real
+ * Nuxt build. The fixture's app.vue calls `useForm` / `injectForm` and
+ * references the rest of the manifest with NO import line; the module is
+ * the only thing that can make those names resolve. A registration
+ * regression would fail the build or ReferenceError during SSR, so a
+ * missing marker in the rendered HTML is the failure signal.
+ */
+describe('attaform/nuxt auto-imports (e2e)', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL('./fixtures/auto-imports', import.meta.url)),
+  })
+
+  it('renders a form built from the auto-imported useForm', async () => {
+    const html = await $fetch('/')
+    expect(html).toContain('auto-import-ok')
+  })
+
+  it('resolves the auto-imported injectForm (no ancestor form present)', async () => {
+    const html = await $fetch('/')
+    expect(html).toContain('no-parent')
+  })
+
+  it('resolves the full auto-imported composable surface', async () => {
+    const html = await $fetch('/')
+    expect(html).toContain('all-composables-resolved')
+  })
+})

--- a/test/nuxt/auto-imports.test.ts
+++ b/test/nuxt/auto-imports.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { attaformAutoImports, attaformAutoImportsMap } from '../../src/runtime/auto-imports'
+import * as zodEntry from '../../src/zod'
+
+/**
+ * Standing diagnostic for the auto-import manifest. It is the single
+ * source of truth behind both the Nuxt module's `addImports` call and
+ * the `attaform/vite` preset re-export, so drift here silently changes
+ * what lands in every consumer's global component scope.
+ */
+describe('attaformAutoImports manifest', () => {
+  const names = attaformAutoImports.map((entry) => entry.name)
+
+  it('surfaces exactly the intended component-scope composables', () => {
+    expect([...names].sort()).toEqual(
+      ['fieldMeta', 'injectForm', 'injectWizard', 'lazy', 'useForm', 'useWizard', 'withMeta'].sort()
+    )
+  })
+
+  it('routes every binding through attaform/zod for the build-time single-adapter rewrite', () => {
+    for (const entry of attaformAutoImports) {
+      expect(entry.from).toBe('attaform/zod')
+    }
+  })
+
+  it('only names bindings that attaform/zod actually exports', () => {
+    // Catches a typo or a rename that leaves the manifest pointing at a
+    // symbol the entry no longer ships — unimport would inject a dead
+    // import that fails at build time in the consumer, not here.
+    for (const entry of attaformAutoImports) {
+      expect(zodEntry).toHaveProperty(entry.name)
+    }
+  })
+
+  it('keeps setup-level and escape-hatch surface out of component scope', () => {
+    // Auto-importing any of these would drop names into every
+    // `<script setup>` that only make sense at plugin-install or
+    // advanced-adapter level.
+    for (const excluded of ['createAttaform', 'useRegister', 'useAbstractForm']) {
+      expect(names).not.toContain(excluded)
+    }
+  })
+
+  it('declares each name once', () => {
+    expect(new Set(names).size).toBe(names.length)
+  })
+
+  it('derives the unplugin-auto-import map without dropping or duplicating a name', () => {
+    // attaformAutoImportsMap groups the flat list by module for
+    // unplugin-auto-import's ImportsMap shape. Round-trip it back to a
+    // flat name set and confirm nothing was lost in the grouping.
+    const flattened = Object.values(attaformAutoImportsMap).flat()
+    expect([...flattened].sort()).toEqual([...names].sort())
+    expect(attaformAutoImportsMap['attaform/zod']).toEqual(names)
+  })
+})

--- a/test/nuxt/module-auto-imports.test.ts
+++ b/test/nuxt/module-auto-imports.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AttaformModuleOptions } from '../../src/nuxt'
+import { attaformAutoImports } from '../../src/runtime/auto-imports'
+
+/**
+ * Drives `attaform/nuxt`'s `setup` against a hand-built fake Nuxt to
+ * prove the auto-import wiring and its `autoImports` toggle, without
+ * standing up a real Nuxt build. `@nuxt/kit`'s `add*` helpers each reach
+ * for a live Nuxt context, so they are replaced with spies; the rest of
+ * the kit (notably `createResolver`) stays real.
+ */
+const { addImports, addPlugin, addVitePlugin } = vi.hoisted(() => ({
+  addImports: vi.fn(),
+  addPlugin: vi.fn(),
+  addVitePlugin: vi.fn(),
+}))
+
+vi.mock('@nuxt/kit', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    // Return a plain callable that runs `setup` with merged options,
+    // skipping Nuxt's option normalization + compatibility checks (which
+    // would demand a real Nuxt instance).
+    defineNuxtModule: (definition: {
+      defaults?: object
+      setup: (options: object, nuxt: object) => void
+    }) => {
+      return (options: object, nuxt: object) =>
+        definition.setup({ ...(definition.defaults ?? {}), ...options }, nuxt)
+    },
+    addImports,
+    addPlugin,
+    addVitePlugin,
+  }
+})
+
+// Imported after the mock is registered so the module's `@nuxt/kit`
+// bindings resolve to the spies above.
+const attaformModule = (await import('../../src/nuxt')).default
+
+// The mocked `defineNuxtModule` returns a bare `(options, nuxt) => void`.
+// Cast through the mock's real runtime shape to invoke it with a fake
+// Nuxt — a test-harness cast, not a library type gap.
+type ModuleInvoke = (options: Partial<AttaformModuleOptions>, nuxt: FakeNuxt) => void
+const invokeModule = attaformModule as unknown as ModuleInvoke
+
+interface FakeNuxt {
+  options: {
+    runtimeConfig: { public: Record<string, unknown> }
+    vite: { optimizeDeps?: { include?: string[] } }
+    rootDir: string
+    dev: boolean
+  }
+  hook: ReturnType<typeof vi.fn>
+}
+
+function makeNuxt(): FakeNuxt {
+  return {
+    options: {
+      runtimeConfig: { public: {} },
+      vite: {},
+      rootDir: process.cwd(),
+      dev: false,
+    },
+    hook: vi.fn(),
+  }
+}
+
+describe('attaform/nuxt auto-import wiring', () => {
+  beforeEach(() => {
+    addImports.mockClear()
+    addPlugin.mockClear()
+    addVitePlugin.mockClear()
+  })
+
+  it('registers the full manifest by default', () => {
+    invokeModule({}, makeNuxt())
+    expect(addImports).toHaveBeenCalledTimes(1)
+    expect(addImports).toHaveBeenCalledWith(attaformAutoImports)
+  })
+
+  it('skips registration when autoImports is false', () => {
+    invokeModule({ autoImports: false }, makeNuxt())
+    expect(addImports).not.toHaveBeenCalled()
+  })
+
+  it('still installs the Vite plugin and runtime plugin when auto-imports are off', () => {
+    // The toggle must gate only `addImports`, never the SSR-critical Vite
+    // transforms or the registry plugin.
+    invokeModule({ autoImports: false }, makeNuxt())
+    expect(addVitePlugin).toHaveBeenCalledTimes(1)
+    expect(addPlugin).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Phase 2 of the schema-entry refactor: auto-imports

Builds on #495 (the barrel flip). This phase makes `attaform`'s form composables reachable in a Nuxt `<script setup>` with **no import line**, and ships a zero-dep Vite preset so plain-Vite projects get the same DX. Non-breaking and additive.

Stacked as **3 bisectable commits** (manifest, Nuxt wiring, Vite preset), each independently green.

### What changed

- **`src/runtime/auto-imports.ts` (new)** — the single source of truth: a flat `attaformAutoImports` manifest of `{ name, from }`, plus a derived `attaformAutoImportsMap` (grouped by module).
- **`attaform/nuxt`** — registers the whole manifest via `addImports`, gated behind a new `autoImports?: boolean` option (default **true**). Replaces the old single `useForm` auto-import, whose target (bare `attaform`) and comment both predated the barrel flip.
- **`attaform/vite`** — re-exports both manifest forms for `unplugin-auto-import`.

| Composable | Auto-imported? | Resolves from |
| --- | --- | --- |
| `useForm`, `useWizard`, `injectForm`, `injectWizard`, `fieldMeta`, `withMeta`, `lazy` | ✅ | `attaform/zod` |
| `useAbstractForm`, `createAttaform`, `useRegister`, serialize helpers | ❌ (explicit import) | — |

**Why `attaform/zod`, not bare `attaform`:** the build-time adapter rewrite intercepts the exact `attaform/zod` specifier and collapses it to the one installed Zod major, so a Nuxt/Vite consumer ships a **single adapter**, not the runtime dispatcher. Post-#495 the two surfaces are byte-identical, so this costs nothing and buys the lean bundle for free. (Bare `attaform` gets the same treatment in Phase 3.)

### 🔶 For your redline — the auto-imported set

The plan flagged this set as tunable. This is the one observable-behavior decision here: these 7 names become globals in every Nuxt app that installs the module. Current call: the composables a form author reaches for *on a page*, excluding setup-level (`createAttaform`) and escape-hatch (`useAbstractForm`) surface. Easy to add/drop entries — the manifest is one array and a test pins it. Flagging per the "reference before API change" guardrail.

### Deviation from the plan

The plan documented `AutoImport({ imports: [attaformAutoImports] })`. Reading `unplugin-auto-import@21`'s actual types, its `imports` is `Arrayable<ImportsMap | PresetName | InlinePreset>` — it does **not** accept a flat `Import[]`. So I added `attaformAutoImportsMap` (the `{ 'attaform/zod': [...] }` `ImportsMap` shape) as the real drop-in, derived from the flat list so the two can't drift. The flat form stays for Nuxt's `addImports` (which *does* take `Import[]`, proven by `pnpm typecheck` at the call site).

### Testing (3 layers, distinct failure modes)

- **`test/nuxt/auto-imports.test.ts`** — pins the manifest: exact set, every `from` is `attaform/zod`, each name is a *real export* of the entry, the exclusions hold, and the map derivation round-trips.
- **`test/nuxt/module-auto-imports.test.ts`** — drives the module `setup` against a fake Nuxt (kit `add*` spied): registers by default, `autoImports:false` skips, and the toggle never gates the SSR-critical Vite/runtime plugins.
- **`test/nuxt-auto-imports.e2e.test.ts` + fixture** — a real Nuxt build whose `app.vue` calls `useForm`/`injectForm` and references the rest of the manifest with **no import line**, asserting the rendered markers. It caught that `fieldMeta` is a registry object (used as `schema.register(fieldMeta, …)`), not a function — so the probe checks for a *defined binding*, not a callable. The fixture source-aliases `attaform/zod` to dodge the `unbuild --stub` jiti shim.

### Size

No rebaseline. `nuxt.mjs` 8.39 KB (cap 14), `vite.mjs` 7.89 KB (cap 13) — the manifest is tiny static data and both entries sit far under cap. The Zod entries are untouched from #495. Added "held" notes to `.size-limit.js` for the archaeology.

### Verification

`pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm test` ✓ (4461 passing, incl. the 3 new suites) · `pnpm check:bundled-types` ✓ · `size-limit` ✓ · `pnpm build:site` ✓ · `pnpm check:site` (vue-tsc) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
