### PR TITLE
fix(v-register): numeric component host clears to blank (#518)

### DIFF
--- a/src/runtime/core/register-api.ts
+++ b/src/runtime/core/register-api.ts
@@ -234,6 +234,19 @@ export function buildRegister<F extends GenericForm>(
       }
     }) as Readonly<Ref<string>>
 
+    // Blank-aware model presentation for a `v-register` component host's
+    // `:modelValue`. The native `:value` path reads `displayValue`, which
+    // returns `''` for a blank path so a cleared numeric input renders
+    // empty while storage still holds the slim `0`. A component's model is
+    // typed, so it can't carry that `''`; instead a blank path presents as
+    // `undefined` -- the typed-model analog of "displayed empty." A naive
+    // numeric component renders `undefined ?? '' === ''`, so a cleared
+    // numeric field reads empty in a v-model-bound component exactly as it
+    // does in a native input. Filled paths present the raw typed storage.
+    const hostModelValue = computed(() =>
+      state.blankPaths.has(pathKey) ? undefined : innerRef.value
+    ) as Readonly<Ref<unknown>>
+
     // Slim default precomputed at register-time. The schema is fixed
     // for the form's lifetime, so this is safe to cache; downstream
     // `markBlank` calls reuse it without re-walking the
@@ -296,6 +309,18 @@ export function buildRegister<F extends GenericForm>(
         ? (computed(() => getDisplayStateAt(segments)) as Readonly<Ref<DisplayState>>)
         : undefined
 
+    // Shared blank-marking op: write the schema's slim default and stage
+    // the blank meta so submit-time validation surfaces "No value
+    // supplied". The slim default keeps storage well-typed
+    // (getDefaultAtPath returns 0 for z.number(), '' for z.string(),
+    // false for z.boolean()). Hoisted out of the object literal so both
+    // the `markBlank` binding (the directive's numeric-clear listener)
+    // and `setValueFromHost` (the component-host analog) route through
+    // one place, and a cleared numeric leaf lands on the same state
+    // whether it came from a native `<input>` or a v-model component.
+    const markBlank = (): boolean =>
+      state.setValueAtPath(segments, slimDefault, withInstanceMeta({ blank: true }))
+
     // `shallowReadonly` is what makes `rv.path`, `rv.formKey`, and the
     // other top-level string fields feel like reactive state in
     // wrapper components: property reads track in computeds /
@@ -306,21 +331,10 @@ export function buildRegister<F extends GenericForm>(
     const internalRv: InternalRegisterValue = {
       innerRef,
       displayValue,
+      hostModelValue,
       lastTypedForm,
 
-      markBlank: (): boolean => {
-        // Write the schema's slim default and stage the blank meta so
-        // submit-time validation surfaces "No value supplied". The slim
-        // default keeps storage well-typed (getDefaultAtPath returns 0
-        // for z.number(), '' for z.string(), false for z.boolean()).
-        return state.setValueAtPath(
-          segments,
-          slimDefault,
-          withInstanceMeta({
-            blank: true,
-          })
-        )
-      },
+      markBlank,
 
       markInteracted: (): void => {
         state.markInteracted(segments)
@@ -359,12 +373,29 @@ export function buildRegister<F extends GenericForm>(
         // markInteracted -- exactly as the native input listener pairs the
         // assigner write with noteInteraction. Without the markInteracted,
         // blur-validation and the reward-early display state would never arm
-        // for a v-model-bound component. The value is authoritative (the
+        // for a v-model-bound component. A real value is authoritative (the
         // component's resolved model type), so it routes through the same
         // no-coercion funnel as setValueWithInternalPath. Mark interacted
         // before the write so any validation the write triggers sees the bit.
         state.markInteracted(segments)
-        const accepted = state.setValueAtPath(segments, value, withInstanceMeta(undefined))
+        // Empty-signal normalization, mirroring the native input listener's
+        // DOM-clear handling (directive.ts). A component clearing a
+        // numeric-only leaf emits an empty signal ('' / null / undefined)
+        // that the slim-primitive gate would reject, freezing form state at
+        // the old value while the component's DOM shows empty. When the
+        // emitted value is one of those signals AND the leaf's slim set does
+        // not admit it, route to markBlank -- storage lands on the slim
+        // default with the blank flag, the same state a native
+        // `<input v-register>` reaches on clear. The slim-set gate keeps a
+        // `.nullable()` / `.optional()` (or `z.file()`) leaf accepting null /
+        // undefined as a genuine value rather than reading it as blank.
+        const isBlankSignal =
+          (value === '' && !acceptsString) ||
+          (value === null && !slimTypes.has('null')) ||
+          (value === undefined && !acceptsUndefined)
+        const accepted = isBlankSignal
+          ? markBlank()
+          : state.setValueAtPath(segments, value, withInstanceMeta(undefined))
         // Dev diagnostic: a host value update flowed in, but nothing was ever
         // wired for this path (no registered element, connected never set). The
         // transform's v-model props ride a component's props / emits, which Vue

--- a/src/runtime/lib/core/transforms/component-bridge-transform.ts
+++ b/src/runtime/lib/core/transforms/component-bridge-transform.ts
@@ -491,8 +491,10 @@ export const componentBridgeTransform: NodeTransform = (node, context) => {
       // drops a prior injection of our own `modelValue` / `onUpdate:modelValue`
       // so a doubly-registered transform pipeline re-injects exactly once
       // (the same strip-then-reinject idempotency the :value path above uses).
-      // :modelValue reads innerRef -- the typed model value (Date / number /
-      // array), not the stringified displayValue a <select> uses.
+      // :modelValue reads hostModelValue -- the typed model value (Date /
+      // number / array), or undefined for a blank path so a cleared numeric
+      // reads empty in the component, not the stringified displayValue a
+      // <select> uses.
       // onUpdate:modelValue routes through setValueFromHost, which writes the
       // value AND flips the sticky `interacted` bit (a v-model host has no DOM
       // input listener to do it), so blur-validation and the reward-early
@@ -511,7 +513,7 @@ export const componentBridgeTransform: NodeTransform = (node, context) => {
       const modelInitExpression = createCompoundExpression([
         '(',
         ...modelValuePropExpArray,
-        ')?.innerRef?.value',
+        ')?.hostModelValue?.value',
       ])
       const modelSimpleExpression = createSimpleExpression(
         flattenExpression(modelInitExpression),

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -2047,6 +2047,17 @@ export type RegisterValue<Value = unknown> = Readonly<{
    */
   displayValue: Readonly<Ref<string>>
   /**
+   * Blank-aware model presentation for a `v-register` component host's
+   * `:modelValue`. Returns `undefined` when the path is in the form's
+   * `blankPaths` set (the typed-model analog of `displayValue`'s `''`),
+   * otherwise the raw typed storage. Lets a cleared numeric field read
+   * empty in a v-model-bound component the way it does in a native
+   * input. Read only by the compile-time component-bridge transform's
+   * `:modelValue` injection.
+   * @internal
+   */
+  hostModelValue: Readonly<Ref<Value | undefined>>
+  /**
    * Add this field's path to the form's `blankPaths` set,
    * writing the slim default to storage. Returns the `setValueAtPath`
    * boolean (`true` accepted, `false` rejected by the slim-primitive

--- a/test/composables/host-numeric-clear.test.ts
+++ b/test/composables/host-numeric-clear.test.ts
@@ -1,0 +1,295 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, withDirectives, type App, type PropType } from 'vue'
+import { z } from 'zod'
+import { z as z3 } from 'zod-v3'
+import { zodAdapter as zodAdapterV4 } from '../../src/runtime/adapters/zod-v4'
+import { zodAdapter as zodAdapterV3 } from '../../src/runtime/adapters/zod-v3'
+import { createFormStore } from '../../src/runtime/core/create-form-store'
+import { buildRegister } from '../../src/runtime/core/register-api'
+import { canonicalizePath } from '../../src/runtime/core/paths'
+import { vRegister } from '../../src/runtime/core/directive'
+import { SSR_COMPONENT_HOST_MODIFIER } from '../../src/runtime/core/register-protocol'
+import { createAttaform } from '../../src/runtime/core/plugin'
+import { useForm, type UseFormReturn } from '../../src/zod'
+import type { AbstractSchema } from '../../src/runtime/types/types-api'
+import type { GenericForm } from '../../src/runtime/types/types-core'
+
+/**
+ * A numeric leaf wrapped in a presentational component and bound by
+ * `v-register` is the "bring your own component" shape. A native
+ * `<input v-register>` special-cases a DOM clear on a numeric-only leaf
+ * (`el.value === ''`) into `markBlank` — storage lands on the slim `0`
+ * with the blank flag, and the box stays empty. `setValueFromHost` (the
+ * component-host analog: v-model desugar → `onUpdate:modelValue`) now
+ * mirrors that: an emitted empty signal ('' / null / undefined) the
+ * slim gate would reject routes to `markBlank` instead of a rejected
+ * write, so form state doesn't freeze at the old value while the
+ * component's DOM shows empty (issue #518).
+ *
+ * The slim-set gate keeps the normalization honest: a `.nullable()` /
+ * `.optional()` leaf still takes null / undefined as a genuine value.
+ *
+ * The reverse direction is `hostModelValue`: a blank path presents as
+ * `undefined` on the `:modelValue` channel (the typed-model analog of
+ * the native path's `''`), so a naive numeric component renders empty
+ * on the round-trip exactly as a native input does.
+ */
+
+// The two adapter factories carry version-divergent generic signatures,
+// so one shared harness can't call both without unifying them to the
+// structural shape they both produce (a curried AbstractSchema factory).
+// Each adapter's schemas are built below with its own `z`, so no
+// cross-version union is ever invoked.
+type HostAdapter = (
+  schema: unknown
+) => (
+  formKey: string,
+  options: { maxRecursionDepth: number }
+) => AbstractSchema<GenericForm, GenericForm>
+
+const adapters = [
+  {
+    name: 'zod-v4',
+    adapt: zodAdapterV4 as unknown as HostAdapter,
+    schemas: {
+      number: z.object({ n: z.number() }),
+      nullable: z.object({ n: z.number().nullable() }),
+      optional: z.object({ n: z.number().optional() }),
+      string: z.object({ n: z.string() }),
+    },
+  },
+  {
+    name: 'zod-v3',
+    adapt: zodAdapterV3 as unknown as HostAdapter,
+    schemas: {
+      number: z3.object({ n: z3.number() }),
+      nullable: z3.object({ n: z3.number().nullable() }),
+      optional: z3.object({ n: z3.number().optional() }),
+      string: z3.object({ n: z3.string() }),
+    },
+  },
+] as const
+
+const KEY = canonicalizePath(['n']).key
+
+describe.each(adapters)(
+  'setValueFromHost numeric-clear normalization [$name]',
+  ({ adapt, schemas }) => {
+    function hostFor(schema: unknown, defaultValues: GenericForm) {
+      const formKey = `host-num-${Math.random().toString(36).slice(2)}`
+      // Materialize the curried adapter the way useAbstractForm does before
+      // handing the store a real AbstractSchema.
+      const abstract = adapt(schema)(formKey, { maxRecursionDepth: 64 })
+      const state = createFormStore({ formKey, schema: abstract, defaultValues })
+      return { state, rv: buildRegister(state, 'host:inst')(['n']) }
+    }
+
+    it('required z.number(): a host-emitted "" blanks the field (slim 0 + blank flag)', () => {
+      const { state, rv } = hostFor(schemas.number, { n: 42 })
+      expect(state.getValueAtPath(['n'])).toBe(42)
+
+      const accepted = rv.setValueFromHost('')
+
+      expect(accepted).toBe(true)
+      expect(state.getValueAtPath(['n'])).toBe(0) // slim default, well-typed
+      expect(state.blankPaths.has(KEY)).toBe(true)
+    })
+
+    it('required z.number(): a host-emitted null blanks the field (common cleared-control signal)', () => {
+      const { state, rv } = hostFor(schemas.number, { n: 42 })
+
+      const accepted = rv.setValueFromHost(null)
+
+      expect(accepted).toBe(true)
+      expect(state.getValueAtPath(['n'])).toBe(0)
+      expect(state.blankPaths.has(KEY)).toBe(true)
+    })
+
+    it('required z.number(): a host-emitted undefined blanks the field', () => {
+      const { state, rv } = hostFor(schemas.number, { n: 42 })
+
+      const accepted = rv.setValueFromHost(undefined)
+
+      expect(accepted).toBe(true)
+      expect(state.getValueAtPath(['n'])).toBe(0)
+      expect(state.blankPaths.has(KEY)).toBe(true)
+    })
+
+    it('required z.number(): a real emitted number writes through (no blank)', () => {
+      const { state, rv } = hostFor(schemas.number, { n: 42 })
+
+      const accepted = rv.setValueFromHost(7)
+
+      expect(accepted).toBe(true)
+      expect(state.getValueAtPath(['n'])).toBe(7)
+      expect(state.blankPaths.has(KEY)).toBe(false)
+    })
+
+    it('z.number().nullable(): a host-emitted null is a genuine value, not a blank signal', () => {
+      const { state, rv } = hostFor(schemas.nullable, { n: 42 })
+
+      const accepted = rv.setValueFromHost(null)
+
+      expect(accepted).toBe(true)
+      expect(state.getValueAtPath(['n'])).toBe(null) // stored, not coerced to 0
+      expect(state.blankPaths.has(KEY)).toBe(false)
+    })
+
+    it('z.number().optional(): a host-emitted undefined is a genuine value, not a blank signal', () => {
+      const { state, rv } = hostFor(schemas.optional, { n: 42 })
+
+      const accepted = rv.setValueFromHost(undefined)
+
+      expect(accepted).toBe(true)
+      expect(state.getValueAtPath(['n'])).toBe(undefined)
+      expect(state.blankPaths.has(KEY)).toBe(false)
+    })
+
+    it('z.string(): a host-emitted "" is a normal text clear, never routed through blank', () => {
+      const { state, rv } = hostFor(schemas.string, { n: 'seed' })
+
+      const accepted = rv.setValueFromHost('')
+
+      expect(accepted).toBe(true)
+      expect(state.getValueAtPath(['n'])).toBe('') // '' is a valid string, stored as-is
+      expect(state.blankPaths.has(KEY)).toBe(false)
+    })
+  }
+)
+
+describe('hostModelValue — blank-aware :modelValue presentation', () => {
+  function numericHost(defaultValues: GenericForm) {
+    const formKey = `host-model-${Math.random().toString(36).slice(2)}`
+    const abstract = zodAdapterV4(z.object({ n: z.number() }))(formKey, { maxRecursionDepth: 64 })
+    const state = createFormStore({ formKey, schema: abstract, defaultValues })
+    return { state, rv: buildRegister(state, 'host:inst')(['n']) }
+  }
+
+  it('presents the raw typed value for a filled path', () => {
+    const { rv } = numericHost({ n: 42 })
+    expect(rv.hostModelValue.value).toBe(42)
+  })
+
+  it('presents undefined for a blank path so a naive component renders empty', () => {
+    const { rv } = numericHost({ n: 42 })
+    rv.setValueFromHost('') // clear -> blank
+
+    // Storage still holds the slim 0, but the model channel presents the
+    // typed-model analog of "empty" so `undefined ?? '' === ''` in the host.
+    expect(rv.hostModelValue.value).toBeUndefined()
+  })
+
+  it('flips back to the typed value once the host re-supplies a number', () => {
+    const { rv } = numericHost({ n: 42 })
+    rv.setValueFromHost('')
+    expect(rv.hostModelValue.value).toBeUndefined()
+
+    rv.setValueFromHost(9)
+    expect(rv.hostModelValue.value).toBe(9)
+  })
+})
+
+// A naive presentational numeric component: parses non-empty input to a
+// number, emits the raw '' on a clear (no number to emit). Its modelValue
+// admits undefined -- that is how a blank field reaches a typed model. No
+// useRegister; the manually-wired v-model pair mirrors what
+// componentBridgeTransform generates (:modelValue reads hostModelValue,
+// @update routes through setValueFromHost).
+const NumHost = defineComponent({
+  name: 'NumHost',
+  props: {
+    modelValue: { type: [Number, String] as PropType<number | string | undefined>, default: '' },
+  },
+  emits: ['update:modelValue'],
+  setup:
+    (props, { emit }) =>
+    () =>
+      h('input', {
+        value: props.modelValue ?? '',
+        onInput: (e: Event) => {
+          const raw = (e.target as HTMLInputElement).value
+          emit('update:modelValue', raw === '' ? '' : Number(raw))
+        },
+      }),
+})
+
+const roundTripSchema = z.object({ n: z.number() })
+type RoundTripApi = UseFormReturn<typeof roundTripSchema>
+
+describe('component host numeric round-trip (integration): clear syncs DOM and state', () => {
+  const apps: App[] = []
+  afterEach(() => {
+    while (apps.length > 0) apps.pop()?.unmount()
+    document.body.innerHTML = ''
+  })
+
+  function mountNumHost(): { api: RoundTripApi; input: () => HTMLInputElement } {
+    const handle: { api?: RoundTripApi } = {}
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const Parent = defineComponent({
+      setup() {
+        const api = useForm({
+          schema: roundTripSchema,
+          defaultValues: { n: 42 },
+          key: `num-host-${Math.random().toString(36).slice(2)}`,
+        })
+        handle.api = api
+        const rv = api.register('n')
+        return () =>
+          withDirectives(
+            h(NumHost, {
+              modelValue: rv.hostModelValue.value,
+              'onUpdate:modelValue': (v: unknown) => rv.setValueFromHost(v),
+            }),
+            [[vRegister, rv, '', { [SSR_COMPONENT_HOST_MODIFIER]: true }]]
+          )
+      },
+    })
+    const app = createApp(Parent).use(createAttaform())
+    apps.push(app)
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    warnSpy.mockRestore()
+    if (handle.api === undefined) throw new Error('mountNumHost: api never set')
+    return {
+      api: handle.api,
+      input: () => root.querySelector('input') as HTMLInputElement,
+    }
+  }
+
+  function typeInto(input: HTMLInputElement, value: string): void {
+    input.value = value
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+  }
+
+  it('seeds the component from the default and accepts a typed number', async () => {
+    const { api, input } = mountNumHost()
+    expect(input().value).toBe('42')
+
+    typeInto(input(), '7')
+    await Promise.resolve()
+
+    expect(api.values.n).toBe(7)
+    expect(api.fields('n').blank).toBe(false)
+  })
+
+  it('clearing the component blanks the field AND leaves the DOM empty (issue #518)', async () => {
+    const { api, input } = mountNumHost()
+    typeInto(input(), '7')
+    await Promise.resolve()
+
+    typeInto(input(), '') // user clears the numeric control
+    await Promise.resolve()
+
+    // State is correct: storage lands on the slim default with the blank
+    // flag, so submit-time validation sees "no value supplied" rather than
+    // silently submitting the frozen 7.
+    expect(api.values.n).toBe(0)
+    expect(api.fields('n').blank).toBe(true)
+    // And the round-trip presents undefined back to the component, so the
+    // box reads empty the way a native <input v-register> would.
+    expect(input().value).toBe('')
+  })
+})

--- a/test/core/directive-blank.test.ts
+++ b/test/core/directive-blank.test.ts
@@ -40,6 +40,7 @@ function makeRegisterValue<T>(initial: T): {
   // (directive-private; off the public RegisterValue type).
   const value: InternalRegisterValue<T> = {
     innerRef: innerRef as InternalRegisterValue<T>['innerRef'],
+    hostModelValue: innerRef as InternalRegisterValue<T>['hostModelValue'],
     displayValue: ref('') as Readonly<Ref<string>>,
     markBlank,
     markInteracted: () => undefined,

--- a/test/core/directive-cleanup.test.ts
+++ b/test/core/directive-cleanup.test.ts
@@ -40,6 +40,7 @@ function makeRegisterValue<T>(
   const path = overrides.path ?? ('mock' as PathKey)
   const value: InternalRegisterValue<T> = {
     innerRef: ref(initial) as InternalRegisterValue<T>['innerRef'],
+    hostModelValue: ref(initial) as InternalRegisterValue<T>['hostModelValue'],
     displayValue: ref('') as Readonly<Ref<string>>,
     markBlank: () => true,
     markInteracted: () => undefined,

--- a/test/core/directive-external-update.test.ts
+++ b/test/core/directive-external-update.test.ts
@@ -33,6 +33,7 @@ function makeRegisterValue<T>(initial: T): MutableMockRv<T> {
   const innerRef = ref(initial)
   return {
     innerRef: innerRef as InternalRegisterValue<T>['innerRef'],
+    hostModelValue: innerRef as InternalRegisterValue<T>['hostModelValue'],
     displayValue: computed(() => {
       const v = innerRef.value
       return v == null ? '' : String(v)

--- a/test/core/directive-modifiers.test.ts
+++ b/test/core/directive-modifiers.test.ts
@@ -56,6 +56,7 @@ function makeRegisterValue<T>(initial: T): {
   })
   const value: MutableMockRv<T> = {
     innerRef: innerRef as InternalRegisterValue<T>['innerRef'],
+    hostModelValue: innerRef as InternalRegisterValue<T>['hostModelValue'],
     // Derive displayValue from innerRef so the mock matches the real
     // RegisterValue's contract (the directive's beforeUpdate reads
     // through displayValue). Doesn't model the blank/unset rule or

--- a/test/core/directive-prop-reactivity.test.ts
+++ b/test/core/directive-prop-reactivity.test.ts
@@ -50,6 +50,7 @@ function makeRegisterValue<T>(initial: T): {
   })
   const value: MutableMockRv<T> = {
     innerRef: innerRef as InternalRegisterValue<T>['innerRef'],
+    hostModelValue: innerRef as InternalRegisterValue<T>['hostModelValue'],
     displayValue: computed(() => {
       const v = innerRef.value
       return v == null ? '' : String(v)

--- a/test/transforms/v-register-component.test.ts
+++ b/test/transforms/v-register-component.test.ts
@@ -131,24 +131,24 @@ describe('v-register on Vue components — AST behaviour', () => {
   })
 
   describe('componentBridgeTransform — fires on EVERY component with v-register (value channel: v-model for plain hosts, :value for select-like)', () => {
-    it('injects the v-model pair (modelValue/innerRef + onUpdate:modelValue/setValueFromHost) + registerValue on a plain component host', () => {
+    it('injects the v-model pair (modelValue/hostModelValue + onUpdate:modelValue/setValueFromHost) + registerValue on a plain component host', () => {
       // The transform's branch `node.tagType === ElementTypes.COMPONENT`
       // makes ANY component with v-register a transform target — even
       // ones whose name has nothing to do with selecting (`<MyInput>`,
       // `<MyTextField>`, `<MyDatePicker>`). A plain input host (no projected
       // <option>s) speaks the standard Vue v-model contract: the transform
-      // injects `modelValue` (reading innerRef — the typed model value) and
-      // `onUpdate:modelValue` (routing through setValueFromHost, which writes
-      // the value and marks interacted), plus the `registerValue` bridge a
-      // wrapper's useRegister reads. It does NOT inject the select-style
-      // `:value`/displayValue bind — that's reserved for select-like hosts
-      // (see the slotted-<option> test below).
+      // injects `modelValue` (reading hostModelValue — the typed model value,
+      // undefined for a blank path) and `onUpdate:modelValue` (routing through
+      // setValueFromHost, which writes the value and marks interacted), plus
+      // the `registerValue` bridge a wrapper's useRegister reads. It does NOT
+      // inject the select-style `:value`/displayValue bind — that's reserved
+      // for select-like hosts (see the slotted-<option> test below).
       const code = compileWith(`<MyInput v-register="form.register('email')" />`, [
         componentBridgeTransform,
       ])
-      expect(code).toContain('innerRef')
+      expect(code).toContain('hostModelValue')
       expect(code).toContain('setValueFromHost')
-      expect(code).toMatch(/modelValue:\s*\(.*\)\?\.innerRef\?\.value/)
+      expect(code).toMatch(/modelValue:\s*\(.*\)\?\.hostModelValue\?\.value/)
       expect(code).toContain('"onUpdate:modelValue":')
       expect(code).toContain('registerValue:')
       // A plain host gets v-model, never the select-style displayValue bind.
@@ -205,7 +205,7 @@ describe('v-register on Vue components — AST behaviour', () => {
         componentBridgeTransform,
       ])
       for (const code of [pascal, explicitClose]) {
-        expect(code).toContain('innerRef')
+        expect(code).toContain('hostModelValue')
         expect(code).toContain('"onUpdate:modelValue":')
         expect(code).toContain('registerValue:')
       }
@@ -224,7 +224,7 @@ describe('v-register on Vue components — AST behaviour', () => {
       // attributes — the documented assignKey escape hatch covers
       // that case.
       const code = compileWith(`<my-input v-register="reg" />`, [componentBridgeTransform])
-      expect(code).toContain('innerRef')
+      expect(code).toContain('hostModelValue')
       expect(code).toContain('"onUpdate:modelValue":')
       expect(code).toContain('registerValue:')
       expect(code).toContain('_directive_register')
@@ -266,7 +266,7 @@ describe('v-register on Vue components — AST behaviour', () => {
          </div>`
       )
       // componentBridgeTransform contributed the v-model pair + registerValue:
-      expect(code).toContain('innerRef')
+      expect(code).toContain('hostModelValue')
       expect(code).toContain('setValueFromHost')
       expect(code).toContain('registerValue:')
       // vRegisterHintTransform wrapped the directive expression.
@@ -282,14 +282,15 @@ describe('v-register on Vue components — AST behaviour', () => {
            <input v-register="form.register('name')" />
          </div>`
       )
-      // The component host now takes the v-model path: modelValue reads
-      // innerRef and onUpdate:modelValue routes through setValueFromHost. The
-      // native <input> takes inputTextAreaNodeTransform's path: a value bind
-      // reading displayValue plus innerRef references in its checkbox/radio
-      // membership ternary. So innerRef shows on both sides; displayValue only
-      // on the native side (the component no longer emits it).
+      // The component host takes the v-model path: modelValue reads
+      // hostModelValue and onUpdate:modelValue routes through setValueFromHost.
+      // The native <input> takes inputTextAreaNodeTransform's path, which
+      // still references innerRef (the value bind reads displayValue, and the
+      // change-listener force-sync reads innerRef). So innerRef now shows only
+      // on the native side, hostModelValue only on the component side.
       const innerRefHits = code.match(/innerRef/g)?.length ?? 0
-      expect(innerRefHits).toBeGreaterThanOrEqual(2)
+      expect(innerRefHits).toBeGreaterThanOrEqual(1)
+      expect(code).toContain('hostModelValue')
       const displayHits = code.match(/displayValue/g)?.length ?? 0
       expect(displayHits).toBeGreaterThanOrEqual(1)
       // The component's v-model update handler is unique to its branch.
@@ -308,7 +309,7 @@ describe('v-register on Vue components — AST behaviour', () => {
       // transform doesn't introspect the expression — it forwards as-is.
       const code = compileFull('<MyInput v-register="form.register(`${prefix}.email`)" />')
       expect(code).toContain('markConnectedOptimistically')
-      expect(code).toContain('innerRef')
+      expect(code).toContain('hostModelValue')
       expect(code).toContain('setValueFromHost')
       // The template literal survives through identifier prefixing.
       expect(code).toContain('${_ctx.prefix}')
@@ -346,7 +347,8 @@ describe('v-register on Vue components — AST behaviour', () => {
         componentBridgeTransform,
         componentBridgeTransform,
       ])
-      const modelValueHits = code.match(/modelValue:\s*\(.*\)\?\.innerRef\?\.value/g)?.length ?? 0
+      const modelValueHits =
+        code.match(/modelValue:\s*\(.*\)\?\.hostModelValue\?\.value/g)?.length ?? 0
       const setterHits = code.match(/setValueFromHost/g)?.length ?? 0
       const regValueHits = code.match(/registerValue:/g)?.length ?? 0
       expect(modelValueHits).toBe(1)


### PR DESCRIPTION
Fixes #518.

## Problem

A numeric leaf (`z.number()`) wrapped in a v-model component and bound by `v-register` desynced when cleared. `setValueFromHost` did a raw `setValueAtPath`, so an emitted `''` was rejected by the slim-primitive gate: form state froze at the old value while the component's DOM showed empty. A native `<input v-register>` on the identical schema blanks correctly. Same directive, same schema, divergent behavior.

There was also a second, quieter asymmetry: `:modelValue` bound raw `innerRef` (storage `0`), so even after correcting the write, the component would receive `0` and render `0` where a native input renders empty.

## Fix (both directions)

**host → state.** `setValueFromHost` now mirrors the native listener's DOM-clear handling: an emitted empty signal (`''` / `null` / `undefined`) that the leaf's slim set rejects routes through `markBlank` instead of a rejected write, landing storage on the slim default with the blank flag. The slim-set gate keeps a `.nullable()` / `.optional()` (or `z.file()`) leaf accepting `null` / `undefined` as a genuine value rather than reading it as blank.

**state → host.** New blank-aware `hostModelValue` computed presents `undefined` for a blank path (the typed-model analog of `displayValue`'s `''`), so a naive numeric component renders empty on the round-trip. The component-bridge transform now binds `:modelValue` to it.

`markBlank` is hoisted into one shared local so the native input listener and `setValueFromHost` route through the same op and can't drift apart.

Not taken: requiring a component host to emit the `unset` sentinel (issue option 3). That pushes plumbing onto every component author and breaks the "v-register just works, native or component" contract.

## Corrected behavior

For `z.object({ n: z.number() })` seeded `{ n: 42 }`, typing then clearing a component host:

| control | `values('n')` | `fields('n').blank` | `input.value` |
|---|---|---|---|
| native `<input v-register>` | `0` | `true` | `""` |
| component host (before) | `7` (stuck) | `false` | `""` |
| component host (after) | `0` | `true` | `""` |

## Tests

- `test/composables/host-numeric-clear.test.ts` (new): the host→state normalization matrix across **both zod adapters** (`''` / `null` / `undefined` / real-number × `number` / `nullable` / `optional` / `string`), the `hostModelValue` presentation, and an end-to-end round-trip built from the issue's `NumHost` repro.
- Updated the component-bridge transform test for the `:modelValue` → `hostModelValue` binding, and added `hostModelValue` to the directive mock `RegisterValue`s.

## Verification

- Full suite: 4481 passed, 26 skipped
- `pnpm typecheck`: clean
- `check:bundled-types`: passes for both v4 and v3 consumers (public type change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
