### PR TITLE
Type-check doc snippets against the built surface (Phase 6)

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -284,6 +284,13 @@ jobs:
       - name: Check bundled types
         run: pnpm check:bundled-types
 
+      # Extracts every `attaform`-importing `ts`/`vue` snippet from the docs
+      # and type-checks it against the same bundled `.d.ts`. Fails only on
+      # surface drift (a doc importing a symbol/subpath the build no longer
+      # exposes); tolerates narrative gaps. Reuses the `dist/` prepack above.
+      - name: Check doc snippets
+        run: pnpm check:doc-snippets
+
   bench:
     name: Performance benchmarks
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,11 @@ apps/site/docs-demos/*/styles.css
 apps/site/public/llms.txt
 apps/site/public/llms-full.txt
 
+# Doc-snippet type-check fixtures, extracted from docs/**/*.md + the llms
+# template by scripts/check-doc-snippets.mjs on every run (source of truth is
+# the markdown; these are regenerated, never committed)
+tests/fixtures/doc-snippets/.generated
+
 # esbuild metafile dumps from the bundle-size analysis tooling
 analysis/meta
 

--- a/docs/multistep/url-sync.md
+++ b/docs/multistep/url-sync.md
@@ -53,9 +53,9 @@ Pass `false` to either side to opt out of the default. The two switches are inde
 
 ```ts
 const wizard = useWizard({
-  steps: [...],
-  restore: false,  // don't read the URL at construction
-  persist: false,  // don't write the URL on navigation
+  steps: [shipping, payment, review],
+  restore: false, // don't read the URL at construction
+  persist: false, // don't write the URL on navigation
 })
 ```
 
