### PR TITLE
feat(plugins)!: rewrite the bare `attaform` barrel to a single adapter under bundler plugins

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -294,6 +294,16 @@ export default [
     // the Zod-default dispatcher + core. Measured at 60.97 KB — byte-for-byte
     // the same as zod.mjs. The `{ useForm }` tripwire below held at 54 KB, so
     // a real single-import consumer pays nothing for the whole-entry growth.
+    //
+    // Under a bundler plugin (attaform/vite|rollup|esbuild|webpack|rspack)
+    // with a single Zod major detected, bare `attaform` is rewritten to the
+    // pinned adapter (Phase 3 — the same rewrite `attaform/zod` already got),
+    // so a plugin-using consumer ships the dist/zod-v4.mjs / dist/zod-v3.mjs
+    // single-adapter weight (see those entries: 56 / 57 KB) rather than this
+    // dispatcher measurement — the recommended `attaform` import is as lean as
+    // the explicit pin. This 62 KB cap is the no-plugin (runtime-dispatch)
+    // ceiling; there is no separate under-plugin measurement because the
+    // rewrite lands the consumer on the zod-v3/v4 entries already capped below.
     limit: '62 KB',
     gzip: true,
     // `zod` is a peer dep, external in the measurement exactly as for

--- a/src/core/detect-zod-major.ts
+++ b/src/core/detect-zod-major.ts
@@ -1,11 +1,13 @@
 /**
- * Shared build-time Zod-major detection and `attaform/zod` alias
- * resolution for the bundler plugins (`attaform/vite`, `attaform/rollup`,
+ * Shared build-time Zod-major detection and adapter-alias resolution for
+ * the bundler plugins (`attaform/vite`, `attaform/rollup`,
  * `attaform/esbuild`, `attaform/webpack`, `attaform/rspack`).
  *
- * The unified `attaform/zod` entry runtime-dispatches between the v3 and
+ * The unified `attaform/zod` entry — and the bare `attaform` barrel, which
+ * re-exports the identical surface — runtime-dispatches between the v3 and
  * v4 adapters, so a bundler that does not rewrite the import ships BOTH.
- * Each plugin rewrites `attaform/zod` to the single matching adapter
+ * Each plugin rewrites those two specifiers (see
+ * {@link REWRITABLE_ZOD_SPECIFIER_FILTER}) to the single matching adapter
  * subpath (`attaform/zod-v3` or `attaform/zod-v4`) based on the Zod major
  * resolved from the consumer's project, so the consumer bundle carries
  * one adapter instead of two. This module holds the detection (pure Node,
@@ -22,6 +24,44 @@ import { join } from 'node:path'
 export const ZOD_UNIFIED_SPECIFIER = 'attaform/zod'
 export const ZOD_V3_SPECIFIER = 'attaform/zod-v3'
 export const ZOD_V4_SPECIFIER = 'attaform/zod-v4'
+export const ZOD_BARREL_SPECIFIER = 'attaform'
+
+/**
+ * The two specifiers a plugin collapses to a single adapter: the explicit
+ * unified `attaform/zod` entry AND the bare `attaform` barrel. Both are
+ * structurally identical (the barrel re-exports the same
+ * `_shared-exports` + `_zod-binding` surface as `attaform/zod`), so both
+ * carry the runtime-dispatching `useForm` that pulls in BOTH adapters —
+ * and both rewrite to the same single adapter when one Zod major is
+ * detected.
+ *
+ * The rewrite is value-safe: every runtime binding the barrel exports
+ * (`useForm`, `fieldMeta`, `withMeta`, plus everything in
+ * `_shared-exports`) is also exported by `attaform/zod-v3` and
+ * `attaform/zod-v4`, so redirecting bare `attaform` to a pinned adapter
+ * can never strand a runtime import. (Type-only exports are erased before
+ * this resolve hook runs and are type-checked against the un-rewritten
+ * `attaform` specifier, so their per-adapter asymmetry is irrelevant.)
+ *
+ * The pattern is anchored (`^...$`) so it matches ONLY those two
+ * specifiers: the pinned adapters (`attaform/zod-v3`, `attaform/zod-v4`)
+ * and every build-tool / other subpath (`attaform/nuxt`, `attaform/vite`,
+ * `attaform/abstract`, `attaform/transforms`, ...) pass through untouched.
+ * It serves double duty — as esbuild's `onResolve` `filter` (a Go RE2
+ * regexp) and, via `.test()`, as the string-match predicate the other
+ * plugins call — so the two representations can never diverge.
+ */
+export const REWRITABLE_ZOD_SPECIFIER_FILTER = /^attaform(?:\/zod)?$/
+
+/**
+ * True when `source` is a specifier the plugins rewrite to a single Zod
+ * adapter: the bare `attaform` barrel or the explicit `attaform/zod`.
+ * Backed by {@link REWRITABLE_ZOD_SPECIFIER_FILTER} so it stays in lockstep
+ * with esbuild's filter.
+ */
+export function isRewritableZodSpecifier(source: string): boolean {
+  return REWRITABLE_ZOD_SPECIFIER_FILTER.test(source)
+}
 
 export type ZodMajorDetection =
   | { major: 3 }

--- a/src/core/webpack-family-plugin.ts
+++ b/src/core/webpack-family-plugin.ts
@@ -5,24 +5,24 @@
  * differs.
  *
  * The plugin taps `normalModuleFactory.beforeResolve` and rewrites the
- * `attaform/zod` request to the matching adapter subpath, the same effect
- * as webpack's own `NormalModuleReplacementPlugin` but tapping the hook
- * directly so the plugin imports nothing from webpack/rspack (keeping
- * attaform dependency-free). The bundler injects the hook API at the
- * consumer's build, so the minimal structural types below are all the
+ * `attaform` / `attaform/zod` request to the matching adapter subpath, the
+ * same effect as webpack's own `NormalModuleReplacementPlugin` but tapping
+ * the hook directly so the plugin imports nothing from webpack/rspack
+ * (keeping attaform dependency-free). The bundler injects the hook API at
+ * the consumer's build, so the minimal structural types below are all the
  * plugin needs to compile.
  *
  * Build-time only: never part of a consumer's browser bundle.
  */
-import { resolveZodAliasTarget, ZOD_UNIFIED_SPECIFIER } from './detect-zod-major'
+import { isRewritableZodSpecifier, resolveZodAliasTarget } from './detect-zod-major'
 
 export interface WebpackFamilyPluginOptions {
   /**
-   * Rewrite `attaform/zod` imports at build time to the matching adapter
-   * subpath, based on the consumer's installed Zod major. Default `true`.
-   * Set to `false` to keep the runtime-dispatch unified entry (ships both
-   * adapters) when a project intentionally mixes Zod versions or resolves
-   * Zod in a non-standard way.
+   * Rewrite `attaform` and `attaform/zod` imports at build time to the
+   * matching adapter subpath, based on the consumer's installed Zod major.
+   * Default `true`. Set to `false` to keep the runtime-dispatch unified
+   * entry (ships both adapters) when a project intentionally mixes Zod
+   * versions or resolves Zod in a non-standard way.
    */
   resolveZodAlias?: boolean
   /**
@@ -69,7 +69,10 @@ export function createWebpackFamilyPlugin(
       if (target === null) return
       compiler.hooks.normalModuleFactory.tap(TAP_NAME, (factory) => {
         factory.hooks.beforeResolve.tap(TAP_NAME, (data) => {
-          if (data.request === ZOD_UNIFIED_SPECIFIER) {
+          // Rewrite both the bare `attaform` barrel and the explicit
+          // `attaform/zod` (both carry the runtime dispatcher) to the one
+          // detected adapter; pinned subpaths pass through untouched.
+          if (isRewritableZodSpecifier(data.request)) {
             data.request = target
           }
         })

--- a/src/esbuild.ts
+++ b/src/esbuild.ts
@@ -1,9 +1,9 @@
 /**
- * `attaform/esbuild` — esbuild plugin that rewrites `attaform/zod`
- * imports to the single matching adapter subpath (`attaform/zod-v3` or
- * `attaform/zod-v4`) at build time, based on the consumer's installed Zod
- * major. Without it, esbuild ships both adapters because the unified
- * `attaform/zod` entry imports both for runtime dispatch.
+ * `attaform/esbuild` — esbuild plugin that rewrites `attaform` and
+ * `attaform/zod` imports to the single matching adapter subpath
+ * (`attaform/zod-v3` or `attaform/zod-v4`) at build time, based on the
+ * consumer's installed Zod major. Without it, esbuild ships both adapters
+ * because those entries import both for runtime dispatch.
  *
  * Usage:
  *
@@ -27,14 +27,14 @@
  * its plugin API at the consumer's build); the structural types below are
  * all it needs to compile.
  */
-import { resolveZodAliasTarget } from './core/detect-zod-major'
+import { resolveZodAliasTarget, REWRITABLE_ZOD_SPECIFIER_FILTER } from './core/detect-zod-major'
 
 /** Options for the esbuild `attaform()` plugin. */
 export interface AttaformEsbuildPluginOptions {
   /**
-   * Rewrite `attaform/zod` imports at build time to the matching adapter
-   * subpath. Default `true`. Set to `false` to keep the runtime-dispatch
-   * unified entry (ships both adapters).
+   * Rewrite `attaform` and `attaform/zod` imports at build time to the
+   * matching adapter subpath. Default `true`. Set to `false` to keep the
+   * runtime-dispatch unified entry (ships both adapters).
    */
   resolveZodAlias?: boolean
   /**
@@ -93,10 +93,12 @@ export function attaform(options: AttaformEsbuildPluginOptions = {}): AttaformEs
       // Nothing to rewrite (opt-out, or unclassifiable version): leave the
       // unified entry in place and register no hook.
       if (target === null) return
-      build.onResolve({ filter: /^attaform\/zod$/ }, async (args) => {
+      build.onResolve({ filter: REWRITABLE_ZOD_SPECIFIER_FILTER }, async (args) => {
         // Re-resolve the rewritten specifier so esbuild returns a real
-        // path. The filter is anchored to the bare unified specifier, so
-        // resolving `attaform/zod-v4` does not re-enter this callback.
+        // path. Both matched specifiers (bare `attaform` and
+        // `attaform/zod`) rewrite to the same detected adapter; the filter
+        // is anchored so resolving `attaform/zod-v4` does not re-enter
+        // this callback.
         const result = await build.resolve(target, {
           kind: args.kind,
           importer: args.importer,

--- a/src/nuxt.ts
+++ b/src/nuxt.ts
@@ -36,9 +36,9 @@ export interface AttaformModuleOptions {
   defaults?: AttaformDefaults
   /**
    * Forwarded to `attaform/vite`'s `resolveZodAlias` option.
-   * Default `true` — `attaform/zod` imports are rewritten at build
-   * time to either `attaform/zod-v3` or `attaform/zod-v4`, based on
-   * the consumer's installed Zod major. Set to `false` to bypass
+   * Default `true` — `attaform` and `attaform/zod` imports are rewritten
+   * at build time to either `attaform/zod-v3` or `attaform/zod-v4`, based
+   * on the consumer's installed Zod major. Set to `false` to bypass
    * the rewrite and ship the runtime-dispatch unified entry instead.
    */
   resolveZodAlias?: boolean

--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -1,9 +1,9 @@
 /**
- * `attaform/rollup` — Rollup plugin that rewrites `attaform/zod` imports
- * to the single matching adapter subpath (`attaform/zod-v3` or
- * `attaform/zod-v4`) at build time, based on the consumer's installed Zod
- * major. Without it, Rollup ships both adapters because the unified
- * `attaform/zod` entry imports both for runtime dispatch.
+ * `attaform/rollup` — Rollup plugin that rewrites `attaform` and
+ * `attaform/zod` imports to the single matching adapter subpath
+ * (`attaform/zod-v3` or `attaform/zod-v4`) at build time, based on the
+ * consumer's installed Zod major. Without it, Rollup ships both adapters
+ * because those entries import both for runtime dispatch.
  *
  * Usage:
  *
@@ -24,14 +24,14 @@
  * its plugin context at the consumer's build); the structural types below
  * are all it needs to compile.
  */
-import { resolveZodAliasTarget, ZOD_UNIFIED_SPECIFIER } from './core/detect-zod-major'
+import { isRewritableZodSpecifier, resolveZodAliasTarget } from './core/detect-zod-major'
 
 /** Options for the Rollup `attaform()` plugin. */
 export interface AttaformRollupPluginOptions {
   /**
-   * Rewrite `attaform/zod` imports at build time to the matching adapter
-   * subpath. Default `true`. Set to `false` to keep the runtime-dispatch
-   * unified entry (ships both adapters).
+   * Rewrite `attaform` and `attaform/zod` imports at build time to the
+   * matching adapter subpath. Default `true`. Set to `false` to keep the
+   * runtime-dispatch unified entry (ships both adapters).
    */
   resolveZodAlias?: boolean
   /**
@@ -77,11 +77,14 @@ export function attaform(options: AttaformRollupPluginOptions = {}): AttaformRol
     },
     resolveId(source, importer) {
       if (aliasTarget === null) return null
-      if (source !== ZOD_UNIFIED_SPECIFIER) return null
+      // Both the bare `attaform` barrel and the explicit `attaform/zod`
+      // carry the runtime dispatcher, so both collapse to the one detected
+      // adapter; the pinned subpaths pass through untouched.
+      if (!isRewritableZodSpecifier(source)) return null
       // Re-run the rewritten specifier through the resolver chain so the
       // matching subpath export lands as a real module. `skipSelf` keeps
       // the hook reentrant (our source check rejects the rewritten target
-      // anyway, since it is no longer the bare unified specifier).
+      // anyway, since it is no longer a rewritable specifier).
       return this.resolve(aliasTarget, importer, { skipSelf: true })
     },
   }

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -1,9 +1,9 @@
 /**
  * `attaform/vite` — Vite plugin that wires the compile-time node
- * transforms with @vitejs/plugin-vue AND rewrites `attaform/zod`
- * imports to either `attaform/zod-v3` or `attaform/zod-v4` at build
- * time, based on the consumer's installed Zod major. The result is
- * one Zod adapter shipped per bundle, with no manual subpath choice.
+ * transforms with @vitejs/plugin-vue AND rewrites `attaform` and
+ * `attaform/zod` imports to either `attaform/zod-v3` or `attaform/zod-v4`
+ * at build time, based on the consumer's installed Zod major. The result
+ * is one Zod adapter shipped per bundle, with no manual subpath choice.
  *
  * Usage (bare Vue 3 consumers):
  *
@@ -22,10 +22,10 @@
  * visibly wrong initial HTML.
  *
  * The `resolveZodAlias` option (default `true`) controls the build-time
- * `attaform/zod` rewrite. Set to `false` if your project intentionally
- * mixes Zod versions or has a non-standard Zod resolution; the unified
- * `attaform/zod` entry's runtime dispatch covers that case at the cost
- * of bundling both adapters.
+ * rewrite of `attaform` / `attaform/zod`. Set to `false` if your project
+ * intentionally mixes Zod versions or has a non-standard Zod resolution;
+ * the unified entry's runtime dispatch covers that case at the cost of
+ * bundling both adapters.
  *
  * Implementation note: this plugin mutates @vitejs/plugin-vue's options
  * via the documented but somewhat informal `api.options` surface used
@@ -34,7 +34,7 @@
  * and wire them yourself.
  */
 import type { Plugin } from 'vite'
-import { resolveZodAliasTarget, ZOD_UNIFIED_SPECIFIER } from './core/detect-zod-major'
+import { isRewritableZodSpecifier, resolveZodAliasTarget } from './core/detect-zod-major'
 import { componentBridgeTransform } from './runtime/lib/core/transforms/component-bridge-transform'
 import { inputTextAreaNodeTransform } from './runtime/lib/core/transforms/input-text-area-transform'
 import { redundantBindingWarnTransform } from './runtime/lib/core/transforms/redundant-binding-warn-transform'
@@ -45,10 +45,10 @@ import { transformSsrAccessed } from './runtime/lib/core/transforms/ssr-accessed
 /** Options for `attaform()`. */
 export interface AttaformVitePluginOptions {
   /**
-   * Rewrite `attaform/zod` imports at build time to either
-   * `attaform/zod-v3` or `attaform/zod-v4`, based on the consumer's
-   * installed Zod major. Default `true` — produces a leaner bundle
-   * for the common case of one Zod version per project.
+   * Rewrite `attaform` and `attaform/zod` imports at build time to
+   * either `attaform/zod-v3` or `attaform/zod-v4`, based on the
+   * consumer's installed Zod major. Default `true` — produces a leaner
+   * bundle for the common case of one Zod version per project.
    *
    * Set to `false` to fall through to the unified entry's runtime
    * dispatch. Useful when:
@@ -74,9 +74,9 @@ interface VitePluginVueApi {
 
 /**
  * Vite plugin that wires the form library's compile-time template
- * transforms into `@vitejs/plugin-vue` and rewrites the unified
- * `attaform/zod` import to the matching adapter subpath. Required
- * for SSR and for hydration accuracy under bare Vue 3.
+ * transforms into `@vitejs/plugin-vue` and rewrites the bare `attaform`
+ * barrel and the unified `attaform/zod` import to the matching adapter
+ * subpath. Required for SSR and for hydration accuracy under bare Vue 3.
  *
  * ```ts
  * // vite.config.ts
@@ -293,13 +293,15 @@ export function attaform(options: AttaformVitePluginOptions = {}): Plugin {
       )
     },
     async resolveId(source, importer) {
-      // Intercept ONLY the exact unified specifier. Explicit subpaths
-      // (`attaform/zod-v3`, `attaform/zod-v4`) and the root entry
-      // (`attaform`) pass through unchanged — that's the documented
-      // escape hatch for power users.
+      // Intercept the bare `attaform` barrel AND the explicit
+      // `attaform/zod` — both carry the runtime dispatcher, so both
+      // collapse to the one detected adapter. The pinned subpaths
+      // (`attaform/zod-v3`, `attaform/zod-v4`) pass through unchanged:
+      // that's the documented escape hatch for power users who want a
+      // specific adapter regardless of what's installed.
       if (!resolveZodAlias) return null
       if (aliasTarget === null) return null
-      if (source !== ZOD_UNIFIED_SPECIFIER) return null
+      if (!isRewritableZodSpecifier(source)) return null
       // Returning the bare specifier directly would freeze it as the
       // resolved id — Vite then ships `/@id/attaform/zod-v4` to the
       // browser and 404s because no plugin loads that virtual URL.

--- a/test/plugins/cross-bundler-alias.test.ts
+++ b/test/plugins/cross-bundler-alias.test.ts
@@ -6,7 +6,16 @@ import { attaform as rollupAttaform } from '../../src/rollup'
 import { attaform as esbuildAttaform } from '../../src/esbuild'
 import { attaform as webpackAttaform } from '../../src/webpack'
 import { attaform as rspackAttaform } from '../../src/rspack'
-import { detectZodMajor, resolveZodAliasTarget } from '../../src/core/detect-zod-major'
+import {
+  detectZodMajor,
+  isRewritableZodSpecifier,
+  resolveZodAliasTarget,
+  REWRITABLE_ZOD_SPECIFIER_FILTER,
+  ZOD_BARREL_SPECIFIER,
+  ZOD_UNIFIED_SPECIFIER,
+  ZOD_V3_SPECIFIER,
+  ZOD_V4_SPECIFIER,
+} from '../../src/core/detect-zod-major'
 
 /**
  * Cross-bundler `attaform/zod` adapter-rewrite plugins (Block E).
@@ -16,9 +25,9 @@ import { detectZodMajor, resolveZodAliasTarget } from '../../src/core/detect-zod
  * bundler devDeps (webpack / rspack aren't installed, per the zero-dep
  * rule; esbuild is only transitively present). The stubs mirror the
  * minimal hook surface each plugin touches and assert the one thing the
- * plugin owns: rewriting the bare `attaform/zod` specifier to the matching
- * adapter subpath. Whether the bundler actually invokes the hook is the
- * bundler's contract, not attaform's.
+ * plugin owns: rewriting the `attaform` and `attaform/zod` specifiers to
+ * the matching adapter subpath. Whether the bundler actually invokes the
+ * hook is the bundler's contract, not attaform's.
  *
  * Per-test fixture roots carry a synthetic `node_modules/zod/package.json`
  * so detection resolves a controlled Zod version without touching the real
@@ -105,6 +114,63 @@ describe('shared zod-major detection', () => {
   })
 })
 
+describe('rewritable-specifier matcher', () => {
+  // The single place the plugins decide WHICH specifiers collapse to one
+  // adapter. `REWRITABLE_ZOD_SPECIFIER_FILTER` doubles as esbuild's Go RE2
+  // `onResolve` filter and, via `.test()`, as `isRewritableZodSpecifier` —
+  // the string check the other plugins call. This table pins the
+  // exact-match discipline: rewrite the bare barrel + `attaform/zod`, never
+  // swallow a pinned adapter (`attaform/zod-v3|v4`) or a build-tool subpath
+  // (`attaform/nuxt`, `attaform/vite`, ...).
+  const rewritable = [ZOD_BARREL_SPECIFIER, ZOD_UNIFIED_SPECIFIER] // 'attaform', 'attaform/zod'
+  const passThrough = [
+    ZOD_V3_SPECIFIER,
+    ZOD_V4_SPECIFIER,
+    'attaform/abstract',
+    'attaform/nuxt',
+    'attaform/vite',
+    'attaform/rollup',
+    'attaform/esbuild',
+    'attaform/webpack',
+    'attaform/rspack',
+    'attaform/transforms',
+    'attaform/devtools-panel',
+    'attaform/types',
+    // near-misses the anchors must reject
+    'attaformx',
+    'xattaform',
+    'attaform/zodx',
+    'attaform/zod-v5',
+    'attaform/zod/deep',
+    'zod',
+    'vue',
+    '',
+  ]
+
+  it('matches exactly the bare barrel and the unified entry', () => {
+    for (const source of rewritable) {
+      expect(isRewritableZodSpecifier(source), source).toBe(true)
+    }
+  })
+
+  it('never matches a pinned adapter, a build-tool subpath, or a near-miss', () => {
+    for (const source of passThrough) {
+      expect(isRewritableZodSpecifier(source), source).toBe(false)
+    }
+  })
+
+  it('keeps the esbuild filter regex and the string predicate in lockstep', () => {
+    // Drift here means esbuild's onResolve fires on a different set than
+    // the other plugins' string check — one bundler would rewrite an
+    // import another leaves alone.
+    for (const source of [...rewritable, ...passThrough]) {
+      expect(REWRITABLE_ZOD_SPECIFIER_FILTER.test(source), source).toBe(
+        isRewritableZodSpecifier(source)
+      )
+    }
+  })
+})
+
 // ── Rollup ──────────────────────────────────────────────────────────
 interface RollupResolveCtx {
   resolve(
@@ -134,10 +200,23 @@ describe('attaform/rollup — resolveId rewrite', () => {
     expect(resolved?.id).toBe('attaform/zod-v3')
   })
 
-  it('passes through explicit subpaths and the root entry unchanged', async () => {
+  it('rewrites the bare attaform barrel to the detected adapter', async () => {
+    const v4 = rollupAttaform({ root: zodV4Root })
+    v4.buildStart()
+    expect((await v4.resolveId.call(rollupCtx(), 'attaform', undefined))?.id).toBe(
+      'attaform/zod-v4'
+    )
+    const v3 = rollupAttaform({ root: zodV3Root })
+    v3.buildStart()
+    expect((await v3.resolveId.call(rollupCtx(), 'attaform', undefined))?.id).toBe(
+      'attaform/zod-v3'
+    )
+  })
+
+  it('passes through pinned adapter subpaths unchanged', async () => {
     const plugin = rollupAttaform({ root: zodV4Root })
     plugin.buildStart()
-    for (const source of ['attaform/zod-v3', 'attaform/zod-v4', 'attaform']) {
+    for (const source of ['attaform/zod-v3', 'attaform/zod-v4']) {
       expect(await plugin.resolveId.call(rollupCtx(), source, undefined)).toBeNull()
     }
   })
@@ -166,11 +245,14 @@ type EsbuildOnResolveCb = (args: {
 function makeEsbuildBuild(): {
   build: Parameters<ReturnType<typeof esbuildAttaform>['setup']>[0]
   getCallback: () => EsbuildOnResolveCb | undefined
+  getFilter: () => RegExp | undefined
 } {
   let cb: EsbuildOnResolveCb | undefined
+  let filter: RegExp | undefined
   const build: Parameters<ReturnType<typeof esbuildAttaform>['setup']>[0] = {
     initialOptions: {},
-    onResolve: (_options, callback) => {
+    onResolve: (options, callback) => {
+      filter = options.filter
       cb = callback
     },
     // Echo the re-resolved specifier so the test reads which subpath the
@@ -182,7 +264,7 @@ function makeEsbuildBuild(): {
       errors: [],
     }),
   }
-  return { build, getCallback: () => cb }
+  return { build, getCallback: () => cb, getFilter: () => filter }
 }
 
 describe('attaform/esbuild — onResolve rewrite', () => {
@@ -198,6 +280,30 @@ describe('attaform/esbuild — onResolve rewrite', () => {
       kind: 'import-statement',
     })
     expect(result.path).toBe('/resolved/attaform/zod-v4')
+  })
+
+  it('registers exactly the shared rewritable-specifier filter (admits the bare barrel)', () => {
+    // esbuild gates which imports reach the callback via the `filter`
+    // regex, not a per-call string check, so the plugin must hand it the
+    // same tested matcher the other plugins use — otherwise bare `attaform`
+    // never reaches the rewrite here.
+    const { build, getFilter } = makeEsbuildBuild()
+    esbuildAttaform({ root: zodV4Root }).setup(build)
+    expect(getFilter()).toBe(REWRITABLE_ZOD_SPECIFIER_FILTER)
+  })
+
+  it('re-resolves the bare attaform barrel through the detected adapter', async () => {
+    const { build, getCallback } = makeEsbuildBuild()
+    esbuildAttaform({ root: zodV3Root }).setup(build)
+    const cb = getCallback()
+    if (cb === undefined) throw new Error('onResolve was not registered')
+    const result = await cb({
+      path: 'attaform',
+      importer: 'app.ts',
+      resolveDir: '/app',
+      kind: 'import-statement',
+    })
+    expect(result.path).toBe('/resolved/attaform/zod-v3')
   })
 
   it('throws at setup when zod is not installed', () => {
@@ -261,12 +367,22 @@ describe.each(webpackFamily)('%s — beforeResolve rewrite', (tag, factory) => {
     expect(data.request).toBe('attaform/zod-v4')
   })
 
-  it('leaves explicit subpaths and unrelated requests unchanged', () => {
+  it('rewrites the bare attaform barrel request to the detected adapter', () => {
+    const { compiler, getBeforeResolve } = makeWebpackCompiler(zodV4Root)
+    factory({ root: zodV4Root }).apply(compiler)
+    const beforeResolve = getBeforeResolve()
+    if (beforeResolve === undefined) throw new Error('beforeResolve was not tapped')
+    const data = { request: 'attaform' }
+    beforeResolve(data)
+    expect(data.request).toBe('attaform/zod-v4')
+  })
+
+  it('leaves pinned subpaths and unrelated requests unchanged', () => {
     const { compiler, getBeforeResolve } = makeWebpackCompiler(zodV3Root)
     factory({ root: zodV3Root }).apply(compiler)
     const beforeResolve = getBeforeResolve()
     if (beforeResolve === undefined) throw new Error('beforeResolve was not tapped')
-    for (const request of ['attaform/zod-v3', 'attaform/zod-v4', 'attaform', 'vue']) {
+    for (const request of ['attaform/zod-v3', 'attaform/zod-v4', 'attaform/nuxt', 'vue']) {
       const data = { request }
       beforeResolve(data)
       expect(data.request).toBe(request)

--- a/test/vite/resolve-alias.test.ts
+++ b/test/vite/resolve-alias.test.ts
@@ -153,18 +153,28 @@ describe('attaform/vite — resolveId alias for `attaform/zod`', () => {
     expect(resolved).toBeNull()
   })
 
-  it('passes through `attaform` (root) unchanged', async () => {
+  it('rewrites `attaform` (root barrel) to `attaform/zod-v4` when zod@4 is installed', async () => {
+    // The bare barrel re-exports the same runtime-dispatching surface as
+    // `attaform/zod`, so it collapses to the same single adapter.
     const config = await resolveWithRoot([vue(), attaform()], zodV4Root)
     const plugin = findAttaformPlugin(config)
-    const resolved = await callResolveId(plugin, 'attaform', undefined)
-    expect(resolved).toBeNull()
+    const resolved = (await callResolveId(plugin, 'attaform', undefined)) as { id: string } | null
+    expect(resolved?.id).toBe('attaform/zod-v4')
   })
 
-  it('does not rewrite when `resolveZodAlias: false` is passed', async () => {
+  it('rewrites `attaform` (root barrel) to `attaform/zod-v3` when zod@3 is installed', async () => {
+    const config = await resolveWithRoot([vue(), attaform()], zodV3Root)
+    const plugin = findAttaformPlugin(config)
+    const resolved = (await callResolveId(plugin, 'attaform', undefined)) as { id: string } | null
+    expect(resolved?.id).toBe('attaform/zod-v3')
+  })
+
+  it('does not rewrite `attaform/zod` or the bare `attaform` barrel when `resolveZodAlias: false`', async () => {
     const config = await resolveWithRoot([vue(), attaform({ resolveZodAlias: false })], zodV4Root)
     const plugin = findAttaformPlugin(config)
-    const resolved = await callResolveId(plugin, 'attaform/zod', undefined)
-    expect(resolved).toBeNull()
+    for (const source of ['attaform/zod', 'attaform']) {
+      expect(await callResolveId(plugin, source, undefined)).toBeNull()
+    }
   })
 
   it('does not throw on missing zod when `resolveZodAlias: false` is passed', async () => {


### PR DESCRIPTION
## Phase 3 of the schema-entry refactor — bare-`attaform` single-adapter rewrite

Extends the build-time single-adapter rewrite so the bundler plugins collapse the **bare `attaform` barrel** to the detected Zod adapter, not just the explicit `attaform/zod`. Branches off `main`; **independent of #496** (Phase 2), so it can land in any order.

### What changes (the observable behavior) ⚠️

Post-repartition, `attaform` ≡ `attaform/zod` (same runtime-dispatching surface). Today only `attaform/zod` gets rewritten to a single adapter under a plugin; bare `attaform` ships **both** adapters via the dispatcher. After this PR, a consumer importing from the *recommended* `attaform` entry under any attaform bundler plugin ships **one** adapter — as lean as the explicit pin.

- `import { useForm } from 'attaform'` under `attaform/vite` (or rollup/esbuild/webpack/rspack), zod@4 installed → rewrites to `attaform/zod-v4` at build time.
- Mixed / undetectable / `resolveZodAlias: false` → no-op (runtime dispatch, as before).
- The existing `attaform/zod` behavior is unchanged.

This is the one observable-behavior change, pre-approved in the locked plan. Flagging per the reference-before-API-change guardrail — the existing **"`attaform` passes through unchanged"** plugin assertions **flip** to rewrite assertions in this PR.

### Why it's safe (value-export superset invariant)

Every **runtime** binding the barrel exports (`useForm`, `fieldMeta`, `withMeta`, + everything in `_shared-exports`) is also exported by `attaform/zod-v3` and `attaform/zod-v4`, so redirecting bare `attaform` to a pinned adapter can never strand a runtime import. Type-only exports (e.g. `PathInput`/`PathOutput`, absent from `/zod-v3`'s public surface) are erased before the resolve hook runs and are type-checked against the **un-rewritten** `attaform` specifier, so their per-adapter asymmetry is irrelevant to the rewrite.

### One design decision to eyeball

`detect-zod-major` gains `ZOD_BARREL_SPECIFIER` + a **single canonical matcher**, `REWRITABLE_ZOD_SPECIFIER_FILTER = /^attaform(?:\/zod)?$/`, that does double duty:
- as **esbuild's** `onResolve` `filter` (a Go RE2 regexp), and
- via `.test()`, as `isRewritableZodSpecifier` — the string check the **vite/rollup/webpack/rspack** plugins call.

One regex → the two representations can't diverge (a new anti-drift test pins that lockstep + the exact-match table). Anchored so it matches **only** `attaform` and `attaform/zod`; the pinned adapters (`/zod-v3`, `/zod-v4`) and every build-tool subpath (`/nuxt`, `/vite`, `/abstract`, ...) pass through untouched.

### apps/site coexistence

The docs site aliases `attaform` → `src/index.ts` (Vite + Nitro). Vite's alias plugin resolves the bare specifier to an absolute src path **before** the attaform plugin's `resolveId` sees it, so the alias wins and the site keeps using source — confirmed by a clean `build:site` (432 routes, 0 errors). No alias/symmetry-test changes.

### Commits (2, bisectable, each green)

- **`d73dd99d`** — the rewrite: `detect-zod-major` matcher + the 4 plugin match sites + docblocks + the test flips/additions. (Tests travel with the src so each commit stays green — the existing suite hard-asserted the old pass-through.)
- **`998aea44`** — `.size-limit.js` note documenting that under a plugin, bare `attaform` ships the zod-v3/v4 single-adapter weight (56/57 KB) rather than the 62 KB dispatcher ceiling.

### Gates (all green)

`typecheck` · `lint` · `pnpm test` (4458 passed / 4 skipped, 349 files) · `check:size`/size-limit (all under cap; plugin bundles +~20 B for the matcher, e.g. rspack 849→869 B / cap 1.25 KB) · `check:bundled-types` (v3+v4) · `build:site` (432 routes, 0 errors) · `check:site` (vue-tsc) · `check:eager` (44.66 kB, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
