### PR TITLE
Ship an Attaform Agent Skill + AI agents docs page (Phase 7)

### DIFF
--- a/apps/site/composables/useDocsNavigation.ts
+++ b/apps/site/composables/useDocsNavigation.ts
@@ -174,6 +174,7 @@ export const docsNavigation: DocsSection[] = [
       { title: 'Types reference', to: '/docs/reference/types' },
       { title: 'Errors reference', to: '/docs/reference/errors' },
       { title: 'Entry-point reference', to: '/docs/reference/entry-points' },
+      { title: 'AI agents', to: '/docs/reference/ai-agents' },
     ],
   },
 ]

--- a/apps/site/scripts/llms.template.md
+++ b/apps/site/scripts/llms.template.md
@@ -35,7 +35,7 @@ const onComplete = wizard.handleSubmit(async (ctx) => {
 })
 ```
 
-Steps can be `useForm` references, bare strings (affordance-only positions), eager function slots, or `lazy(ctx => ...)` markers. `wizard.handleSubmit` validates the active form and advances on intermediate steps, then validates every form in parallel on the final step.
+Steps can be `useForm` references, bare strings (affordance-only positions), `null` / `undefined` (filtered out), eager function slots, or `lazy(ctx => ...)` markers. `wizard.handleSubmit` validates every step from any position and calls `onSubmit` once with all values; it never advances. `wizard.tryNext()` is the gated Next: it validates the active step and advances only on a clean pass.
 
 ## Quick reference
 
@@ -59,8 +59,8 @@ The form handle returned by `useForm({ schema })`:
 The wizard handle returned by `useWizard({ steps })`:
 
 - `wizard.currentStep`, `wizard.activeForm`, `wizard.activeIndex`, `wizard.count`, `wizard.isFinalStep` position.
-- `wizard.next()`, `wizard.back()`, `wizard.goTo(key)`, `wizard.reset()` navigation.
-- `wizard.handleSubmit(onSubmit, onError?)` universal submit. Intermediate steps validate the active form and advance; the final step validates every form in parallel.
+- `wizard.next()`, `wizard.back()`, `wizard.goTo(key)`, `wizard.tryNext()`, `wizard.reset()` navigation. `tryNext()` validates the active step and advances only if it passes; the others move the pin without validating.
+- `wizard.handleSubmit(onSubmit, onError?)` whole-wizard submit. Validates every step from any position and calls `onSubmit` once with all values; it never advances (compose with `tryNext` / `next` to move between steps).
 - `wizard.forms.<key>` typed map of step forms.
 - `wizard.allValues`, `wizard.allErrors`, `wizard.statuses` namespaced aggregates.
 - `wizard.progress`, `wizard.canAdvance`, `wizard.canGoBack`, `wizard.complete`, `wizard.done` derived signals.

--- a/docs/reference/ai-agents.md
+++ b/docs/reference/ai-agents.md
@@ -1,0 +1,61 @@
+---
+title: AI agents
+description: The tooling Attaform ships for AI coding assistants. A generated llms.txt index, a full-text llms-full.txt dump, and an installable Attaform skill, so an agent builds a form the idiomatic way the first time.
+metaRows:
+  - label: Category
+    value: Reference
+  - label: Index
+    value: /llms.txt
+    kind: code
+  - label: Full text
+    value: /llms-full.txt
+    kind: code
+  - label: Skill
+    value: skills/attaform
+    kind: code
+---
+
+# AI agents
+
+> Attaform hands your coding assistant the same map the humans get. Three artifacts, all kept honest by the build: a curated `llms.txt` index, a full-text `llms-full.txt` dump, and an installable Attaform skill. Point an agent at them and the first form it writes reaches for `useForm`, binds with `v-register`, and submits through `handleSubmit`, no correction round needed.
+
+::docs-meta-table
+::
+
+Large language models are excellent Attaform authors when they can see the surface. Left to guess, a low-context model reaches for whatever it assumes a form library looks like: the wrong import, a hand-rolled `v-model`, a write straight through `values`. Every artifact on this page exists to replace that guess with the real shape.
+
+## `llms.txt`: the curated index
+
+[attaform.dev/llms.txt](/llms.txt) is the front door for an agent. It opens with the mental model, lists every documentation page as a titled link, and carries a compact API cheat-sheet plus the core idioms. It is small enough to drop into a prompt whole.
+
+It is a build artifact, regenerated from the live documentation on every deploy. The links come from the site's own navigation and the headline code comes from a type-checked snippet, so the index cannot silently drift from the site it points at. When an agent needs more than the index gives, the links carry it into the full docs.
+
+## `llms-full.txt`: every page, concatenated
+
+[attaform.dev/llms-full.txt](/llms-full.txt) is every documentation page stitched into one file, in reading order, with the site's markup stripped back to plain prose and code. Reach for it when a model has the context budget to hold the whole manual at once, or when you want to hand off Attaform's complete documentation in a single paste. Like the index, it regenerates on every build, so it is always the current docs.
+
+## The Attaform skill
+
+Attaform ships an Agent Skill: a `SKILL.md` that teaches an assistant how to actually build a form, distilled from real Attaform apps into a short list of recipes and rules. It covers the import surface, the build-a-form shape, reading validation state, routing server errors, and wizards. Where `llms.txt` is a reference an agent reads, the skill is guidance an agent follows while it writes.
+
+The skill travels inside the package. After installing Attaform, it sits at:
+
+```
+node_modules/attaform/skills/attaform/SKILL.md
+```
+
+To make it available to a skill-aware assistant, copy the skill folder into your project's skills directory:
+
+```sh
+cp -r node_modules/attaform/skills/attaform .claude/skills/
+```
+
+The assistant then loads the Attaform skill whenever it works on a form in your repo. Because the skill ships with the package, it moves in lockstep with the version you have installed.
+
+## Pointing an agent at Attaform
+
+- **A quick task in a chat.** Paste the contents of `llms.txt`, or link it, and ask for the form. The index is sized to fit.
+- **A capable agent with room to spare.** Hand it `llms-full.txt` for the complete documentation in one file.
+- **An assistant working in your codebase.** Install the skill so every form it touches follows the idioms without a reminder.
+
+All three point the same direction: the schema is the form, `v-register` binds it, and `handleSubmit` ships it. Give an agent that map and it builds Attaform forms the way you would.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
   "files": [
-    "dist"
+    "dist",
+    "skills"
   ],
   "sideEffects": false,
   "engines": {

--- a/scripts/check-doc-snippets.mjs
+++ b/scripts/check-doc-snippets.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 /**
  * Doc-snippet staleness gate. Extracts every fenced `ts` / `vue` code
- * block that imports from `attaform` out of the docs (and the curated
- * llms.txt template), then type-checks each against the *built*
+ * block that imports from `attaform` out of the docs, the published
+ * Agent Skill, and the curated llms.txt template, then type-checks each
+ * against the *built*
  * `dist/*.d.mts` — the exact surface a consumer sees. A docs example
  * that imports a symbol the library no longer exports (the drift that
  * prompted the schema-entry refactor) fails here instead of silently
@@ -47,6 +48,11 @@ const generatedDir = resolve(fixtureRoot, '.generated')
 const tsconfigPath = resolve(fixtureRoot, 'tsconfig.json')
 
 const docsDir = resolve(repoRoot, 'docs')
+// The published Agent Skill (skills/attaform/SKILL.md) teaches the same
+// `attaform` imports it documents; scanning it here type-checks the
+// skill's code against the built surface, so it can't ship a stale
+// import any more than a docs page can.
+const skillsDir = resolve(repoRoot, 'skills')
 // The curated llms.txt template carries hand-written `ts` blocks (the
 // wizard "API at a glance", the Quick reference cheat-sheet) that live
 // nowhere in docs/ — including it type-checks that curated code too.
@@ -134,6 +140,7 @@ rmSync(generatedDir, { recursive: true, force: true })
 mkdirSync(generatedDir, { recursive: true })
 
 const sources = collectMarkdown(docsDir)
+if (existsSync(skillsDir)) sources.push(...collectMarkdown(skillsDir))
 if (existsSync(llmsTemplate)) sources.push(llmsTemplate)
 
 const fixtures = []

--- a/skills/attaform/SKILL.md
+++ b/skills/attaform/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: attaform
+description: Build type-safe, schema-driven forms in Vue 3 and Nuxt with Attaform (first-class Zod). Use when creating, editing, or debugging a form (inputs, validation, submission, multistep wizards, or SSR) in a project that has the `attaform` package installed. Covers the correct import surface, the useForm handle, the v-register directive, reading validation state, handleSubmit, server-error routing, and wizards.
+license: MIT
+---
+
+# Building forms with Attaform
+
+Attaform turns a Zod schema into a reactive, typed Vue form: one schema declares the shape, the defaults, the validation, and the per-field errors, and Attaform builds the reactive surface around it. Use this skill when writing or editing a form in a project that depends on `attaform`.
+
+## Imports
+
+Everything comes from the `attaform` barrel:
+
+```ts
+import {
+  useForm,
+  useWizard,
+  injectForm,
+  injectWizard,
+  useRegister,
+  fieldMeta,
+  withMeta,
+  lazy,
+} from 'attaform'
+```
+
+- **Do not import `useForm` from `attaform/abstract`.** That entry is the bring-your-own-adapter escape hatch: it exports `useAbstractForm`, which needs a schema adapter wired by hand. A Zod project wants `useForm` from `attaform`. (This mismatch is the single most common first-try mistake.)
+- `attaform/zod` is the same surface named explicitly; `attaform/zod-v3` and `attaform/zod-v4` pin a Zod major. Any of these works; default to `attaform`.
+- In **Nuxt** with the module installed (`attaform/nuxt`), this surface auto-imports and the `v-register` directive is registered globally, so a component needs no import lines at all. In **plain Vite**, add the Attaform plugin from `attaform/vite` plus the auto-import preset it exports.
+
+## Build a form
+
+Three moves: hoist the schema, hand it to `useForm`, bind each input with `v-register`. Submit through `form.handleSubmit`.
+
+```vue
+<script setup lang="ts">
+  import { useForm } from 'attaform'
+  import { z } from 'zod'
+
+  const schema = z.object({
+    email: z.email('Enter a valid email'),
+    password: z.string().min(8, 'At least 8 characters'),
+  })
+
+  const form = useForm({ schema, key: 'sign-in' })
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    await fetch('/api/sign-in', { method: 'POST', body: JSON.stringify(values) })
+  })
+</script>
+
+<template>
+  <form @submit.prevent="onSubmit">
+    <label>
+      Email
+      <input v-register="form.register('email')" autocomplete="email" />
+      <em v-if="form.fields.email.showErrors">{{ form.fields.email.firstError?.message }}</em>
+    </label>
+    <label>
+      Password
+      <input type="password" v-register="form.register('password')" autocomplete="off" />
+      <em v-if="form.fields.password.showErrors">{{ form.fields.password.firstError?.message }}</em>
+    </label>
+    <button :disabled="form.meta.submitting" type="submit">Sign in</button>
+  </form>
+</template>
+```
+
+Prefer an explicit `key` (`useForm({ schema, key: 'sign-in' })`): it makes the form reachable through `injectForm('sign-in')`, survives parent refactors, and reads clearly at the call site. Anonymous `useForm({ schema })` is the fallback for a single throwaway form.
+
+## Rules
+
+- **Use the form handle. Don't destructure.** Keep the `const form = useForm(...)` handle and reach for `form.register(...)`, `form.setValue(...)`, `form.meta`. Destructuring loses the reactive bindings and the central noun.
+- **Bind with `v-register`; never write through `form.values`.** Inputs write back through the directive, which also injects SSR values and keeps ARIA in sync. `form.values` is a read view, and it is a callable proxy (so `typeof form.values === 'function'`): `schema.safeParse(form.values)` compiles but fails at runtime with "expected object, received function". To check validity read `form.meta.valid`; for a plain snapshot call `form.values()` (or `form.values('a.b')` for a subtree).
+- **Let `handleSubmit` do the work.** It validates, calls `onSubmit` with the parsed values, and on an invalid submit focuses the first offending field (client-invalid fields and server errors set via `setErrors` alike). No manual focus call and no `novalidate` ceremony are needed.
+- **Never disable the submit button on validity.** Let the user click; the failed submit focuses the first error and reveals it, which is clearer than a disabled button (which also drops out of the tab order for keyboard and screen-reader users). Gate only on `form.meta.submitting` (a submit in flight) or `!form.meta.dirty` (an edit form with nothing to save). If a field's only guard was the disabled button, move the requirement into the schema (`.min(1)`, `.refine(...)`) so `handleSubmit` actually fails on it.
+- **Read errors through `field.showErrors` and `field.firstError?.message`.** The visibility heuristic lives in `showErrors` (reward-early, punish-late); reaching into `field.errors[0]` directly bypasses it. The async "checking" indicator is `field.showPending`.
+- **Route server errors through `form.setErrors(...)` inside the callback.** `setErrors` replaces the whole user-error layer, so call `form.clearErrors()` at the top of the submit for a fresh attempt. If the backend emits Attaform's `ValidationError` shape (`{ message, path, code, data }`), pass it straight in; do not build a translation layer.
+- **Banners read `form.meta.firstOwnError`,** the form's own error bucket, not `form.errors([])` (which is the whole-form aggregate and would surface field errors in the summary).
+- **Accessibility is automatic.** `v-register` keeps `aria-invalid`, `aria-busy`, `aria-required`, and `aria-describedby` in sync and emits them during SSR. Put `form.fields.<path>.aria.errorId` on the error element so `aria-describedby` resolves. Author any ARIA attribute yourself to take that one over, or pass `autoAria: false` to opt out.
+- **Reach with `?.` on injected forms.** `injectForm()` and `injectWizard()` return `T | null`; chain optional access (`form?.register('email')`) at every consumption site.
+- **Put labels on the schema, not the template.** `z.string().register(fieldMeta, { label: 'Email' })`; read it back through `form.fields.email.label` (resolved, with a humanized-path fallback when nothing is registered).
+- **Native inputs first.** Bind `<input>`, `<select>`, `<textarea>` with `v-register`. Reach for `useRegister` only inside a custom input component that wraps a native control.
+- **`v-register` alone does binding, SSR value injection, and ARIA.** Do not stack `@change` handlers, reset-signal props, or watchers on top of it. If a control seems to need that scaffolding, the idiomatic shape is being missed.
+
+## Wizards
+
+Compose multiple `useForm` instances under `useWizard`:
+
+```ts
+import { useForm, useWizard } from 'attaform'
+
+const account = useForm({ schema: accountSchema, key: 'account' })
+const profile = useForm({ schema: profileSchema, key: 'profile' })
+
+const wizard = useWizard({ steps: [account, 'review', profile] })
+
+const onComplete = wizard.handleSubmit(async (ctx) => {
+  await fetch('/onboarding', { method: 'POST', body: JSON.stringify(ctx.values) })
+})
+```
+
+- A step is a `useForm` reference, a **bare string** (an informational or affordance step with no schema and no `useForm`), `null` / `undefined` (filtered out), or a function returning one of those.
+- **`wizard.tryNext()`** is the gated Next: it validates the active step and advances only on a clean pass, revealing that step's errors in place otherwise. Bind it straight to a button (`@click="wizard.tryNext()"`).
+- **`wizard.handleSubmit(onSubmit)`** validates every step from any position and calls `onSubmit` once with every form's values. It **never advances**; wire it to the final Submit. Navigation and submission are separate verbs.
+- Reach a step form from a descendant with `injectForm('account')`. Keyed lookup resolves by component-tree position and mount timing, not as a global address, so create the form in the coordinating ancestor and inject it downward rather than in a leaf.
+
+## SSR
+
+SSR is automatic under the Nuxt module or the Vite plugin: field values, `checked`, and `selected` are injected into the first paint and ARIA is emitted, with no extra wiring. Confirm any SSR behavior through the real build (curl the rendered HTML), not a bare unit render: the value injection is a build-time compiler transform that a plain Vitest render does not run, so an isolated render can false-negative.
+
+## Going deeper
+
+- `llms.txt` (curated index): https://attaform.dev/llms.txt
+- `llms-full.txt` (every doc, concatenated): https://attaform.dev/llms-full.txt
+- Docs: https://attaform.dev
+- Source and issues: https://github.com/attaform/Attaform


### PR DESCRIPTION
## Phase 7 — the Attaform Agent Skill + AI agents docs page

Seventh phase of the schema-entry refactor (the AI-agent-tooling workstream). Phase 5 generated `llms.txt`, Phase 6 gated the docs against the built surface; this phase ships the two artifacts that turn Attaform from *discoverable* into *installable* for a coding assistant: an Agent Skill and a docs page that points agents at all three artifacts.

Seeded from a real-world idioms doc distilled from a downstream Attaform app (the "how you actually build a form" gold input), reconciled against the current `main` surface.

### What lands

- **`skills/attaform/SKILL.md`** — an Agent Skill an assistant loads while writing forms *in a consumer's repo*. Distinct from `llms.txt` (a hosted index an agent reads): the skill is the self-contained procedural recipe an agent *follows*. It teaches the import surface (everything from `attaform`, not the `/abstract` escape hatch — the mis-import that started this whole refactor), the build-a-form shape, the rules (handle-not-destructure, `v-register` over writing `values`, errors via `showErrors`/`firstError`, `setErrors` server-error routing, `firstOwnError` banners, never-disable-submit, automatic ARIA), wizards (`tryNext` vs `handleSubmit`), and SSR. Shipped in the package `files` so it installs into `node_modules`; a skill-aware assistant loads it by copying the folder into `.claude/skills/`.
- **`docs/reference/ai-agents.md`** — a Reference-section page covering the three artifacts (`llms.txt`, `llms-full.txt`, the skill) and how to point an agent at each. Self-references into the regenerated `llms.txt` index (now listed under Reference) and `llms-full.txt`.

### The skill can't restale

`check:doc-snippets` (the Phase 6 gate) now scans `skills/**` too, so every `attaform` import in `SKILL.md` is type-checked against the built `dist` on every CI run. A stale import in the skill fails CI instead of shipping to consumers, which is the exact failure this workstream exists to prevent. The skill adds 3 snippets to the gate; it stays green (0 surface errors).

### Drift the Cubic idioms cross-reference caught (commit 1)

Grounding the skill against real usage surfaced a stale description in the **`llms.txt` template spine**: it said `wizard.handleSubmit` "advances on intermediate steps." Source (`use-wizard.ts:134`, `types-wizard.ts:207`) is the opposite: `handleSubmit` validates the whole step list from any position and **never advances**; `wizard.tryNext()` is the gated Next. The **docs pages** (`multistep/handle-submit`, `use-wizard`, `patterns`) were already correct — only the hand-written template had drifted (the import gate can't see prose), and the nav cheat-sheet had also dropped `tryNext`. Both fixed. Flagged here because it's a correction to a shipped artifact, beyond the literal Phase 7 scope.

### Grain-of-salt reconciliation

The source idioms doc is written against published **0.26.0**, where the downstream app imports from `attaform/zod` (split imports; "types live in `attaform/zod`, not the index"). This refactor supersedes that: post barrel-flip, everything comes from `attaform`. The skill documents **current `main`**, not the 0.26.0 split-import shape. Every API name in the skill (`fieldMeta`, `useRegister`, `field.label`, `form.meta.firstOwnError`, `wizard.tryNext`, ...) was verified against source before writing, since the gate tolerates property-access drift and only fails on import drift.

### Verification

- `pnpm check:doc-snippets` — **0 surface errors** across 83 snippets (67 ts, 16 vue) from 47 files (was 80/46); the +3 are the skill's blocks, all type-checking against `dist`.
- `pnpm build:site` — **435 routes, link-checker 0 failing / 0 errors / 0 warnings** across 189 pages; `llms.txt` + `llms-full.txt` regenerated (corrected wizard prose in, AI agents page indexed).
- `commitlint` clean (the lone `footer-leading-blank` warning is the house norm).
- Four bisectable commits, each green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