@@ -119,7 +119,7 @@ const checkout = useWizard({
 })
 
 const support = useWizard({
-  steps: [...],
+  steps: [shipping, payment, review],
   restore: () => {
     const url = new URL(window.location.href)
     const step = url.searchParams.get('support-step')

--- a/docs/reference/entry-points.md
+++ b/docs/reference/entry-points.md
@@ -158,7 +158,7 @@ The Vite plugin. Required under bare Vue + Vite for SSR-correct `v-register` bin
 // vite.config.ts
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
-import attaform from 'attaform/vite'
+import { attaform } from 'attaform/vite'
 
 export default defineConfig({
   plugins: [vue(), attaform()],
@@ -172,7 +172,7 @@ The same plugin ships for other bundlers at `attaform/rollup`, `attaform/esbuild
 Raw Vue compiler-core node transforms. Use only when wiring a custom bundler pipeline; the Vite plugin already wraps these for the common case.
 
 ```ts
-import { vRegisterTransform } from 'attaform/transforms'
+import { vRegisterHintTransform, vRegisterPreambleTransform } from 'attaform/transforms'
 ```
 
 ## `attaform/devtools-panel`

--- a/docs/server-and-ssr/ssr-bare-vue.md
+++ b/docs/server-and-ssr/ssr-bare-vue.md
@@ -128,7 +128,7 @@ For bare Vue + Vite, install `attaform/vite` to ensure `v-register` bindings com
 // vite.config.ts
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
-import attaform from 'attaform/vite'
+import { attaform } from 'attaform/vite'
 
 export default defineConfig({
   plugins: [vue(), attaform()],

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "check:coverage": "node scripts/run-with-webstorage-flag.mjs vitest run --coverage",
     "check:bench": "node scripts/check-bench.mjs",
     "check:bundled-types": "node scripts/check-bundled-types.mjs",
+    "check:doc-snippets": "node scripts/check-doc-snippets.mjs",
     "check:site": "pnpm dev:prepare && pnpm --filter attaform-site typecheck",
     "fallow": "DO_NOT_TRACK=1 FALLOW_TELEMETRY=0 npx --yes fallow@2.88.3 --score",
     "version": "node scripts/promote-changelog.mjs && (node scripts/generate-release-notes.mjs || echo '[version] release-notes step failed; continuing') && node scripts/sync-doc-versions.mjs && git add CHANGELOG.md RELEASES.md docs/scorecard/cii-best-practices-answers.md",

--- a/scripts/check-doc-snippets.mjs
+++ b/scripts/check-doc-snippets.mjs
@@ -1,0 +1,299 @@
+#!/usr/bin/env node
+/**
+ * Doc-snippet staleness gate. Extracts every fenced `ts` / `vue` code
+ * block that imports from `attaform` out of the docs (and the curated
+ * llms.txt template), then type-checks each against the *built*
+ * `dist/*.d.mts` — the exact surface a consumer sees. A docs example
+ * that imports a symbol the library no longer exports (the drift that
+ * prompted the schema-entry refactor) fails here instead of silently
+ * misleading a reader or a low-context model.
+ *
+ * Scope — import-bearing blocks only. A block that imports from
+ * `attaform` is asserting the public surface; a bare fragment
+ * (`form.setValue(...)` with no import) is not independently
+ * type-checkable and is deliberately skipped. This mirrors the origin
+ * story: the failure mode is a wrong *import*, and an import lives in a
+ * `ts` block or an SFC `<script setup>`, never in a template-only `vue`
+ * fragment — so those self-exclude.
+ *
+ * Engine — one `tsc` pass over a generated fixture project, mirroring
+ * `check:bundled-types`: same bundler-resolution tsconfig, same real
+ * `dist` (built via `pnpm prepack` if stubbed). `vue` blocks contribute
+ * their `<script setup>` (where the import + form wiring live); the
+ * template is not type-checked (a missing `v-register` is a directive,
+ * not a type error, so vue-tsc would add false positives for no signal).
+ *
+ * Usage:
+ *   pnpm check:doc-snippets
+ *
+ * Side effects:
+ *   - Builds `dist/` if missing/stubbed (`pnpm prepack`).
+ *   - Regenerates `tests/fixtures/doc-snippets/.generated/*.ts`
+ *     (gitignored) and runs `tsc` over them.
+ *   - Exits non-zero on any compile error, remapped to the source
+ *     markdown file + line.
+ */
+import { execSync } from 'node:child_process'
+import { readFileSync, writeFileSync, readdirSync, rmSync, mkdirSync, existsSync, statSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve, relative, join } from 'node:path'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(here, '..')
+const distDir = resolve(repoRoot, 'dist')
+const sentinelDts = resolve(distDir, 'zod-v4.d.ts')
+const fixtureRoot = resolve(repoRoot, 'tests/fixtures/doc-snippets')
+const generatedDir = resolve(fixtureRoot, '.generated')
+const tsconfigPath = resolve(fixtureRoot, 'tsconfig.json')
+
+const docsDir = resolve(repoRoot, 'docs')
+// The curated llms.txt template carries hand-written `ts` blocks (the
+// wizard "API at a glance", the Quick reference cheat-sheet) that live
+// nowhere in docs/ — including it type-checks that curated code too.
+const llmsTemplate = resolve(repoRoot, 'apps/site/scripts/llms.template.md')
+
+const KEEP_LANGS = new Set(['ts', 'typescript', 'vue'])
+const ATTAFORM_IMPORT = /\bfrom\s+['"]attaform(?:\/[\w-]+)?['"]/
+
+// --- collect markdown sources (deterministic order) ---------------------
+function collectMarkdown(dir) {
+  const out = []
+  for (const name of readdirSync(dir).sort()) {
+    const full = join(dir, name)
+    if (statSync(full).isDirectory()) out.push(...collectMarkdown(full))
+    else if (name.endsWith('.md')) out.push(full)
+  }
+  return out
+}
+
+// --- fence parsing ------------------------------------------------------
+// Any ```-prefixed line opens a block; a bare ``` closes it. Content
+// inside a block is never re-scanned, so a ```ts shown literally inside
+// another fence can't be mistaken for a real block.
+function parseFencedBlocks(text) {
+  const lines = text.split('\n')
+  const blocks = []
+  let i = 0
+  while (i < lines.length) {
+    const open = /^```([A-Za-z][\w-]*)?/.exec(lines[i])
+    if (open) {
+      const lang = (open[1] || '').toLowerCase()
+      const fenceLine = i + 1 // 1-based
+      const body = []
+      i++
+      while (i < lines.length && !/^```\s*$/.test(lines[i])) {
+        body.push(lines[i])
+        i++
+      }
+      blocks.push({ lang, fenceLine, body })
+      i++ // skip the closing fence
+    } else {
+      i++
+    }
+  }
+  return blocks
+}
+
+// The `<script setup>` inner content of a vue block, plus the source
+// line its first line sits on. Null when the block has no script.
+function extractVueScript(block) {
+  const openIdx = block.body.findIndex((l) => /<script\b/.test(l))
+  if (openIdx === -1) return null
+  const closeIdx = block.body.findIndex((l, k) => k > openIdx && /<\/script>/.test(l))
+  if (closeIdx === -1) return null
+  return {
+    lines: block.body.slice(openIdx + 1, closeIdx),
+    // body[0] is at (fenceLine + 1); the inner's first line is body[openIdx + 1].
+    startLine: block.fenceLine + 1 + (openIdx + 1),
+  }
+}
+
+// Fixture line numbers (1-based) that belong to an `import`/`export … from
+// 'attaform…'` statement — single- or multi-line. An error on one of these
+// lines is real surface drift (a symbol or subpath the built dist no longer
+// exposes); everything else is a narrative gap the tolerant gate accepts.
+function attaformImportLineSet(fixtureText) {
+  const lines = fixtureText.split('\n')
+  const set = new Set()
+  for (let i = 0; i < lines.length; i++) {
+    if (!/\bfrom\s+['"]attaform(?:\/[\w-]+)?['"]/.test(lines[i])) continue
+    set.add(i + 1)
+    // A brace import wrapped across lines puts `from '…'` on its own line;
+    // walk back to the opening `import {` so a bad member on any line counts.
+    if (!/\b(?:import|export)\b/.test(lines[i])) {
+      let k = i - 1
+      while (k >= 0 && !/\b(?:import|export)\b/.test(lines[k])) set.add(k-- + 1)
+      if (k >= 0) set.add(k + 1)
+    }
+  }
+  return set
+}
+
+// --- generate fixtures --------------------------------------------------
+rmSync(generatedDir, { recursive: true, force: true })
+mkdirSync(generatedDir, { recursive: true })
+
+const sources = collectMarkdown(docsDir)
+if (existsSync(llmsTemplate)) sources.push(llmsTemplate)
+
+const fixtures = []
+const stats = { ts: 0, vue: 0, files: new Set() }
+let counter = 0
+
+for (const file of sources) {
+  const rel = relative(repoRoot, file)
+  for (const block of parseFencedBlocks(readFileSync(file, 'utf8'))) {
+    if (!KEEP_LANGS.has(block.lang)) continue
+    if (!ATTAFORM_IMPORT.test(block.body.join('\n'))) continue
+
+    let codeLines
+    let codeStartLine
+    if (block.lang === 'vue') {
+      const script = extractVueScript(block)
+      if (!script || !ATTAFORM_IMPORT.test(script.lines.join('\n'))) continue
+      codeLines = script.lines
+      codeStartLine = script.startLine
+      stats.vue++
+    } else {
+      codeLines = block.body
+      codeStartLine = block.fenceLine + 1
+      stats.ts++
+    }
+
+    counter++
+    const slug = rel.replace(/[^\w.-]+/g, '__').replace(/\.md$/, '')
+    const fixtureName = `${String(counter).padStart(3, '0')}-${slug}.ts`
+    // Line 1 is this header; the first code line is fixture line 2, which
+    // maps back to `codeStartLine` in the source markdown.
+    const contents = `// @source ${rel}:${block.fenceLine}\n${codeLines.join('\n')}\n`
+    writeFileSync(join(generatedDir, fixtureName), contents, 'utf8')
+    fixtures.push({
+      fixtureName,
+      sourceRel: rel,
+      fenceLine: block.fenceLine,
+      codeStartLine,
+      lang: block.lang,
+      surfaceLines: attaformImportLineSet(contents),
+    })
+    stats.files.add(rel)
+  }
+}
+
+if (fixtures.length === 0) {
+  console.error(
+    '[check-doc-snippets] extracted 0 snippets — the fence parser or the attaform-import filter is broken\n' +
+      '  (docs carry dozens of `import ... from "attaform"` blocks). Aborting rather than passing vacuously.',
+  )
+  process.exit(1)
+}
+
+// --- ensure a real bundle (not the unbuild --stub shim) -----------------
+function distIsRealBundle() {
+  try {
+    // `unbuild --stub` writes `export * from "/app/src/..."`; a real
+    // bundle imports from `./shared/...` chunks.
+    return !readFileSync(sentinelDts, 'utf8').slice(0, 256).includes('/src/')
+  } catch {
+    return false
+  }
+}
+
+if (!distIsRealBundle()) {
+  console.log('[check-doc-snippets] dist/ missing or stubbed — building real bundle first')
+  execSync('pnpm prepack', { cwd: repoRoot, stdio: 'inherit' })
+}
+
+// --- type-check ---------------------------------------------------------
+console.log(
+  `[check-doc-snippets] type-checking ${fixtures.length} doc snippets ` +
+    `(${stats.ts} ts, ${stats.vue} vue) from ${stats.files.size} files against dist/*.d.mts`,
+)
+
+let tscOutput = ''
+try {
+  // `--pretty false` gives the compact `path(line,col): error TS…` form the
+  // classifier below parses (and drops ANSI colour). tsc still exits non-zero
+  // on tolerated narrative errors, so the pass/fail decision is ours, not its.
+  execSync(`pnpm exec tsc --pretty false --project "${tsconfigPath}"`, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  })
+} catch (err) {
+  tscOutput = `${err.stdout || ''}${err.stderr || ''}`
+}
+
+// --- classify: attaform-surface drift (fail) vs narrative gap (tolerate) ---
+// The tolerant gate (chosen deliberately) fails ONLY on errors that land on an
+// `attaform` import line — a removed export, a wrong subpath, a missing default.
+// API-shape drift is `check:bundled-types`' job; here the unique signal is
+// "every documented `attaform` import still resolves". Narrative gaps — a block
+// that reuses `schema`/`form` from an earlier block, references the multistep
+// example cast, or imports a placeholder consumer file — are reported, not failed.
+const byName = new Map(fixtures.map((f) => [f.fixtureName, f]))
+const TSC_ERROR = /^(.*?\.ts)\((\d+),\d+\): error (TS\d+): (.*)$/
+const surfaceErrors = []
+const tolerated = []
+
+for (const raw of tscOutput.split('\n')) {
+  const match = TSC_ERROR.exec(raw.trim())
+  if (!match) continue
+  const [, pathStr, lineStr, code, message] = match
+  const fixtureName = pathStr.split(/[\\/]/).pop()
+  const fx = byName.get(fixtureName)
+  const entry = { fx, line: Number(lineStr), code, message, raw: raw.trim() }
+  // An error we can't attribute to a known fixture (the shim, a project-level
+  // "no inputs" error) is treated as surface too, so infra breakage fails loudly.
+  if (!fx || fx.surfaceLines.has(entry.line)) surfaceErrors.push(entry)
+  else tolerated.push(entry)
+}
+
+function locate(entry) {
+  if (!entry.fx) return entry.raw
+  const sourceLine = entry.fx.codeStartLine + (entry.line - 2)
+  return `${entry.fx.sourceRel}:${sourceLine}  ${entry.code}: ${entry.message}  [${entry.fx.lang} block @ ${entry.fx.sourceRel}:${entry.fx.fenceLine}]`
+}
+
+// --- tolerated breakdown (kept legible so "green" never hides real drift) ---
+const BENIGN = {
+  TS2304: 'undefined example identifier',
+  TS18004: 'shorthand property not in scope',
+  TS2307: 'placeholder / consumer module',
+  TS7006: 'untyped example callback param',
+}
+const review = tolerated.filter((e) => !BENIGN[e.code])
+const benignCounts = {}
+for (const e of tolerated) if (BENIGN[e.code]) benignCounts[e.code] = (benignCounts[e.code] || 0) + 1
+const toleratedFixtures = new Set(tolerated.map((e) => (e.fx ? e.fx.fixtureName : e.raw))).size
+
+function printToleratedSummary() {
+  if (!tolerated.length) return
+  console.log(`  tolerated ${tolerated.length} narrative gap(s) across ${toleratedFixtures} snippet(s) (not surface drift):`)
+  for (const [code, count] of Object.entries(benignCounts).sort((a, b) => b[1] - a[1])) {
+    console.log(`    ${String(count).padStart(4)}× ${BENIGN[code]} (${code})`)
+  }
+  if (review.length) {
+    console.log(`  ${review.length} typed mismatch(es) tolerated per the surface-only policy — worth an eyeball:`)
+    for (const e of review) console.log(`    ${locate(e)}`)
+  }
+}
+
+if (surfaceErrors.length) {
+  console.error(
+    `\n[check-doc-snippets] FAILED — ${surfaceErrors.length} attaform-surface error(s): a docs import no longer matches dist:\n`,
+  )
+  for (const e of surfaceErrors) console.error(`  ${locate(e)}`)
+  console.error(
+    '\n  Fix the doc to match the published surface (or the surface, if the doc is right).\n' +
+      `  Extracted fixtures are on disk for inspection: ${relative(repoRoot, generatedDir)}/`,
+  )
+  printToleratedSummary()
+  process.exit(1)
+}
+
+console.log(
+  `[check-doc-snippets] ok — 0 attaform-surface errors across ${fixtures.length} snippets ` +
+    `(${stats.ts} ts, ${stats.vue} vue) from ${stats.files.size} files`,
+)
+printToleratedSummary()
+process.exit(0)

--- a/tests/fixtures/doc-snippets/tsconfig.json
+++ b/tests/fixtures/doc-snippets/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "lib": ["es2020", "es2022.error", "dom"],
+    "types": []
+  },
+  "include": ["./.generated/*.ts", "./vue-auto-imports.d.ts"]
+}

--- a/tests/fixtures/doc-snippets/vue-auto-imports.d.ts
+++ b/tests/fixtures/doc-snippets/vue-auto-imports.d.ts
@@ -1,0 +1,21 @@
+// Ambient shim for the Vue reactivity helpers that docs SFC `<script setup>`
+// blocks reach for without an explicit import, because Nuxt auto-imports them.
+// Declaring them as globals keeps an extracted snippet honest about the
+// `attaform` surface it exercises, without false-failing on an unimported
+// `ref`. A block that DOES import these from `vue` simply shadows the global.
+import type * as vue from 'vue'
+
+declare global {
+  const ref: typeof vue.ref
+  const computed: typeof vue.computed
+  const reactive: typeof vue.reactive
+  const watch: typeof vue.watch
+  const watchEffect: typeof vue.watchEffect
+  const onMounted: typeof vue.onMounted
+  const nextTick: typeof vue.nextTick
+  const shallowRef: typeof vue.shallowRef
+  const toRef: typeof vue.toRef
+  const toRefs: typeof vue.toRefs
+}
+
+export {}


### PR DESCRIPTION
## Phase 6 — CI staleness gate for doc snippets

Sixth phase of the schema-entry refactor (the AI-agent-tooling workstream). Phase 5 made `llms.txt` a build artifact; this phase makes the *docs themselves* type-checked against the shipped surface, so a code block can no longer quietly import a symbol the build doesn't export. That drift is the literal origin of this whole refactor (a low-context model mis-imported `useForm`).

### What it does

`scripts/check-doc-snippets.mjs` (zero-dep) extracts every fenced `ts` / `vue` block that imports from `attaform` out of `docs/**/*.md` (plus the curated `llms.template.md`), writes each to a fixture, and type-checks the set against the **built `dist/*.d.mts`** — the exact surface a consumer sees. It mirrors `check:bundled-types`: same `moduleResolution: bundler` tsconfig, same real-bundle sentinel (`pnpm prepack` if `dist` is stubbed), one `tsc` pass. It runs as a **step in the `size` CI job**, reusing that job's `dist` prepack, and is a pre-push gate (outside `pnpm check`, exactly like `check:bundled-types`).

**Scope — import-bearing blocks.** A block that imports from `attaform` is asserting the public surface; a bare fragment (`form.setValue(...)` with no import) is not independently checkable and is skipped. Import-scoping self-excludes the 68 template-only `vue` fragments (an import is a *script* line), and for the 25 SFC blocks with a `<script setup>` it checks the script (where the import + wiring live). Extraction: **80 snippets (65 ts, 15 vue) from 46 files.**

### The decision: tolerant, surface-only (your call)

79 of 80 blocks also trip ~130 *non-surface* errors from the docs' narrative style: a block reuses `const schema` / `form` from an earlier block, references the multistep `shipping`/`payment`/`review` cast (defined once on `use-wizard.md`, used across 6 downstream pages), or imports a placeholder consumer file (`./App.vue`, `your-ui-kit`, `./my-adapter`). Per your pick, the gate is **tolerant**: a snippet fails **only** on an error that lands on an `attaform` import line (a removed export, a wrong subpath, a missing default). Everything else is reported, not failed. API-shape drift stays `check:bundled-types`' job; this gate's unique signal is *"every documented `attaform` import still resolves."*

The report stays legible so green never hides real drift:

```
[check-doc-snippets] ok — 0 attaform-surface errors across 80 snippets (65 ts, 15 vue) from 46 files
  tolerated 139 narrative gap(s) across 41 snippet(s) (not surface drift):
     105× undefined example identifier (TS2304)
      14× shorthand property not in scope (TS18004)
       9× placeholder / consumer module (TS2307)
       4× untyped example callback param (TS7006)
  7 typed mismatch(es) tolerated per the surface-only policy — worth an eyeball:
    ...
```

### Real drift it caught (fixed in commit 1)

Three docs imports no longer matched the built surface:

1. **`entry-points.md`** — `import { vRegisterTransform } from 'attaform/transforms'`. That export is gone; the surface is `vRegisterHintTransform` / `vRegisterPreambleTransform`.
2. **`entry-points.md` + `ssr-bare-vue.md`** — `import attaform from 'attaform/vite'` (default). The vite entry exports `attaform` **named** (`export { attaform, ... }`), no default → a consumer's build would break. Fixed to `import { attaform }`.
3. **`url-sync.md`** — two `steps: [...]` placeholders that are invalid TypeScript a reader can't paste; replaced with the section's `[shipping, payment, review]` cast.

### Flags for review

- **`attaform/vite` default export (surface question, not folded in).** I fixed the docs to the named import to match the current surface. But bundler plugins conventionally ship a default too (`import vue from '@vitejs/plugin-vue'`), and the docs evidently expected one. Adding `export default attaform` to the 5 plugin entries (`vite`/`rollup`/`esbuild`/`webpack`/`rspack`) would make `import attaform from 'attaform/vite'` work — additive, Cubic-safe. Held for your call as a separate follow-up (it's an observable surface change).
- **A real generic-wrapper trap the gate surfaced (tolerated, worth your eyes).** `app-defaults.md` documents `useAppForm<S extends z.ZodObject>(opts: Parameters<typeof attaformUseForm<S>>[0])`, which now trips `TS2589` (excessively deep): post-barrel-flip, `attaform`'s `useForm` is the heavier unified dispatcher, and a generic wrapper over it blows the instantiation depth. A consumer copying that pattern hits the same wall. It's a type-system limitation touching the inference surface (echoes the #422 generic-wrapper work), so I did **not** fix it inline — it needs your read on the documented pattern.
- **The other tolerated "eyeball" mismatches are benign.** The custom-adapters / abstract-schema `validateAtPath` `TS2322` is the generic-`F` return-provability limit of writing a generic adapter inline (the method *set* is fully current — a renamed member would show as a missing/excess-property error, and none do). The coercion `{}` and ssr `{} | null` are placeholder values.
- **Gate legibility.** "Green" means "no `attaform` surface drift," and the run always prints the tolerated breakdown + the typed-mismatch list so a reviewer can see exactly what was accepted.

### Verification

- `pnpm check:doc-snippets` — **0 surface errors, exit 0**; 139 narrative gaps tolerated across 41 snippets, cleanly bucketed.
- **Prove-break**: a probe doc with `import { useNonexistentThing } from 'attaform'` failed the gate (`TS2305`, remapped to the exact source line) while a narrative gap in the same probe was tolerated; deleting the probe returned it to green.
- Prettier clean on the changeset (`url-sync.md` reformatted its now-valid `ts` fence); `.generated/` gitignored; two bisectable commits, each green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
