### PR TITLE
Make the Agent Skill web-native + copy-as-markdown across the docs (Phase 7.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,12 +34,14 @@ apps/site/docs-demos/*/styles.css
 
 # Generated AI-agent surface (composed by scripts/generate-llms.mjs on
 # dev/build; sources of truth are llms.template.md + docs/**/*.md +
-# docs-demos/quick-start/snippet.vue for the text files, and skills/attaform/**
-# for the served skill mirror + alias)
+# docs-demos/quick-start/snippet.vue for the text files, skills/attaform/**
+# for the served skill mirror + alias, and docs/**/*.md for the per-page
+# cleaned Markdown endpoints)
 apps/site/public/llms.txt
 apps/site/public/llms-full.txt
 apps/site/public/skill.md
 apps/site/public/skills/
+apps/site/public/docs/
 
 # Doc-snippet type-check fixtures, extracted from docs/**/*.md + the llms
 # template by scripts/check-doc-snippets.mjs on every run (source of truth is

--- a/.gitignore
+++ b/.gitignore
@@ -32,11 +32,14 @@ apps/site/public/_pagefind
 # dev/build time; source of truth is registry.mjs + each demo's styles.json)
 apps/site/docs-demos/*/styles.css
 
-# Generated AI-agent index + full-text dump (composed from the docs, the nav,
-# and the canonical snippet by scripts/generate-llms.mjs on dev/build; source of
-# truth is llms.template.md + docs/**/*.md + docs-demos/quick-start/snippet.vue)
+# Generated AI-agent surface (composed by scripts/generate-llms.mjs on
+# dev/build; sources of truth are llms.template.md + docs/**/*.md +
+# docs-demos/quick-start/snippet.vue for the text files, and skills/attaform/**
+# for the served skill mirror + alias)
 apps/site/public/llms.txt
 apps/site/public/llms-full.txt
+apps/site/public/skill.md
+apps/site/public/skills/
 
 # Doc-snippet type-check fixtures, extracted from docs/**/*.md + the llms
 # template by scripts/check-doc-snippets.mjs on every run (source of truth is

--- a/apps/site/components/content/SkillViewer.vue
+++ b/apps/site/components/content/SkillViewer.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+  // Renders the shipped Agent Skill inline, read from the web-served mirror
+  // (skills/attaform/SKILL.md, written into public/ by the generator) so it is
+  // always the version the package ships. Fetched client-side: a public asset
+  // is not reachable through the prerender-time internal fetch, so the static
+  // paint shows the raw-file link and the viewer fills in on hydration. No
+  // top-level await keeps this a synchronous content component (it renders
+  // through ContentRenderer). The copy button hands an agent that exact
+  // markdown to drop into a .claude/skills folder.
+  const { data: skill } = useAsyncData(
+    'attaform-skill-md',
+    () => $fetch<string>('/skills/attaform/SKILL.md', { responseType: 'text' }),
+    { server: false }
+  )
+</script>
+
+<template>
+  <div class="not-prose my-6 overflow-hidden rounded-xl border border-border bg-surface/40">
+    <div class="flex items-center justify-between gap-3 border-b border-border bg-bg/50 px-4 py-2">
+      <code class="font-mono text-xs text-fg-muted">skills/attaform/SKILL.md</code>
+      <UiCopyButton v-if="skill" :text="skill" label="Copy the skill as markdown" />
+      <a v-else href="/skill.md" class="text-xs text-accent hover:underline">View raw</a>
+    </div>
+    <pre
+      v-if="skill"
+      class="max-h-[28rem] overflow-auto px-4 py-3 font-mono text-xs leading-relaxed text-fg"
+      v-text="skill"
+    />
+    <p v-else class="px-4 py-3 text-sm text-fg-muted">
+      Read the skill at
+      <a href="/skill.md" class="text-accent hover:underline">attaform.dev/skill.md</a>.
+    </p>
+  </div>
+</template>

--- a/apps/site/components/content/SkillViewer.vue
+++ b/apps/site/components/content/SkillViewer.vue
@@ -9,7 +9,7 @@
   // markdown to drop into a .claude/skills folder.
   const { data: skill } = useAsyncData(
     'attaform-skill-md',
-    () => $fetch<string>('/skills/attaform/SKILL.md', { responseType: 'text' }),
+    () => fetch('/skills/attaform/SKILL.md').then((r) => (r.ok ? r.text() : null)),
     { server: false }
   )
 </script>

--- a/apps/site/components/docs/DocsCopyMarkdown.vue
+++ b/apps/site/components/docs/DocsCopyMarkdown.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+  import { computed, onBeforeUnmount, ref } from 'vue'
+  import { Check, Copy, FileText } from 'lucide-vue-next'
+
+  // The page-level "copy as markdown" pair that sits by the docs title.
+  // Copy fetches the page's cleaned .md endpoint (written into public/ by
+  // generate-llms.mjs) and writes it to the clipboard; the .md link opens
+  // that same file. Both point at `${route.path}.md`, e.g.
+  // /docs/reference/ai-agents.md. Clipboard access is client-gated and
+  // wrapped in try/catch — it can throw in private mode or an insecure
+  // context — so a failed copy silently no-ops and the .md link remains.
+  const props = defineProps<{ path: string }>()
+
+  // Strip a trailing slash before appending .md so a trailing-slash route
+  // (e.g. /docs/foo/) still points at /docs/foo.md rather than /docs/foo/.md.
+  const mdHref = computed(() => `${props.path.replace(/\/$/, '')}.md`)
+
+  const copied = ref(false)
+  let resetTimer: ReturnType<typeof setTimeout> | null = null
+
+  async function copyMarkdown() {
+    if (!import.meta.client) return
+    try {
+      const md = await $fetch<string>(mdHref.value, { responseType: 'text' })
+      await navigator.clipboard.writeText(md)
+      copied.value = true
+      if (resetTimer) clearTimeout(resetTimer)
+      resetTimer = setTimeout(() => (copied.value = false), 1500)
+    } catch {
+      // Silent fallback — see comment above.
+    }
+  }
+
+  onBeforeUnmount(() => {
+    if (resetTimer) clearTimeout(resetTimer)
+  })
+</script>
+
+<template>
+  <div class="flex items-center gap-1 text-xs">
+    <button
+      type="button"
+      class="inline-flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-fg-muted transition-[background-color,color] duration-(--duration-fast) hover:bg-surface-2 hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-ring"
+      :aria-label="copied ? 'Copied' : 'Copy page as markdown'"
+      @click="copyMarkdown"
+    >
+      <Check v-if="copied" class="h-3.5 w-3.5 text-success" :stroke-width="2.25" />
+      <Copy v-else class="h-3.5 w-3.5" :stroke-width="2" />
+      <span>{{ copied ? 'Copied' : 'Copy' }}</span>
+    </button>
+    <a
+      :href="mdHref"
+      class="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-fg-muted transition-[background-color,color] duration-(--duration-fast) hover:bg-surface-2 hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-ring"
+    >
+      <FileText class="h-3.5 w-3.5" :stroke-width="2" />
+      <span>.md</span>
+    </a>
+  </div>
+</template>

