### PR TITLE
fix(v-register): invalid-submit focus lands on no-latch component hosts

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -868,7 +868,15 @@ export default [
     // #523): same shared eager core (useForm({ disabled })) plus gate().
     // zod-v3.mjs, the tightest full adapter entry, crossed by 0.39 KB.
     // Measured at 57.74 KB.
-    limit: '58 KB',
+    //
+    // Raised 58 → 59 KB on the no-latch-host focus branch (#538): the shared
+    // core chunk gains the focus-first-error anchor for no-latch component
+    // hosts. create-form-store adds the hostTargets map, resolveHostFocusTarget,
+    // and the host-root weave into getFirstErrorElement's DOM-order walk, plus
+    // the markHostConnected host-el thread. zod-v3.mjs, the tightest adapter
+    // bundle, crossed 58 first (index / zod hold ~0.1 KB, zod-v4 ~0.2 KB).
+    // Measured at 58.17 KB.
+    limit: '59 KB',
     gzip: true,
     ignore: ['zod'],
     modifyEsbuildConfig: asEsm,
@@ -886,7 +894,12 @@ export default [
     // disabled data freeze in the shared core (threaded through useAbstractForm)
     // plus gate(). No Zod adapter here, but the core and wizard surface both
     // grow. Measured at 46.85 KB.
-    limit: '47 KB',
+    //
+    // Raised 47 → 48 KB on the no-latch-host focus branch (#538): the same
+    // shared-core focus anchor (hostTargets, resolveHostFocusTarget, the
+    // getFirstErrorElement weave) reaches this entry through useAbstractForm.
+    // Measured at 47.23 KB.
+    limit: '48 KB',
     gzip: true,
     modifyEsbuildConfig: asEsm,
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,20 @@
 # Changelog
 
 ## Unreleased
+### Fixed
 
-_No unreleased changes yet._
+- **Invalid-submit focus and scroll now land on a `v-register` component host
+  that renders no single native control.** `handleSubmit` and `tryNext` focus
+  the first offending field on an invalid submit, but a host wrapping an ARIA
+  composite (`role=radio` / `checkbox` / `listbox` / `slider`), several native
+  controls (a checkbox group, an address subform), or no control at all
+  registered no focus target, so the error was announced with nowhere for a
+  keyboard or screen-reader user to land. Such a host now records its root as
+  the field's focus anchor and resolves it to the first focusable descendant at
+  submit time, weaving into the same document-order "first error" walk as
+  native controls. The guarantee holds for any accessible component library
+  (reka-ui, Radix Vue, Headless UI, Ark, or a hand-rolled widget), since the
+  fix keys on the structural no-control shape, not on any one library. (#538)
 
 ## v0.27.4
 ### Changed

--- a/src/runtime/core/create-form-store.ts
+++ b/src/runtime/core/create-form-store.ts
@@ -72,6 +72,46 @@ import { mergeSparseHydration } from './merge-hydration'
  */
 const isContainer = (value: unknown): boolean => Array.isArray(value) || isPlainRecord(value)
 
+// Focusable candidates inside a no-latch component host, in the order the
+// browser would tab through them (document order at query time). A composite
+// widget exposes its entry point as a genuinely focusable element -- a
+// roving-tabindex group's active item (`[tabindex="0"]`), a `role="slider"`
+// thumb, a listbox/combobox trigger `<button>`, or a real `<input>` segment --
+// so match natively focusable elements plus anything given a non-negative
+// tabindex. `type="hidden"` inputs and `tabindex="-1"` mirrors (reka-ui's
+// BubbleInput and the like) are excluded: they can never be the user's focus
+// target. Disabled controls are filtered at resolve time.
+const HOST_FOCUS_TARGET_SELECTOR = [
+  'input:not([type="hidden"])',
+  'select',
+  'textarea',
+  'button',
+  'a[href]',
+  '[tabindex]:not([tabindex="-1"])',
+  '[contenteditable="true"]',
+].join(', ')
+
+/**
+ * The focus-first-error target for a no-latch `v-register` component host. The
+ * host binds a value but owns no single control, so resolve its root to the
+ * first visible, enabled focusable descendant -- the tab stop a keyboard user
+ * entering the widget lands on (the first radio of a group, a slider thumb, a
+ * listbox trigger, the first pin segment). Falls back to the host root itself
+ * when nothing focusable is found, so `scrollToFirstError` still has a target
+ * even if `focus()` can't land. `offsetParent === null` mirrors
+ * `getFirstErrorElement`'s own visibility gate (skips `display:none` subtrees).
+ */
+function resolveHostFocusTarget(hostRoot: HTMLElement): HTMLElement {
+  const candidates = hostRoot.querySelectorAll<HTMLElement>(HOST_FOCUS_TARGET_SELECTOR)
+  for (const el of candidates) {
+    if (!el.isConnected) continue
+    if (el.offsetParent === null) continue
+    if (el.matches(':disabled')) continue
+    return el
+  }
+  return hostRoot
+}
+
 /**
  * Per-form closure state — the single store owned by each `useForm` call.
  * Bundles the form value, the summary record, element references, field
@@ -643,8 +683,19 @@ export type FormStore<F extends GenericForm, G extends GenericForm = F> = {
    * (a composite widget, or none found). The directive calls it on mount
    * (`true`) and unmount (`false`). Distinct from the SSR-only
    * `markConnectedOptimistically`; idempotent on the leading edge.
+   *
+   * `hostEl` (the host root) is recorded on connect as this path's
+   * focus-first-error anchor, scoped to `formInstanceId` the same way a
+   * registered control is. A no-latch host enters no `elements` record, so
+   * without this it is absent from `getFirstErrorElement`'s walk; the anchor
+   * lets that walk resolve a focus target from the host subtree.
    */
-  markHostConnected(path: Path, connected: boolean): void
+  markHostConnected(
+    path: Path,
+    connected: boolean,
+    hostEl: HTMLElement,
+    formInstanceId: string
+  ): void
 
   // --- derived ---
   /**
@@ -1337,9 +1388,25 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
   // `key` and both register into the same `elements` Map.
   const elementToFormInstance = new WeakMap<HTMLElement, string>()
 
-  // Lazy DOM-order sort cache. Holds every registered element flattened
-  // across paths, sorted by `compareDocumentPosition` (DOM-tree order).
-  // Invalidated to `null` on any register/deregister; rebuilt on next
+  // Focus-first-error anchors for no-latch `v-register` component hosts
+  // (composite widgets, multi-control or control-less hosts). Such a host
+  // binds a value but registers no single control, so it never enters
+  // `elements` and would be invisible to `getFirstErrorElement`. Keyed by
+  // canonical path key; the host root drives the DOM-order walk and resolves
+  // to a focusable descendant at submit time, and `formInstanceId` scopes it
+  // to the owning `useForm()` instance exactly as `elementToFormInstance`
+  // does for registered controls. A path holds at most one anchor, and never
+  // both an anchor and a registered element — `registerElement` drops the
+  // anchor when a control latches (e.g. a late self-heal supersede).
+  const hostTargets = new Map<
+    PathKey,
+    { path: Path; hostRoot: HTMLElement; formInstanceId: string }
+  >()
+
+  // Lazy DOM-order sort cache. Holds every registered element plus every
+  // no-latch host root flattened across paths, sorted by
+  // `compareDocumentPosition` (DOM-tree order). Invalidated to `null` on any
+  // register/deregister or host connect/disconnect; rebuilt on next
   // `getFirstErrorElement` read. The cache amortises the sort across
   // multiple submit failures between mutations — a 100-field form with
   // 5 failed submits and no DOM changes pays one O(n log n) sort, not
@@ -1352,7 +1419,12 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
   // sync layout per comparison and breaks under `display: none`. Tree-
   // order is the right tradeoff for a hot path; the 99% case (semantic
   // source-order rendering) works correctly.
-  let sortedRegistrationsCache: Array<{ path: Path; element: HTMLElement }> | null = null
+  let sortedRegistrationsCache: Array<{
+    path: Path
+    element: HTMLElement
+    host: boolean
+    formInstanceId: string
+  }> | null = null
   // Errors are split by source so each writer touches exactly one slot.
   // Schema validation owns `schemaErrors`; the `setErrors` / `clearErrors`
   // API owns `userErrors`. The two stores merge on read via `getErrorsForPath` and
@@ -3219,6 +3291,11 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
       record.elements.add(raw)
     }
     elementToFormInstance.set(element, formInstanceId)
+    // A real control now owns this path's focus target, so drop any no-latch
+    // host anchor for it: a late self-heal supersede (a single control that
+    // rendered after mount) latches here after `markHostConnected` recorded
+    // the root. The two focus channels are mutually exclusive per path.
+    hostTargets.delete(key)
     sortedRegistrationsCache = null
     // Connect transition. Lift focused/blurred from `null`
     // (no-element-meaningless) to optimistic booleans only when they
@@ -3289,7 +3366,12 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     })
   }
 
-  function markHostConnected(path: Path, connected: boolean): void {
+  function markHostConnected(
+    path: Path,
+    connected: boolean,
+    hostEl: HTMLElement,
+    formInstanceId: string
+  ): void {
     // Client-side connected marking for a `v-register` component host that
     // binds value through the v-model channel but exposes no single inner
     // control to latch (a composite widget, or none discovered). Distinct
@@ -3300,6 +3382,14 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
     const { key } = canonicalizePath(path)
     const current = fields.get(key)
     if (connected) {
+      // Record the host root as this path's focus-first-error anchor even if
+      // `connected` is already true (a re-mark): the element may have changed.
+      // Skipped when a real control already owns the path (`registerElement`
+      // dropped any anchor and owns the focus target now).
+      if (!elements.has(key)) {
+        hostTargets.set(key, { path, hostRoot: hostEl, formInstanceId })
+        sortedRegistrationsCache = null
+      }
       if (current?.connected === true) return
       // Connect transition, mirroring `registerElement`: lift focused /
       // blurred from null to optimistic booleans only when currently null.
@@ -3309,6 +3399,10 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
         blurred: current?.blurred ?? true,
       })
     } else {
+      // Drop the focus anchor first, unconditionally: the host root is
+      // detaching regardless of whether the field record still reads
+      // connected (a latch supersede may have flipped it via the element Set).
+      if (hostTargets.delete(key)) sortedRegistrationsCache = null
       if (current?.connected !== true) return
       // Disconnect transition, mirroring `deregisterElement`'s empty-Set
       // branch: focused / blurred are DOM-state and meaningless with nothing
@@ -4007,23 +4101,25 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
   function getFirstErrorElement(
     formInstanceId: string
   ): { path: Path; element: HTMLElement } | null {
-    // Single-pass DOM-order walk over every registered element. The
-    // sort cache is rebuilt lazily on the first read after a register/
-    // deregister; subsequent calls amortise to O(n) until the next
-    // mutation.
+    // Single-pass DOM-order walk over every registered element plus every
+    // no-latch host root. The sort cache is rebuilt lazily on the first read
+    // after a register/deregister or host connect/disconnect; subsequent
+    // calls amortise to O(n) until the next mutation.
     sortedRegistrationsCache ??= rebuildSortedRegistrations()
 
     for (const entry of sortedRegistrationsCache) {
       // Scope to this form instance — when two `useForm()` calls share
-      // a key, both write into `elements`; this filter keeps each
-      // form's submit from focusing the other's input.
-      if (elementToFormInstance.get(entry.element) !== formInstanceId) continue
+      // a key, both write into `elements` / `hostTargets`; this filter keeps
+      // each form's submit from focusing the other's field. The instance tag
+      // is denormalised onto the entry at rebuild time.
+      if (entry.formInstanceId !== formInstanceId) continue
 
       // `el.isConnected` covers "component was unmounted, element
       // removed from DOM" cases that lag the FieldRecord.connected
       // flag. `el.offsetParent === null` catches `display:none` and
       // its ancestor chain — the browser won't focus or scroll to a
-      // hidden element anyway, so we keep walking.
+      // hidden element anyway, so we keep walking. For a host entry the
+      // element is the host root; a hidden host is skipped the same way.
       if (!entry.element.isConnected) continue
       if (entry.element.offsetParent === null) continue
 
@@ -4037,20 +4133,54 @@ export function createFormStore<F extends GenericForm, G extends GenericForm = F
       // focus target and the visible error set from ever drifting apart.
       if (getErrorsForPath(entry.path).length === 0) continue
 
-      return { path: entry.path, element: entry.element }
+      // A registered control is its own focus target. A no-latch host owns
+      // no single control, so resolve its root to the first focusable
+      // descendant (the tab stop a user entering the widget would land on);
+      // the resolver falls back to the root itself, keeping scroll-to-error
+      // a target even when nothing inside can take focus.
+      const element = entry.host ? resolveHostFocusTarget(entry.element) : entry.element
+      return { path: entry.path, element }
     }
     return null
   }
 
-  function rebuildSortedRegistrations(): Array<{ path: Path; element: HTMLElement }> {
-    const flat: Array<{ path: Path; element: HTMLElement }> = []
+  function rebuildSortedRegistrations(): Array<{
+    path: Path
+    element: HTMLElement
+    host: boolean
+    formInstanceId: string
+  }> {
+    const flat: Array<{ path: Path; element: HTMLElement; host: boolean; formInstanceId: string }> =
+      []
     for (const [, record] of elements) {
-      for (const el of record.elements) flat.push({ path: record.path, element: el })
+      for (const el of record.elements) {
+        flat.push({
+          path: record.path,
+          element: el,
+          host: false,
+          formInstanceId: elementToFormInstance.get(el) ?? '',
+        })
+      }
+    }
+    // No-latch host roots. `registerElement` drops the anchor when a control
+    // latches, so a path is never in both maps; guard anyway so a rebuild
+    // between a latch and the anchor delete never double-lists a path.
+    for (const [key, target] of hostTargets) {
+      if (elements.has(key)) continue
+      flat.push({
+        path: target.path,
+        element: target.hostRoot,
+        host: true,
+        formInstanceId: target.formInstanceId,
+      })
     }
     // `compareDocumentPosition` returns a bitmask. The
     // `DOCUMENT_POSITION_FOLLOWING` bit (0x04) is set when the argument
     // node FOLLOWS the receiver in document order, which means the
-    // receiver comes first → return -1 to keep `a` before `b`.
+    // receiver comes first → return -1 to keep `a` before `b`. A host root
+    // and a control are distinct elements across fields (a no-latch host has
+    // no registered descendant), so the comparison is always a clean
+    // before/after, never a containment tie.
     flat.sort((a, b) =>
       a.element.compareDocumentPosition(b.element) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1
     )

--- a/src/runtime/core/directive.ts
+++ b/src/runtime/core/directive.ts
@@ -1155,7 +1155,7 @@ function latchHostControl(el: HTMLElement, rv: RegisterValue, control: HTMLEleme
 // self-heal latch can detach them itself before the control's own focus / blur
 // listeners take over.
 function setupNoLatchHost(el: HTMLElement, rv: RegisterValue): void {
-  rv.markHostConnected(true)
+  rv.markHostConnected(true, el)
   const focusin: EventListener = (event) => {
     const from = (event as FocusEvent).relatedTarget
     if (from instanceof Node && el.contains(from)) return
@@ -1434,7 +1434,7 @@ const vRegisterDynamic: RegisterModelDynamicCustomDirective = {
         // host-root teardownAria above never reached this descendant.
         teardownAria(latchedControl as AriaCarrier)
         value.deregisterElement(latchedControl)
-      } else value.markHostConnected(false)
+      } else value.markHostConnected(false, el)
       componentHostLatch.delete(el)
     }
 

--- a/src/runtime/core/register-api.ts
+++ b/src/runtime/core/register-api.ts
@@ -445,8 +445,8 @@ export function buildRegister<F extends GenericForm>(
         state.markConnectedOptimistically(segments)
       },
 
-      markHostConnected: (connected: boolean): void => {
-        state.markHostConnected(segments, connected)
+      markHostConnected: (connected: boolean, hostEl: HTMLElement): void => {
+        state.markHostConnected(segments, connected, hostEl, formInstanceId)
       },
 
       markFocused: (focused: boolean): void => {

--- a/src/runtime/types/types-api.ts
+++ b/src/runtime/types/types-api.ts
@@ -1964,9 +1964,16 @@ export type RegisterValue<Value = unknown> = Readonly<{
    * but exposes no single inner control to register -- a composite widget,
    * or none found. The directive calls it on mount / unmount; distinct from
    * the SSR-only `markConnectedOptimistically`.
+   *
+   * `hostEl` is the host root element, recorded on connect as the field's
+   * focus-first-error anchor: a no-latch host registers no control, so it
+   * would otherwise be invisible to `focusFirstError` / `scrollToFirstError`
+   * (which walk the registered-element set). On an invalid submit the error
+   * walk resolves the host root to its first focusable descendant. The
+   * directive passes the same element on both edges.
    * @internal
    */
-  markHostConnected: (connected: boolean) => void
+  markHostConnected: (connected: boolean, hostEl: HTMLElement) => void
   /**
    * Mark this field focused (`true`) or blurred (`false`) for a `v-register`
    * component host with no single latched control -- a composite widget whose

--- a/test/composables/focus-scroll.test.ts
+++ b/test/composables/focus-scroll.test.ts
@@ -1041,3 +1041,185 @@ describe('getFirstErrorElement — blank-required fields (issue #468)', () => {
     app.unmount()
   })
 })
+
+describe('focusFirstError — no-latch component host (#538)', () => {
+  let focusSpy: ReturnType<typeof vi.spyOn>
+  let scrollSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    if (typeof HTMLElement.prototype.scrollIntoView !== 'function') {
+      HTMLElement.prototype.scrollIntoView = function scrollIntoView() {
+        return undefined
+      }
+    }
+    focusSpy = vi.spyOn(HTMLElement.prototype, 'focus')
+    scrollSpy = vi.spyOn(HTMLElement.prototype, 'scrollIntoView')
+    Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+      configurable: true,
+      get(this: HTMLElement) {
+        return this.style.display === 'none' ? null : this.parentNode
+      },
+    })
+  })
+
+  afterEach(() => {
+    focusSpy.mockRestore()
+    scrollSpy.mockRestore()
+  })
+
+  // A `v-register` component host that renders an ARIA composite (a
+  // `role=radiogroup` of `<button role=radio>`, zero native controls) takes
+  // the directive's no-latch path: it binds a value but registers no single
+  // control, so `markHostConnected(true, hostRoot)` is the only wiring. The
+  // store records the host root as the field's focus-first-error anchor, and
+  // resolves it to a focusable descendant at submit time. `email` is a plain
+  // native input; `nickname` is the composite host.
+  function mountHostForm(opts: {
+    errorsFor: (keyof Form)[]
+    order?: ('email' | 'nickname')[]
+    hostHasFocusable?: boolean
+  }) {
+    type Returned = ReturnType<typeof useForm<Form>>
+    const handle: { api?: Returned } = {}
+    const hasFocusable = opts.hostHasFocusable ?? true
+
+    const App = defineComponent({
+      setup() {
+        const validator = (_data: unknown, _path: Path | undefined) => ({
+          data: undefined,
+          errors: opts.errorsFor.map((k) => ({
+            message: `${k} is bad`,
+            path: [k as string],
+            formKey: 'host-focus-form',
+            code: 'atta:test-fixture',
+          })),
+          success: false as const,
+          formKey: 'host-focus-form',
+        })
+        handle.api = useForm<Form>({
+          schema: fakeSchema<Form>(defaults, validator),
+          key: 'host-focus-form',
+        })
+        return () => {
+          const order = opts.order ?? (['nickname'] as ('email' | 'nickname')[])
+          const nodes = order.map((name) => {
+            if (name === 'email') {
+              const reg = handle.api?.register('email')
+              return h('input', {
+                'data-field': 'email',
+                ref: (el: unknown) => {
+                  if (el instanceof HTMLInputElement && reg) reg.registerElement(el)
+                },
+              })
+            }
+            // The no-latch host: a role=radiogroup wrapper around ARIA
+            // radio buttons (or non-focusable spans, for the fallback case).
+            const reg = handle.api?.register('nickname')
+            const options = hasFocusable
+              ? [0, 1].map((i) =>
+                  h('button', { type: 'button', role: 'radio', 'data-radio': String(i) }, 'x')
+                )
+              : [0, 1].map((i) => h('span', { 'data-inert': String(i) }, 'x'))
+            return h(
+              'div',
+              {
+                role: 'radiogroup',
+                'data-field': 'nickname',
+                ref: (el: unknown) => {
+                  if (el instanceof HTMLElement && reg) reg.markHostConnected(true, el)
+                },
+              },
+              options
+            )
+          })
+          return h('form', nodes)
+        }
+      },
+    })
+
+    const app = createApp(App).use(createAttaform())
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+    return { app, api: handle.api as Returned, root }
+  }
+
+  it('resolves the host root to its first focusable descendant (a role=radio button)', async () => {
+    const { api, app } = mountHostForm({ errorsFor: ['nickname'] })
+    await api.handleSubmit(async () => {})()
+    focusSpy.mockClear()
+    expect(api.focusFirstError()).toBe(true)
+    const focused = focusSpy.mock.instances.at(-1) as HTMLElement | undefined
+    expect(focused?.getAttribute('role')).toBe('radio')
+    expect(focused?.getAttribute('data-radio')).toBe('0')
+    app.unmount()
+  })
+
+  it('scroll-to-first-error scrolls the resolved host target', async () => {
+    const { api, app } = mountHostForm({ errorsFor: ['nickname'] })
+    await api.handleSubmit(async () => {})()
+    scrollSpy.mockClear()
+    expect(api.scrollToFirstError()).toBe(true)
+    const scrolled = scrollSpy.mock.instances.at(-1) as HTMLElement | undefined
+    expect(scrolled?.getAttribute('role')).toBe('radio')
+    app.unmount()
+  })
+
+  it('respects DOM order: a native field before the host wins; the host wins when first', async () => {
+    // Native `email` rendered before the host → the native input wins.
+    const first = mountHostForm({ errorsFor: ['email', 'nickname'], order: ['email', 'nickname'] })
+    await first.api.handleSubmit(async () => {})()
+    focusSpy.mockClear()
+    expect(first.api.focusFirstError()).toBe(true)
+    const nativeFocused = focusSpy.mock.instances.at(-1) as HTMLElement | undefined
+    expect(nativeFocused?.getAttribute('data-field')).toBe('email')
+    first.app.unmount()
+
+    // Host rendered before the native field → the host's first radio wins,
+    // proving host roots interleave with registered controls in DOM order.
+    const second = mountHostForm({ errorsFor: ['email', 'nickname'], order: ['nickname', 'email'] })
+    await second.api.handleSubmit(async () => {})()
+    focusSpy.mockClear()
+    expect(second.api.focusFirstError()).toBe(true)
+    const hostFocused = focusSpy.mock.instances.at(-1) as HTMLElement | undefined
+    expect(hostFocused?.getAttribute('role')).toBe('radio')
+    second.app.unmount()
+  })
+
+  it('leaves field.element undefined — the host owns no single control', async () => {
+    const { api, app } = mountHostForm({ errorsFor: ['nickname'] })
+    await nextTick()
+    // The host binds a value channel and reads connected from the host mark,
+    // but it registers no control, so the focus anchor never leaks into the
+    // FieldState element accessor.
+    expect(api.fields.nickname.connected).toBe(true)
+    expect(api.fields.nickname.element).toBeNull()
+    app.unmount()
+  })
+
+  it('falls back to the host root when nothing inside can take focus', async () => {
+    const { api, app } = mountHostForm({ errorsFor: ['nickname'], hostHasFocusable: false })
+    await api.handleSubmit(async () => {})()
+    focusSpy.mockClear()
+    // No focusable descendant, so the target is the host root itself: still a
+    // target (keeps "first error" ordering, gives scroll something to hit),
+    // and `focus()` on an unfocusable root is a graceful no-op.
+    expect(api.focusFirstError()).toBe(true)
+    const focused = focusSpy.mock.instances.at(-1) as HTMLElement | undefined
+    expect(focused?.getAttribute('role')).toBe('radiogroup')
+    app.unmount()
+  })
+
+  it('returns false when the host is hidden (display:none)', async () => {
+    const { api, app, root } = mountHostForm({ errorsFor: ['nickname'] })
+    const host = root.querySelector('[role=radiogroup]') as HTMLElement
+    host.style.display = 'none'
+    await api.handleSubmit(async () => {})()
+    focusSpy.mockClear()
+    // The host root's offsetParent is null, so the walk skips it exactly as
+    // it skips a hidden registered control; no other errored field remains.
+    expect(api.focusFirstError()).toBe(false)
+    expect(focusSpy).not.toHaveBeenCalled()
+    app.unmount()
+  })
+})

--- a/test/third-party-components/v-register-cross-library.test.ts
+++ b/test/third-party-components/v-register-cross-library.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   createApp,
   defineComponent,
@@ -31,6 +31,8 @@ import {
   ComboboxRoot,
   ComboboxAnchor,
   ComboboxInput,
+  RadioGroupRoot,
+  RadioGroupItem,
 } from 'reka-ui'
 
 /**
@@ -421,6 +423,80 @@ const MultiRootComponent = defineComponent({
       h('span', 'sibling root node'),
     ]
   },
+})
+
+// ---------------------------------------------------------------------------
+// Invalid-submit focus for no-latch hosts (#538)
+// ---------------------------------------------------------------------------
+
+describe('cross-library matrix: invalid-submit focus (#538)', () => {
+  let focusSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    focusSpy = vi.spyOn(HTMLElement.prototype, 'focus')
+    // jsdom does no layout, so offsetParent is always null and every element
+    // reads "hidden" to the error walk. Force a truthy value for visible
+    // elements so `getFirstErrorElement` and `resolveHostFocusTarget` behave
+    // as they would in a real browser. (Mirrors the focus-scroll suite.)
+    Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+      configurable: true,
+      get(this: HTMLElement) {
+        return this.style.display === 'none' ? null : this.parentNode
+      },
+    })
+  })
+
+  afterEach(() => {
+    focusSpy.mockRestore()
+  })
+
+  it('RadioGroup (ARIA composite, zero native controls): invalid submit focuses the first role=radio', async () => {
+    // The exact reported shape: a v-register host that renders <button
+    // role=radio> options, not a native <input>. It takes the no-latch path,
+    // so before the fix it registered no element and focus-first-error had no
+    // target. Now the host root is the field's anchor and resolves to the
+    // first radio.
+    const m = await mountHost(z.object({ field: z.string().min(1) }), (_rv, vm) =>
+      h(RadioGroupRoot, { ...vm }, () => [
+        h(RadioGroupItem, { value: 'a' }, () => 'A'),
+        h(RadioGroupItem, { value: 'b' }, () => 'B'),
+      ])
+    )
+    expect(m.host()?.getAttribute('role')).toBe('radiogroup')
+    // No native control was latched: the field is connected via the host mark.
+    expect(m.inner('input')).toBeNull()
+    expect(m.api.fields.field.connected).toBe(true)
+
+    // Submit empty -> min(1) fails -> the invalid-submit policy runs.
+    await m.api.handleSubmit(async () => {})()
+    focusSpy.mockClear()
+    expect(m.api.focusFirstError()).toBe(true)
+    const focused = focusSpy.mock.instances.at(-1)
+    if (!(focused instanceof HTMLElement)) throw new Error('no element focused')
+    expect(focused.getAttribute('role')).toBe('radio')
+  })
+
+  it('Slider (control-less, role=slider): invalid submit focuses the thumb', async () => {
+    // String field for a clean `connected` read (same rationale as the Slider
+    // case above); the empty default fails min(1) so the field errors on
+    // submit, while the Slider renders from the array modelValue fallback.
+    const m = await mountHost(z.object({ field: z.string().min(1) }), (_rv, vm) =>
+      h(
+        SliderRoot,
+        { ...vm, modelValue: Array.isArray(vm['modelValue']) ? vm['modelValue'] : [50] },
+        () => [h(SliderTrack, () => [h(SliderRange)]), h(SliderThumb, { index: 0 })]
+      )
+    )
+    expect(m.inner('input')).toBeNull()
+    expect(m.api.fields.field.connected).toBe(true)
+
+    await m.api.handleSubmit(async () => {})()
+    focusSpy.mockClear()
+    expect(m.api.focusFirstError()).toBe(true)
+    const focused = focusSpy.mock.instances.at(-1)
+    if (!(focused instanceof HTMLElement)) throw new Error('no element focused')
+    expect(focused.getAttribute('role')).toBe('slider')
+  })
 })
 
 describe('cross-library matrix: value channel + escape path', () => {


### PR DESCRIPTION
## What

`handleSubmit` and `tryNext` promise to focus (and scroll to) the first offending field on an invalid submit. That guarantee silently did **not** hold for a `v-register` component host that renders no single native control: an ARIA composite (`role=radio` / `checkbox` / `listbox` / `slider`), several native controls (a checkbox group, an address subform), or a control-less widget. The field validated and showed its error, but focus never moved, so a keyboard or screen-reader user was told "This field is required" with nowhere to land.

Closes #538.

## Root cause

Such a host takes the directive's **no-latch** path: it binds a value through the v-model channel but registers no single control, so `markHostConnected(true)` was the only wiring. `getFirstErrorElement` walks only the registered-element set, so the host was structurally invisible to the focus walk. (Verified end to end, including that reka-ui's `VisuallyHiddenInput` mirror is correctly dropped by the `tabindex="-1"` filter, so a radio group reaches the no-latch path.)

Note this is distinct from the multi-root/fragment host case (where Vue drops the directive entirely and emits the "never attached to" warning); that remains a separate, already-documented limitation.

## The fix

Three parts, all keyed on the **structural** no-control shape rather than any one library:

1. **`markHostConnected(connected, hostEl)`** now carries the host root (internal `RegisterValue` signature change).
2. The store records that root as the field's **focus anchor** (scoped to the form instance like a registered control), weaves it into the same document-order "first error" walk, and resolves it to its **first focusable descendant at submit time** (the tab stop a user entering the widget lands on), falling back to the root so scroll still has a target.
3. `registerElement` **drops the anchor** if a single control later self-heals into a latch, so a path is never both latched and anchored.

`field.element` stays `null` for a no-latch host: the anchor is a focus-only channel and never leaks into `FieldState`. Focus, scroll, and `both` policies all heal at once, since they share `getFirstErrorElement`.

Because the fix is structural, the guarantee now holds for any accessible component library you bring (reka-ui, Radix Vue, Headless UI, Ark, or a hand-rolled widget).

## Tests

- **`focus-scroll.test.ts`** (store logic): a no-latch host resolves to its first focusable descendant, interleaves with native fields in document order, keeps `field.element` null, falls back to the root when nothing focusable exists, and is skipped when hidden.
- **`v-register-cross-library.test.ts`** (real directive path against reka-ui): a `RadioGroup` (the exact reported `<button role=radio>` case) and a `Slider` both focus a real descendant on an invalid submit.

Both suites bite: stashing the source change flips the fix-dependent assertions red.

## Verification

`pnpm typecheck` · `eslint` · `prettier` · `check:bundled-types` (public `.d.ts` carries the new shape) · full `pnpm test` (**363 files, 4640 passed, 0 failed**) · `prepack` build (pre-push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
