### PR TITLE
chore(exports): expose ./package.json for tooling resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,8 @@
     },
     "./types": {
       "types": "./dist/index.d.mts"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "keywords": [
     "vue",


### PR DESCRIPTION
## What

Adds `"./package.json": "./package.json"` to the `exports` map.

## Why

Since the package ships an `exports` map, Node blocks any subpath not listed in it. `require('attaform/package.json')` (and `import.meta.resolve('attaform/package.json')`) therefore fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`, so tooling that wants to read the resolved version has to reach into `node_modules/.pnpm` by hand. Exposing `./package.json` is the standard one-line fix.

`package.json` is already in the published tarball, so this exposes nothing new; it just makes the existing file resolvable.

## Verification

```
$ node -e "console.log(require('attaform/package.json').version)"
0.27.1
```

Valid JSON, prettier-clean. No dist/type/build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
