### PR TITLE
Ship the `npx attaform skill` installer and surface the AI tooling (Phase 8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ npm install attaform zod
 </script>
 
 <template>
-  <form @submit.prevent="onSubmit">
+  <form @submit="onSubmit">
     <label>
       Email
       <input v-register="form.register('email')" autocomplete="email" />
@@ -52,7 +52,7 @@ npm install attaform zod
     </label>
     <label>
       Password
-      <input type="password" v-register="form.register('password')" autocomplete="off" />
+      <input v-register="form.register('password')" type="password" autocomplete="off" />
       <em v-if="form.fields.password.showErrors">{{ form.fields.password.firstError?.message }}</em>
     </label>
     <button :disabled="form.meta.submitting" type="submit">Sign in</button>

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Hand the schema to `useForm`, bind each input with `v-register`, and Attaform ow
 - **`useWizard` for multistep.** Compose forms into a flow with shared navigation, per-step validation, state retained across steps, and deep-link restore. [useWizard →](https://attaform.dev/docs/multistep/use-wizard)
 - **SSR-native.** Server-rendered HTML matches the hydrated client with no flash. Auto-wired in Nuxt, one Vite plugin for bare Vue. [SSR in Nuxt →](https://attaform.dev/docs/server-and-ssr/ssr-nuxt)
 - **DevTools built in.** Inspect every form on the page, walk its history, and edit values live. No probes to install. [DevTools panel →](https://attaform.dev/docs/devtools-and-debugging/devtools-panel)
+- **Built for AI-assisted coding.** Ships an `llms.txt` index, a full-text docs dump, and an installable Agent Skill (`npx attaform skill`), so your coding assistant writes idiomatic Attaform the first time. [AI agents →](https://attaform.dev/docs/reference/ai-agents)
 - **Secure by construction.** Zero runtime dependencies (no supply-chain surface), prototype-pollution-safe deep writes, and Attaform never throws into your app. [Security policy →](./SECURITY.md)
 
 ## Documentation
@@ -84,6 +85,7 @@ Full docs live at **[attaform.dev](https://attaform.dev)**.
 - [Entry points](https://attaform.dev/docs/reference/entry-points): every public export, grouped by subpath.
 - [Performance](https://attaform.dev/docs/server-and-ssr/performance): how it scales, when to worry.
 - [Troubleshooting](https://attaform.dev/docs/devtools-and-debugging/troubleshooting): common gotchas and fixes.
+- [AI agents](https://attaform.dev/docs/reference/ai-agents): `llms.txt`, the full-text docs dump, and an installable skill for coding assistants.
 - [Changelog](./CHANGELOG.md): full release history.
 
 ## Status

--- a/apps/site/components/content/ProseA.vue
+++ b/apps/site/components/content/ProseA.vue
@@ -5,8 +5,12 @@
   // legitimately points at github.com (repo source, issues, releases),
   // npm, MDN, etc., and pulling readers off the docs page on those
   // links is rude. In-site routes (Nuxt Content's normalised paths)
-  // pass through to NuxtLink for client-side navigation; relative /
-  // anchor links render as plain <a>.
+  // pass through to NuxtLink for client-side navigation. Links to a
+  // static file the site serves from public/ (llms.txt, skill.md, a
+  // per-page .md) render as a plain <a>: NuxtLink would ask Vue Router
+  // to resolve and prefetch a route that does not exist. Relative /
+  // anchor links also render as plain <a>.
+  import { isStaticFilePath } from '~/utils/prose-link'
 
   const props = defineProps<{
     href?: string
@@ -19,8 +23,14 @@
     const h = props.href ?? ''
     return /^[a-z][a-z0-9+.-]*:/i.test(h) && !isExternal.value
   })
+  const isStaticFile = computed(() => isStaticFilePath(props.href))
   const isInternalRoute = computed(
-    () => !isExternal.value && !isAnchor.value && !isProtocolOther.value && Boolean(props.href)
+    () =>
+      !isExternal.value &&
+      !isAnchor.value &&
+      !isProtocolOther.value &&
+      !isStaticFile.value &&
+      Boolean(props.href)
   )
 </script>
 

--- a/apps/site/docs-demos/async-refinements/App.vue
+++ b/apps/site/docs-demos/async-refinements/App.vue
@@ -32,7 +32,7 @@
 </script>
 
 <template>
-  <form class="demo" @submit.prevent="onSubmit">
+  <form class="demo" @submit="onSubmit">
     <label>
       <span>Username (taken: ada, champ, athlete)</span>
       <input v-register="form.register('username')" />

--- a/apps/site/docs-demos/container-display-state/App.vue
+++ b/apps/site/docs-demos/container-display-state/App.vue
@@ -43,7 +43,7 @@
 </script>
 
 <template>
-  <form class="demo" @submit.prevent="onSubmit">
+  <form class="demo" @submit="onSubmit">
     <div class="readout banner" :class="form.meta.displayState">
       <span class="badge" :class="form.meta.displayState">{{ form.meta.displayState }}</span>
       <span>{{ bannerText[form.meta.displayState] }}</span>

--- a/apps/site/docs-demos/defaults-sync-factory/App.vue
+++ b/apps/site/docs-demos/defaults-sync-factory/App.vue
@@ -40,7 +40,7 @@
 
 <template>
   <div class="demo layout split">
-    <form class="card" @submit.prevent="onSubmit">
+    <form class="card" @submit="onSubmit">
       <header>
         <h4>Report session</h4>
         <button type="button" class="ghost" @click="onNewSession">New session</button>

--- a/apps/site/docs-demos/discriminated-unions/App.vue
+++ b/apps/site/docs-demos/discriminated-unions/App.vue
@@ -32,7 +32,7 @@
 </script>
 
 <template>
-  <form class="demo" @submit.prevent="onSubmit">
+  <form class="demo" @submit="onSubmit">
     <fieldset>
       <legend>Notify me by</legend>
       <label class="row">

--- a/apps/site/docs-demos/display-state/App.vue
+++ b/apps/site/docs-demos/display-state/App.vue
@@ -29,7 +29,7 @@
 </script>
 
 <template>
-  <form class="demo" @submit.prevent="onSubmit">
+  <form class="demo" @submit="onSubmit">
     <div class="stack">
       <label>
         <span>Username (taken: ada, champ, athlete)</span>

--- a/apps/site/docs-demos/fields/App.vue
+++ b/apps/site/docs-demos/fields/App.vue
@@ -37,7 +37,7 @@
 </script>
 
 <template>
-  <form class="demo" @submit.prevent="onSubmit">
+  <form class="demo" @submit="onSubmit">
     <label>
       <span>{{ form.fields.email.label }}</span>
       <input

--- a/apps/site/docs-demos/focus-scroll/App.vue
+++ b/apps/site/docs-demos/focus-scroll/App.vue
@@ -20,7 +20,7 @@
 </script>
 
 <template>
-  <form class="demo" @submit.prevent="onSubmit">
+  <form class="demo" @submit="onSubmit">
     <p class="hint">
       Submit with empty form.fields to see focus + scroll pull to the first invalid path. Click the
       buttons to dispatch each helper imperatively.

--- a/apps/site/docs-demos/handle-submit/App.vue
+++ b/apps/site/docs-demos/handle-submit/App.vue
@@ -23,7 +23,7 @@
 </script>
 
 <template>
-  <form class="demo" @submit.prevent="onSubmit">
+  <form class="demo" @submit="onSubmit">
     <label>
       Email
       <input v-register="form.register('email')" autocomplete="email" />

--- a/apps/site/docs-demos/inject-form/App.vue
+++ b/apps/site/docs-demos/inject-form/App.vue
@@ -16,7 +16,7 @@
 </script>
 
 <template>
-  <form class="demo" @submit.prevent="onSubmit">
+  <form class="demo" @submit="onSubmit">
     <label>
       Email (in the parent component)
       <input v-register="form.register('email')" autocomplete="email" />

--- a/apps/site/docs-demos/meta/App.vue
+++ b/apps/site/docs-demos/meta/App.vue
@@ -29,7 +29,7 @@
 </script>
 
 <template>
-  <form class="demo" @submit.prevent="onSubmit">
+  <form class="demo" @submit="onSubmit">
     <label>
       <span>Email</span>
       <input v-register="form.register('email')" autocomplete="email" />

--- a/apps/site/docs-demos/preprocess/App.vue
+++ b/apps/site/docs-demos/preprocess/App.vue
@@ -25,7 +25,7 @@
 
 <template>
   <div class="demo layout split">
-    <form class="stack" @submit.prevent="onSubmit">
+    <form class="stack" @submit="onSubmit">
       <label>
         Email
         <input

--- a/apps/site/docs-demos/quick-start/snippet.vue
+++ b/apps/site/docs-demos/quick-start/snippet.vue
@@ -27,7 +27,7 @@
 </script>
 
 <template>
-  <form @submit.prevent="onSubmit">
+  <form @submit="onSubmit">
     <label>
       Email
       <input v-register="form.register('email')" autocomplete="email" />
@@ -35,7 +35,7 @@
     </label>
     <label>
       Password
-      <input type="password" v-register="form.register('password')" autocomplete="off" />
+      <input v-register="form.register('password')" type="password" autocomplete="off" />
       <em v-if="form.fields.password.showErrors">{{ form.fields.password.firstError?.message }}</em>
     </label>
     <button :disabled="form.meta.submitting" type="submit">Sign in</button>

--- a/apps/site/docs-demos/root-errors/App.vue
+++ b/apps/site/docs-demos/root-errors/App.vue
@@ -22,7 +22,7 @@
 </script>
 
 <template>
-  <form class="demo" @submit.prevent="onSubmit">
+  <form class="demo" @submit="onSubmit">
     <p v-if="form.meta.firstOwnError" class="banner error" role="alert">
       {{ form.meta.firstOwnError.message }}
     </p>

--- a/apps/site/docs-demos/server-side-errors/App.vue
+++ b/apps/site/docs-demos/server-side-errors/App.vue
@@ -60,7 +60,7 @@
 </script>
 
 <template>
-  <form class="demo" @submit.prevent="onSubmit">
+  <form class="demo" @submit="onSubmit">
     <p class="hint">
       Enter the wrong password (the demo accepts <code>hunter2</code>) to land a field error, or
       sign in as <code>locked@example.com</code> to see a form-level lockout whose

--- a/apps/site/docs-demos/storage-shape/App.vue
+++ b/apps/site/docs-demos/storage-shape/App.vue
@@ -32,7 +32,7 @@
 
 <template>
   <div class="demo layout split">
-    <form class="stack" @submit.prevent="onSubmit">
+    <form class="stack" @submit="onSubmit">
       <label>
         flag (boolean)
         <input v-register="form.register('flag')" type="checkbox" />

--- a/apps/site/docs-demos/the-form/App.vue
+++ b/apps/site/docs-demos/the-form/App.vue
@@ -22,7 +22,7 @@
 
 <template>
   <div class="demo layout split">
-    <form class="stack" @submit.prevent="onSubmit">
+    <form class="stack" @submit="onSubmit">
       <label>
         Email
         <input v-register="form.register('email')" autocomplete="email" />

--- a/apps/site/docs-demos/transforms-async/App.vue
+++ b/apps/site/docs-demos/transforms-async/App.vue
@@ -65,7 +65,7 @@
 </script>
 
 <template>
-  <form class="demo" @submit.prevent="onSubmit">
+  <form class="demo" @submit="onSubmit">
     <p class="hint">
       Pick one or more plain <code>.txt</code> files with one entry per line. Attaform reads them,
       turns each line into a tidy URL, drops anything that is not a web address, then lowercases the

--- a/apps/site/docs-demos/type-safety/App.vue
+++ b/apps/site/docs-demos/type-safety/App.vue
@@ -36,7 +36,7 @@
 
 <template>
   <div class="demo layout split">
-    <form class="stack" @submit.prevent="onSubmit">
+    <form class="stack" @submit="onSubmit">
       <label>
         Email
         <input v-register="form.register('email')" placeholder="andy@" autocomplete="email" />

--- a/apps/site/docs-demos/url-availability-check/App.vue
+++ b/apps/site/docs-demos/url-availability-check/App.vue
@@ -83,7 +83,7 @@
 
 <template>
   <div class="demo layout split">
-    <form class="stack" @submit.prevent="onSubmit">
+    <form class="stack" @submit="onSubmit">
       <label>
         Your site URL
         <input

--- a/apps/site/docs-demos/validate-on-modes/App.vue
+++ b/apps/site/docs-demos/validate-on-modes/App.vue
@@ -68,7 +68,7 @@
           <p class="hint">{{ item.caption }}</p>
         </section>
 
-        <form class="stack" @submit.prevent="item.onSubmit">
+        <form class="stack" @submit="item.onSubmit">
           <label>
             Handle
             <input

--- a/apps/site/docs-demos/variant-forms/App.vue
+++ b/apps/site/docs-demos/variant-forms/App.vue
@@ -32,7 +32,7 @@
 </script>
 
 <template>
-  <form class="demo" @submit.prevent="onSubmit">
+  <form class="demo" @submit="onSubmit">
     <label>
       Payment method
       <select v-register="form.register('method')">

--- a/apps/site/pages/docs/[...slug].vue
+++ b/apps/site/pages/docs/[...slug].vue
@@ -166,12 +166,12 @@
     <article class="min-w-0 max-w-3xl flex-1">
       <DocsBreadcrumb class="mb-8" />
       <template v-if="page">
-        <!-- Page-level "copy as markdown" pair, sitting top-right just
+        <!-- Page-level "copy as markdown" pair, sitting left-aligned just
              above the H1 (which renders inside ContentRenderer). Copies
              the page's cleaned .md endpoint or opens it; both resolve to
              `${route.path}.md`. Inside v-if="page" so a 404 never shows a
              control for a page with no underlying .md. -->
-        <div class="mb-4 flex justify-end">
+        <div class="mb-4 -ml-2 flex justify-start">
           <DocsCopyMarkdown :path="route.path" />
         </div>
         <div class="docs-article-enter docs-prose prose prose-neutral max-w-none dark:prose-invert">

--- a/apps/site/pages/index.vue
+++ b/apps/site/pages/index.vue
@@ -46,7 +46,7 @@
     `${LT}/script>`,
     '',
     `${LT}template>`,
-    `  ${LT}form @submit.prevent="onSubmit">`,
+    `  ${LT}form @submit="onSubmit">`,
     `    ${LT}input v-register="form.register('email')" />`,
     `    ${LT}p v-if="form.fields.email.showErrors">{{ form.fields.email.firstError?.message }}${LT}/p>`,
     '',

--- a/apps/site/pages/index.vue
+++ b/apps/site/pages/index.vue
@@ -13,6 +13,7 @@
     ArrowRight,
     ExternalLink,
   } from 'lucide-vue-next'
+  import type { Component } from 'vue'
 
   // Feature cards on the homepage. Same single-color icon-chip
   // discipline as the docs landing: every chip on this page uses
@@ -131,7 +132,7 @@
     }),
   ])
 
-  const features = [
+  const features: Array<{ icon: Component; title: string; body: string; wide?: boolean }> = [
     {
       icon: ShieldCheck,
       title: 'Schema-driven types',
@@ -176,6 +177,7 @@
       icon: Bot,
       title: 'Built for AI agents',
       body: 'An `llms.txt` index, a full-text docs dump, and an installable Agent Skill ship with the package, so your coding assistant writes idiomatic Attaform the first time. `npx attaform skill`.',
+      wide: true,
     },
   ]
 </script>
@@ -459,7 +461,12 @@
         </div>
 
         <div class="mt-16 grid gap-x-12 gap-y-10 md:grid-cols-2">
-          <div v-for="feature in features" :key="feature.title" class="flex gap-4">
+          <div
+            v-for="feature in features"
+            :key="feature.title"
+            class="flex gap-4"
+            :class="{ 'md:col-span-2': feature.wide }"
+          >
             <div
               class="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-accent-soft text-accent-soft-fg"
             >

--- a/apps/site/pages/index.vue
+++ b/apps/site/pages/index.vue
@@ -9,6 +9,7 @@
     Workflow,
     TerminalSquare,
     Webhook,
+    Bot,
     ArrowRight,
     ExternalLink,
   } from 'lucide-vue-next'
@@ -170,6 +171,11 @@
       icon: Webhook,
       title: 'Server-side errors',
       body: '`form.setErrors(response.errors)` mounts server-sent `ValidationError[]` into the same reactive surface your template already reads, each error carrying an optional `data` payload.',
+    },
+    {
+      icon: Bot,
+      title: 'Built for AI agents',
+      body: 'An `llms.txt` index, a full-text docs dump, and an installable Agent Skill ship with the package, so your coding assistant writes idiomatic Attaform the first time. `npx attaform skill`.',
     },
   ]
 </script>

--- a/apps/site/repl-demos/shipment-demo.vue
+++ b/apps/site/repl-demos/shipment-demo.vue
@@ -643,7 +643,7 @@
 
 <template>
   <div class="page">
-    <form class="form" @submit.prevent="onSubmit">
+    <form class="form" @submit="onSubmit">
       <header class="form-header">
         <h1>Cargo shipment booking</h1>
         <p>4 steps · your manifest waits at the dock</p>

--- a/apps/site/utils/prose-link.ts
+++ b/apps/site/utils/prose-link.ts
@@ -1,0 +1,20 @@
+// Link classification shared with ProseA.vue (the markdown <a> renderer).
+// Extracted so the non-obvious "is this a static file, not a route?"
+// rule carries a fast unit test without mounting the component.
+
+/**
+ * True when an href points at a static file the site serves from
+ * `public/` (for example `/llms.txt`, `/skill.md`, or a per-page
+ * `/docs/foo.md`) rather than a Nuxt route.
+ *
+ * Such links must render as a plain `<a>`: routed through NuxtLink, Vue
+ * Router tries to resolve and prefetch a route that does not exist,
+ * which logs "No match found" in dev and wastes a prefetch in prod. Docs
+ * routes are extensionless, so a file extension on the last path segment
+ * is the tell. Query and hash are ignored.
+ */
+export function isStaticFilePath(href: string | undefined): boolean {
+  if (!href) return false
+  const path = href.replace(/[?#].*$/, '')
+  return /\/[^/]+\.[a-z0-9]+$/i.test(path)
+}

--- a/bin/attaform.mjs
+++ b/bin/attaform.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * Attaform CLI.
+ *
+ * `attaform skill [dir]` copies the bundled Agent Skill (which ships in
+ * the package under `skills/attaform/`) into a project so an AI
+ * assistant loads it while working on a form. The skill moves in
+ * lockstep with the installed Attaform version: run through `npx` in a
+ * project that already has Attaform and it copies that version's skill.
+ *
+ * Zero dependencies (Node built-ins only), so it ships verbatim with no
+ * build step.
+ */
+import { cpSync, existsSync, readdirSync } from 'node:fs'
+import { relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// The skill directory bundled in the package, resolved relative to this
+// file (`bin/attaform.mjs` -> `skills/attaform/`). It ships via the
+// package.json `files` entry, so it is present in both the git checkout
+// and the installed package.
+const SKILL_SOURCE = fileURLToPath(new URL('../skills/attaform/', import.meta.url))
+const DEFAULT_SKILLS_DIR = '.claude/skills'
+
+function usage() {
+  console.log(
+    [
+      'Usage: attaform skill [dir]',
+      '',
+      "  Copy Attaform's Agent Skill into your project so an AI assistant",
+      '  loads it while working on a form.',
+      '',
+      `  [dir]   Skills directory to install into (default: ${DEFAULT_SKILLS_DIR}).`,
+      '          Point it at another runtime, e.g. attaform skill .cursor/skills',
+    ].join('\n'),
+  )
+}
+
+function countFiles(dir) {
+  let total = 0
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    total += entry.isDirectory() ? countFiles(resolve(dir, entry.name)) : 1
+  }
+  return total
+}
+
+function installSkill(skillsDir) {
+  const dest = resolve(skillsDir, 'attaform')
+  const existed = existsSync(dest)
+  cpSync(SKILL_SOURCE, dest, { recursive: true })
+
+  const where = relative(process.cwd(), dest) || dest
+  const count = countFiles(dest)
+  console.log(
+    `${existed ? 'Updated' : 'Installed'} the Attaform skill (${count} file${count === 1 ? '' : 's'}) at ${where}/`,
+  )
+  console.log('Your assistant will load it while it works on a form in this project.')
+}
+
+const [command, dirArg] = process.argv.slice(2)
+
+if (command === undefined || command === '-h' || command === '--help' || command === 'help') {
+  usage()
+  process.exit(0)
+}
+
+if (command !== 'skill') {
+  console.error(`attaform: unknown command "${command}"\n`)
+  usage()
+  process.exit(1)
+}
+
+try {
+  installSkill(dirArg ?? DEFAULT_SKILLS_DIR)
+} catch (error) {
+  console.error(`attaform: could not install the skill: ${error instanceof Error ? error.message : String(error)}`)
+  process.exit(1)
+}

--- a/docs/cross-cutting-state/inject-form.md
+++ b/docs/cross-cutting-state/inject-form.md
@@ -43,7 +43,7 @@ Parent owns the form (no `key`):
 </script>
 
 <template>
-  <form @submit.prevent="onSubmit">
+  <form @submit="onSubmit">
     <EmailRow />
     <ProfileGroup />
     <button>Sign up</button>

--- a/docs/devtools-and-debugging/troubleshooting.md
+++ b/docs/devtools-and-debugging/troubleshooting.md
@@ -35,7 +35,7 @@ The schema generic couldn't be inferred. Two likely causes:
 </script>
 
 <template>
-  <form @submit.prevent="onSubmit">...</form>
+  <form @submit="onSubmit">...</form>
 </template>
 ```
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -91,7 +91,18 @@ export default defineConfig({
 
 Everything outside that set stays an explicit import: the plugin (`createAttaform`), the custom-input composable (`useRegister`), and the bring-your-own-adapter `useAbstractForm` from `attaform/abstract`. A registered auto-import always loses to an explicit or local binding of the same name, so opting out is only needed when you'd rather keep the names out of global scope entirely.
 
+## Optional: Agent skill
+
+Building with an AI coding assistant? Attaform ships an [Agent Skill](/docs/reference/ai-agents) that teaches it to write idiomatic Attaform: reach for `useForm`, bind with `v-register`, submit through `handleSubmit`. One command drops it into your project:
+
+```sh
+npx attaform skill
+```
+
+The skill travels inside the package, so it stays in lockstep with the version you have installed. That same page also covers the machine-readable [`llms.txt`](/llms.txt) index and the full-text [`llms-full.txt`](/llms-full.txt) dump you can hand an agent directly.
+
 ## Where to next
 
 - [Quick start](/docs/getting-started/quick-start): your first form, end-to-end.
 - [Your first schema](/docs/getting-started/your-first-schema): what Attaform reads from a Zod definition.
+- [AI agents](/docs/reference/ai-agents): the skill, `llms.txt`, and the full-text docs dump for coding assistants.

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -16,3 +16,5 @@ Type-safe end to end. Errors surface at compile time, and the runtime keeps ever
 The sidebar walks top to bottom as a learning narrative: install, schema, bind, validate, submit, persist. Drop in anywhere. Every concept is its own URL, its own definition, its own demo.
 
 If you're new, start with the [Quick start](/docs/getting-started/quick-start). If you want our philosophy first, read [Why Attaform](/docs/getting-started/why-attaform); if you want the receipts, [Benchmarks](/docs/comparison/benchmarks) measures Attaform against the Vue form-library field in a real browser. If you're hunting a specific surface, the sidebar's last category, **Reference**, is alphabetical and indexed.
+
+Reading with a coding assistant? These docs are machine-readable too. Point it at [`llms.txt`](/llms.txt) for the whole index, or install the [Agent Skill](/docs/reference/ai-agents) so it writes idiomatic Attaform from the first try. The [AI agents](/docs/reference/ai-agents) page lays out every option.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -50,7 +50,7 @@ Bind inputs to schema paths with `v-register`:
 
 ```vue
 <template>
-  <form @submit.prevent="onSubmit">
+  <form @submit="onSubmit">
     <label>
       Email
       <input v-register="form.register('email')" autocomplete="email" />
@@ -58,7 +58,7 @@ Bind inputs to schema paths with `v-register`:
     </label>
     <label>
       Password
-      <input type="password" v-register="form.register('password')" autocomplete="off" />
+      <input v-register="form.register('password')" type="password" autocomplete="off" />
       <em v-if="form.fields.password.showErrors">{{ form.fields.password.firstError?.message }}</em>
     </label>
     <button :disabled="form.meta.submitting" type="submit">Sign in</button>

--- a/docs/multistep/handle-submit.md
+++ b/docs/multistep/handle-submit.md
@@ -41,7 +41,7 @@ metaRows:
 </script>
 
 <template>
-  <form @submit.prevent="onFinish">
+  <form @submit="onFinish">
     <!-- step body -->
     <button :disabled="wizard.submitting" type="submit">Finish</button>
   </form>
@@ -166,7 +166,7 @@ Disabling the button is belt-and-braces; the wizard refuses re-entry on its own.
 
 - **Empty steps list.** `handleSubmit` dev-warns and resolves no-op. `onSubmit` and `onError` are never invoked.
 - **Re-entrant submission.** The second call dev-warns and resolves no-op; the first call continues to settle.
-- **No `Event` argument.** Imperative calls (`onFinish()` with no event) work the same as `<form @submit.prevent>`; the `preventDefault` step is skipped.
+- **No `Event` argument.** Imperative calls (`onFinish()` with no event) work the same as `<form @submit>`; the `preventDefault` step is skipped.
 
 ## Where to next
 

--- a/docs/reading-the-form/meta.md
+++ b/docs/reading-the-form/meta.md
@@ -154,7 +154,7 @@ Cleared by `form.reset()` alongside the submission counters.
 `instanceId` distinguishes two mounts of the same shared form. Two `useForm({ key: 'signup' })` calls return the same FormStore (so writes in one reflect in the other), but `form.meta.instanceId` differs. Useful when devtools, telemetry, or e2e selectors need to disambiguate which mount triggered an event.
 
 ```vue
-<form :data-form-id="form.meta.instanceId" @submit.prevent="onSubmit">
+<form :data-form-id="form.meta.instanceId" @submit="onSubmit">
   …
 </form>
 ```

--- a/docs/reading-the-form/the-form.md
+++ b/docs/reading-the-form/the-form.md
@@ -59,7 +59,7 @@ const onSubmit = form.handleSubmit(async (values) => {
 })
 ```
 
-`handleSubmit` gates dispatch on validation. Returns a handler ready for `<form @submit.prevent>`.
+`handleSubmit` gates dispatch on validation. Returns a handler ready for `<form @submit>` (it calls `preventDefault` for you, so `.prevent` is redundant).
 
 ## Per-field writes
 

--- a/docs/reference/ai-agents.md
+++ b/docs/reference/ai-agents.md
@@ -47,19 +47,21 @@ Read or copy it above, or fetch it directly at [attaform.dev/skill.md](/skill.md
 
 ### Install it into your project
 
-The skill travels inside the package. After installing Attaform, it sits at:
+The skill travels inside the package, so one command copies it into place. From your project root:
 
-```
-node_modules/attaform/skills/attaform/SKILL.md
+```sh
+npx attaform skill
 ```
 
-Copy the whole skill folder, the main file and its `references/`, into your project's skills directory:
+That drops the whole skill, the main file and its `references/`, into `.claude/skills/attaform/`. Run it again after you upgrade Attaform to refresh the skill in place: because it ships inside the package, running it in a project that has Attaform installed copies that exact version's skill. Aiming at another assistant's skills folder is a trailing path away, for example `npx attaform skill .cursor/skills`.
+
+Prefer to place it by hand? The skill sits at `node_modules/attaform/skills/attaform/`, so you can copy the folder yourself:
 
 ```sh
 cp -r node_modules/attaform/skills/attaform .claude/skills/
 ```
 
-The assistant then loads the Attaform skill whenever it works on a form in your repo. Because the skill ships with the package, it moves in lockstep with the version you have installed.
+Either way, the assistant then loads the Attaform skill whenever it works on a form in your repo.
 
 ## Pointing an agent at Attaform
 

--- a/docs/submitting/handle-submit.md
+++ b/docs/submitting/handle-submit.md
@@ -37,7 +37,7 @@ const submit = form.handleSubmit(
 )
 ```
 
-The return value is a function ready for `<form @submit.prevent>`. Call signature: `(event?: Event) => Promise<void>`.
+The return value is a function ready for `<form @submit>`. Call signature: `(event?: Event) => Promise<void>`. It calls `event.preventDefault()` for you when it receives the submit event, so bind it with `@submit`, not `@submit.prevent`: the `.prevent` modifier would only prevent the default a second time.
 
 ## The dispatch contract
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -457,6 +457,10 @@ export default [
       'apps/bench-arena/scripts/**',
       '.prettierrc.cjs',
       'scripts/**',
+      // Published Node CLI (`attaform skill`) — a standalone zero-dep
+      // script run through `npx`, not part of the library's typed source.
+      // Same rationale as the repo-root `scripts/**` tooling above.
+      'bin/**',
       // Bundled-types regression fixture imports from `dist/*` to
       // typecheck the published `.d.ts` shape; intentionally sits
       // outside the source tsconfig, so eslint's typed-rule pipeline

--- a/package.json
+++ b/package.json
@@ -5,8 +5,12 @@
   "types": "./dist/index.d.mts",
   "files": [
     "dist",
-    "skills"
+    "skills",
+    "bin"
   ],
+  "bin": {
+    "attaform": "./bin/attaform.mjs"
+  },
   "sideEffects": false,
   "engines": {
     "node": ">=22.0.0"

--- a/skills/attaform/SKILL.md
+++ b/skills/attaform/SKILL.md
@@ -54,7 +54,7 @@ Three moves: hoist the schema, hand it to `useForm`, bind each input with `v-reg
 </script>
 
 <template>
-  <form @submit.prevent="onSubmit">
+  <form @submit="onSubmit">
     <label>
       Email
       <input v-register="form.register('email')" autocomplete="email" />
@@ -76,7 +76,7 @@ Prefer an explicit `key` (`useForm({ schema, key: 'sign-in' })`): it makes the f
 
 - **Use the form handle. Don't destructure.** Keep `const form = useForm(...)` and reach for `form.register(...)`, `form.setValue(...)`, `form.meta`. Destructuring loses the reactive bindings.
 - **Bind with `v-register`; never write through `form.values`.** `form.values` is a read view and a callable proxy (`typeof form.values === 'function'`), so `schema.safeParse(form.values)` compiles but fails at runtime. Read `form.meta.valid` for validity; call `form.values()` for a plain snapshot (`form.values('a.b')` for a subtree).
-- **Let `handleSubmit` do the work.** It validates, calls `onSubmit` with the parsed values, and focuses the first offending field on an invalid submit. No manual focus and no `novalidate` ceremony.
+- **Let `handleSubmit` do the work.** It validates, calls `onSubmit` with the parsed values, and focuses the first offending field on an invalid submit. No manual focus and no `novalidate` ceremony. Bind it with `@submit`, not `@submit.prevent`: the handler calls `event.preventDefault()` for you, so `.prevent` only prevents twice.
 - **Never disable the submit button on validity.** Let the user click; the failed submit focuses the first error and reveals it. Gate only on `form.meta.submitting` or `!form.meta.dirty`. If a field's only guard was the disabled button, move the requirement into the schema (`.min(1)`, `.refine(...)`). See `references/validation.md`.
 - **Read errors through `field.showErrors` and `field.firstError?.message`.** The visibility heuristic lives in `showErrors`; reaching into `field.errors[0]` bypasses it. The async "checking" indicator is `field.showPending`.
 - **Route server errors through `form.setErrors(...)` inside the callback.** `setErrors` replaces the whole user-error layer, so call `form.clearErrors()` at the top of the submit for a fresh attempt. See `references/errors.md`.

--- a/src/runtime/composables/use-wizard.ts
+++ b/src/runtime/composables/use-wizard.ts
@@ -1013,7 +1013,7 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
   // The error thrown or rejected by the most recent `wizard.handleSubmit`
   // callback (or its `onError`), coerced to a real `Error`. Mirrors
   // `form.meta.submitError`: cleared at submit entry, parked here instead
-  // of re-thrown, so binding the handler to `@submit.prevent` never
+  // of re-thrown, so binding the handler to `@submit` never
   // manufactures a `window` unhandledrejection.
   const submitError = ref<Error | null>(null)
   // Monotonic latch: flips true the first time a `handleSubmit` resolves
@@ -1383,7 +1383,7 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
         }
       } catch (err) {
         // Park the throw on `submitError`, coerced to a real Error; never
-        // re-throw. The handler is bound to DOM events (`@submit.prevent`),
+        // re-throw. The handler is bound to DOM events (`@submit`),
         // so a rejected promise would surface as a `window`
         // unhandledrejection — a phantom crash for an already-handled
         // failure. The `finally` still resets `submitting`, so navigation

--- a/src/runtime/core/process-form.ts
+++ b/src/runtime/core/process-form.ts
@@ -437,7 +437,7 @@ export function buildProcessForm<F extends GenericForm, Out extends GenericForm 
    *     (path-scoped when the throw was well-constructed, form-level `[]`
    *     otherwise); a wrapped `SubmitErrorHandlerError` is the exception
    *     and stays `submitError`-only. The handler does NOT re-throw: a
-   *     rejecting `onSubmit` bound to `@submit.prevent` would otherwise
+   *     rejecting `onSubmit` bound to `@submit` would otherwise
    *     surface as a `window` unhandledrejection (a phantom crash for an
    *     already-handled server failure). Both template and imperative
    *     callers read the outcome from `submitError` / `submitted`; the
@@ -621,7 +621,7 @@ export function buildProcessForm<F extends GenericForm, Out extends GenericForm 
         // origin on `.cause`).
         //
         // Deliberately NOT re-thrown: the handler is bound to DOM events
-        // (`@submit.prevent` / `@click`), so a rejected promise here would
+        // (`@submit` / `@click`), so a rejected promise here would
         // surface as a `window` unhandledrejection — a phantom crash for
         // what is usually an already-handled server failure. The error is
         // recorded on `submitError` for both template and imperative

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -1575,12 +1575,13 @@ export type GetDisplayState = (prev: DisplayMachine, ctx: DisplayCtx) => Display
  * it to a `<form>`:
  *
  * ```vue
- * <form @submit.prevent="onSubmit">…</form>
+ * <form @submit="onSubmit">…</form>
  * ```
  *
- * It optionally accepts the originating `Event` so it can sit on
- * `@submit` directly (without `.prevent` if you want to call
- * `event.preventDefault()` yourself).
+ * It accepts the originating `Event` and calls `event.preventDefault()`
+ * itself, so bind it with `@submit`, not `@submit.prevent` (the
+ * modifier would only prevent the default a second time). Called
+ * imperatively with no event, the `preventDefault` step is skipped.
  */
 export type SubmitHandler = (event?: Event) => Promise<void>
 
@@ -3403,7 +3404,7 @@ export type FormMeta<F = unknown> = FieldState<F> & {
    * of each new submission attempt; stays `null` on success.
    *
    * The submit handler does NOT re-throw — its returned promise always
-   * resolves, so binding it to `@submit.prevent` never manufactures a
+   * resolves, so binding it to `@submit` never manufactures a
    * `window` unhandledrejection. This is the channel for an UNEXPECTED
    * submit failure (a thrown exception or rejected promise), read the
    * same way in templates and after an imperative `await submit()`. An
@@ -3580,10 +3581,11 @@ export type UseFormReturnType<
    * Wraps your submit logic with validation and error routing.
    *
    * ```ts
-   * <form @submit.prevent="form.handleSubmit(
+   * const onSubmit = form.handleSubmit(
    *   (data) => api.signup(data),
    *   (errors) => console.log(errors),
-   * )">
+   * )
+   * // Bind the returned handler: <form @submit="onSubmit">
    * ```
    *
    * `data` is the strictly-typed parsed value — refinements have

--- a/test/docs-site-prose-link.test.ts
+++ b/test/docs-site-prose-link.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { isStaticFilePath } from '../apps/site/utils/prose-link'
+
+/*
+ * ProseA (apps/site/components/content/ProseA.vue) renders markdown
+ * links. A link to a static public file (llms.txt, skill.md, a per-page
+ * .md) must NOT go through NuxtLink: Vue Router would try to resolve and
+ * prefetch a route that does not exist ("No match found" in dev, a
+ * wasted prefetch in prod). This guards the file-vs-route rule the
+ * component uses to pick a plain <a> over NuxtLink.
+ */
+
+describe('isStaticFilePath', () => {
+  it('flags static public files by their extension', () => {
+    expect(isStaticFilePath('/llms.txt')).toBe(true)
+    expect(isStaticFilePath('/llms-full.txt')).toBe(true)
+    expect(isStaticFilePath('/skill.md')).toBe(true)
+    expect(isStaticFilePath('/docs/reference/ai-agents.md')).toBe(true)
+  })
+
+  it('ignores query and hash when testing the extension', () => {
+    expect(isStaticFilePath('/skill.md?v=2')).toBe(true)
+    expect(isStaticFilePath('/skill.md#top')).toBe(true)
+  })
+
+  it('leaves extensionless in-site routes as routes', () => {
+    expect(isStaticFilePath('/docs/reference/ai-agents')).toBe(false)
+    expect(isStaticFilePath('/docs/getting-started/installation')).toBe(false)
+    expect(isStaticFilePath('/')).toBe(false)
+    expect(isStaticFilePath('/play')).toBe(false)
+  })
+
+  it('does not treat a dotted mid-path segment as a file', () => {
+    expect(isStaticFilePath('/docs/reading-the-form/errors')).toBe(false)
+  })
+
+  it('handles an empty or missing href', () => {
+    expect(isStaticFilePath('')).toBe(false)
+    expect(isStaticFilePath(undefined)).toBe(false)
+  })
+})

--- a/test/packaging/skill-cli.test.ts
+++ b/test/packaging/skill-cli.test.ts
@@ -1,0 +1,81 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+/*
+ * The `attaform skill` CLI copies the bundled Agent Skill into a project.
+ * These tests run the real bin as a subprocess against throwaway
+ * directories and assert the skill tree lands, so a regression in the
+ * copy logic (or a bundled file dropping out of `skills/`) is caught
+ * before publish. No new dependency: the bin is Node built-ins only.
+ */
+
+const repoRoot = join(__dirname, '..', '..')
+const binPath = join(repoRoot, 'bin', 'attaform.mjs')
+const sourceSkill = join(repoRoot, 'skills', 'attaform', 'SKILL.md')
+
+function runBin(args: string[], cwd: string = repoRoot) {
+  return spawnSync(process.execPath, [binPath, ...args], { cwd, encoding: 'utf-8' })
+}
+
+let workDir: string
+
+beforeAll(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'attaform-skill-cli-'))
+})
+
+afterAll(() => {
+  rmSync(workDir, { recursive: true, force: true })
+})
+
+describe('attaform skill', () => {
+  it('copies the skill tree into an explicit directory', () => {
+    const target = join(workDir, 'explicit')
+    const result = runBin(['skill', target])
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('Installed')
+    // The main file and a nested reference both land, proving the
+    // recursive copy preserves the on-disk shape.
+    expect(existsSync(join(target, 'attaform', 'SKILL.md'))).toBe(true)
+    expect(existsSync(join(target, 'attaform', 'references', 'wizards.md'))).toBe(true)
+    // The copy is byte-for-byte the bundled source.
+    expect(readFileSync(join(target, 'attaform', 'SKILL.md'), 'utf-8')).toBe(
+      readFileSync(sourceSkill, 'utf-8')
+    )
+  })
+
+  it('reports an update when the skill already exists', () => {
+    const target = join(workDir, 'twice')
+    runBin(['skill', target])
+    const second = runBin(['skill', target])
+
+    expect(second.status).toBe(0)
+    expect(second.stdout).toContain('Updated')
+  })
+
+  it('creates the default .claude/skills path when no directory is given', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'attaform-skill-default-'))
+    const result = runBin(['skill'], cwd)
+
+    expect(result.status).toBe(0)
+    expect(existsSync(join(cwd, '.claude', 'skills', 'attaform', 'SKILL.md'))).toBe(true)
+    rmSync(cwd, { recursive: true, force: true })
+  })
+
+  it('prints usage and exits cleanly with no command', () => {
+    const result = runBin([])
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('Usage: attaform skill')
+  })
+
+  it('rejects an unknown command with a nonzero exit', () => {
+    const result = runBin(['bogus'])
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('unknown command')
+  })
+})


