### PR TITLE
feat(use-wizard): expose gate role on wizard.statuses[key].gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,21 @@
 
 ## Unreleased
 
-_No unreleased changes yet._
+### Added
+
+- **`wizard.statuses[key].gate` exposes each step's gate role as a readable
+  signal, so a consumer (notably a server persisting flow state) can track
+  which prerequisites a session has met.** A `gate()` step reads
+  `'uncleared'` while its member form is unconfirmed and `'cleared'` once
+  confirmed by a clean member submit or a seeded-valid form gate at mount;
+  every step that is not a gate reads `null`. It reflects the wizard's live
+  compiled shape, so a conditional gate that a function slot drops reverts
+  to `null`. It is independent of `locked`, which reports whether a step is
+  sealed behind an earlier uncleared gate: the first uncleared gate reads
+  `gate: 'uncleared'` with `locked: false`, while a later gate stacked
+  behind it reads both `gate: 'uncleared'` and `locked: true`. Restore a met
+  prerequisite in a later session by seeding its member form's
+  `defaultValues` valid; `gate` is read-only. (#532)
 
 ## v0.27.2
 ### Added

--- a/docs/multistep/gate.md
+++ b/docs/multistep/gate.md
@@ -105,6 +105,28 @@ Every gated step reports `wizard.statuses[key].locked === true`, so a progress r
 
 The whole-wizard [`wizard.handleSubmit`](/docs/multistep/use-wizard) honors the same guarantee: it refuses to complete while any gate is uncleared, even if every form happens to validate, and routes the attempt to the gate through its `onError` callback.
 
+## Reading the gate role
+
+Alongside `locked`, each step's status carries `wizard.statuses[key].gate`, the step's own role as a prerequisite:
+
+- `null` when the step is not a `gate()`.
+- `'uncleared'` while its member form is unconfirmed, so it seals every later step.
+- `'cleared'` once confirmed by a clean member submit, or by a seeded-valid form gate at mount.
+
+`gate` and `locked` are independent axes. `gate` says whether this step is a prerequisite and whether it is met; `locked` says whether the step is sealed behind an earlier uncleared gate. The first uncleared gate reads `gate: 'uncleared'` with `locked: false` (you have to reach it to clear it), while a later gate stacked behind it reads `gate: 'uncleared'` with `locked: true`.
+
+Because `gate` reflects the wizard's live state, it is the signal to persist. A server can record which prerequisites a session has met:
+
+```ts
+for (const step of wizard.steps) {
+  if (wizard.statuses[step.key]?.gate === 'cleared') {
+    markPrerequisiteMet(step.key)
+  }
+}
+```
+
+To restore that expectation in a later session, seed each satisfied gate's member form with the confirmed values as its `defaultValues`. A form gate whose member form rehydrates already valid is pre-cleared at mount, so the flow renders open from the first byte on the server. The restore path is the member form's `defaultValues`; `gate` itself is read-only.
+
 ## Where to next
 
 - [Step slots](/docs/multistep/step-slots) for the four slot kinds `gate()` wraps.

--- a/src/runtime/composables/use-wizard.ts
+++ b/src/runtime/composables/use-wizard.ts
@@ -74,6 +74,7 @@ const PENDING_STATUS: FormStatus = {
   submitted: false,
   errorCount: 0,
   locked: false,
+  gate: null,
 }
 
 /** Status surfaced for noop forms (string-slot affordance steps). Noops
@@ -86,6 +87,7 @@ const NOOP_VALID_STATUS: FormStatus = {
   submitted: false,
   errorCount: 0,
   locked: false,
+  gate: null,
 }
 
 /** Shared empty lock set for wizards that declare no `locked` policy, so
@@ -962,12 +964,17 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
     if (cached !== undefined) return cached
     const source = asStatusSource(form)
     const computedStatus = computed<FormStatus>(() => {
-      // `locked` is orthogonal to the readiness trichotomy below: it is
-      // overlaid on whatever base status this form resolves to, so a
-      // locked step reads `locked: true` whether it is ready, pending, a
-      // noop, or seeded. Constants pass through untouched on the common
-      // unlocked path so their identity survives.
+      // `locked` and `gate` are orthogonal to the readiness trichotomy
+      // below: both overlay whatever base status this form resolves to.
+      // `locked` = sealed behind an earlier uncleared gate; `gate` = this
+      // step's OWN prerequisite role (null unless it compiles to a
+      // `gate()`). Constants pass through untouched on the common
+      // unlocked + ungated path so their identity survives.
       const locked = navLockSet.value.has(form.key)
+      let gate: FormStatus['gate'] = null
+      if (gatePositions.value.includes(form.key)) {
+        gate = clearedGates.has(form.key) ? 'cleared' : 'uncleared'
+      }
       if (isFormReady(form.key)) {
         const meta = source.meta
         if (meta !== undefined && meta !== null) {
@@ -977,19 +984,22 @@ export function useWizard<const S extends ReadonlyArray<StepSlot>>(
             submitted: meta.submitted,
             errorCount: meta.errorCount,
             locked,
+            gate,
           }
         }
       }
       // Noop forms surface as always-valid even before their (trivial)
       // schema settle has registered — noop schemas resolve synchronously
-      // so this branch is mostly defensive, but it keeps the
-      // status surface stable for string-slot keys at t=0.
+      // so this branch is mostly defensive, but it keeps the status
+      // surface stable for string-slot keys at t=0. A string slot can
+      // itself be a gate (`gate('terms')`), so the gate overlay applies
+      // here too.
       if (noopForms.has(form.key)) {
-        return locked ? { ...NOOP_VALID_STATUS, locked: true } : NOOP_VALID_STATUS
+        return locked || gate !== null ? { ...NOOP_VALID_STATUS, locked, gate } : NOOP_VALID_STATUS
       }
       const seed = seedRef.value?.[form.key]
-      if (seed !== undefined) return { ...seed, locked }
-      return locked ? { ...PENDING_STATUS, locked: true } : PENDING_STATUS
+      if (seed !== undefined) return { ...seed, locked, gate }
+      return locked || gate !== null ? { ...PENDING_STATUS, locked, gate } : PENDING_STATUS
     })
     statusCache.set(form.key, computedStatus)
     return computedStatus

--- a/src/runtime/types/types-wizard.ts
+++ b/src/runtime/types/types-wizard.ts
@@ -47,13 +47,24 @@ export type AnyForm = {
  *    `submissionAttempts > 0` is the "user has tried" signal.
  *  - `errorCount` — `form.meta.errorCount`. Count of active validation
  *    errors (zero when valid).
- *  - `locked`: `true` when this step sits after an uncleared `gate()`
- *    (see `gate`). Its member form is frozen (data writes no-op) and
- *    navigation to it is refused, so a stepper can render it as an
- *    unreachable gate. `false` when no gate seals it.
+ *  - `locked`: `true` when this step sits after an uncleared gate. Its
+ *    member form is frozen (data writes no-op) and navigation to it is
+ *    refused, so a stepper can render it as an unreachable step. `false`
+ *    when no gate seals it. Orthogonal to `gate`: the first uncleared
+ *    gate reads `locked: false` (you must reach it to clear it), while a
+ *    later gate sealed behind it reads both `gate: 'uncleared'` and
+ *    `locked: true`.
+ *  - `gate`: this step's own role as a hard prerequisite. `null` when the
+ *    step is not a `gate()`; `'uncleared'` while its member form is
+ *    unconfirmed (so it seals every later step); `'cleared'` once
+ *    confirmed by a clean member submit or a seeded-valid form gate at
+ *    mount. Reflects the live compiled shape, so a conditional `gate()`
+ *    that a function slot drops resolves to `null`.
  *
  * Noop forms generated for string slots surface as default-valid
- * (`{ valid: true, dirty: false, submitted: false, errorCount: 0, locked: false }`).
+ * (`{ valid: true, dirty: false, submitted: false, errorCount: 0, locked: false, gate: null }`),
+ * unless the string slot is a `gate('...')`, whose `gate` tracks the
+ * in-session acknowledgment.
  */
 export type FormStatus = {
   readonly valid: boolean
@@ -61,15 +72,16 @@ export type FormStatus = {
   readonly submitted: boolean
   readonly errorCount: number
   readonly locked: boolean
+  readonly gate: 'cleared' | 'uncleared' | null
 }
 
 /**
  * Seed shape accepted by `useWizard({ defaultStatuses })`. Mirrors
- * `FormStatus` minus `locked`: the lock flag is computed live from the
- * wizard's gates and overlaid on every status read, so a seed never
- * carries it (a seeded value would be ignored).
+ * `FormStatus` minus its two live-computed flags, `locked` and `gate`:
+ * both are derived from the wizard's gates and overlaid on every status
+ * read, so a seed never carries them (a seeded value would be ignored).
  */
-export type FormStatusSeed = Omit<FormStatus, 'locked'>
+export type FormStatusSeed = Omit<FormStatus, 'locked' | 'gate'>
 
 /**
  * Flat error shape returned per form by `wizard.allErrors[key]`. Each

--- a/test/composables/wizard-default-statuses.test.ts
+++ b/test/composables/wizard-default-statuses.test.ts
@@ -177,6 +177,7 @@ describe('useWizard — defaultStatuses', () => {
       submitted: result.a.meta.submitted,
       errorCount: result.a.meta.errorCount,
       locked: false,
+      gate: null,
     })
   })
 

--- a/test/composables/wizard-gate-ssr.test.ts
+++ b/test/composables/wizard-gate-ssr.test.ts
@@ -62,6 +62,11 @@ describe('gate() SSR enforcement', () => {
     expect(handle.wizard.currentStep).toBe('ssr-consent')
     expect(handle.wizard.statuses['ssr-payment'].locked).toBe(true)
     expect(html).toContain('ssr-consent')
+
+    // The gate role serializes on the server, so a consumer can persist it:
+    // the consent reads 'uncleared', the plain payment step reads null.
+    expect(handle.wizard.statuses['ssr-consent'].gate).toBe('uncleared')
+    expect(handle.wizard.statuses['ssr-payment'].gate).toBe(null)
   })
 
   it('lets a seeded-valid gate honor a server deep link into a downstream step', async () => {
@@ -95,5 +100,7 @@ describe('gate() SSR enforcement', () => {
     // Rehydrated consent → gate pre-cleared at construction → downstream open.
     expect(handle.wizard.currentStep).toBe('ssr2-payment')
     expect(handle.wizard.statuses['ssr2-payment'].locked).toBe(false)
+    // The seeded-valid gate reads 'cleared' in the very first server render.
+    expect(handle.wizard.statuses['ssr2-consent'].gate).toBe('cleared')
   })
 })

--- a/test/composables/wizard-gate.test.ts
+++ b/test/composables/wizard-gate.test.ts
@@ -446,18 +446,95 @@ describe.each(adapters)('useWizard gate() — $name', ({ useForm, z }) => {
     apps.push(app)
     await awaitSettle()
 
-    // Below threshold: kyc is an ordinary step, `confirm` is reachable.
+    // Below threshold: kyc is an ordinary step, `confirm` is reachable,
+    // and kyc carries no gate role.
     expect(handle.wizard.statuses.confirm.locked).toBe(false)
+    expect(handle.wizard.statuses.kyc.gate).toBe(null)
 
     // Cross the threshold: the same slot resolves to gate(kyc) → `confirm`
-    // seals until kyc submits.
+    // seals until kyc submits, and kyc now reads as an uncleared gate.
     handle.transfer.setValue('amount', 25_000)
     await awaitSettle()
     expect(handle.wizard.statuses.confirm.locked).toBe(true)
+    expect(handle.wizard.statuses.kyc.gate).toBe('uncleared')
 
-    // Back under the threshold: the gate drops, `confirm` reopens.
+    // Back under the threshold: the gate drops, `confirm` reopens, and
+    // kyc's gate role reverts to null.
     handle.transfer.setValue('amount', 100)
     await awaitSettle()
     expect(handle.wizard.statuses.confirm.locked).toBe(false)
+    expect(handle.wizard.statuses.kyc.gate).toBe(null)
+  })
+
+  // --- the .gate status field (readable gate role) ----------------------
+
+  it('exposes a step gate role: null for plain, uncleared then cleared for a gate', async () => {
+    const { wizard, terms } = mountWizard()
+    await awaitSettle()
+
+    // A gate reports its own role; plain downstream steps report null. The
+    // callable single-key form and the drilled form agree.
+    expect(wizard.statuses.terms.gate).toBe('uncleared')
+    expect(wizard.statuses('terms').gate).toBe('uncleared')
+    expect(wizard.statuses.shipping.gate).toBe(null)
+    expect(wizard.statuses.payment.gate).toBe(null)
+
+    // Checking the box (intent) does NOT clear it: still 'uncleared'.
+    terms.setValue('accepted', true)
+    await awaitSettle()
+    expect(wizard.statuses.terms.gate).toBe('uncleared')
+
+    // A clean submit (confirmation) flips it to 'cleared'.
+    await terms.handleSubmit(() => {})()
+    await awaitSettle()
+    expect(wizard.statuses.terms.gate).toBe('cleared')
+
+    // reset re-arms the gate.
+    wizard.reset()
+    await awaitSettle()
+    expect(wizard.statuses.terms.gate).toBe('uncleared')
+  })
+
+  it('reads gate and locked as independent axes (a later gate is both uncleared and locked)', async () => {
+    // welcome (affordance) gates first; terms (form) is itself a gate AND
+    // sits behind the uncleared welcome, so it reads uncleared + locked.
+    const { wizard } = mountWizard(({ terms, shipping, payment }) => [
+      gate('welcome'),
+      gate(terms),
+      shipping,
+      payment,
+    ])
+    await awaitSettle()
+
+    // The first uncleared gate is reachable; a later gate is sealed behind
+    // it yet still reports its own uncleared role.
+    expect(wizard.statuses.welcome.gate).toBe('uncleared')
+    expect(wizard.statuses.welcome.locked).toBe(false)
+    expect(wizard.statuses.terms.gate).toBe('uncleared')
+    expect(wizard.statuses.terms.locked).toBe(true)
+    expect(wizard.statuses.shipping.gate).toBe(null)
+    expect(wizard.statuses.shipping.locked).toBe(true)
+
+    // Acknowledge welcome: it clears, terms becomes the reachable gate but
+    // is still its own uncleared prerequisite.
+    await wizard.next()
+    await awaitSettle()
+    expect(wizard.statuses.welcome.gate).toBe('cleared')
+    expect(wizard.statuses.welcome.locked).toBe(false)
+    expect(wizard.statuses.terms.gate).toBe('uncleared')
+    expect(wizard.statuses.terms.locked).toBe(false)
+  })
+
+  it('reads a seeded-valid form gate as cleared from mount', async () => {
+    const { wizard } = mountWizard(
+      ({ terms, shipping, payment }) => [gate(terms), shipping, payment],
+      { termsDefaults: { accepted: true } }
+    )
+    await awaitSettle()
+
+    // Rehydrated consent is pre-cleared, so its gate role reads 'cleared'
+    // synchronously (the timing the SSR landing relies on).
+    expect(wizard.statuses.terms.gate).toBe('cleared')
+    expect(wizard.statuses.shipping.gate).toBe(null)
   })
 })

--- a/test/core/wizard-statuses-proxy.test.ts
+++ b/test/core/wizard-statuses-proxy.test.ts
@@ -22,6 +22,7 @@ const pending: FormStatus = {
   submitted: false,
   errorCount: 0,
   locked: false,
+  gate: null,
 }
 
 function makeProxy<K extends string>(map: Record<K, FormStatus>) {
@@ -42,8 +43,8 @@ function makeProxy<K extends string>(map: Record<K, FormStatus>) {
 describe('buildWizardStatusesProxy', () => {
   it('exposes per-key entries via property access', () => {
     const { proxy } = makeProxy({
-      a: { valid: true, dirty: false, submitted: false, errorCount: 0, locked: false },
-      b: { valid: false, dirty: true, submitted: false, errorCount: 2, locked: false },
+      a: { valid: true, dirty: false, submitted: false, errorCount: 0, locked: false, gate: null },
+      b: { valid: false, dirty: true, submitted: false, errorCount: 2, locked: false, gate: null },
     })
     expect(proxy.a.valid).toBe(true)
     expect(proxy.b.errorCount).toBe(2)
@@ -51,7 +52,14 @@ describe('buildWizardStatusesProxy', () => {
 
   it('returns a single entry via callable form', () => {
     const { proxy } = makeProxy({
-      cargo: { valid: true, dirty: false, submitted: false, errorCount: 0, locked: false },
+      cargo: {
+        valid: true,
+        dirty: false,
+        submitted: false,
+        errorCount: 0,
+        locked: false,
+        gate: null,
+      },
     })
     const status = proxy('cargo') as FormStatus
     expect(status.valid).toBe(true)
@@ -60,7 +68,7 @@ describe('buildWizardStatusesProxy', () => {
   it('returns the full record via no-arg callable form', () => {
     const { proxy } = makeProxy({
       a: pending,
-      b: { valid: true, dirty: false, submitted: false, errorCount: 0, locked: false },
+      b: { valid: true, dirty: false, submitted: false, errorCount: 0, locked: false, gate: null },
     })
     const all = proxy() as Record<string, FormStatus>
     expect(all['a']).toMatchObject(pending)
@@ -72,7 +80,14 @@ describe('buildWizardStatusesProxy', () => {
     const { proxy, sources } = makeProxy({ a: pending })
     expect(proxy.a.valid).toBe(false)
     const aSource = sources.a as ReturnType<typeof ref<FormStatus>>
-    aSource.value = { valid: true, dirty: true, submitted: true, errorCount: 0, locked: false }
+    aSource.value = {
+      valid: true,
+      dirty: true,
+      submitted: true,
+      errorCount: 0,
+      locked: false,
+      gate: null,
+    }
     expect(proxy.a.valid).toBe(true)
     expect(proxy.a.dirty).toBe(true)
   })
@@ -123,7 +138,7 @@ describe('buildWizardStatusesProxy', () => {
 
   it('serializes via toJSON to the current record snapshot', () => {
     const { proxy } = makeProxy({
-      a: { valid: true, dirty: false, submitted: false, errorCount: 0, locked: false },
+      a: { valid: true, dirty: false, submitted: false, errorCount: 0, locked: false, gate: null },
     })
     const serialized = JSON.parse(JSON.stringify(proxy))
     expect(serialized.a.valid).toBe(true)

--- a/test/types/wizard-statuses-types.test.ts
+++ b/test/types/wizard-statuses-types.test.ts
@@ -18,13 +18,14 @@ import type {
  */
 
 describe('wizard status types', () => {
-  it('FormStatus has valid / dirty / submitted / errorCount / locked fields', () => {
+  it('FormStatus has valid / dirty / submitted / errorCount / locked / gate fields', () => {
     expectTypeOf<FormStatus>().toEqualTypeOf<{
       readonly valid: boolean
       readonly dirty: boolean
       readonly submitted: boolean
       readonly errorCount: number
       readonly locked: boolean
+      readonly gate: 'cleared' | 'uncleared' | null
     }>()
   })
 


### PR DESCRIPTION
## Summary

Exposes a readable per-step gate signal on the wizard status surface: `wizard.statuses[key].gate`. It answers "is this step a hard prerequisite, and has it been met" in one read, so a consumer (notably a server persisting flow state) can track which gates a session has cleared. Follow-up to the `gate()` feature shipped in v0.27.2 (#523).

## The field

```ts
wizard.statuses('kyc').gate // 'cleared' | 'uncleared' | null
```

- `null` when the step is not a `gate()`.
- `'uncleared'` while a gate's member form is unconfirmed (so it seals every later step).
- `'cleared'` once confirmed by a clean member submit, or by a seeded-valid form gate at mount.

It reflects the wizard's live compiled shape, so a conditional gate that a function slot drops (`() => amount > 10_000 ? gate(kyc) : kyc`) reverts to `null`. Affordance gates (`gate('terms')`) track the in-session acknowledgment.

`FormStatus` gains the field; `FormStatusSeed` excludes it (computed live from the gates, exactly like `locked`).

## Two independent axes

`gate` describes whether *this* step is a prerequisite and whether it is met; the existing `locked` describes whether the step is sealed *behind* an earlier uncleared gate. They compose, and can co-occur:

| step | `.gate` | `.locked` |
|---|---|---|
| first uncleared gate | `'uncleared'` | `false` |
| a cleared gate | `'cleared'` | `false` |
| later gate sealed behind an earlier uncleared gate | `'uncleared'` | `true` |
| plain step behind an uncleared gate | `null` | `true` |
| plain, reachable step | `null` | `false` |

A gate is never auto-un-`locked`: only the first uncleared gate is reachable.

## Server round-trip

The read side is this field; the write side is the seeding that already exists. Persist which prerequisites a session met:

```ts
for (const step of wizard.steps) {
  if (wizard.statuses[step.key]?.gate === 'cleared') markPrerequisiteMet(step.key)
}
```

Restore in a later session by seeding each satisfied gate's member form with the confirmed values as its `defaultValues`; a form gate whose member form rehydrates already valid is pre-cleared at mount, so the flow renders open from the first byte on the server. `gate` itself is read-only.

## Implementation

`statusFor` derives `gate` from `gatePositions` + `clearedGates` and overlays it on every return path (ready, noop/affordance, seeded, pending), the same way `locked` is overlaid. No new reactive state: it rides the sets the gate machinery already maintains, so a plain wizard reads `null` everywhere at no extra cost.

## Testing

- **`wizard-gate.test.ts`** (both Zod adapters): the `.gate` lifecycle (`null` -> `'uncleared'` -> `'cleared'` -> re-armed on `reset()`), the two-axes co-occurrence (a later gate reads `gate: 'uncleared'` + `locked: true`), a seeded-valid form gate reading `'cleared'` at mount, and the conditional KYC pattern augmented to assert `.gate` flips `null` <-> `'uncleared'` as the threshold is crossed.
- **`wizard-gate-ssr.test.ts`**: `.gate` asserted on the server render (uncleared deep-link and seeded-valid landing).
- **`wizard-statuses-types.test.ts`**: `FormStatus` type extended to the new field.
- The three meta-tests that assert a full status shape (proxy, statuses-types, default-statuses) updated.

## Verification

`pnpm typecheck` clean, 65 gate/status tests green across v3 + v4, full suite green, all `check:size` caps hold (index 54.59 / 55, abstract 39.16 / 40; the field costs nothing meaningful), `check:doc-snippets` reports 0 surface errors.

The CHANGELOG entry follows in a second commit so it can carry this PR's number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
