### PR TITLE
test(use-wizard): guard bare gate(form) as a first-class step (#530)

### DIFF
--- a/docs/multistep/gate.md
+++ b/docs/multistep/gate.md
@@ -40,6 +40,8 @@ const wizard = useWizard({ steps: [gate(consent), shipping, payment] })
 
 `gate(consent)` seals `shipping` and `payment` until `consent` is confirmed. Ordering places the gate: put it immediately before what it guards, and everything to its right is gated.
 
+`gate()` is first-class wherever a step goes: drop it straight into `steps` as shown here, or return it from a [function or `lazy()` slot](/docs/multistep/step-slots). A bare `gate(consent)` and a `() => gate(consent)` resolve to the same gated step.
+
 ## Confirmation, not intent
 
 A gate clears on a member form's **clean submit**, not the moment a value passes validation. Checking the consent box makes `consent` valid, but the rail stays sealed. Pressing Next (or calling `wizard.tryNext()`) submits the form, and that submit is the confirmation that opens the gate.

--- a/test/composables/wizard-gate.test.ts
+++ b/test/composables/wizard-gate.test.ts
@@ -410,6 +410,62 @@ describe.each(adapters)('useWizard gate() — $name', ({ useForm, z }) => {
     }
   })
 
+  it('treats a bare gate(form) top-level step as first-class, identical to a thunk-wrapped gate (#530)', async () => {
+    // A bare `gate(consent)` dropped straight into `steps` must land ON the
+    // gate (index 0) and seal downstream, exactly like `() => gate(consent)`,
+    // never initialize past it. The consent carries NO defaultValues (the
+    // reported shape): `z.literal(true)` fills `accepted: true` as its sole
+    // structural default, so a seed-clear keyed on live validity would wrongly
+    // open the gate at mount. Both slot forms must stay uncleared.
+    const builders: Array<(consent: AnyForm, data: AnyForm) => StepSlot[]> = [
+      (consent, data) => [gate(consent), () => data],
+      (consent, data) => [() => gate(consent), () => data],
+    ]
+    for (const buildSteps of builders) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const handle: any = {}
+      const App = defineComponent({
+        setup() {
+          const consent = useForm({
+            key: 'consent',
+            schema: z.object({ accepted: z.literal(true) }),
+          })
+          const data = useForm({
+            key: 'data',
+            schema: z.object({ name: z.string().min(1) }),
+            defaultValues: { name: '' },
+          })
+          const wizard = useWizard({
+            steps: buildSteps(consent, data),
+            restore: false,
+            persist: false,
+          })
+          // The #530 claim is about construction-time landing, so snapshot
+          // the pin the instant construction returns.
+          handle.constructionIndex = wizard.activeIndex
+          handle.wizard = wizard
+          return () => h('div')
+        },
+      })
+      const app = createApp(App).use(createAttaform())
+      app.config.warnHandler = () => {}
+      app.mount(document.createElement('div'))
+      apps.push(app)
+
+      // Lands on the gate at construction, not past it.
+      expect(handle.constructionIndex).toBe(0)
+      await awaitSettle()
+      // Stays there once every watcher has flushed: the gate is its own
+      // uncleared prerequisite and the downstream step is sealed.
+      expect(handle.wizard.activeIndex).toBe(0)
+      expect(handle.wizard.statuses.consent.gate).toBe('uncleared')
+      expect(handle.wizard.statuses.data.locked).toBe(true)
+
+      for (const mounted of apps.splice(0)) mounted.unmount()
+      document.body.innerHTML = ''
+    }
+  })
+
   it('gates conditionally from a function slot (the KYC threshold pattern)', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const handle: any = {}


### PR DESCRIPTION
## Summary

Re #530. The report says a bare `gate(form)` passed directly as a step initializes the wizard *past* the gate (`activeIndex === 1`), while a thunk-wrapped `() => gate(form)` lands on it (`activeIndex === 0`).

**It does not reproduce in real usage.** In a mounted component, on both the reported `v0.27.2` and current `main`, a bare `gate(consent)` and a `() => gate(consent)` both land ON the gate at index 0, leave it uncleared, and seal the downstream step. This PR lands a standing regression test proving that, plus a one-line docs clarification, and closes the issue as not-reproducing.

## Investigation

| harness | `[gate(consent), () => data]` (bare) | `[() => gate(consent), () => data]` (thunk) |
|---|---|---|
| mounted component, `v0.27.2` | index **0** | index **0** |
| mounted component, `main` | index **0** | index **0** |
| literal top-level (as written in the issue) | throws `OutsideSetupError` | throws `OutsideSetupError` |

Two findings pin it down:

- **The literal repro can't run.** `useForm` throws `OutsideSetupError` outside a `setup()`, so the spike had a setup/mount wrapper that isn't in the issue. That wrapper is where the `index 1` came from, not the wizard.
- **The landing code is byte-identical between `v0.27.2` and `main`** (`firstKey` / `resolveLandingKey` / `commitActiveKey` / `navLockSet` / the initial pin). The only behavior change in this region since `0.27.2` is #528, which moves strictly toward staying *sealed*.

And even a hypothetical `index 1` would not be a bypass: `activeIndex` is only the cursor. Enforcement is the data-layer freeze (`externalLock`) plus `navLockSet`, both derived from step *positions* and cleared-gate state, independent of the pin. `commitActiveKey` is the sole writer and redirects any nav-locked target back to the gate, so seating on a sealed step isn't reachable through the reactive machinery. The downstream step stays frozen and `locked` regardless.

## What this PR adds

- **Regression test** (`test/composables/wizard-gate.test.ts`, both Zod adapters): a bare `gate(consent)` and a `() => gate(consent)` resolve to the same gated step. Construction lands at index 0, the gate reads `uncleared`, and the downstream step reads `locked`. The consent carries **no** `defaultValues` (the reported `z.literal(true)` shape), so this also re-guards that a bare consent never seed-clears on its structural default.
- **Docs note** (`docs/multistep/gate.md`): `gate()` is first-class as a bare step or nested in a function / `lazy()` slot, resolving to the same gated step. The report surfaced uncertainty about whether bare-as-step is supported; it is, and the docs already lead with it.

No behavior change, so no CHANGELOG entry.

## Testing

- `pnpm test test/composables/wizard-gate.test.ts` (both adapters, 42 tests green)
- Full suite green (4619 passed, 4 skipped), `pnpm typecheck` clean, ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