### PR DESCRIPTION
## Phase 8: `npx attaform skill` installs the Agent Skill

The last piece of the schema-entry / AI-discoverability arc. Phase 7 (#501) shipped the Agent Skill inside the package; Phase 7.1 (#502) made it web-native. This adds the one-command installer that turns the manual copy the AI-agents page documented into:

```sh
npx attaform skill
```

It also folds in the docs-side follow-ups flagged while reviewing the AI page: the copy-control alignment, static-file prose links no longer routing through NuxtLink, a sweep that surfaces the AI tooling across the docs / README / homepage (with a full-width feature card), and a docs-wide correction of the submit binding.

### The installer

`bin/attaform.mjs` is a standalone, zero-dependency Node script (built-ins only). `attaform skill [dir]` recursively copies the bundled `skills/attaform/` into the project's `.claude/skills/attaform/`:

- **Defaults to `.claude/skills/`**, or takes a trailing path for another runtime, e.g. `npx attaform skill .cursor/skills`.
- **Idempotent:** re-run after `npm update attaform` to refresh the skill in place (reports "Installed" vs "Updated").
- **Version-locked by construction:** the bin resolves its source relative to itself, so running through `npx` in a project that already has Attaform copies *that* version's skill. No network fetch, no drift.
- **Namespaced target:** it only ever writes `.../attaform/`, never touching your other skills.
- Unknown command prints usage and exits nonzero; no args prints help and exits 0.

It ships verbatim (no build step) via `package.json` `files` + `bin`. `bin/**` is eslint-ignored for the same reason `scripts/**` is: standalone Node tooling, not typed library source. Zero new dependencies.

The AI-agents page now leads with the one-liner and keeps the manual `cp -r` as a by-hand fallback.

### Copy-control alignment fix

The `[Copy] [.md]` pair on each docs page sat right-aligned on the line above the title, which read as detached from the heading. It is now flush-left directly above the H1, with a `-ml-2` cancelling the button's `px-2` so the label lines up optically with the title text.

### Static-file prose links render as plain anchors

A markdown link to a file the site serves from `public/` (`llms.txt`, `llms-full.txt`, `skill.md`, a per-page `.md`) was going through `ProseA` to `<NuxtLink>`, which asked Vue Router to resolve and prefetch a route that does not exist. That logged `No match found for location with path "/skill.md"` in the dev console (and fired a wasted prefetch in prod). Docs routes are extensionless, so a file extension on the last path segment marks a static asset: `ProseA` now sends those to a plain `<a>` and keeps `<NuxtLink>` for in-site routes. The rule lives in a pure `isStaticFilePath` helper with a unit guard so it cannot be quietly regressed.

### Surface the AI tooling

The skill, `llms.txt`, and `llms-full.txt` were reachable only from the last entry in the Reference nav, so a browsing human (or their assistant) would never find them. This promotes the tooling on the pages people land on: an `Optional: Agent skill` section on the installation page, a Highlights bullet plus a Documentation entry in the README, a **Built for AI agents** feature card on the homepage, and a note in the introduction's "How these docs read" that the whole corpus is machine-readable. All links point at the existing AI-agents page and the generated `/llms.txt` / `/llms-full.txt`.

### Submit binding: `@submit`, not `@submit.prevent`

The handler returned by `form.handleSubmit` / `wizard.handleSubmit` calls `event.preventDefault()` itself, so `@submit.prevent="onSubmit"` prevents the default twice. Swept the docs, demos, README, and skill to the plain `@submit` binding, and called out the redundancy on the handle-submit reference page and in the skill's rules. Bare `<form @submit.prevent>` forms (no handler) are left as-is: there the modifier is the only thing stopping the reload. Also corrected the public docblocks, including the inline `@submit.prevent="form.handleSubmit(...)"` example, which was a latent bug independent of `.prevent` (Vue compiles the inline call as `$event => form.handleSubmit(...)`, so the returned handler is created and never invoked) — rewritten to assign the handler then bind it.

### Verification

- **Packaging test** (`test/packaging/skill-cli.test.ts`, 5 cases) runs the real bin as a subprocess against throwaway dirs: explicit-dir install lands the tree byte-for-byte, a re-run reports an update, the default `.claude/skills/` path is created from nothing, no-command prints usage (exit 0), and an unknown command exits 1.
- **ProseA guard** (`test/docs-site-prose-link.test.ts`, 5 cases) pins the static-file-vs-route classification.
- `pnpm typecheck`, `pnpm lint`, and Prettier all clean.
- `pnpm build:site`: **435 routes, Link Checker 0 errors / 0 warnings / 0 failing of 189**; the skill mirror / `skill.md` alias / per-page `.md` all regenerate, the homepage compiles with the new feature card, and neither the `ProseA` change nor the new AI-tooling links cause a link-checker regression.
- Smoke-tested the CLI by hand: default install, `.cursor/skills` override, re-run update, and the unknown-command exit path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
