### PR TITLE
Force chokidar polling so @nuxt/content sees docs changes in Docker dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,18 @@ services:
       # gives every Node process the headroom it needs without pressuring
       # the host.
       NODE_OPTIONS: --max-old-space-size=8192
+      # Force chokidar to poll for file changes. @nuxt/content runs its own
+      # chokidar source watcher over `docs/` (separate from Vite's, which
+      # already polls via nuxt.config's `vite.server.watch`). macOS fsevents
+      # don't propagate through the Docker bind mount, so content misses
+      # docs adds + edits and keeps serving a stale SQLite DB until the dev
+      # server restarts (a new .md page 404s, an edit doesn't hot-reload).
+      # Content's `chokidar.watch()` sets no `usePolling` and exposes no knob
+      # for it, but chokidar 5 reads CHOKIDAR_USEPOLLING as a global override
+      # that reaches every instance regardless of dependency depth. 300ms
+      # matches the Vite watch interval next door.
+      CHOKIDAR_USEPOLLING: 'true'
+      CHOKIDAR_INTERVAL: '300'
     # Long-running idle container; use `make up` (boots dev server) or `make shell` to interact
     command: ['sh', '-c', 'tail -f /dev/null']
 

--- a/test/docs-site-dev-watcher-polling.test.ts
+++ b/test/docs-site-dev-watcher-polling.test.ts
@@ -50,3 +50,26 @@ describe('docs-site config: Vite watcher polling for Docker bind-mount reliabili
     expect(source).toMatch(/binaryInterval:\s*\d+/)
   })
 })
+
+/**
+ * @nuxt/content runs its OWN chokidar source watcher over `docs/`, separate
+ * from Vite's above. It passes no `usePolling` and exposes no config knob, so
+ * across the Docker bind mount it misses docs/ adds + edits and keeps serving
+ * a stale SQLite DB until the dev server restarts (a new page 404s, an edit
+ * doesn't hot-reload). chokidar 5 reads `CHOKIDAR_USEPOLLING` as a global
+ * override that reaches content's watcher regardless of dependency depth; the
+ * docs-dev container sets it plus a matching interval. This pins both so a
+ * contributor dropping them fails before reintroducing the staleness window.
+ */
+describe('docs-site config: @nuxt/content watcher polling for Docker bind-mount reliability', () => {
+  const composePath = fileURLToPath(new URL('../docker-compose.yml', import.meta.url))
+  const compose = readFileSync(composePath, 'utf8')
+
+  it('the dev container forces chokidar polling', () => {
+    expect(compose).toMatch(/CHOKIDAR_USEPOLLING:\s*'?(?:true|1)'?/)
+  })
+
+  it('the dev container sets a chokidar poll interval', () => {
+    expect(compose).toMatch(/CHOKIDAR_INTERVAL:\s*'?\d+'?/)
+  })
+})


### PR DESCRIPTION
## Force chokidar polling so @nuxt/content sees docs changes in Docker dev

### The problem

Adding or editing a `docs/**/*.md` page while the dev server runs doesn't show up: a new page 404s in dev (the "missing docs page" callout), an edit doesn't hot-reload, and the only fix is restarting the dev server.

### Root cause

`@nuxt/content` runs its **own** chokidar watcher over `docs/`, separate from Vite's. We already made Vite's watcher poll (`vite.server.watch.usePolling` in `nuxt.config`, pinned by a test) because macOS fsevents don't propagate through the Docker bind mount. Content's watcher has the same problem but is a separate instance: `@nuxt/content`'s `module.mjs` calls `chokidar.watch(dirsToWatch, { ignoreInitial, ignored })` with no `usePolling`, and content exposes no config knob for it. So content misses the file events and keeps serving its stale SQLite DB (`apps/site/.data/content/contents.sqlite`) until a restart rebuilds it.

### Fix

chokidar 5 (content's version) reads `CHOKIDAR_USEPOLLING` as a **global override** that reaches every chokidar instance "regardless of usage / dependency depth" (its own source comment). Setting it in the dev container's environment makes content's watcher poll without patching content. `CHOKIDAR_INTERVAL=300` matches the Vite watch interval next door.

- Touches only the `docker-compose.yml` dev container. **CI runs pnpm directly (no compose), so it is unaffected.**
- A regression test pins both env vars, alongside the existing Vite-polling guard.

### Applying it

The container has to pick up the new env once (`make up`, or `docker compose up -d` to recreate). After that, docs adds/edits hot-reload live and the stale-content restarts stop. If a page is already stuck from a prior session, clear the cache once: `rm -rf apps/site/.data apps/site/.nuxt/content`.

### Verification

- `test/docs-site-dev-watcher-polling.test.ts` — 4 pass (2 Vite, 2 content); the new cases pin `CHOKIDAR_USEPOLLING` + `CHOKIDAR_INTERVAL`.
- `pnpm typecheck`, lint, and Prettier clean.
- End-to-end (docs edits hot-reloading in the Docker dev) is yours to confirm on the container: CI and this sandbox can't drive a cross-bind-mount file watcher, so the proof is the verified chokidar behavior plus your dev after one recreate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