--- a/apps/site/components/docs/DocsCopyMarkdown.vue
+++ b/apps/site/components/docs/DocsCopyMarkdown.vue
@@ -21,8 +21,9 @@
   async function copyMarkdown() {
     if (!import.meta.client) return
     try {
-      const md = await $fetch<string>(mdHref.value, { responseType: 'text' })
-      await navigator.clipboard.writeText(md)
+      const res = await fetch(mdHref.value)
+      if (!res.ok) return
+      await navigator.clipboard.writeText(await res.text())
       copied.value = true
       if (resetTimer) clearTimeout(resetTimer)
       resetTimer = setTimeout(() => (copied.value = false), 1500)

--- a/apps/site/nuxt.config.ts
+++ b/apps/site/nuxt.config.ts
@@ -446,6 +446,13 @@ export default defineNuxtConfig({
   linkChecker: {
     failOnError: true,
     strictNuxtContentPaths: true,
+    // The per-page raw-Markdown endpoints (public/docs/**/*.md, emitted by
+    // generate-llms.mjs) are static build artifacts, not Nuxt Content
+    // routes, so strictNuxtContentPaths would read the in-page "copy as
+    // markdown" links as broken content paths. Exclude the .md endpoints
+    // from inspection; the generator guarantees they exist. Merged with
+    // (not replacing) the module's default excludeLinks regexes.
+    excludeLinks: [/^\/docs\/.*\.md$/],
   },
   // @nuxt/content's Shiki integration. Pinning the themes and lang
   // set here is intentional — the default theme set is broad and

--- a/apps/site/pages/docs/[...slug].vue
+++ b/apps/site/pages/docs/[...slug].vue
@@ -166,6 +166,14 @@
     <article class="min-w-0 max-w-3xl flex-1">
       <DocsBreadcrumb class="mb-8" />
       <template v-if="page">
+        <!-- Page-level "copy as markdown" pair, sitting top-right just
+             above the H1 (which renders inside ContentRenderer). Copies
+             the page's cleaned .md endpoint or opens it; both resolve to
+             `${route.path}.md`. Inside v-if="page" so a 404 never shows a
+             control for a page with no underlying .md. -->
+        <div class="mb-4 flex justify-end">
+          <DocsCopyMarkdown :path="route.path" />
+        </div>
         <div class="docs-article-enter docs-prose prose prose-neutral max-w-none dark:prose-invert">
           <ContentRenderer :value="page" />
         </div>

--- a/apps/site/scripts/generate-llms.mjs
+++ b/apps/site/scripts/generate-llms.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 /**
- * Generate the AI-agent index and full-text dump for the docs site, and keep
+ * Generate the AI-agent surface for the docs site (the llms.txt index, the
+ * llms-full.txt dump, and a web-fetchable copy of the Agent Skill), and keep
  * the README + quick-start page's headline code single-sourced from one tested
  * snippet. Zero dependencies (Node built-ins only), so it can run in any build
  * environment without touching the dependency graph.
@@ -24,7 +25,7 @@
  * Inputs: the canonical snippet SFC, the docs navigation (the sidebar's own
  * source of truth), every `docs/**` page's frontmatter, and package.json.
  */
-import { readFileSync, writeFileSync, readdirSync, existsSync, statSync } from 'node:fs'
+import { readFileSync, writeFileSync, readdirSync, existsSync, statSync, mkdirSync } from 'node:fs'
 import { dirname, resolve, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -340,6 +341,32 @@ function syncCommitted(snippet) {
   return drifted
 }
 
+// ─── Served Agent Skill ──────────────────────────────────────────────
+//
+// Mirror the package's Agent Skill (`skills/attaform/**`) into `public/`
+// so an agent can be pointed at a URL without installing the package and
+// digging through node_modules. The skill's `references/` links are
+// relative, so the mirror keeps the same directory shape and they
+// resolve on the web exactly as they do on disk. `public/skill.md` is a
+// memorable top-level alias for the main file. All build artifacts,
+// single-sourced from the git skill, so they cannot drift.
+function writeSkillArtifacts() {
+  const srcDir = resolve(repoRoot, 'skills/attaform')
+  const outDir = resolve(siteRoot, 'public/skills/attaform')
+  mkdirSync(join(outDir, 'references'), { recursive: true })
+
+  const main = readFileSync(join(srcDir, 'SKILL.md'), 'utf8')
+  writeFileSync(join(outDir, 'SKILL.md'), main)
+  writeFileSync(resolve(siteRoot, 'public/skill.md'), main)
+
+  const refsDir = join(srcDir, 'references')
+  const refs = existsSync(refsDir) ? readdirSync(refsDir).filter((f) => f.endsWith('.md')) : []
+  for (const f of refs) {
+    writeFileSync(join(outDir, 'references', f), readFileSync(join(refsDir, f), 'utf8'))
+  }
+  log(`wrote public/skill.md + public/skills/attaform/** (${refs.length} reference file(s))`)
+}
+
 // ─── Run ─────────────────────────────────────────────────────────────
 const snippet = loadSnippet()
 const nav = loadDocsNavigation()
@@ -361,6 +388,8 @@ if (leftover) throw new Error(`generate-llms: unreplaced template placeholder ${
 writeFileSync(resolve(siteRoot, 'public/llms.txt'), `${llms.trim()}\n`)
 writeFileSync(resolve(siteRoot, 'public/llms-full.txt'), buildFullText(nav))
 log('wrote public/llms.txt + public/llms-full.txt')
+
+writeSkillArtifacts()
 
 const drifted = syncCommitted(snippet)
 if (drifted.length) {

--- a/apps/site/scripts/generate-llms.mjs
+++ b/apps/site/scripts/generate-llms.mjs
@@ -367,6 +367,30 @@ function writeSkillArtifacts() {
   log(`wrote public/skill.md + public/skills/attaform/** (${refs.length} reference file(s))`)
 }
 
+// ─── Per-page Markdown endpoints ─────────────────────────────────────
+//
+// Emit a cleaned Markdown copy of every docs page at
+// `public/docs/<path>.md`, so each page has a fetchable raw-Markdown
+// endpoint (attaform.dev/docs/<path>.md) beside its HTML and the in-page
+// "copy as Markdown" control has one source to read. The same MDC
+// stripper used for llms-full.txt runs so component blocks (live demos,
+// meta strips) do not leak into the text; the page's own `# H1` stays as
+// the title. Excluded dirs (via allDocRels) are skipped, matching the
+// index and full-text dump.
+function writePerPageMarkdown() {
+  const outRoot = resolve(siteRoot, 'public/docs')
+  let count = 0
+  for (const rel of allDocRels()) {
+    const doc = readDoc(rel)
+    if (!doc) continue
+    const outPath = join(outRoot, rel)
+    mkdirSync(dirname(outPath), { recursive: true })
+    writeFileSync(outPath, `${stripMdc(doc.body).trim()}\n`)
+    count++
+  }
+  log(`wrote public/docs/**/*.md (${count} page(s))`)
+}
+
 // ─── Run ─────────────────────────────────────────────────────────────
 const snippet = loadSnippet()
 const nav = loadDocsNavigation()
@@ -390,6 +414,7 @@ writeFileSync(resolve(siteRoot, 'public/llms-full.txt'), buildFullText(nav))
 log('wrote public/llms.txt + public/llms-full.txt')
 
 writeSkillArtifacts()
+writePerPageMarkdown()
 
 const drifted = syncCommitted(snippet)
 if (drifted.length) {

--- a/docs/reference/ai-agents.md
+++ b/docs/reference/ai-agents.md
@@ -11,7 +11,7 @@ metaRows:
     value: /llms-full.txt
     kind: code
   - label: Skill
-    value: skills/attaform
+    value: /skill.md
     kind: code
 ---
 
@@ -36,7 +36,16 @@ It is a build artifact, regenerated from the live documentation on every deploy.
 
 ## The Attaform skill
 
-Attaform ships an Agent Skill: a `SKILL.md` that teaches an assistant how to actually build a form, distilled from real Attaform apps into a short list of recipes and rules. It covers the import surface, the build-a-form shape, reading validation state, routing server errors, and wizards. Where `llms.txt` is a reference an agent reads, the skill is guidance an agent follows while it writes.
+Attaform ships an Agent Skill: a `SKILL.md` that teaches an assistant how to actually build a form, distilled from real Attaform apps into a short list of recipes and rules. Where `llms.txt` is a reference an agent reads, the skill is guidance an agent follows while it writes.
+
+It is built for progressive disclosure. The main file covers the common case end to end: the import surface, the build-a-form shape, the core rules, and short wizard and SSR summaries. It links five reference files an agent loads only when the task reaches their area, served alongside it under `references/`: wizards, errors, custom components, SSR, and validation. The lean main keeps the everyday case cheap, and the depth is one hop away when a form needs it.
+
+::skill-viewer
+::
+
+Read or copy it above, or fetch it directly at [attaform.dev/skill.md](/skill.md).
+
+### Install it into your project
 
 The skill travels inside the package. After installing Attaform, it sits at:
 
@@ -44,7 +53,7 @@ The skill travels inside the package. After installing Attaform, it sits at:
 node_modules/attaform/skills/attaform/SKILL.md
 ```
 
-To make it available to a skill-aware assistant, copy the skill folder into your project's skills directory:
+Copy the whole skill folder, the main file and its `references/`, into your project's skills directory:
 
 ```sh
 cp -r node_modules/attaform/skills/attaform .claude/skills/

--- a/skills/attaform/SKILL.md
+++ b/skills/attaform/SKILL.md
@@ -62,7 +62,7 @@ Three moves: hoist the schema, hand it to `useForm`, bind each input with `v-reg
     </label>
     <label>
       Password
-      <input type="password" v-register="form.register('password')" autocomplete="off" />
+      <input v-register="form.register('password')" type="password" autocomplete="off" />
       <em v-if="form.fields.password.showErrors">{{ form.fields.password.firstError?.message }}</em>
     </label>
     <button :disabled="form.meta.submitting" type="submit">Sign in</button>

--- a/skills/attaform/SKILL.md
+++ b/skills/attaform/SKILL.md
@@ -114,11 +114,11 @@ SSR is automatic under the Nuxt module or the Vite plugin: field values, `checke
 
 Load one when the task reaches its area:
 
-- **`references/wizards.md`** — multistep flows: the declarative step registry, `tryNext` vs `handleSubmit`, using a wizard as a flat multi-form coordinator, and how keyed `injectForm` / `injectWizard` resolve.
-- **`references/errors.md`** — routing server and API errors: the `ValidationError` envelope, `setErrors` / `clearErrors`, the own-vs-subtree error axis, banners, and the one-normalizer pattern.
-- **`references/custom-components.md`** — wrapping an input or binding a third-party component: `useRegister`, the three orthogonal primitives, attribute fallthrough, and the optional `form-key` prop.
-- **`references/ssr.md`** — debugging SSR and hydration: why the value injection is a build-time transform, how to confirm it faithfully, and the test traps to avoid.
-- **`references/validation.md`** — designing the schema: client-is-UX / server-is-truth, keeping closed sets in sync, and why a clearable edit field is a required string.
+- **`references/wizards.md`**: multistep flows. The declarative step registry, `tryNext` vs `handleSubmit`, using a wizard as a flat multi-form coordinator, and how keyed `injectForm` / `injectWizard` resolve.
+- **`references/errors.md`**: routing server and API errors. The `ValidationError` envelope, `setErrors` / `clearErrors`, the own-vs-subtree error axis, banners, and the one-normalizer pattern.
+- **`references/custom-components.md`**: wrapping an input or binding a third-party component. `useRegister`, the three orthogonal primitives, attribute fallthrough, and the optional `form-key` prop.
+- **`references/ssr.md`**: debugging SSR and hydration. Why the value injection is a build-time transform, how to confirm it faithfully, and the test traps to avoid.
+- **`references/validation.md`**: designing the schema. Client-is-UX / server-is-truth, keeping closed sets in sync, and why a clearable edit field is a required string.
 
 ## Going deeper
 

--- a/skills/attaform/SKILL.md
+++ b/skills/attaform/SKILL.md
@@ -8,6 +8,8 @@ license: MIT
 
 Attaform turns a Zod schema into a reactive, typed Vue form: one schema declares the shape, the defaults, the validation, and the per-field errors, and Attaform builds the reactive surface around it. Use this skill when writing or editing a form in a project that depends on `attaform`.
 
+This file covers the common case end to end. For depth on one area, load the matching file in `references/` (indexed at the bottom).
+
 ## Imports
 
 Everything comes from the `attaform` barrel:
@@ -25,7 +27,8 @@ import {
 } from 'attaform'
 ```
 
-- **Do not import `useForm` from `attaform/abstract`.** That entry is the bring-your-own-adapter escape hatch: it exports `useAbstractForm`, which needs a schema adapter wired by hand. A Zod project wants `useForm` from `attaform`. (This mismatch is the single most common first-try mistake.)
+- **Do not import `useForm` from `attaform/abstract`.** That entry is the bring-your-own-adapter escape hatch: it exports `useAbstractForm`, which needs a schema adapter wired by hand. A Zod project wants `useForm` from `attaform`. This mismatch is the single most common first-try mistake.
+- Types come from the same barrel: `import type { AnyForm, WizardCtx, Json, ValidationError } from 'attaform'`.
 - `attaform/zod` is the same surface named explicitly; `attaform/zod-v3` and `attaform/zod-v4` pin a Zod major. Any of these works; default to `attaform`.
 - In **Nuxt** with the module installed (`attaform/nuxt`), this surface auto-imports and the `v-register` directive is registered globally, so a component needs no import lines at all. In **plain Vite**, add the Attaform plugin from `attaform/vite` plus the auto-import preset it exports.
 
@@ -71,22 +74,22 @@ Prefer an explicit `key` (`useForm({ schema, key: 'sign-in' })`): it makes the f
 
 ## Rules
 
-- **Use the form handle. Don't destructure.** Keep the `const form = useForm(...)` handle and reach for `form.register(...)`, `form.setValue(...)`, `form.meta`. Destructuring loses the reactive bindings and the central noun.
-- **Bind with `v-register`; never write through `form.values`.** Inputs write back through the directive, which also injects SSR values and keeps ARIA in sync. `form.values` is a read view, and it is a callable proxy (so `typeof form.values === 'function'`): `schema.safeParse(form.values)` compiles but fails at runtime with "expected object, received function". To check validity read `form.meta.valid`; for a plain snapshot call `form.values()` (or `form.values('a.b')` for a subtree).
-- **Let `handleSubmit` do the work.** It validates, calls `onSubmit` with the parsed values, and on an invalid submit focuses the first offending field (client-invalid fields and server errors set via `setErrors` alike). No manual focus call and no `novalidate` ceremony are needed.
-- **Never disable the submit button on validity.** Let the user click; the failed submit focuses the first error and reveals it, which is clearer than a disabled button (which also drops out of the tab order for keyboard and screen-reader users). Gate only on `form.meta.submitting` (a submit in flight) or `!form.meta.dirty` (an edit form with nothing to save). If a field's only guard was the disabled button, move the requirement into the schema (`.min(1)`, `.refine(...)`) so `handleSubmit` actually fails on it.
-- **Read errors through `field.showErrors` and `field.firstError?.message`.** The visibility heuristic lives in `showErrors` (reward-early, punish-late); reaching into `field.errors[0]` directly bypasses it. The async "checking" indicator is `field.showPending`.
-- **Route server errors through `form.setErrors(...)` inside the callback.** `setErrors` replaces the whole user-error layer, so call `form.clearErrors()` at the top of the submit for a fresh attempt. If the backend emits Attaform's `ValidationError` shape (`{ message, path, code, data }`), pass it straight in; do not build a translation layer.
-- **Banners read `form.meta.firstOwnError`,** the form's own error bucket, not `form.errors([])` (which is the whole-form aggregate and would surface field errors in the summary).
-- **Accessibility is automatic.** `v-register` keeps `aria-invalid`, `aria-busy`, `aria-required`, and `aria-describedby` in sync and emits them during SSR. Put `form.fields.<path>.aria.errorId` on the error element so `aria-describedby` resolves. Author any ARIA attribute yourself to take that one over, or pass `autoAria: false` to opt out.
+- **Use the form handle. Don't destructure.** Keep `const form = useForm(...)` and reach for `form.register(...)`, `form.setValue(...)`, `form.meta`. Destructuring loses the reactive bindings.
+- **Bind with `v-register`; never write through `form.values`.** `form.values` is a read view and a callable proxy (`typeof form.values === 'function'`), so `schema.safeParse(form.values)` compiles but fails at runtime. Read `form.meta.valid` for validity; call `form.values()` for a plain snapshot (`form.values('a.b')` for a subtree).
+- **Let `handleSubmit` do the work.** It validates, calls `onSubmit` with the parsed values, and focuses the first offending field on an invalid submit. No manual focus and no `novalidate` ceremony.
+- **Never disable the submit button on validity.** Let the user click; the failed submit focuses the first error and reveals it. Gate only on `form.meta.submitting` or `!form.meta.dirty`. If a field's only guard was the disabled button, move the requirement into the schema (`.min(1)`, `.refine(...)`). See `references/validation.md`.
+- **Read errors through `field.showErrors` and `field.firstError?.message`.** The visibility heuristic lives in `showErrors`; reaching into `field.errors[0]` bypasses it. The async "checking" indicator is `field.showPending`.
+- **Route server errors through `form.setErrors(...)` inside the callback.** `setErrors` replaces the whole user-error layer, so call `form.clearErrors()` at the top of the submit for a fresh attempt. See `references/errors.md`.
+- **Banners read `form.meta.firstOwnError`,** the form's own error bucket, not `form.errors([])` (the whole-form aggregate). See `references/errors.md`.
+- **Accessibility is automatic.** `v-register` keeps `aria-invalid`, `aria-busy`, `aria-required`, and `aria-describedby` in sync and emits them during SSR. Put `form.fields.<path>.aria.errorId` on the error element so `aria-describedby` resolves. Author any ARIA attribute yourself to take it over, or pass `autoAria: false` to opt out.
 - **Reach with `?.` on injected forms.** `injectForm()` and `injectWizard()` return `T | null`; chain optional access (`form?.register('email')`) at every consumption site.
-- **Put labels on the schema, not the template.** `z.string().register(fieldMeta, { label: 'Email' })`; read it back through `form.fields.email.label` (resolved, with a humanized-path fallback when nothing is registered).
-- **Native inputs first.** Bind `<input>`, `<select>`, `<textarea>` with `v-register`. Reach for `useRegister` only inside a custom input component that wraps a native control.
+- **Put labels on the schema, not the template.** `z.string().register(fieldMeta, { label: 'Email' })`; read it back through `form.fields.email.label` (resolved, with a humanized-path fallback).
+- **Native inputs first.** Bind `<input>`, `<select>`, `<textarea>` with `v-register`. Reach for `useRegister` only inside a custom input component. See `references/custom-components.md`.
 - **`v-register` alone does binding, SSR value injection, and ARIA.** Do not stack `@change` handlers, reset-signal props, or watchers on top of it. If a control seems to need that scaffolding, the idiomatic shape is being missed.
 
 ## Wizards
 
-Compose multiple `useForm` instances under `useWizard`:
+Compose multiple `useForm` instances under `useWizard`. Navigation and submission are separate verbs: `wizard.tryNext()` is the gated Next (validates the active step, advances on a clean pass), and `wizard.handleSubmit(onSubmit)` validates every step from any position and calls `onSubmit` once with all values, but **never advances**.
 
 ```ts
 import { useForm, useWizard } from 'attaform'
@@ -101,14 +104,21 @@ const onComplete = wizard.handleSubmit(async (ctx) => {
 })
 ```
 
-- A step is a `useForm` reference, a **bare string** (an informational or affordance step with no schema and no `useForm`), `null` / `undefined` (filtered out), or a function returning one of those.
-- **`wizard.tryNext()`** is the gated Next: it validates the active step and advances only on a clean pass, revealing that step's errors in place otherwise. Bind it straight to a button (`@click="wizard.tryNext()"`).
-- **`wizard.handleSubmit(onSubmit)`** validates every step from any position and calls `onSubmit` once with every form's values. It **never advances**; wire it to the final Submit. Navigation and submission are separate verbs.
-- Reach a step form from a descendant with `injectForm('account')`. Keyed lookup resolves by component-tree position and mount timing, not as a global address, so create the form in the coordinating ancestor and inject it downward rather than in a leaf.
+A step is a `useForm` reference, a bare string (an informational step with no schema), `null` / `undefined` (filtered out), or a function returning one of those. Full patterns, the declarative step registry, and the keyed-injection gotchas live in `references/wizards.md`.
 
 ## SSR
 
-SSR is automatic under the Nuxt module or the Vite plugin: field values, `checked`, and `selected` are injected into the first paint and ARIA is emitted, with no extra wiring. Confirm any SSR behavior through the real build (curl the rendered HTML), not a bare unit render: the value injection is a build-time compiler transform that a plain Vitest render does not run, so an isolated render can false-negative.
+SSR is automatic under the Nuxt module or the Vite plugin: field values, `checked`, and `selected` are injected into the first paint and ARIA is emitted, with no extra wiring. Confirm any SSR behavior through the real build (curl the rendered HTML), not a bare unit render. The value injection is a build-time compiler transform that a plain Vitest render does not run. See `references/ssr.md`.
+
+## Reference files
+
+Load one when the task reaches its area:
+
+- **`references/wizards.md`** — multistep flows: the declarative step registry, `tryNext` vs `handleSubmit`, using a wizard as a flat multi-form coordinator, and how keyed `injectForm` / `injectWizard` resolve.
+- **`references/errors.md`** — routing server and API errors: the `ValidationError` envelope, `setErrors` / `clearErrors`, the own-vs-subtree error axis, banners, and the one-normalizer pattern.
+- **`references/custom-components.md`** — wrapping an input or binding a third-party component: `useRegister`, the three orthogonal primitives, attribute fallthrough, and the optional `form-key` prop.
+- **`references/ssr.md`** — debugging SSR and hydration: why the value injection is a build-time transform, how to confirm it faithfully, and the test traps to avoid.
+- **`references/validation.md`** — designing the schema: client-is-UX / server-is-truth, keeping closed sets in sync, and why a clearable edit field is a required string.
 
 ## Going deeper
 

--- a/skills/attaform/references/custom-components.md
+++ b/skills/attaform/references/custom-components.md
@@ -1,0 +1,72 @@
+# Custom components
+
+Reach for these only when a native `<input>`, `<select>`, or `<textarea>` bound with `v-register` will not do. Most fields never need a wrapper.
+
+## Three orthogonal primitives
+
+There is deliberately no `useField(path)` that returns `{ register, fields, errors }` in one call. The three concerns are kept separate on purpose:
+
+- **`register(path)` returns an instance, not a path abstraction.** Two inputs can register the same path and move in sync: they share the path's field _state_, but each `register()` call has its own transforms and DOM lifecycle. A single bundled binding would have to pretend there is one binding per path.
+- **`fields(path)` is path-keyed leaf state**: `value`, `touched`, `dirty`, `blank`, `errors`, `label`, `aria`, the display signals. The noun is the path.
+- **`errors` is a related but separate concern**, not the same thing as field state.
+
+The three lines are the idiom, not a bundle. Small primitives age better than convenient bundles.
+
+## A single-field wrapper
+
+The parent binds with `v-register`; the wrapper re-forwards that same instance and reads state from it:
+
+```vue
+<!-- parent -->
+<UiTextField v-register="form.register('email')" type="email" />
+```
+
+```vue
+<!-- UiTextField.vue -->
+<script setup lang="ts">
+  import { computed } from 'vue'
+  import { injectForm, useRegister } from 'attaform'
+
+  const rv = useRegister() // the forwarded instance
+  const form = injectForm(rv?.formKey) // the owning form, by the instance's key
+  const field = computed(() => form?.fields(rv?.segments ?? [])) // reactive leaf state
+</script>
+
+<template>
+  <label>
+    <span>{{ field?.label }}</span>
+    <input v-register="rv" />
+    <em v-if="field?.showErrors">{{ field.firstError?.message }}</em>
+  </label>
+</template>
+```
+
+`rv` and `field` may be `undefined` until the parent directive attaches, so defend every read with `?.`. `rv.path`, `rv.segments`, and `rv.formKey` pierce directly in script setup without `.value`.
+
+For a **compound** component that binds _multiple_ paths (a date range exposing start and end, an address subform), skip `useRegister` (it assumes a single binding) and reach for `injectForm<Form>()`, then call `form.register(path)` for each field.
+
+## Let the library own display and ARIA
+
+- Read the display signals straight in the template: `field.showErrors` gates the error row, `field.showPending` gates an async "checking" indicator (it is anti-flash timed), `field.firstError?.message` is the text.
+- `v-register`'s `autoAria` (on by default) keeps `aria-invalid`, `aria-busy`, and `aria-required` in sync. It wires the _error_ id, and only while the field is in its error state, so author `aria-describedby` yourself if a _static_ hint should stay associated too.
+- **`v-register` alone does binding, SSR value injection, and ARIA.** Do not stack `@change` handlers, `:reset-signal` props, redundant directive imports, or watchers on top of it. If a control seems to need that scaffolding, find the idiomatic shape rather than hand-rolling around it.
+
+## Third-party components
+
+`v-register` binds a third-party component host, not just a native element, as long as the component renders a real form control and forwards attributes to it. The directive marks the host and injects the same binding, SSR, and ARIA it gives a native input.
+
+## Do not re-declare native attributes as props
+
+Attribute fallthrough already delivers `id`, `aria-*`, `class`, and the like to the root element. Declare a Vue prop only when script needs to _consume_ the value; otherwise let it fall through. If the component root is not the control, set `inheritAttrs: false` and retarget the attributes onto the control with `v-bind="$attrs"`.
+
+## An optional `form-key` prop
+
+When the parent form has a key, give the wrapper an optional `form-key` prop and resolve through it, falling back to ambient injection for the single-throwaway-form case:
+
+```ts
+const form = formKey ? injectForm(formKey) : injectForm()
+```
+
+## Extend the surface, do not shrink it
+
+A wrapper composable should expose the library's full surface and add derived accessors on top, not return a hand-picked subset that strands state the library already computed. Spreading the raw handle plus your derived fields keeps everything reachable.

--- a/skills/attaform/references/custom-components.md
+++ b/skills/attaform/references/custom-components.md
@@ -45,7 +45,7 @@ The parent binds with `v-register`; the wrapper re-forwards that same instance a
 
 For a **compound** component that binds _multiple_ paths (a date range exposing start and end, an address subform), skip `useRegister` (it assumes a single binding) and reach for `injectForm<Form>()`, then call `form.register(path)` for each field.
 
-## Let the library own display and ARIA
+## Let Attaform own display and ARIA
 
 - Read the display signals straight in the template: `field.showErrors` gates the error row, `field.showPending` gates an async "checking" indicator (it is anti-flash timed), `field.firstError?.message` is the text.
 - `v-register`'s `autoAria` (on by default) keeps `aria-invalid`, `aria-busy`, and `aria-required` in sync. It wires the _error_ id, and only while the field is in its error state, so author `aria-describedby` yourself if a _static_ hint should stay associated too.
@@ -69,4 +69,4 @@ const form = formKey ? injectForm(formKey) : injectForm()
 
 ## Extend the surface, do not shrink it
 
-A wrapper composable should expose the library's full surface and add derived accessors on top, not return a hand-picked subset that strands state the library already computed. Spreading the raw handle plus your derived fields keeps everything reachable.
+A wrapper composable should expose Attaform's full surface and add derived accessors on top, not return a hand-picked subset that strands state Attaform already computed. Spreading the raw handle plus your derived fields keeps everything reachable.

--- a/skills/attaform/references/errors.md
+++ b/skills/attaform/references/errors.md
@@ -1,0 +1,62 @@
+# Errors
+
+Attaform holds three error layers (schema validation, blank-required, and user-set) and reads them back through one surface. Server and API errors go through the user-set layer via `form.setErrors`; you rarely touch the other two directly.
+
+## Routing server errors
+
+Inside the submit callback, clear the stale user layer, then route the failure through `setErrors`:
+
+```ts
+const onSubmit = form.handleSubmit(async (values) => {
+  form.clearErrors()
+  try {
+    await save(values)
+  } catch (err) {
+    form.setErrors(normalizeErrors(err))
+  }
+})
+```
+
+- `setErrors(errors | updater | (path, errors))` is a **whole-layer replace**, so `clearErrors()` at the top of a fresh attempt drops errors a previous submit set. `clearErrors(path?)` scopes the clear.
+- `handleSubmit` focuses the first offending field for user-set errors exactly as it does for client-invalid fields, so a `setErrors` call inside the callback needs no separate focus step.
+
+## The `ValidationError` envelope
+
+If your backend emits Attaform's `ValidationError` shape, it pipes straight into `setErrors` with no translation layer:
+
+```ts
+import type { ValidationError, Json } from 'attaform'
+
+// { message: string; path: (string | number)[]; code?: string; data?: Json | null }
+```
+
+- One entry per message at `path: [field]`; a form-level error is `path: []`; a dotted key splits into segments.
+- A structured non-field payload (a lockout timestamp, a challenge token) is **one form-level error** whose `.data` carries the payload, never exploded into phantom field errors.
+- **Do not build a translation layer** to adapt a payload that already is Attaform's type. If the only friction is a type mismatch (your `data` typed `Record<string, unknown>` rather than Attaform's `Json`), fix the _type_, not with code: `data: z.custom<Json>().nullish()`. Messages come from one source (the server), not a frontend copy map.
+
+A thrown `onSubmit` is also caught and surfaces as a single form-level error, so a bare `throw` is the shortcut when you have no per-field array to distribute. Reach for `setErrors` when the server hands you an array that should target individual fields.
+
+## The own vs subtree axis
+
+Every `FieldState` node (leaves, containers, and the form root) exposes two error axes:
+
+| Accessor                                | Scope                                           |
+| --------------------------------------- | ----------------------------------------------- |
+| `node.ownErrors` / `node.firstOwnError` | errors at **this path exactly**, no descendants |
+| `node.errors` / `form.errors(path)`     | the **subtree**: this path plus descendants     |
+
+On a leaf the two axes coincide. They diverge on containers and on the form root.
+
+## Banners
+
+A form-level banner wants the root's **own** bucket, not the aggregate:
+
+```ts
+const banner = computed(() => form.meta.firstOwnError)
+```
+
+Do not use `form.errors([])` for a banner: `errors(path)` uniformly means "path plus descendants", so `errors([])` is the whole-form aggregate and would surface individual field errors in the summary. `form.meta.firstOwnError` is the correct root-only read. The same own axis surfaces a container-level `.refine()` error, for example `form.fields.address.firstOwnError`.
+
+## One normalizer, always non-empty
+
+Route every form's error handling through a single normalizer that sits at the error-reading layer, above the transport, and **always returns a non-empty error set**. The fallback is load-bearing: a network drop, a non-standard 500, or a contract violation whose error array came back empty should still yield one generic form-level error, so the user never sees a submit that silently no-ops. Keep this one chokepoint rather than digging the envelope at each call site.

--- a/skills/attaform/references/ssr.md
+++ b/skills/attaform/references/ssr.md
@@ -19,9 +19,8 @@ The reason is the transform above. A plain Vitest render (bare `vue()`, no Attaf
 - **Do not hand-wire `attaform/vite` into `vitest.config.ts`** to force a green. That fakes a third compile pipeline that matches neither production nor a clean unit test, and it hides the real reason a bare test cannot see the value.
 - A faithful SSR test goes through the real build: a Nuxt-level test with `@nuxt/test-utils`. The one lower-level exception is a test that itself invokes `@vue/compiler-sfc`'s `compileTemplate` with Attaform's real node transforms, which reproduces the compiled path honestly.
 
-## Two concerns that stay in your app
+## One concern that stays in your app
 
-These come up around SSR forms but are the app's responsibility, not something Attaform wires for you:
+Attaform handles the SSR-adjacent details itself: the value injection above, and error-focus (which requests `focusVisible: true`, so the ring paints even when focus moves programmatically to a radio or checkbox). One SSR pattern is still the app's responsibility:
 
 - **Seeding a page-owned form from async data races SSR.** If an ancestor lifts a form (so it can be injected downward) and seeds it from an async query through an immediate `watch`, the server's watch runs before the query resolves and does not re-fire, so the server renders empty while the client hydrates filled: a hydration mismatch. Seed **both legs**: a client immediate `watch` and a server `onServerPrefetch` that awaits the query, then seeds. A form created lazily behind a resolved gate never hits this.
-- **Programmatic error-focus does not paint a focus ring on non-text controls.** `focusFirstError` calls a plain `.focus()`. After a pointer-triggered submit, focus lands on a radio or checkbox (a test asserting focus passes) but paints no `:focus-visible` ring. Put the indicator on a wrapper with `focus-within:` so it shows for programmatic focus, and confirm focus _visibility_ in the real app, not just an assertion that focus moved.

--- a/skills/attaform/references/ssr.md
+++ b/skills/attaform/references/ssr.md
@@ -1,0 +1,27 @@
+# SSR
+
+SSR is automatic under the Nuxt module or the Vite plugin. Field values, `checked`, and `selected` are rendered into the first paint and ARIA is emitted, with no extra wiring. You do not opt in and you do not configure it. What follows matters mostly when you are _debugging_ SSR or writing a test that touches it.
+
+## The value injection is a build-time transform
+
+On the compiled template path, `v-register`'s SSR value / `checked` / `selected` injection is a **build-time Vue-compiler transform** (from `attaform/vite`, wired by the `attaform/nuxt` module), not a runtime `getSSRProps`. On that path `getSSRProps` emits only the `aria-*` attributes; the value rides on the compile-time transform. On the runtime render-function path (a hand-written `h()` component), the value instead comes through `getSSRProps`. Both paths reach the same rendered HTML; they differ only in _which_ mechanism carries the value.
+
+One consequence worth knowing: a `<input :type="...">` with a _dynamic_ type bails the input transform, so give an input a static `type` when you want the compile-time SSR value.
+
+## Confirm SSR through the real build
+
+Always confirm an Attaform SSR claim through the **real build**: curl or inspect the server-rendered HTML of a real (or throwaway) page. Never judge SSR behavior from a bare unit render.
+
+The reason is the transform above. A plain Vitest render (bare `vue()`, no Attaform compiler transform) **cannot** see SSR-injected values for a compiled form component, so a check written there fails even when production is correct. A naive isolated Node render experiment false-negatives for the same reason: the transform is not present, so even the correct shape looks broken.
+
+## Test traps
+
+- **Do not hand-wire `attaform/vite` into `vitest.config.ts`** to force a green. That fakes a third compile pipeline that matches neither production nor a clean unit test, and it hides the real reason a bare test cannot see the value.
+- A faithful SSR test goes through the real build: a Nuxt-level test with `@nuxt/test-utils`. The one lower-level exception is a test that itself invokes `@vue/compiler-sfc`'s `compileTemplate` with Attaform's real node transforms, which reproduces the compiled path honestly.
+
+## Two concerns that stay in your app
+
+These come up around SSR forms but are the app's responsibility, not something Attaform wires for you:
+
+- **Seeding a page-owned form from async data races SSR.** If an ancestor lifts a form (so it can be injected downward) and seeds it from an async query through an immediate `watch`, the server's watch runs before the query resolves and does not re-fire, so the server renders empty while the client hydrates filled: a hydration mismatch. Seed **both legs**: a client immediate `watch` and a server `onServerPrefetch` that awaits the query, then seeds. A form created lazily behind a resolved gate never hits this.
+- **Programmatic error-focus does not paint a focus ring on non-text controls.** `focusFirstError` calls a plain `.focus()`. After a pointer-triggered submit, focus lands on a radio or checkbox (a test asserting focus passes) but paints no `:focus-visible` ring. Put the indicator on a wrapper with `focus-within:` so it shows for programmatic focus, and confirm focus _visibility_ in the real app, not just an assertion that focus moved.

--- a/skills/attaform/references/validation.md
+++ b/skills/attaform/references/validation.md
@@ -1,0 +1,40 @@
+# Validation
+
+Attaform validates against the form's own Zod schema and drives the display signals from it. The schema is the contract; design it deliberately.
+
+## Client is UX, server is truth
+
+The client schema is a **UX gate only**. A direct request bypasses it entirely, so the server must validate every input independently. Client validation exists to give fast inline feedback, not to protect the backend. Write the schema for the person filling the form; never lean on it as a security boundary.
+
+## Keep closed sets in sync
+
+Where a field is a closed set on both sides (a country, a size band, a status), derive the client `z.enum` from the same option list the control renders, and mirror the server's set. The client should reject _exactly_ what the server would, never stricter on a value the server accepts. A drift between the two shows up as a form that blocks a submit the backend would have taken.
+
+## Reflect server truth, not optimism
+
+On a successful mutation, reset the form from the returned resource or re-read a server-truth source, rather than trusting the values you submitted. A success message should sit on server-confirmed state, not on the optimistic input. This keeps the form honest when the server normalizes, defaults, or rejects part of what you sent.
+
+## A clearable edit field is a required string
+
+A field the user must be able to **clear** should be a required, possibly-empty string, not `.optional()`:
+
+```ts
+const schema = z.object({
+  // Wrong for a clearable edit field: a cleared value drops from the payload,
+  // and a partial-update backend reads the omission as "unchanged".
+  // nickname: z.string().optional(),
+
+  // Right: an empty string still transmits, so the clear reaches the server.
+  nickname: z.string(),
+})
+```
+
+A cleared `.optional()` field drops out of the payload, and a partial-update backend that treats an absent key as "leave unchanged" silently ignores the clear. Use `z.string()` (allowed empty) so the cleared value is sent and the update takes.
+
+## Move real requirements into the schema
+
+If a field's only guard was a disabled submit button, that requirement is not enforced once you stop disabling the button (which you should, see the core rules). Put the requirement in the schema (`.min(1)`, `.refine(...)`) so `handleSubmit` actually fails on it and focuses the field. A field left as a bare `z.string()` or `z.boolean()` accepts empty or `false`, which is often not what an "acknowledge" checkbox or a required text field means.
+
+## The display signals
+
+The per-field `showErrors` / `showSuccess` / `showPending` signals already encode a reward-early, punish-late display policy: an error is revealed once the user has engaged with the field, success is shown when earned, and the async pending state is anti-flash timed. Read those signals; do not rebuild the visibility heuristic from raw `errors` and `touched`.

--- a/skills/attaform/references/wizards.md
+++ b/skills/attaform/references/wizards.md
@@ -44,10 +44,10 @@ The `onSubmit` callback receives a context, not a bare values object:
 
 ```ts
 const onComplete = wizard.handleSubmit(async (ctx) => {
-  // ctx.values     — aggregate keyed by form key (mirrors wizard.allValues)
-  // ctx.get(form)  — typed parsed output for one form ref
-  // ctx.currentKey — the step that fired the submit
-  // ctx.isFinal    — positional: is currentKey the last step?
+  // ctx.values is the aggregate keyed by form key (mirrors wizard.allValues)
+  // ctx.get(form) returns one form's typed parsed output
+  // ctx.currentKey is the step that fired the submit
+  // ctx.isFinal is positional: whether currentKey is the last step
   await fetch('/onboarding', { method: 'POST', body: JSON.stringify(ctx.values) })
 })
 ```
@@ -58,10 +58,10 @@ const onComplete = wizard.handleSubmit(async (ctx) => {
 
 The wizard handle exposes the flow's rolled-up state, all reactive:
 
-- `wizard.forms[key]` — the live form handle for a step (a facade typed as a form).
-- `wizard.allValues` / `wizard.allErrors` — every form's values / aggregate errors, keyed.
-- `wizard.activeForm` — the currently active step's form facade.
-- `wizard.statuses` — per-form status; `wizard.progress`, `wizard.canAdvance`, `wizard.canGoBack`, `wizard.isFinalStep`, `wizard.visited`.
+- `wizard.forms[key]`: the live form handle for a step (a facade typed as a form).
+- `wizard.allValues` / `wizard.allErrors`: every form's values / aggregate errors, keyed.
+- `wizard.activeForm`: the currently active step's form facade.
+- `wizard.statuses`: per-form status. Plus `wizard.progress`, `wizard.canAdvance`, `wizard.canGoBack`, `wizard.isFinalStep`, `wizard.visited`.
 
 ## A declarative step registry
 

--- a/skills/attaform/references/wizards.md
+++ b/skills/attaform/references/wizards.md
@@ -1,0 +1,104 @@
+# Wizards
+
+`useWizard` composes existing `useForm` instances into a multistep flow with navigation, per-step status, and one aggregate submit. Navigation and submission are separate verbs; keep them separate.
+
+## Step slots
+
+A step slot is one of:
+
+- a `useForm` reference,
+- a **bare string**: an always-valid noop step (key = the string), the native primitive for an informational or affordance screen with no schema,
+- `null` / `undefined`: filtered out of the flow,
+- a **function** returning any of those, for runtime branching,
+- a `lazy((ctx) => ...)`-wrapped function, which memoizes its resolution and re-fires only when its own tracked reads change.
+
+```ts
+import { useForm, useWizard } from 'attaform'
+
+const account = useForm({ schema: accountSchema, key: 'account' })
+const profile = useForm({ schema: profileSchema, key: 'profile' })
+
+const wizard = useWizard({ key: 'onboarding', steps: [account, 'review', profile] })
+```
+
+## Navigation vs submission
+
+- **`wizard.tryNext(): Promise<boolean>`** is the gated Next. It validates the active step and advances only on a clean pass, revealing that step's errors in place otherwise. It resolves to whether it advanced, and it is inline-bindable: `@click="wizard.tryNext()"`.
+- **`wizard.next()` / `wizard.back()` / `wizard.goTo(key)`** are positional moves with no validation gate. Use them for a Back button or a jump; use `tryNext` for a forward move that should validate.
+- **`wizard.handleSubmit(onSubmit, onError?)`** validates **every** step from any position and calls `onSubmit` once with all forms' values. It **never advances**. Wire it to the final Submit.
+
+For a forward move that runs a custom callback before advancing, compose the step form's own submit with `next`:
+
+```ts
+const onStepDone = account.handleSubmit(async (values) => {
+  await saveDraft(values)
+  wizard.next()
+})
+```
+
+`handleSubmit` validating the whole list from any step means there is no "only the last step validates everything" caveat: a user who steps back, edits, and submits from the middle still gets the whole flow validated, and `done` still latches on success. `ctx.isFinal` reports only _where_ the submit fired, never _what_ was validated.
+
+## The submit context
+
+The `onSubmit` callback receives a context, not a bare values object:
+
+```ts
+const onComplete = wizard.handleSubmit(async (ctx) => {
+  // ctx.values     — aggregate keyed by form key (mirrors wizard.allValues)
+  // ctx.get(form)  — typed parsed output for one form ref
+  // ctx.currentKey — the step that fired the submit
+  // ctx.isFinal    — positional: is currentKey the last step?
+  await fetch('/onboarding', { method: 'POST', body: JSON.stringify(ctx.values) })
+})
+```
+
+`ctx.get(account)` is the type-safe read for one form: it returns that form's parsed output typed from its schema, which survives across a component graph because the form ref carries its schema.
+
+## Reading aggregate state
+
+The wizard handle exposes the flow's rolled-up state, all reactive:
+
+- `wizard.forms[key]` — the live form handle for a step (a facade typed as a form).
+- `wizard.allValues` / `wizard.allErrors` — every form's values / aggregate errors, keyed.
+- `wizard.activeForm` — the currently active step's form facade.
+- `wizard.statuses` — per-form status; `wizard.progress`, `wizard.canAdvance`, `wizard.canGoBack`, `wizard.isFinalStep`, `wizard.visited`.
+
+## A declarative step registry
+
+When steps carry metadata (title, a visibility predicate, persisted keys), drive the whole wizard from one registry rather than scattering the shape. `WizardCtx` is `{ forms, currentKey }` and reactive, so a `when` predicate can branch on live form values and re-evaluate as they change:
+
+```ts
+import { useWizard } from 'attaform'
+import type { AnyForm, WizardCtx } from 'attaform'
+
+interface StepDef {
+  key: string
+  title: string
+  form: AnyForm | null // null becomes a bare-string noop slot
+  when?: (ctx: WizardCtx) => boolean // omitted means always shown
+}
+
+const registry: StepDef[] = [
+  { key: 'intent', title: 'Get started', form: null },
+  { key: 'account', title: 'Your account', form: account },
+  { key: 'profile', title: 'Your profile', form: profile },
+]
+
+const wizard = useWizard({
+  key: 'onboarding',
+  steps: registry.map(
+    (s) => (ctx: WizardCtx) => ((s.when?.(ctx) ?? true) ? (s.form ?? s.key) : undefined)
+  ),
+})
+```
+
+Everything derives from the registry: the step slots, the titles, any persisted key list. Add, remove, reorder, or gate a step by editing the registry alone. Do not add speculative registry fields with no consumer; add a hook when the second consumer arrives.
+
+## Keyed injection resolves by tree and timing
+
+A string key passed to `injectForm('account')` or `injectWizard('onboarding')` _reads_ like a global address but resolves by the **caller's component-tree position and mount timing**, not as a global lookup:
+
+- `provide` / `inject` is descendant-only, so a form created in a **leaf** is unreachable from an **ancestor**.
+- A keyed form is not resolvable until the creating component's `setup` has run, so mount order matters.
+
+The consequence: a purely structural refactor can silently break a lookup. The stable shape is to **lift a shared form's creation to the coordinating ancestor** (the component that owns the wizard) and have leaves `injectForm(key)` it downward by a prop key. Always chain `?.` on the result, which is `T | null`.


### PR DESCRIPTION
## Phase 7.1 — the Agent Skill goes web-native + copy-as-markdown across the docs

Follows Phase 7 (#501, the Agent Skill + AI agents docs page). Phase 7 made Attaform *discoverable* by an agent; this makes the skill *web-native* (progressive-disclosure, fetchable, rendered + copyable on the site) and brings the llms.txt-era "copy as markdown" convention to every docs page.

One coherent PR: four feature phases (below) plus two small follow-ups (an em-dash / naming polish on the skill prose, and a switch to native `fetch` in the two components so lint stays clean).

### A — the skill goes progressive-disclosure

Splits the flat `SKILL.md` into a lean main (imports, build-a-form, tightened one-line rules, short wizard + SSR summaries, a reference index) plus five `references/*.md` an agent loads only when the task reaches their area: `wizards`, `errors`, `custom-components`, `ssr`, `validation`. The depth is seeded from real downstream usage notes distilled from an Attaform app, reconciled to the current `main` surface: every import is from the bare `attaform` barrel (types included), no version history, no back-compat framing. Every API name was verified against source.

**Reconciliation worth flagging:** the source notes carried a wizard flat-coordinator workaround (`goTo` the last step before `handleSubmit`). That is stale. `handleSubmit` now validates the whole step list from any position and never advances (source: `use-wizard.ts`, `types-wizard.ts`), so the workaround is dropped and the current behavior documented instead.

### B — serve the skill web-fetchably

The generator mirrors `skills/attaform/**` into `public/skills/attaform/**` (keeping the on-disk directory shape so the skill's relative `references/` links resolve on the web) and writes a memorable `public/skill.md` alias: point an agent at `attaform.dev/skill.md`. Single-sourced from the git skill each build.

### C — render + copy the skill on the AI agents page

A `SkillViewer` content component reads the served mirror and renders the skill in a scrollable block with a one-click copy-as-markdown button (reusing `UiCopyButton`). The read is client-side: a public asset is not reachable through the prerender-time internal fetch (an earlier build-time `?raw` import also collides with Nuxt Content's `.md` handling), so the static paint shows a link to the raw file and the viewer fills in on hydration. The skill's integrity is guaranteed upstream by the doc-snippet gate + the regenerated mirror; this page is just the viewer.

### D — copy-as-markdown + raw `.md` across all docs

Every docs page now has a fetchable `attaform.dev/docs/<path>.md` (cleaned with the same MDC stripper `llms-full.txt` uses, so live demos and meta strips do not leak) and an in-page `[Copy] [.md]` control by the title, guarded so a 404 shows no control. The `.md` endpoints are static build artifacts, not Nuxt Content routes, so they are excluded from the link checker's strict content-path inspection (merged with, not replacing, its default excludes).

### The whole surface stays honest by the build

`check:doc-snippets` now type-checks the reference files' `attaform` imports against `dist` alongside the main skill; the served mirror, the alias, and the per-page `.md` all regenerate from source each build and are gitignored. Nothing can drift, and there are zero new dependencies.

### Verification

- `pnpm check:doc-snippets` — **0 attaform-surface errors** across 87 snippets (70 ts, 17 vue) from 50 files; the reference files that carry `attaform` imports type-check against `dist`.
- `pnpm build:site` — **435 routes**, link-checker **0 errors**; the served skill, alias, and 79 per-page `.md` endpoints all emit.
- Playwright (headless, against the built output) — the skill renders client-side and copies on the AI page (clipboard holds `SKILL.md`); the docs copy control fetches the cleaned `.md` and copies it; a missing page shows no control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
