### PR TITLE
docs: sweep demos + docs to the bare `attaform` surface (Phase 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ npm install attaform zod
 ```vue
 <script setup lang="ts">
   import { z } from 'zod'
-  import { useForm } from 'attaform/zod' // auto-detects your Zod major
+  import { useForm } from 'attaform' // auto-detects your Zod major
 
   const schema = z.object({
     username: z.string().min(2, 'At least 2 characters'),

--- a/apps/site/docs-demos/arrays-and-tuples/App.vue
+++ b/apps/site/docs-demos/arrays-and-tuples/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/async-refinements/App.vue
+++ b/apps/site/docs-demos/async-refinements/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/autosave/App.vue
+++ b/apps/site/docs-demos/autosave/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   import { computed, ref } from 'vue'
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import { useAutosave, type SaveStatus } from './useAutosave'
   import './styles.css'

--- a/apps/site/docs-demos/blank-field-state/App.vue
+++ b/apps/site/docs-demos/blank-field-state/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { unset, useForm } from 'attaform/zod'
+  import { unset, useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/checkbox/App.vue
+++ b/apps/site/docs-demos/checkbox/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/clear/App.vue
+++ b/apps/site/docs-demos/clear/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/coercion/App.vue
+++ b/apps/site/docs-demos/coercion/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/container-display-state/App.vue
+++ b/apps/site/docs-demos/container-display-state/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/custom-assigners/App.vue
+++ b/apps/site/docs-demos/custom-assigners/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { assignKey, type CustomDirectiveRegisterAssignerFn } from 'attaform'
   import { z } from 'zod'
   import { onMounted, useTemplateRef } from 'vue'

--- a/apps/site/docs-demos/defaults-async-factory/App.vue
+++ b/apps/site/docs-demos/defaults-async-factory/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   import { ref } from 'vue'
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/defaults-sync-factory/App.vue
+++ b/apps/site/docs-demos/defaults-sync-factory/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   import { ref } from 'vue'
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/dictionary-forms/App.vue
+++ b/apps/site/docs-demos/dictionary-forms/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   import { ref } from 'vue'
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/discriminated-unions/App.vue
+++ b/apps/site/docs-demos/discriminated-unions/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/display-state/App.vue
+++ b/apps/site/docs-demos/display-state/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/errors/App.vue
+++ b/apps/site/docs-demos/errors/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/field-arrays/App.vue
+++ b/apps/site/docs-demos/field-arrays/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/fields/App.vue
+++ b/apps/site/docs-demos/fields/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm, withMeta } from 'attaform/zod'
+  import { useForm, withMeta } from 'attaform'
   import { z } from 'zod'
   import { ref, onMounted } from 'vue'
   import './styles.css'

--- a/apps/site/docs-demos/file/App.vue
+++ b/apps/site/docs-demos/file/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/first-schema/App.vue
+++ b/apps/site/docs-demos/first-schema/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/focus-scroll/App.vue
+++ b/apps/site/docs-demos/focus-scroll/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/form-list/App.vue
+++ b/apps/site/docs-demos/form-list/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/form-record/App.vue
+++ b/apps/site/docs-demos/form-record/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   import { computed, ref } from 'vue'
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/handle-submit/App.vue
+++ b/apps/site/docs-demos/handle-submit/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/inject-form/App.vue
+++ b/apps/site/docs-demos/inject-form/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { schema } from './schema'
   import ProfileFieldset from './ProfileFieldset.vue'
   import StatusPill from './StatusPill.vue'

--- a/apps/site/docs-demos/inputs-to-submit/App.vue
+++ b/apps/site/docs-demos/inputs-to-submit/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/meta/App.vue
+++ b/apps/site/docs-demos/meta/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/modifiers/App.vue
+++ b/apps/site/docs-demos/modifiers/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/optional-clear-cycle/App.vue
+++ b/apps/site/docs-demos/optional-clear-cycle/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/optional-nullable/App.vue
+++ b/apps/site/docs-demos/optional-nullable/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/per-field-validation/App.vue
+++ b/apps/site/docs-demos/per-field-validation/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/preprocess/App.vue
+++ b/apps/site/docs-demos/preprocess/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   import { computed, ref } from 'vue'
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/quick-start/App.vue
+++ b/apps/site/docs-demos/quick-start/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/radio/App.vue
+++ b/apps/site/docs-demos/radio/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/records/App.vue
+++ b/apps/site/docs-demos/records/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/reset/App.vue
+++ b/apps/site/docs-demos/reset/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/root-errors/App.vue
+++ b/apps/site/docs-demos/root-errors/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/schema-defaults/App.vue
+++ b/apps/site/docs-demos/schema-defaults/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { unset, useForm } from 'attaform/zod'
+  import { unset, useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/schema-to-inputs/App.vue
+++ b/apps/site/docs-demos/schema-to-inputs/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/select/App.vue
+++ b/apps/site/docs-demos/select/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/server-side-errors/App.vue
+++ b/apps/site/docs-demos/server-side-errors/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   import { computed } from 'vue'
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/set-value/App.vue
+++ b/apps/site/docs-demos/set-value/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/step-slots/App.vue
+++ b/apps/site/docs-demos/step-slots/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   import { ref } from 'vue'
-  import { useForm, useWizard, lazy } from 'attaform/zod'
+  import { useForm, useWizard, lazy } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/storage-shape/App.vue
+++ b/apps/site/docs-demos/storage-shape/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   import { ref } from 'vue'
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/text-number-textarea/App.vue
+++ b/apps/site/docs-demos/text-number-textarea/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/the-form/App.vue
+++ b/apps/site/docs-demos/the-form/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/third-party-primevue/App.vue
+++ b/apps/site/docs-demos/third-party-primevue/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import InputText from 'primevue/inputtext'
   import Password from 'primevue/password'

--- a/apps/site/docs-demos/third-party-reka-ui/App.vue
+++ b/apps/site/docs-demos/third-party-reka-ui/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import {
     NumberFieldRoot,

--- a/apps/site/docs-demos/transforms-async/App.vue
+++ b/apps/site/docs-demos/transforms-async/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import type { RegisterTransform } from 'attaform'
   import { z } from 'zod'
   import './styles.css'

--- a/apps/site/docs-demos/transforms/App.vue
+++ b/apps/site/docs-demos/transforms/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import type { RegisterTransform } from 'attaform'
   import { z } from 'zod'
   import './styles.css'

--- a/apps/site/docs-demos/type-safety/App.vue
+++ b/apps/site/docs-demos/type-safety/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   import { ref } from 'vue'
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/undo-redo/App.vue
+++ b/apps/site/docs-demos/undo-redo/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/unset/App.vue
+++ b/apps/site/docs-demos/unset/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm, unset } from 'attaform/zod'
+  import { useForm, unset } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/url-availability-check/App.vue
+++ b/apps/site/docs-demos/url-availability-check/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   import { ref } from 'vue'
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/use-register/App.vue
+++ b/apps/site/docs-demos/use-register/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import FieldRow from './FieldRow.vue'
   import './styles.css'

--- a/apps/site/docs-demos/use-wizard/App.vue
+++ b/apps/site/docs-demos/use-wizard/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm, useWizard } from 'attaform/zod'
+  import { useForm, useWizard } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/v-register/App.vue
+++ b/apps/site/docs-demos/v-register/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/validate-on-modes/App.vue
+++ b/apps/site/docs-demos/validate-on-modes/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/validation-lifecycle/App.vue
+++ b/apps/site/docs-demos/validation-lifecycle/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import { ref } from 'vue'
   import './styles.css'

--- a/apps/site/docs-demos/values/App.vue
+++ b/apps/site/docs-demos/values/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/variant-forms/App.vue
+++ b/apps/site/docs-demos/variant-forms/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/docs-demos/variant-memory/App.vue
+++ b/apps/site/docs-demos/variant-memory/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   import './styles.css'
 

--- a/apps/site/pages/index.vue
+++ b/apps/site/pages/index.vue
@@ -32,7 +32,7 @@
   const signupSnippet = [
     `${LT}script setup lang="ts">`,
     "  import { z } from 'zod'",
-    "  import { useForm } from 'attaform/zod'",
+    "  import { useForm } from 'attaform'",
     '',
     '  const schema = z.object({',
     '    email: z.string().email(),',

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -6,7 +6,7 @@
 
 Attaform's core idea is that the schema IS the form. One Zod schema declares the shape, the defaults, the validation, the per-field errors, and the input/output types. Attaform builds the reactive surface around it.
 
-The single entry point `attaform/zod` dispatches between Zod v3 and v4 per call, so projects on either version (or a mix) share one import. The Nuxt module auto-wires the plugin, the `v-register` directive, the SSR plumbing, and the DevTools panel. Bare Vue + Vite works through the Vite plugin without Nuxt.
+The default entry `attaform` dispatches between Zod v3 and v4 per call, so projects on either version (or a mix) share one import; `attaform/zod` is the same surface, named explicitly. The Nuxt module auto-wires the plugin, the `v-register` directive, the SSR plumbing, and the DevTools panel. Bare Vue + Vite works through the Vite plugin without Nuxt.
 
 Forms are bound to native inputs through the `v-register` directive, which also keeps each field's aria attributes in sync with its validation state. Submission goes through `form.handleSubmit(onSubmit)`. Multistep flows compose multiple `useForm` instances under `useWizard`. Undo/redo, server-error routing, and a Nuxt DevTools panel are all opt-in.
 
@@ -15,7 +15,7 @@ Forms are bound to native inputs through the `v-register` directive, which also 
 ```ts
 // script setup
 import { z } from 'zod'
-import { useForm } from 'attaform/zod'
+import { useForm } from 'attaform'
 
 const schema = z.object({
   email: z.email(),
@@ -57,7 +57,7 @@ The form handle exposes reactive reads (`form.values`, `form.errors`, `form.fiel
 Multistep flows compose forms under `useWizard`:
 
 ```ts
-import { useForm, useWizard } from 'attaform/zod'
+import { useForm, useWizard } from 'attaform'
 
 const account = useForm({ schema: accountSchema, key: 'account' })
 const profile = useForm({ schema: profileSchema, key: 'profile' })
@@ -204,7 +204,7 @@ Patterns that keep Attaform code clean.
 
 ## Reference
 
-- [Entry points](https://attaform.dev/docs/reference/entry-points): every package subpath (`attaform`, `attaform/zod`, `attaform/zod-v3`, `attaform/zod-v4`, `attaform/vite`, `attaform/nuxt`, `attaform/devtools-panel`).
+- [Entry points](https://attaform.dev/docs/reference/entry-points): every package subpath (`attaform`, `attaform/zod`, `attaform/zod-v3`, `attaform/zod-v4`, `attaform/abstract`, `attaform/vite`, `attaform/nuxt`, `attaform/devtools-panel`).
 - [Errors](https://attaform.dev/docs/reference/errors): `AttaformErrorCode` table and the error class hierarchy.
 - [Types](https://attaform.dev/docs/reference/types): every exported type.
 - [Custom adapters](https://attaform.dev/docs/reference/custom-adapters): building a non-Zod schema adapter.

--- a/apps/site/repl-demos/blank-starter.vue
+++ b/apps/site/repl-demos/blank-starter.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
 
   const form = useForm({

--- a/apps/site/repl-demos/shipment-demo.vue
+++ b/apps/site/repl-demos/shipment-demo.vue
@@ -14,7 +14,7 @@
 
   import { computed, nextTick, ref, watch } from 'vue'
   import { z } from 'zod'
-  import { fieldMeta, useForm, useWizard, unset, withMeta } from 'attaform/zod'
+  import { fieldMeta, useForm, useWizard, unset, withMeta } from 'attaform'
   import type { FieldState } from 'attaform'
 
   // ─── Mock async services ─────────────────────────────────────────

--- a/docs/binding-inputs/coercion.md
+++ b/docs/binding-inputs/coercion.md
@@ -67,7 +67,7 @@ useForm({ coerce: [...defaultCoercionRules, defineCoercion({ ... })] })
 Spread `defaultCoercionRules` to extend; pass a bare array to **replace** entirely. Adding a string → Date rule for ISO timestamps:
 
 ```ts
-import { useForm } from 'attaform/zod'
+import { useForm } from 'attaform'
 import { defaultCoercionRules, defineCoercion } from 'attaform'
 
 useForm({
@@ -93,7 +93,7 @@ Now `<input type="text" v-register="form.register('publishedAt')" />` against a 
 Set coercion at the plugin level so every form picks up the same custom rule without per-form opt-in:
 
 ```ts
-import { createAttaform } from 'attaform/zod'
+import { createAttaform } from 'attaform'
 import { defaultCoercionRules, defineCoercion } from 'attaform'
 
 createAttaform({

--- a/docs/binding-inputs/third-party-components.md
+++ b/docs/binding-inputs/third-party-components.md
@@ -35,7 +35,7 @@ reka-ui ships headless primitives, so each control above is unstyled markup the 
 
 ```vue
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
   // A text field from the component library you already use:
   import { TextField } from 'your-ui-kit'

--- a/docs/cross-cutting-state/app-defaults.md
+++ b/docs/cross-cutting-state/app-defaults.md
@@ -129,7 +129,7 @@ Global defaults shape options like `strict` and `validateOn`. Per-form initial v
 Three patterns:
 
 ```ts
-import { unset } from 'attaform/zod'
+import { unset } from 'attaform'
 
 // 1. Plain values: explicit defaults flow into storage and the form
 //    is not blank for those leaves.
@@ -159,7 +159,7 @@ If you need defaults but don't want to touch the plugin (third-party component l
 
 ```ts
 // composables/useAppForm.ts
-import { useForm as attaformUseForm } from 'attaform/zod'
+import { useForm as attaformUseForm } from 'attaform'
 import type { z } from 'zod'
 
 export function useAppForm<S extends z.ZodObject>(opts: Parameters<typeof attaformUseForm<S>>[0]) {

--- a/docs/cross-cutting-state/inject-form.md
+++ b/docs/cross-cutting-state/inject-form.md
@@ -34,7 +34,7 @@ Parent owns the form (no `key`):
 ```vue
 <!-- SignupForm.vue -->
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
 
   const form = useForm<Form>({ schema })
   const onSubmit = form.handleSubmit(async (values) => {
@@ -56,7 +56,7 @@ Any descendant grabs the same form:
 ```vue
 <!-- EmailRow.vue -->
 <script setup lang="ts">
-  import { injectForm } from 'attaform/zod'
+  import { injectForm } from 'attaform'
 
   const form = injectForm<Form>()
 </script>
@@ -77,7 +77,7 @@ Floating save buttons, sidebar status widgets, anything in a different branch of
 ```vue
 <!-- FloatingSaveButton.vue (anywhere in the app) -->
 <script setup lang="ts">
-  import { injectForm } from 'attaform/zod'
+  import { injectForm } from 'attaform'
 
   const form = injectForm<Form>('signup')
   const onSave = () => form?.handleSubmit(async (values) => api.post('/signup', values))()

--- a/docs/devtools-and-debugging/troubleshooting.md
+++ b/docs/devtools-and-debugging/troubleshooting.md
@@ -20,7 +20,7 @@ Three independent causes:
 The schema generic couldn't be inferred. Two likely causes:
 
 - Your schema is typed as bare `ZodObject` without its concrete shape. Use the literal (`z.object({ email: z.string() })`) or give the variable a precise type.
-- You imported `useForm` from `attaform` (the schema-agnostic core entry) but passed a Zod schema directly. Import from `attaform/zod`, `attaform/zod-v3`, or `attaform/zod-v4` instead.
+- You imported `useAbstractForm` from `attaform/abstract` and passed a Zod schema without wrapping it in an adapter. `useAbstractForm` expects an `AbstractSchema`; for a Zod schema, import `useForm` from `attaform` (or `attaform/zod`), which wraps it for you.
 
 ## "`handleSubmit` doesn't run when I submit the form"
 

--- a/docs/getting-started/from-inputs-to-submit.md
+++ b/docs/getting-started/from-inputs-to-submit.md
@@ -25,7 +25,7 @@ The demo binds two inputs (an `email` and a `newsletter` checkbox) and wires a s
 This page focuses on two helpers off the form: `handleSubmit` (the submit-wrapping factory) and `meta` (the form's reactive status board). Hoist the schema and save the form:
 
 ```ts
-import { useForm } from 'attaform/zod'
+import { useForm } from 'attaform'
 import { z } from 'zod'
 
 const schema = z.object({

--- a/docs/getting-started/from-schema-to-inputs.md
+++ b/docs/getting-started/from-schema-to-inputs.md
@@ -25,7 +25,7 @@ The demo binds five native inputs (a text input for `fullName`, a numeric `age`,
 `useForm` is the entry point. Hand it a Zod schema; it returns a reactive form carrying every binding helper this page uses. Save the return value and reach for the pieces by name:
 
 ```ts
-import { useForm } from 'attaform/zod'
+import { useForm } from 'attaform'
 import { z } from 'zod'
 
 const schema = z.object({

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -25,7 +25,7 @@ export default defineNuxtConfig({
 })
 ```
 
-What this gets you: `useForm` / `useWizard` / `injectForm` / `useRegister` as auto-imports, the SSR hydration plumbing, the Vite plugin, and the Attaform tab inside Nuxt DevTools.
+What this gets you: the form composables as auto-imports (`useForm`, `useWizard`, `injectForm`, `injectWizard`, `fieldMeta`, `withMeta`, `lazy`; see [Auto-imports](#auto-imports)), the SSR hydration plumbing, the Vite plugin, and the Attaform tab inside Nuxt DevTools.
 
 ## Optional: Vue 3 plugin
 
@@ -58,6 +58,38 @@ export default defineConfig({
 ```
 
 What this gets you: SSR-rendered `v-register` bindings that match the client-rendered output on initial HTML (no flicker between server paint and hydration), and a leaner production bundle (one Zod adapter shipped instead of both).
+
+## Auto-imports
+
+Both the Nuxt module and the Vite plugin can register Attaform's form composables as auto-imports, so a component reaches for them inside `<script setup>` with no `import` line. The set is the same either way: `useForm`, `useWizard`, `injectForm`, `injectWizard`, `fieldMeta`, `withMeta`, and `lazy`.
+
+Under Nuxt, the module registers them for you. Toggle the whole set with the `autoImports` option:
+
+```ts
+// nuxt.config.ts
+export default defineNuxtConfig({
+  modules: ['attaform/nuxt'],
+  attaform: {
+    autoImports: true, // default; set false to import the composables yourself
+  },
+})
+```
+
+On bare Vue 3 + Vite, feed the same manifest to `unplugin-auto-import`. `attaform/vite` re-exports it as `attaformAutoImportsMap`, ready to drop into the plugin's `imports` array:
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite'
+import AutoImport from 'unplugin-auto-import/vite'
+import vue from '@vitejs/plugin-vue'
+import { attaform, attaformAutoImportsMap } from 'attaform/vite'
+
+export default defineConfig({
+  plugins: [AutoImport({ imports: ['vue', attaformAutoImportsMap] }), vue(), attaform()],
+})
+```
+
+Everything outside that set stays an explicit import: the plugin (`createAttaform`), the custom-input composable (`useRegister`), and the bring-your-own-adapter `useAbstractForm` from `attaform/abstract`. A registered auto-import always loses to an explicit or local binding of the same name, so opting out is only needed when you'd rather keep the names out of global scope entirely.
 
 ## Where to next
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -25,7 +25,7 @@ Try the form below: clear the password and submit to watch focus pull to the bro
 Hand `useForm` a Zod schema and the reactive form comes back ready. This page reaches for three properties on the returned form: `register` for the input binding, `handleSubmit` for the submit gate, and `fields` for per-field error reads.
 
 ```ts
-import { useForm } from 'attaform/zod'
+import { useForm } from 'attaform'
 import { z } from 'zod'
 
 const schema = z.object({

--- a/docs/getting-started/your-first-schema.md
+++ b/docs/getting-started/your-first-schema.md
@@ -25,7 +25,7 @@ Type into any of the demo's four inputs (`email`, `password`, `displayName`, `ag
 `useForm` is Attaform's entry point. Hand it a Zod schema and it returns a reactive form carrying every helper a template needs: a per-input binding factory, a per-field state map, and the live parsed values. Save the return value and reach for the pieces by name:
 
 ```ts
-import { useForm } from 'attaform/zod'
+import { useForm } from 'attaform'
 import { z } from 'zod'
 
 const schema = z.object({

--- a/docs/multistep/aggregates.md
+++ b/docs/multistep/aggregates.md
@@ -27,7 +27,7 @@ metaRows:
 The final step of a wizard often shows everything the user entered, gated behind a confirm-and-submit button. `wizard.allValues` is the cross-step read surface, keyed by step key:
 
 ```ts
-import { useForm, useWizard } from 'attaform/zod'
+import { useForm, useWizard } from 'attaform'
 import { z } from 'zod'
 
 const accountSchema = z.object({ email: z.email(), name: z.string().min(1) })

--- a/docs/multistep/handle-submit.md
+++ b/docs/multistep/handle-submit.md
@@ -28,7 +28,7 @@ metaRows:
 
 ```vue
 <script setup lang="ts">
-  import { useForm, useWizard } from 'attaform/zod'
+  import { useForm, useWizard } from 'attaform'
 
   const wizard = useWizard({ steps: [shipping, payment, review] })
 

--- a/docs/multistep/inject-wizard.md
+++ b/docs/multistep/inject-wizard.md
@@ -31,7 +31,7 @@ The parent owns the wizard (no `key`):
 ```vue
 <!-- CheckoutWizard.vue -->
 <script setup lang="ts">
-  import { useForm, useWizard } from 'attaform/zod'
+  import { useForm, useWizard } from 'attaform'
   import { z } from 'zod'
 
   const shippingSchema = z.object({ address: z.string(), city: z.string() })
@@ -57,7 +57,7 @@ Any descendant grabs the same wizard:
 ```vue
 <!-- ProgressRail.vue -->
 <script setup lang="ts">
-  import { injectWizard } from 'attaform/zod'
+  import { injectWizard } from 'attaform'
 
   const wizard = injectWizard()
 </script>
@@ -97,7 +97,7 @@ Sticky finish buttons, sidebar status widgets, or any component in a different b
 ```vue
 <!-- FloatingFinishButton.vue (anywhere in the app) -->
 <script setup lang="ts">
-  import { injectWizard } from 'attaform/zod'
+  import { injectWizard } from 'attaform'
 
   const wizard = injectWizard('checkout-wizard')
 
@@ -166,7 +166,7 @@ Guard the return so the consumer disappears cleanly when the wizard isn't mounte
 
 ```vue
 <script setup lang="ts">
-  import { injectWizard } from 'attaform/zod'
+  import { injectWizard } from 'attaform'
 
   const wizard = injectWizard('checkout-wizard')
 </script>

--- a/docs/multistep/patterns.md
+++ b/docs/multistep/patterns.md
@@ -26,7 +26,7 @@ metaRows:
 The default shape: a list of forms in reading order. `wizard.next()` advances and `wizard.back()` retreats; neither validates (navigation and submission are separate verbs). Out-of-bounds calls dev-warn and no-op.
 
 ```ts
-import { useForm, useWizard } from 'attaform/zod'
+import { useForm, useWizard } from 'attaform'
 import { z } from 'zod'
 
 const accountSchema = z.object({ email: z.email() })
@@ -69,7 +69,7 @@ See [Step slots](/docs/multistep/step-slots) for the affordance-slot story.
 When the next step depends on a live value on an earlier form, use a function slot. The slot is a `(ctx) => Form | string | undefined` callback that re-evaluates reactively as its tracked reads change:
 
 ```ts
-import { useForm, useWizard } from 'attaform/zod'
+import { useForm, useWizard } from 'attaform'
 import { z } from 'zod'
 
 const accountSchema = z.object({ kind: z.enum(['user', 'organization']) })

--- a/docs/multistep/statuses.md
+++ b/docs/multistep/statuses.md
@@ -39,7 +39,7 @@ Each field tracks the per-step form's `meta`. A step's status flips when its met
 `wizard.statuses` is both a drillable record and a callable accessor. Same data, three call shapes:
 
 ```ts
-import { useForm, useWizard } from 'attaform/zod'
+import { useForm, useWizard } from 'attaform'
 import { z } from 'zod'
 
 const accountSchema = z.object({ email: z.email() })
@@ -65,7 +65,7 @@ The classic use case is a step indicator: one dot per form, painted with its cur
 
 ```vue
 <script setup lang="ts">
-  import { useForm, useWizard } from 'attaform/zod'
+  import { useForm, useWizard } from 'attaform'
 
   const wizard = useWizard({ steps: [account, profile, review] })
 </script>
@@ -139,7 +139,7 @@ Unknown keys in the seed object dev-warn at construction; the wizard ignores the
 
 ```ts
 import { watch } from 'vue'
-import { useForm, useWizard } from 'attaform/zod'
+import { useForm, useWizard } from 'attaform'
 
 const wizard = useWizard({ steps: [account, profile, review] })
 

--- a/docs/multistep/step-slots.md
+++ b/docs/multistep/step-slots.md
@@ -32,7 +32,7 @@ The demo below stitches all four kinds into one flow: a `'welcome'` string, a si
 ## The four kinds at a glance
 
 ```ts
-import { useForm, useWizard, lazy } from 'attaform/zod'
+import { useForm, useWizard, lazy } from 'attaform'
 
 const shipping = useForm({ schema: shippingSchema, key: 'shipping' })
 const business = useForm({ schema: businessSchema, key: 'business' })
@@ -177,7 +177,7 @@ lazy((ctx) => buildPricingFor(ctx.forms.account.values.region))
 ### How it works
 
 ```ts
-import { useForm, useWizard, lazy } from 'attaform/zod'
+import { useForm, useWizard, lazy } from 'attaform'
 
 const wizard = useWizard({
   steps: [

--- a/docs/multistep/url-sync.md
+++ b/docs/multistep/url-sync.md
@@ -27,7 +27,7 @@ metaRows:
 `useWizard` does URL sync out of the box. Construct a wizard with nothing but `steps`, and the wizard reads `?step=<key>` from the URL at construction and mirrors `currentStep` back to it on every navigation:
 
 ```ts
-import { useForm, useWizard } from 'attaform/zod'
+import { useForm, useWizard } from 'attaform'
 
 const wizard = useWizard({
   steps: ['welcome', shipping, payment, 'final-review'],
@@ -98,7 +98,7 @@ The restore callback is invoked at construction and re-evaluated reactively (its
 The default `?step=<key>` works fine until two wizards land on the same page. Then the second wizard's writes overwrite the first's. Give each wizard its own param via custom callbacks:
 
 ```ts
-import { useForm, useWizard } from 'attaform/zod'
+import { useForm, useWizard } from 'attaform'
 
 const checkout = useWizard({
   steps: [shipping, payment, review],

--- a/docs/multistep/use-wizard.md
+++ b/docs/multistep/use-wizard.md
@@ -39,7 +39,7 @@ Attaform separates two concepts that often get conflated in multistep code:
 A wizard's `steps` list mixes the two freely. The shape of a typical onboarding flow:
 
 ```ts
-import { useForm, useWizard } from 'attaform/zod'
+import { useForm, useWizard } from 'attaform'
 import { z } from 'zod'
 
 const shippingSchema = z.object({ address: z.string(), city: z.string() })
@@ -66,7 +66,7 @@ Affordance steps are a first-class building block, not an edge case. Onboarding 
 Each entry in `steps` is a **slot**. Four slot kinds compose the list:
 
 ```ts
-import { useForm, useWizard, lazy } from 'attaform/zod'
+import { useForm, useWizard, lazy } from 'attaform'
 
 const wizard = useWizard({
   steps: [
@@ -168,7 +168,7 @@ wizard.goTo('shipping-review') // jump to a specific step by key
 A wizard with no extra options reads its starting step from `?step=<key>` on the URL and writes the active step back as the user navigates. Reloads land on the same step, the browser back / forward buttons walk the flow, and the URL is shareable. On the server, the wizard reads the incoming request's `?step` so deep-links render the right step on the first byte.
 
 ```ts
-import { useForm, useWizard } from 'attaform/zod'
+import { useForm, useWizard } from 'attaform'
 
 const wizard = useWizard({
   steps: ['welcome', shipping, payment, 'final-review'],

--- a/docs/reading-the-form/fields.md
+++ b/docs/reading-the-form/fields.md
@@ -156,7 +156,7 @@ Schema-registered presentational hints, the path that produced this FieldState, 
 Register schema metadata with `withMeta` (works on Zod 3 and Zod 4) or the native `schema.register(fieldMeta, {...})` chain (Zod 4):
 
 ```ts
-import { withMeta } from 'attaform/zod'
+import { withMeta } from 'attaform'
 
 const schema = z.object({
   email: withMeta(z.email(), {

--- a/docs/reading-the-form/list.md
+++ b/docs/reading-the-form/list.md
@@ -29,7 +29,7 @@ Reach for `list` wherever you render a repeating field. Pair it with the array i
 
 ```vue
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
 
   const schema = z.object({

--- a/docs/reading-the-form/record.md
+++ b/docs/reading-the-form/record.md
@@ -29,7 +29,7 @@ Declare the record on your schema, then iterate `form.record` by its key. The ke
 
 ```vue
 <script setup lang="ts">
-  import { useForm } from 'attaform/zod'
+  import { useForm } from 'attaform'
   import { z } from 'zod'
 
   const schema = z.object({

--- a/docs/reading-the-form/the-form.md
+++ b/docs/reading-the-form/the-form.md
@@ -64,7 +64,7 @@ const onSubmit = form.handleSubmit(async (values) => {
 ## Per-field writes
 
 ```ts
-import { unset } from 'attaform/zod'
+import { unset } from 'attaform'
 
 form.setValue('email', 'new@example.com')
 form.setValue('age', unset) // flag any path blank by passing the sentinel

--- a/docs/reference/custom-adapters.md
+++ b/docs/reference/custom-adapters.md
@@ -143,11 +143,11 @@ Assume your library exposes:
 import type {
   AbstractSchema,
   DefaultValuesResponse,
+  GenericForm,
   SlimPrimitiveKind,
   ValidationError,
   ValidationResponse,
-} from 'attaform'
-import type { GenericForm } from 'attaform'
+} from 'attaform/abstract'
 
 const PERMISSIVE: ReadonlySet<SlimPrimitiveKind> = new Set<SlimPrimitiveKind>([
   'string',
@@ -223,13 +223,13 @@ export function myLibAdapter<F extends GenericForm>(schema: MyLibSchema<F>): Abs
 }
 ```
 
-Wire your adapter through the schema-agnostic `useForm`:
+Wire your adapter through `useAbstractForm`:
 
 ```ts
-import { useForm } from 'attaform'
+import { useAbstractForm } from 'attaform/abstract'
 import { myLibAdapter } from './my-adapter'
 
-const form = useForm({ schema: myLibAdapter(mySchema) })
+const form = useAbstractForm({ schema: myLibAdapter(mySchema) })
 ```
 
 ## Zod-v3 vs. Zod-v4: an introspection asymmetry
@@ -240,4 +240,4 @@ Worth knowing if you're studying the reference implementations: the v4 adapter e
 
 - [The schema contract](/docs/schemas/contract): the high-level mental model `AbstractSchema` implements.
 - [Types reference](/docs/reference/types): every type the contract references.
-- [Entry-point reference](/docs/reference/entry-points): which subpath ships `AbstractSchema` (the framework-agnostic `attaform`).
+- [Entry-point reference](/docs/reference/entry-points): which subpath ships `AbstractSchema` (`attaform/abstract`).

--- a/docs/reference/entry-points.md
+++ b/docs/reference/entry-points.md
@@ -4,13 +4,13 @@ description: Every package subpath Attaform exposes and what ships from each. Im
 metaRows:
   - label: Category
     value: Reference
-  - label: Subpaths
-    value: 9
+  - label: Entry points
+    value: 14
   - label: Recommended entry
-    value: attaform/zod
-    kind: code
-  - label: Framework-agnostic
     value: attaform
+    kind: code
+  - label: Bring your own adapter
+    value: attaform/abstract
     kind: code
 ---
 
@@ -21,57 +21,81 @@ metaRows:
 ::docs-meta-table
 ::
 
-Nine subpaths. New projects pick `attaform/zod`; the others cover Zod v3 holdouts, framework-agnostic core, Nuxt / Vite integrations, compiler internals, the DevTools panel, and the type-only types subpath.
+New projects pick `attaform`. The other subpaths cover explicit Zod pins, the bring-your-own-adapter escape hatch, the Nuxt and Vite integrations, the compiler internals, the DevTools panel, and the type-only surface.
 
-## `attaform/zod`: the recommended entry
+## `attaform`: the recommended entry
 
-Zod v4 adapter. The canonical entry for new projects.
+The default entry, and the one new projects reach for. `useForm` here takes a Zod schema and infers every field type from it. It auto-detects the installed Zod major (v3 or v4) and routes to the matching adapter: under the `attaform/vite` plugin (or `attaform/nuxt`, which installs it) that resolution happens at build time so the bundle ships one adapter, and without a plugin the entry dispatches at runtime instead.
 
 ```ts
-import { useForm, withMeta, zodAdapter, fieldMeta } from 'attaform/zod'
+import { createAttaform, useForm } from 'attaform'
 ```
 
-Ships:
+The Zod-default form surface:
 
-- `useForm`: the typed-Zod wrapper around the framework-agnostic `useForm`.
-- `useWizard`, `injectForm`, `useRegister`: same composables, re-exported.
-- `zodAdapter`: explicit adapter constructor (most consumers don't need this; `useForm({ schema })` wraps automatically).
-- `fieldMeta` / `withMeta`: schema-attached field metadata (label, description, placeholder).
-- `kindOf`, `ZodKind`, `assertZodVersion`: runtime Zod-introspection helpers.
-- `FieldMetaPayload`: the metadata shape.
+- `useForm`: the Zod wrapper that infers field types from your schema.
+- `useWizard`, `lazy`: the multistep orchestrator and its lazy-step helper.
+- `injectForm`, `injectWizard`: reach a provided form or wizard from a descendant component.
+- `useRegister`: the composable behind `v-register`, for building custom input components.
+- `fieldMeta`, `withMeta`: schema-attached field metadata (label, description, placeholder), backed by a cross-adapter store.
 - `unset`, `isUnset`: the blank-anywhere sentinel and its type guard.
+
+On top of that surface, `attaform` re-exports the framework-agnostic toolkit (the plugin, the directive layer, the SSR bridge, the error classes, the path primitives) that every entry carries. It's listed in full under [The framework-agnostic toolkit](#the-framework-agnostic-toolkit).
+
+What `attaform` does NOT ship: the version-specific Zod internals (`zodAdapter`, `kindOf`, `ZodKind`, `assertZodVersion`, `UnsupportedSchemaError`). Those diverge between v3 and v4, so they live only on the pinned `attaform/zod-v3` and `attaform/zod-v4` subpaths.
+
+## `attaform/zod`: the explicit Zod pin
+
+The same surface as `attaform`, named explicitly. It is byte-identical: `attaform` is defined as `attaform/zod` re-exported. Reach for it when you want the import line to name Zod out loud, or when a codebase already standardized on it. New projects don't need the extra characters, and existing `attaform/zod` code keeps working with no change.
+
+```ts
+import { useForm } from 'attaform/zod'
+```
 
 ## `attaform/zod-v3`
 
-Zod v3 adapter for projects still on v3. New projects should use `attaform/zod`.
+The Zod v3 adapter, pinned with no runtime dispatch, for projects still on v3.
 
 ```ts
 import { useForm, withMeta } from 'attaform/zod-v3'
 ```
 
-Surface matches `attaform/zod` one-for-one: `useForm`, `injectForm`, `useRegister`, `useWizard`, `withMeta`, `fieldMeta`, `unset`. The runtime introspection is leaner (`isZodSchemaType` only); see [`AbstractSchema`](/docs/schemas/abstract-schema#zod-v3-vs-zod-v4-an-introspection-asymmetry) for the discussion.
+Ships the same form surface as `attaform`, plus the v3 `zodAdapter` and the `isZodSchemaType` guard. Its runtime introspection is leaner than v4's; see [`AbstractSchema`](/docs/schemas/abstract-schema#zod-v3-vs-zod-v4-an-introspection-asymmetry) for the discussion.
 
 ## `attaform/zod-v4`
 
-Explicit Zod v4 entry. Currently identical to `attaform/zod`; kept for forward-compat naming. New code should import from `attaform/zod`.
+The Zod v4 adapter, pinned explicitly. It's the same adapter `attaform` selects when it detects zod@4, committed at the import instead of by detection.
 
-## `attaform`: framework-agnostic core
+```ts
+import { useForm } from 'attaform/zod-v4'
+```
 
-The schema-agnostic entry. Drop here when:
+Ships the richer v4 introspection set on top of the shared form surface: `zodAdapter`, `kindOf`, `ZodKind`, `assertZodVersion`, `UnsupportedSchemaError`, and the `PathInput` / `PathOutput` type helpers.
 
-- You're wiring a custom schema library via [`AbstractSchema`](/docs/schemas/abstract-schema).
-- You need directive-layer symbols (`vRegister`, `assignKey`, `RegisterTransform`) not re-exported by the typed entries.
-- You're writing SSR bootstrap code (`renderAttaformState`, `hydrateAttaformState`, `escapeForInlineScript`).
+## `attaform/abstract`: bring your own adapter
+
+The schema-agnostic escape hatch. `useAbstractForm` works against any object implementing [`AbstractSchema`](/docs/schemas/abstract-schema): a custom adapter, a non-Zod validation library, or a hand-rolled shape. The Zod entries wrap their schema for you; this entry hands you the unwrapped composable and expects an adapter.
+
+```ts
+import { useAbstractForm } from 'attaform/abstract'
+```
+
+Ships `useAbstractForm`, the `AbstractSchema` contract type, `FieldMetaPayload`, and the same framework-agnostic toolkit every entry carries. There is deliberately no `useForm` alias here: a same-named wrong-variant export fails deep at the first schema call instead of at the import site, and removing that footgun is the whole reason the escape hatch is its own entry. This is a lower-level surface than the Zod entries; reach for it only when you're integrating a schema library Attaform doesn't ship an adapter for.
+
+## The framework-agnostic toolkit
+
+Every entry re-exports the same schema-agnostic core, so this set is identical whether you import it from `attaform`, `attaform/zod`, or `attaform/abstract`. Pick the entry by which form composable you want; the toolkit rides along.
 
 ```ts
 import {
   // Plugin + registry
   createAttaform,
   useRegistry,
-  // Schema-agnostic composables
-  useForm,
-  injectForm,
+  // Multistep, injection, custom inputs
   useWizard,
+  lazy,
+  injectForm,
+  injectWizard,
   useRegister,
   // Directive layer
   vRegister,
@@ -112,7 +136,7 @@ Also re-exports every public type from `runtime/types/types-api` and `runtime/ty
 
 ## `attaform/nuxt`
 
-The Nuxt module. Auto-installs the plugin, auto-imports `useForm`, wires the DevTools panel.
+The Nuxt module. Auto-installs the plugin, auto-imports the form composables, and wires the DevTools panel.
 
 ```ts
 // nuxt.config.ts
@@ -124,11 +148,11 @@ export default defineNuxtConfig({
 })
 ```
 
-After installing, `useForm` is a global auto-import. Import `injectForm`, `useWizard`, `useRegister`, and the rest of the surface explicitly from `attaform/zod` (or `attaform` for the framework-agnostic flavor). See [SSR hydration: Nuxt](/docs/server-and-ssr/ssr-nuxt) for the full setup.
+After installing, `useForm`, `useWizard`, `injectForm`, `injectWizard`, `fieldMeta`, `withMeta`, and `lazy` are all global auto-imports (toggle with the module's `autoImports` option). `useAbstractForm`, `createAttaform`, and `useRegister` stay explicit imports by design. See [Installation](/docs/getting-started/installation#auto-imports) for the full setup and [SSR hydration: Nuxt](/docs/server-and-ssr/ssr-nuxt) for the server wiring.
 
 ## `attaform/vite`
 
-The Vite plugin. Required under bare Vue + Vite for SSR-correct `v-register` bindings.
+The Vite plugin. Required under bare Vue + Vite for SSR-correct `v-register` bindings, and the piece that rewrites `attaform` / `attaform/zod` to a single Zod adapter at build time.
 
 ```ts
 // vite.config.ts
@@ -141,7 +165,7 @@ export default defineConfig({
 })
 ```
 
-See [SSR hydration: bare Vue](/docs/server-and-ssr/ssr-bare-vue) for the matching server / client wiring.
+The same plugin ships for other bundlers at `attaform/rollup`, `attaform/esbuild`, `attaform/webpack`, and `attaform/rspack`. See [SSR hydration: bare Vue](/docs/server-and-ssr/ssr-bare-vue) for the matching server and client wiring.
 
 ## `attaform/transforms`
 
@@ -157,7 +181,7 @@ The DevTools panel internals. The [Attaform DevTools panel](/docs/devtools-and-d
 
 ## `attaform/types`
 
-Type-only subpath. Re-exports every type from the runtime; useful when you want types in a `.d.ts` consumer file without pulling in the runtime barrel:
+Type-only subpath. Re-exports every type from the runtime, useful when you want types in a `.d.ts` consumer file without pulling in the runtime barrel:
 
 ```ts
 import type { UseFormReturnType, FieldState, ValidationError } from 'attaform/types'
@@ -167,25 +191,26 @@ For runtime imports under typical app code, import directly from `attaform`; the
 
 ## Which subpath for which job?
 
-| You want to…                                          | Import from       |
-| ----------------------------------------------------- | ----------------- |
-| Build a form in a Vue 3 / Nuxt app on Zod v4          | `attaform/zod`    |
-| Build a form in an app stuck on Zod v3                | `attaform/zod-v3` |
-| Wire a custom schema library (Valibot, ArkType, …)    | `attaform`        |
-| Install the Nuxt module                               | `attaform/nuxt`   |
-| Install the Vite plugin under bare Vue + Vite         | `attaform/vite`   |
-| Reach directive symbols (`vRegister`, `assignKey`, …) | `attaform`        |
-| Use SSR helpers (`renderAttaformState`, etc.)         | `attaform`        |
-| Catch an Attaform-thrown error by class               | `attaform`        |
-| Type-only imports in a `.d.ts` file                   | `attaform/types`  |
+| You want to…                                          | Import from         |
+| ----------------------------------------------------- | ------------------- |
+| Build a form in a Vue 3 / Nuxt app (Zod v3 or v4)     | `attaform`          |
+| Pin the Zod v3 adapter explicitly                     | `attaform/zod-v3`   |
+| Pin the Zod v4 adapter explicitly                     | `attaform/zod-v4`   |
+| Wire a custom or non-Zod schema library               | `attaform/abstract` |
+| Install the Nuxt module                               | `attaform/nuxt`     |
+| Install the Vite plugin under bare Vue + Vite         | `attaform/vite`     |
+| Reach directive symbols (`vRegister`, `assignKey`, …) | `attaform`          |
+| Use SSR helpers (`renderAttaformState`, etc.)         | `attaform`          |
+| Catch an Attaform-thrown error by class               | `attaform`          |
+| Type-only imports in a `.d.ts` file                   | `attaform/types`    |
 
-## The framework-agnostic story
+## The Zod-default story
 
-`attaform` (the bare entry) doesn't import Zod. Everything you see in `attaform/zod` is a typed wrapper around `attaform`'s exports: same composables, same return shapes, with Zod-specific inference layered on top. If you ever need to bypass the Zod typing (writing a generic helper that should work across schema libraries), import from `attaform` directly and supply the `Form` generic yourself.
+`attaform` and `attaform/zod` are the same surface: the barrel re-exports the unified Zod binding, so `useForm` infers your field types from a Zod schema out of the box. The abstraction underneath stays schema-agnostic. `attaform/abstract` exposes it directly through `useAbstractForm`, which takes an `AbstractSchema` adapter instead of a Zod schema, and every Zod entry is a thin typed wrapper over that same core. If you're integrating a schema library Attaform doesn't ship an adapter for, [`AbstractSchema`](/docs/schemas/abstract-schema) is the contract to implement.
 
 ## Where to next
 
-- [The schema contract](/docs/schemas/contract): the bridge between the typed entries and the framework-agnostic core.
+- [The schema contract](/docs/schemas/contract): the bridge between the typed entries and the schema-agnostic core.
 - [Types reference](/docs/reference/types): every type, grouped by purpose.
 - [Errors reference](/docs/reference/errors): every Attaform-thrown error class.
 - [`AbstractSchema`](/docs/schemas/abstract-schema): the contract for non-Zod schema libraries.

--- a/docs/schemas/abstract-schema.md
+++ b/docs/schemas/abstract-schema.md
@@ -146,11 +146,11 @@ Assume your library exposes:
 import type {
   AbstractSchema,
   DefaultValuesResponse,
+  GenericForm,
   SlimPrimitiveKind,
   ValidationError,
   ValidationResponse,
-} from 'attaform'
-import type { GenericForm } from 'attaform'
+} from 'attaform/abstract'
 
 const PERMISSIVE: ReadonlySet<SlimPrimitiveKind> = new Set<SlimPrimitiveKind>([
   'string',
@@ -226,13 +226,13 @@ export function myLibAdapter<F extends GenericForm>(schema: MyLibSchema<F>): Abs
 }
 ```
 
-Wire your adapter through the schema-agnostic `useForm`:
+Wire your adapter through `useAbstractForm`:
 
 ```ts
-import { useForm } from 'attaform'
+import { useAbstractForm } from 'attaform/abstract'
 import { myLibAdapter } from './my-adapter'
 
-const form = useForm({ schema: myLibAdapter(mySchema) })
+const form = useAbstractForm({ schema: myLibAdapter(mySchema) })
 ```
 
 ## Zod-v3 vs. Zod-v4: an introspection asymmetry
@@ -243,4 +243,4 @@ Worth knowing if you're studying the reference implementations: the v4 adapter e
 
 - [The schema contract](/docs/schemas/contract): the high-level mental model `AbstractSchema` implements.
 - [Types reference](/docs/reference/types): every type the contract references.
-- [Entry-point reference](/docs/reference/entry-points): which subpath ships `AbstractSchema` (the framework-agnostic `attaform`).
+- [Entry-point reference](/docs/reference/entry-points): which subpath ships `AbstractSchema` (`attaform/abstract`).

--- a/docs/schemas/contract.md
+++ b/docs/schemas/contract.md
@@ -5,7 +5,7 @@ metaRows:
   - label: Category
     value: Conceptual
   - label: Default adapter
-    value: attaform/zod (Zod v4)
+    value: attaform (Zod v4)
     kind: code
   - label: Also shipped
     value: attaform/zod-v3
@@ -105,7 +105,7 @@ Both fire at parse time (`handleSubmit`, `validate`, `validateAsync`); storage h
 Labels, descriptions, placeholders, and free-form annotations live on the schema itself. `withMeta` attaches them at any node.
 
 ```ts
-import { withMeta } from 'attaform/zod'
+import { withMeta } from 'attaform'
 
 const schema = z.object({
   email: withMeta(z.email(), {
@@ -133,17 +133,17 @@ const schema = z.object({
 
 ## Zod adapters
 
-`attaform/zod` wraps Zod v4 and is the canonical import for new projects. It walks the schema once at construction, caches structural metadata, and implements `AbstractSchema` against Zod's runtime.
+`attaform` is the canonical import for new projects. `useForm` here takes a Zod schema, walks it once at construction, caches structural metadata, and implements `AbstractSchema` against Zod's runtime. It auto-detects the installed Zod major (v4 by default, v3 when that's what's installed) and routes to the matching adapter.
 
 ```ts
-import { useForm } from 'attaform/zod'
+import { useForm } from 'attaform'
 ```
 
-For projects still on Zod v3, swap the import: `attaform/zod-v3`. The consumer-facing surface is identical; the parsing engine and metadata walker differ to match v3's internals.
+`attaform/zod` is the same surface named explicitly, and `attaform/zod-v3` / `attaform/zod-v4` pin one adapter with no detection. For projects still on Zod v3, `attaform/zod-v3` is the pin. The consumer-facing surface is identical across all four; the parsing engine and metadata walker differ to match each major's internals.
 
 ## Schema-agnostic core
 
-The core package (`attaform`) doesn't import Zod. It consumes any object that implements `AbstractSchema`, a small contract covering identity, defaults, shape introspection, and validation. The Zod adapters cover the bulk of real-world schemas; reach for [`AbstractSchema`](/docs/schemas/abstract-schema) directly when you're wiring Valibot, ArkType, Effect Schema, or a hand-rolled validator.
+Underneath the Zod entries, the core doesn't know about Zod at all. It consumes any object that implements `AbstractSchema`, a small contract covering identity, defaults, shape introspection, and validation. `attaform/abstract` exposes that core directly through `useAbstractForm`, which takes an `AbstractSchema` adapter instead of a Zod schema. The Zod adapters cover the bulk of real-world schemas; reach for [`AbstractSchema`](/docs/schemas/abstract-schema) and `attaform/abstract` when you're wiring Valibot, ArkType, Effect Schema, or a hand-rolled validator.
 
 ## Refinements vs. transforms
 

--- a/docs/schemas/defaults.md
+++ b/docs/schemas/defaults.md
@@ -76,7 +76,7 @@ This is the right place for environment-specific defaults: a "remember me" toggl
 ## Three patterns for `defaultValues`
 
 ```ts
-import { unset } from 'attaform/zod'
+import { unset } from 'attaform'
 
 // 1. Plain values: explicit defaults flow into storage
 useForm({ schema, defaultValues: { email: 'me@example.com', count: 10 } })

--- a/docs/schemas/dictionary-forms.md
+++ b/docs/schemas/dictionary-forms.md
@@ -31,7 +31,7 @@ The demo is a team roster keyed by member id. The ids are data you only learn at
 A dictionary form declares a `z.record` schema as the root, not nested under a key. The key schema constrains what counts as a valid key; the value schema validates each entry:
 
 ```ts
-import { useForm } from 'attaform/zod'
+import { useForm } from 'attaform'
 import { z } from 'zod'
 
 const schema = z.record(

--- a/docs/schemas/discriminated-unions.md
+++ b/docs/schemas/discriminated-unions.md
@@ -28,7 +28,7 @@ Pick a notify channel (Email, SMS, or Push) and watch the field below the radios
 ## The schema
 
 ```ts
-import { useForm } from 'attaform/zod'
+import { useForm } from 'attaform'
 import { z } from 'zod'
 
 const schema = z.object({

--- a/docs/schemas/optional-nullable.md
+++ b/docs/schemas/optional-nullable.md
@@ -139,7 +139,7 @@ The errors flow from the schema; the modifiers shape what counts as empty. A req
 `.optional()` and `.nullable()` are schema-level; they declare that the empty case is type-valid. Sometimes you want a leaf that's _type-required_ but starts in a deliberate "no value yet" state without changing the schema. That's `unset`:
 
 ```ts
-import { unset } from 'attaform/zod'
+import { unset } from 'attaform'
 
 const schema = z.object({ pickup: z.string().min(1, 'Required') })
 const form = useForm({ schema, defaultValues: { pickup: unset } })

--- a/docs/schemas/records.md
+++ b/docs/schemas/records.md
@@ -80,7 +80,7 @@ form.setValue('prefs', { ...form.values.prefs, [userId]: true }) // whole-record
 To flag a record entry blank, reach for `unset`:
 
 ```ts
-import { unset } from 'attaform/zod'
+import { unset } from 'attaform'
 form.setValue(`prefs.${userId}`, unset)
 ```
 

--- a/docs/schemas/variant-forms.md
+++ b/docs/schemas/variant-forms.md
@@ -30,7 +30,7 @@ The demo is a checkout payment method. A payment is exactly one of card, bank tr
 A variant form declares a `z.discriminatedUnion` schema as the root, not nested under a key. One discriminator (`method`) picks the variant; each variant is a regular Zod schema:
 
 ```ts
-import { useForm } from 'attaform/zod'
+import { useForm } from 'attaform'
 import { z } from 'zod'
 
 const schema = z.discriminatedUnion('method', [

--- a/docs/server-and-ssr/ssr-nuxt.md
+++ b/docs/server-and-ssr/ssr-nuxt.md
@@ -54,7 +54,7 @@ The client-side form is identical to the server one; no second round of validati
 
 ## Auto-imports
 
-The Nuxt module auto-imports `useForm` from the unified entry point. No `import` statement needed in `<script setup>`:
+The Nuxt module auto-imports the form composables you reach for inside `<script setup>`: `useForm`, `useWizard`, `injectForm`, `injectWizard`, `fieldMeta`, `withMeta`, and `lazy`. No `import` statement needed:
 
 ```vue
 <script setup lang="ts">
@@ -62,14 +62,15 @@ The Nuxt module auto-imports `useForm` from the unified entry point. No `import`
 </script>
 ```
 
-For the Zod-typed wrapper (`useForm` from `attaform/zod`), or for any other helper (`injectForm`, `useWizard`, `useRegister`, `unset`, `defaultDisplayState`), import explicitly:
+Everything else stays an explicit import from `attaform`: the plugin (`createAttaform`), the custom-input composable (`useRegister`), the `unset` sentinel, and the `defaultDisplayState` reducer.
 
 ```vue
 <script setup lang="ts">
-  import { injectForm, useWizard } from 'attaform/zod'
-  import { defaultDisplayState, unset } from 'attaform'
+  import { defaultDisplayState, unset, useRegister } from 'attaform'
 </script>
 ```
+
+Toggle the whole set with the module's `autoImports` option (default on); see [Installation](/docs/getting-started/installation#auto-imports) for the full list.
 
 ## App-wide defaults under Nuxt
 

--- a/docs/validation/blank.md
+++ b/docs/validation/blank.md
@@ -97,7 +97,7 @@ If the schema is `z.string().min(1)` instead, the lifecycle is the same on `blan
 Sometimes you do want a string or boolean leaf to start blank: a "please choose" indicator on a checkbox, a deferred-fill text field. That's an explicit consumer signal, not runtime inference. Use the `unset` sentinel:
 
 ```ts
-import { unset, useForm } from 'attaform/zod'
+import { unset, useForm } from 'attaform'
 
 useForm({
   schema: z.object({ agreed: z.boolean(), note: z.string() }),

--- a/docs/validation/url-availability-check.md
+++ b/docs/validation/url-availability-check.md
@@ -39,7 +39,7 @@ Preprocess and async refine map onto that work cleanly. Preprocess **prepares** 
 Hoist the schema next to the form so the type flows through `useForm` cleanly. Two sentinels (`EMPTY_URL` and `INVALID_URL`) bridge the two layers; both are strings so the inner `z.string()` accepts them, and refine recognizes them by exact equality.
 
 ```ts
-import { useForm } from 'attaform/zod'
+import { useForm } from 'attaform'
 import { z } from 'zod'
 
 const EMPTY_URL = '__atta:empty-url__'

--- a/docs/writing-and-mutating/set-value.md
+++ b/docs/writing-and-mutating/set-value.md
@@ -74,7 +74,7 @@ The one difference: `setValue` writes are **never coerced**. Coercion is for use
 To flag a path as displayed-empty, pass the `unset` sentinel. The runtime writes the schema's slim value at that path and joins the path to `form.blankPaths` so the bound input renders empty.
 
 ```ts
-import { unset } from 'attaform/zod'
+import { unset } from 'attaform'
 
 form.setValue('middleName', unset) // storage holds '', form.blankPaths has 'middleName'
 form.setValue('profile', unset) // recursive, marks every primitive descendant

--- a/docs/writing-and-mutating/unset.md
+++ b/docs/writing-and-mutating/unset.md
@@ -41,7 +41,7 @@ Reads through `form.values.<path>` always see the slim value. Storage never hold
 The sentinel works at every position the consumer can address:
 
 ```ts
-import { unset, useForm } from 'attaform/zod'
+import { unset, useForm } from 'attaform'
 
 const schema = z.object({
   email: z.string(),
@@ -119,7 +119,7 @@ form.fields('income').blank // true
 `unset` and `isUnset` ship from every entry point: `attaform`, `attaform/zod`, `attaform/zod-v3`, `attaform/zod-v4`. The `Unset` type is exported alongside for explicit type annotations:
 
 ```ts
-import { unset, isUnset, type Unset } from 'attaform/zod'
+import { unset, isUnset, type Unset } from 'attaform'
 
 function maybeBlank(v: string | Unset): string | undefined {
   return isUnset(v) ? undefined : v


### PR DESCRIPTION
## Phase 4 — docs/demos sweep to the new import surface

Fourth phase of the schema-entry refactor. Phases 1-3 (barrel flip + `/abstract` #495, auto-imports #496, bare-`attaform` single-adapter rewrite #497) shipped the new import surface; this PR brings every doc, demo, and consumer-facing example in line with it.

### Mechanical sweep

`attaform/zod` → `attaform` (byte-identical modules post-Phase-1) across:

- **61 demo `App.vue`** files (`apps/site/docs-demos`), which transclude into the docs so the visible code updates with them
- **30 markdown guides** plus the README's single example
- the two flagship **REPL demos** (blank-starter, shipment) and the **homepage hero** snippet

Preserved deliberately: the explicit `attaform/zod-v3` / `attaform/zod-v4` pins, the entry-point catalog references, and the "ships from every entry" prose.

### Editorial fixes (the reframe Phase 1 forced)

Phase 1 made `attaform` the Zod default and moved the schema-agnostic form to `attaform/abstract` (`useAbstractForm`). Several pages still taught the old mental model, some now factually wrong:

- **`reference/entry-points.md`** — rebuilt around `attaform` as the recommended entry; `attaform/zod` demoted to explicit pin; new `attaform/abstract` section; corrected the auto-import note to the real seven-name set. Also fixed two pre-existing inaccuracies: the unified entries do NOT ship `zodAdapter` / `kindOf` / `ZodKind` / `assertZodVersion` (those are pin-only), and the toolkit symbols ARE re-exported by every entry.
- **`schemas/abstract-schema.md` + `reference/custom-adapters.md`** — `import { AbstractSchema, … } from 'attaform'` no longer resolves (`AbstractSchema` is `/abstract`-exclusive now); repointed the contract types to `attaform/abstract` and wired the adapter through `useAbstractForm`.
- **`devtools-and-debugging/troubleshooting.md`** — the "imported `useForm` from `attaform` + a Zod schema" footgun is the one Phase 1 eliminated; reframed to the current footgun (`useAbstractForm` with an unwrapped Zod schema).
- **`schemas/contract.md`** — "`attaform/zod` is the canonical import" and "the core package (`attaform`) doesn't import Zod" were both inverted; corrected.
- **`server-and-ssr/ssr-nuxt.md`** — auto-import section listed only `useForm` and told readers to import `injectForm` / `useWizard` explicitly, but Phase 2 auto-imports all seven; rewritten.
- **`getting-started/installation.md`** — new **Auto-imports** section (Nuxt automatic + plain-Vite `attaformAutoImportsMap`); corrected the Nuxt module summary.
- **`public/llms.txt`** — the AI-agent index called `attaform/zod` "the single entry point"; corrected the framing + imports + added `/abstract`. Stopgap until Phase 5 regenerates it from the docs.

### Verification

- `pnpm check:site` (vue-tsc over every transcluded demo) — green
- `pnpm build:site` — **432 routes prerendered, Nuxt Link Checker: 0 failing pages, 0 errors, 0 warnings** (validates the new `#auto-imports` anchor + all cross-page links), REPL bundle clean
- pre-commit hook (prettier + eslint + Docker vue-tsc) on every commit — green

### Notes for review

- The `attaform/abstract` support tier is deliberately lighter than the Zod path (per the locked plan): no new `/abstract` demo, just the reference + contract pages repointed.
- `custom-adapters.md` and `abstract-schema.md` are near-duplicate contract pages (pre-existing). I fixed both identically rather than dedup them; flag if you want them merged.
- `llms.txt` was touched as a correctness stopgap only; Phase 5 owns regenerating it from the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
